### PR TITLE
docs: nest two-space child lists so they render nested on the published site (rf2-3bq6)

### DIFF
--- a/docs/EP/EP-0003-resource-queries.md
+++ b/docs/EP/EP-0003-resource-queries.md
@@ -62,22 +62,22 @@ ruling:
   panel were updated. A stale `:loaded` entry still refetches (fresh-skip never
   swallows a stale refresh).
 - **Fixed (PR #3794, ssr-restore cluster)** — three P1 SSR/restore correctness gaps:
-  - **SSR blocking-resource drain** — the SSR blocking-resource drain/timeout loop was helper-only
-    and not wired into the Ring and streaming render paths; a never-settling
-    blocking resource could render against an unchecked loading/skeleton state.
-    The drain/timeout policy is now integrated into both SSR render paths so
-    current-navigation blocking resources settle before render or install a
-    settled timeout error entry.
-  - **Hydration refetch planner** — the hydration refetch planner only invoked reconciliation, and
-    redacted projected data could be misclassified as usable data. Hydration now
-    refetches stale/omitted/redacted entries needed by the live route while fresh
-    serialized entries do not double-fetch, and the redacted sentinel is treated as
-    metadata-only, not usable data.
-  - **Epoch restore** — epoch restore reconciled dangling work-ledger rows and settled
-    resource entries but left pending mutation instances holding current-work and
-    generation, so a late pre-restore mutation reply could still patch/populate/
-    invalidate post-restore state. Restore now terminally settles restored pending
-    mutation instances, so stale pre-restore mutation replies are suppressed.
+    - **SSR blocking-resource drain** — the SSR blocking-resource drain/timeout loop was helper-only
+      and not wired into the Ring and streaming render paths; a never-settling
+      blocking resource could render against an unchecked loading/skeleton state.
+      The drain/timeout policy is now integrated into both SSR render paths so
+      current-navigation blocking resources settle before render or install a
+      settled timeout error entry.
+    - **Hydration refetch planner** — the hydration refetch planner only invoked reconciliation, and
+      redacted projected data could be misclassified as usable data. Hydration now
+      refetches stale/omitted/redacted entries needed by the live route while fresh
+      serialized entries do not double-fetch, and the redacted sentinel is treated as
+      metadata-only, not usable data.
+    - **Epoch restore** — epoch restore reconciled dangling work-ledger rows and settled
+      resource entries but left pending mutation instances holding current-work and
+      generation, so a late pre-restore mutation reply could still patch/populate/
+      invalidate post-restore state. Restore now terminally settles restored pending
+      mutation instances, so stale pre-restore mutation replies are suppressed.
 - **Fixed (PR #3795, xray-resources cluster)** — resource
   accessors redacted live entries *before* projection, so default
   `list-resource-instances` / `get-resource-state` could lose status, owners,
@@ -313,12 +313,12 @@ dependencies.
   resources — see §Non-Goals) each landed in a dedicated
   successor EP, all now **final**, all amending `spec/016-Resources.md` (which
   governs):
-  - **[EP-0019](EP-0019-optimistic-mutation-rollback.md)** — optimistic mutation
-    apply / commit / rollback / reconcile (the deferred optimistic-update slice).
-  - **[EP-0020](EP-0020-active-owner-polling.md)** — active-owner polling (the
-    deferred polling slice).
-  - **[EP-0021](EP-0021-infinite-resources.md)** — infinite / load-more resources
-    (the deferred infinite-resources slice).
+    - **[EP-0019](EP-0019-optimistic-mutation-rollback.md)** — optimistic mutation
+      apply / commit / rollback / reconcile (the deferred optimistic-update slice).
+    - **[EP-0020](EP-0020-active-owner-polling.md)** — active-owner polling (the
+      deferred polling slice).
+    - **[EP-0021](EP-0021-infinite-resources.md)** — infinite / load-more resources
+      (the deferred infinite-resources slice).
   This EP remains the unamended record of the original scope; each successor back-links here.
 
 - **Graduation graded by [EP-0006](EP-0006-runtime-subsystem-contract.md)

--- a/docs/EP/EP-0004-subscription-inputs.md
+++ b/docs/EP/EP-0004-subscription-inputs.md
@@ -310,9 +310,9 @@ For `(subscribe [:article/page :a1])`:
 
 1. Resolve `:article/page` in the registrar.
 2. Produce input query vectors:
-   - no query vectors for a layer-1 app-db reader;
-   - literal query vectors for a literal `:inputs`;
-   - `(input-fn [:article/page :a1])` for the parametric form.
+    - no query vectors for a layer-1 app-db reader;
+    - literal query vectors for a literal `:inputs`;
+    - `(input-fn [:article/page :a1])` for the parametric form.
 3. Validate that the result is a vector of query vectors.
 4. Subscribe to each input query vector in the same frame.
 5. Call the computation function with the resolved input values and the outer

--- a/docs/EP/EP-0007-one-name-per-fact.md
+++ b/docs/EP/EP-0007-one-name-per-fact.md
@@ -129,14 +129,14 @@ class that dominated this review cycle.
    the stable contract.
 3. **Cross-layer distinctions are named rules.** Where layers use different
    words for related concepts, Conventions records the rule. Initial rules:
-   - *Public-opt vs runtime-context*: `:frame` is the public dispatch/subscribe
-     opt and trace tag; `:rf.frame/id` is the same stamp's runtime-context
-     spelling. (Already ruled by EP-0002 R3; recorded here as the pattern's
-     first instance.)
-   - *HTTP-response vocabulary vs navigation vocabulary*: server response
-     surfaces use header vocabulary (`:location` for redirects); client
-     navigation surfaces use `:url`. Different concepts, deliberately different
-     words.
+    - *Public-opt vs runtime-context*: `:frame` is the public dispatch/subscribe
+      opt and trace tag; `:rf.frame/id` is the same stamp's runtime-context
+      spelling. (Already ruled by EP-0002 R3; recorded here as the pattern's
+      first instance.)
+    - *HTTP-response vocabulary vs navigation vocabulary*: server response
+      surfaces use header vocabulary (`:location` for redirects); client
+      navigation surfaces use `:url`. Different concepts, deliberately different
+      words.
 4. **One authoritative home per fact; mirrors are projections.** Denormalized
    copies (indexes, dual-homed owners, derived fields) are declared
    recomputable projections of the authoritative home, never co-equal sources.

--- a/docs/EP/EP-0013-app-values-and-runtime-realms.md
+++ b/docs/EP/EP-0013-app-values-and-runtime-realms.md
@@ -128,11 +128,11 @@ implementation and the `/spec` correction (#4272).
   — *structural/section keys stay bare; FACT keys get owner-qualified* — these
   are facts ABOUT the module/app, so the **KEYS** are owner-qualified (the values
   were already `:rf.capability/*`-qualified):
-  - module ownership declaration: `:owns` → **`:rf.module/owns`**;
-  - module capability requirement: `:requires` → **`:rf.module/requires`**
-    (parallel to `:rf.cofx/requires` over coeffects — naming the contract);
-  - app-value union capability set: `:requires` → **`:rf.app/requires`**
-    (parallel to `:rf.app/id`).
+    - module ownership declaration: `:owns` → **`:rf.module/owns`**;
+    - module capability requirement: `:requires` → **`:rf.module/requires`**
+      (parallel to `:rf.cofx/requires` over coeffects — naming the contract);
+    - app-value union capability set: `:requires` → **`:rf.app/requires`**
+      (parallel to `:rf.app/id`).
 
   The structural section keys (`:id`, `:events`, `:subs`, `:routes`, `:source`,
   `:modules`, `:registrations`) stay **bare**. The shipped constructor

--- a/docs/EP/EP-0019-optimistic-mutation-rollback.md
+++ b/docs/EP/EP-0019-optimistic-mutation-rollback.md
@@ -365,22 +365,22 @@ write:
 2. **Send** the managed request.
 3. **Accept / suppress** the host reply (the landed work-id + generation gate).
 4. **Settle the optimistic apply** *then* apply success-time consequences:
-   - **`:ok` (accepted) → COMMIT.** The authoritative `:populates` / `:patches`
-     run (they overwrite the optimistic value with the server's), then
-     `:invalidates`. The optimistic apply is *cleared* from each entry's live
-     list. Populate-as-authoritative-load (Rider 1) means a populated key is
-     not re-fetched by this mutation's own invalidation. The recorded inverse is
-     discarded (the commit superseded it). Emit `:rf.mutation/reconciled`.
-   - **`:error` / accepted `:cancelled` → ROLLBACK.** For each recorded inverse,
-     apply the **conflict rule** below. Emit `:rf.mutation/rolled-back`.
-   - **stale / superseded → NEITHER.** A stale reply (a re-execute under the
-     same instance, or `:rf.mutation/clear`) is suppressed exactly as today
-     (the mandatory stale-suppression boundary). Its optimistic apply was
-     **already superseded** by the newer execute's apply (which re-snapshotted
-     the entry *as the optimistic value*, recording its own inverse), so the
-     stale reply's inverse is **discarded, never replayed** — the current
-     generation owns the entry. This is the determinism guarantee for
-     superseded responses.
+    - **`:ok` (accepted) → COMMIT.** The authoritative `:populates` / `:patches`
+      run (they overwrite the optimistic value with the server's), then
+      `:invalidates`. The optimistic apply is *cleared* from each entry's live
+      list. Populate-as-authoritative-load (Rider 1) means a populated key is
+      not re-fetched by this mutation's own invalidation. The recorded inverse is
+      discarded (the commit superseded it). Emit `:rf.mutation/reconciled`.
+    - **`:error` / accepted `:cancelled` → ROLLBACK.** For each recorded inverse,
+      apply the **conflict rule** below. Emit `:rf.mutation/rolled-back`.
+    - **stale / superseded → NEITHER.** A stale reply (a re-execute under the
+      same instance, or `:rf.mutation/clear`) is suppressed exactly as today
+      (the mandatory stale-suppression boundary). Its optimistic apply was
+      **already superseded** by the newer execute's apply (which re-snapshotted
+      the entry *as the optimistic value*, recording its own inverse), so the
+      stale reply's inverse is **discarded, never replayed** — the current
+      generation owns the entry. This is the determinism guarantee for
+      superseded responses.
 5. **Instance settlement** (settle the row, work-ledger row).
 6. **Continuation** — `:reply-to`, unchanged (fires only for the accepted
    terminal reply, after settle).

--- a/docs/EP/EP-0024-unified-frame-identity-and-lifecycle.md
+++ b/docs/EP/EP-0024-unified-frame-identity-and-lifecycle.md
@@ -173,26 +173,26 @@ Non-goals:
   to final EP-0023. If accepted, this EP records the amendment and graduates
   into the named specs.
 - **API-review findings**:
-  - `ai/findings/API-review/codex/frame-object-record-unification.md`
-  - `ai/findings/API-review/codex/frame-targeting-and-lifecycle.md`
-  - `ai/findings/API-review/codex/registrar-query-addressing.md`
-  - `ai/findings/API-review/claude/frame-targeting-and-carrying.md` — the
-    empirical 0-caller backbone (`frame-first` `(dispatch f ev)`,
-    `frame-bound-fn`/`frame-bound-fn*`, `subscribe*` have zero real call sites in
-    examples and tools) that grounds the helper-removal slices below.
+    - `ai/findings/API-review/codex/frame-object-record-unification.md`
+    - `ai/findings/API-review/codex/frame-targeting-and-lifecycle.md`
+    - `ai/findings/API-review/codex/registrar-query-addressing.md`
+    - `ai/findings/API-review/claude/frame-targeting-and-carrying.md` — the
+      empirical 0-caller backbone (`frame-first` `(dispatch f ev)`,
+      `frame-bound-fn`/`frame-bound-fn*`, `subscribe*` have zero real call sites in
+      examples and tools) that grounds the helper-removal slices below.
 - **Related work already identified**:
-  - Unsubscribe target normalization symmetry is fixed separately.
-  - An internal frame-record resolver is factored separately if not absorbed by
-    this EP.
-  - HTTP test-support helpers are moved out of the core facade separately.
-  - The registrar query/read address grammar after EP-0023 has its own **home**
-    (ruled: drop `:realm`, keep `:frame`). EP-0024 references that home and does
-    not re-decide it (see §Registrar and generation reads).
-  - A separate item recorded the `spec/002-Frames.md` ↔ `spec/API.md` `make-frame`
-    contradiction (002-Frames still documented the pre-EP-0023 keyword-returning
-    `make-frame`). This EP's §One constructor partially resolves it by unifying
-    `make-frame`; the spec-graduation wave for `spec/002-Frames.md` subsumes or
-    hands off to that fix.
+    - Unsubscribe target normalization symmetry is fixed separately.
+    - An internal frame-record resolver is factored separately if not absorbed by
+      this EP.
+    - HTTP test-support helpers are moved out of the core facade separately.
+    - The registrar query/read address grammar after EP-0023 has its own **home**
+      (ruled: drop `:realm`, keep `:frame`). EP-0024 references that home and does
+      not re-decide it (see §Registrar and generation reads).
+    - A separate item recorded the `spec/002-Frames.md` ↔ `spec/API.md` `make-frame`
+      contradiction (002-Frames still documented the pre-EP-0023 keyword-returning
+      `make-frame`). This EP's §One constructor partially resolves it by unifying
+      `make-frame`; the spec-graduation wave for `spec/002-Frames.md` subsumes or
+      hands off to that fix.
 
 ## Specification
 

--- a/docs/EP/EP-0025-data-classification.md
+++ b/docs/EP/EP-0025-data-classification.md
@@ -483,7 +483,7 @@ section-by-section map.
    sensitive-vs-large precedence + nested suppression; `[[]]` whole-value; cross-frame
    isolation; profile-aware egress (default-redacts / raw-local-passes); SSR allowlist +
    projection; MCP/Xray/off-box-sink redaction; per-subsystem generated-instance create
-   + teardown; malformed-payload fail-loud.
+    + teardown; malformed-payload fail-loud.
 
 ### Repo-wide propagation — one bead per area (be exhaustive)
 
@@ -491,18 +491,18 @@ Cross-cutting change (every egress boundary; removes "marks"). Sweep, beyond the
 specs (8), `/docs/core` (9), and `/skills` (10):
 
 - **`/tools` — the consumer / egress side (the half that delivers the value):**
-  - **`mcp-base`** — the shared redaction lives here: read the new registry; project
-    every value returned to an AI client.
-  - **`re-frame2-pair-mcp` + `story-mcp`** — every read (app-db, subs, traces, epochs)
-    is projected before it reaches the AI client.
-  - **`xray`** — every panel that shows a value (event detail, app-db diff,
-    subscriptions, machine inspector, schema-violation timeline, AI co-pilot rail)
-    projects; surface "what's classified" from the registry; **strip all "marks"
-    references.**
-  - **`story` + `machines-viz`** — displayed / serialized values project (machine
-    `:data`, variant EDN).
-  - **`mcp-conformance`** — add classification-redaction wire conformance.
-  - **`testbed-support`, `template`** — marks residue + any classification teaching.
+    - **`mcp-base`** — the shared redaction lives here: read the new registry; project
+      every value returned to an AI client.
+    - **`re-frame2-pair-mcp` + `story-mcp`** — every read (app-db, subs, traces, epochs)
+      is projected before it reaches the AI client.
+    - **`xray`** — every panel that shows a value (event detail, app-db diff,
+      subscriptions, machine inspector, schema-violation timeline, AI co-pilot rail)
+      projects; surface "what's classified" from the registry; **strip all "marks"
+      references.**
+    - **`story` + `machines-viz`** — displayed / serialized values project (machine
+      `:data`, variant EDN).
+    - **`mcp-conformance`** — add classification-redaction wire conformance.
+    - **`testbed-support`, `template`** — marks residue + any classification teaching.
 - **`/examples`** — update any example using classification to the four effects;
   confirm no `:sensitive {:app-db}` / schema-prop / marks usage remains.
 - **`/testbeds`** — review the classification-relevant beds (`schema_violation`,

--- a/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
+++ b/docs/EP/EP-0032-re-frame-ui-reactivity-and-ownership.md
@@ -284,21 +284,21 @@ error by the ABI guard.
   (rf2-r7ahi) requires the settled originals to stay visible, so all five are
   preserved here — `spec/006-ReactiveSubstrate.md` (host-checkpoint render
   batching) remains the current normative truth:
-  - **§Abstract** originally read "Notification is **push**: *one constant-work
-    mark per dirty cell per run-to-completion drain*, committed after the pull
-    alternative was falsified by benchmark (4.0×–6.5× worse, gap growing with
-    scale)".
-  - **Goals** originally read "committed push economics with *drain-quiescence
-    batching* and a test flush".
-  - **§One ViewCell per view** originally read "one `useSyncExternalStore` over a
-    scalar revision snapshot, one *notification per drain*".
-  - **Invariant 6** originally read "one notification per dirty cell *per drain
-    (boundary at quiescence, never epoch close)*".
-  - **§Push economics** originally read "Every queued event commits its own epoch
-    record inside the run-to-completion drain; *at quiescence each dirty cell
-    flushes exactly once and React performs one read/render batch for the whole
-    drain*, on a true microtask (never a macrotask that could let a torn frame
-    paint)".
+    - **§Abstract** originally read "Notification is **push**: *one constant-work
+      mark per dirty cell per run-to-completion drain*, committed after the pull
+      alternative was falsified by benchmark (4.0×–6.5× worse, gap growing with
+      scale)".
+    - **Goals** originally read "committed push economics with *drain-quiescence
+      batching* and a test flush".
+    - **§One ViewCell per view** originally read "one `useSyncExternalStore` over a
+      scalar revision snapshot, one *notification per drain*".
+    - **Invariant 6** originally read "one notification per dirty cell *per drain
+      (boundary at quiescence, never epoch close)*".
+    - **§Push economics** originally read "Every queued event commits its own epoch
+      record inside the run-to-completion drain; *at quiescence each dirty cell
+      flushes exactly once and React performs one read/render batch for the whole
+      drain*, on a true microtask (never a macrotask that could let a torn frame
+      paint)".
 
   The correction is factual — the shipped scheduler batches at the host
   checkpoint, never at drain quiescence — but per the ruling it is recorded, not

--- a/docs/EP/EP-0038-the-fresco-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-fresco-view-layer-programme.md
@@ -282,34 +282,34 @@ taken by the operator. The design record carries the matching HD-020 addendum
 (`docs/design/fresco/decisions.md`).
 
 - **The requirement set, R0–R8.**
-  - **R0 — one SSR story.** Fresco participates in re-frame2's *existing*
-    Spec 011 (`spec/011-SSR.md`) mechanism — the payload policy, the
-    `#__rf_payload` EDN embed, the `hydrate!` boot helper and the reserved
-    `:rf/hydrate` db adoption before first render, the hydration-mismatch
-    machinery, `ssr-ring` as the HTTP host — **never a parallel Fresco-only
-    mechanism**.
-  - **R1 — pure server render.** A server render is produced purely from a db
-    snapshot.
-  - **R2 — hydration adopts.** Zero hydration mismatch, server node identity
-    preserved (React adopts the server DOM, never re-creates it), and exactly
-    one body pass.
-  - **R3 — reactivity adopted on hydrateRoot's schedule.** Subscriptions come
-    live on React's own hydration schedule; the settle horizon is best-effort,
-    never a caller contract.
-  - **R4 — the live page.** Events and the controlled door work
-    post-hydration to the `rf2-2rtt6.67` equivalence standard.
-  - **R5 — the `defhost` SSR policy is activated.** HD-011's declared
-    placeholder becomes the real `:ssr` option — **three values as of
-    2026-08-05** (`rf2-l0wfx`): `:client-only` (the default), a
-    `{:fallback …}`, and `:render`, which is the author asserting the
-    component is server-safe and is the only policy under which a crossing's
-    children reach the server response. A declared fallback is inert markup by
-    enforcement (`rf2-nv07k`).
-  - **R6 — the ledger discipline holds server-side.** HD-002's discipline is
-    unbroken on the server: a server render is an abandoned render, leaving
-    zero durable registration.
-  - **R7 — scope is stated known-losses style.**
-  - **R8 — witnesses carry SHA + repro commands.**
+    - **R0 — one SSR story.** Fresco participates in re-frame2's *existing*
+      Spec 011 (`spec/011-SSR.md`) mechanism — the payload policy, the
+      `#__rf_payload` EDN embed, the `hydrate!` boot helper and the reserved
+      `:rf/hydrate` db adoption before first render, the hydration-mismatch
+      machinery, `ssr-ring` as the HTTP host — **never a parallel Fresco-only
+      mechanism**.
+    - **R1 — pure server render.** A server render is produced purely from a db
+      snapshot.
+    - **R2 — hydration adopts.** Zero hydration mismatch, server node identity
+      preserved (React adopts the server DOM, never re-creates it), and exactly
+      one body pass.
+    - **R3 — reactivity adopted on hydrateRoot's schedule.** Subscriptions come
+      live on React's own hydration schedule; the settle horizon is best-effort,
+      never a caller contract.
+    - **R4 — the live page.** Events and the controlled door work
+      post-hydration to the `rf2-2rtt6.67` equivalence standard.
+    - **R5 — the `defhost` SSR policy is activated.** HD-011's declared
+      placeholder becomes the real `:ssr` option — **three values as of
+      2026-08-05** (`rf2-l0wfx`): `:client-only` (the default), a
+      `{:fallback …}`, and `:render`, which is the author asserting the
+      component is server-safe and is the only policy under which a crossing's
+      children reach the server response. A declared fallback is inert markup by
+      enforcement (`rf2-nv07k`).
+    - **R6 — the ledger discipline holds server-side.** HD-002's discipline is
+      unbroken on the server: a server render is an abandoned render, leaving
+      zero durable registration.
+    - **R7 — scope is stated known-losses style.**
+    - **R8 — witnesses carry SHA + repro commands.**
 - **Non-goals, explicitly:** streaming, RSC, islands/partial hydration, no-JS
   progressive enhancement, SEO metadata, and SSR-speed-as-bar — HD-012 and the
   Motivation's "fast applications, not fast SSR" line stand unchanged.

--- a/docs/api/re-frame.adapter.reagent.md
+++ b/docs/api/re-frame.adapter.reagent.md
@@ -27,9 +27,9 @@ The adapter ships in two artefacts: `day8/re-frame2-reagent` (full) and `day8/re
    :dispose-adapter! …}
   ```
 - **Description**: The Reagent adapter map: the substrate spec you pass to `(rf/init! ...)` to install the browser-default Reagent substrate (stock `reagent.core` / `reagent.dom.client`).
-  - There is no default-adapter registry and no keyword form. Require the adapter ns and pass its `adapter` Var explicitly at the call site.
-  - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns this map itself — that is the installed-adapter value, and its presence is how you ask whether an adapter is seated. The discriminator is a KEY on it: `(:kind (rf/current-adapter))` reads `:rf.adapter/reagent`.
-  - The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md); children stay trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`).
+    - There is no default-adapter registry and no keyword form. Require the adapter ns and pass its `adapter` Var explicitly at the call site.
+    - When this adapter is installed, `current-adapter` (in [`re-frame.core`](re-frame.core.md)) returns this map itself — that is the installed-adapter value, and its presence is how you ask whether an adapter is seated. The discriminator is a KEY on it: `(:kind (rf/current-adapter))` reads `:rf.adapter/reagent`.
+    - The Reagent `frame-provider` is the substrate-agnostic provider from [`re-frame.core`](re-frame.core.md); children stay trailing-positional hiccup (`[rf/frame-provider {:frame …} & children]`).
 - **Example**:
   ```clojure
   (:require [re-frame.core :as rf]
@@ -79,7 +79,7 @@ The Root these functions manage is tracked by the same active-root ownership as 
   (client-root)
   ```
 - **Description**: Allocate an inert client-root handle and return it. Does no DOM work, so it is safe at namespace load under a `defonce`, in tests, and on Node. The React Root is created (or hydrated) by the first `render!` through the handle.
-  - The handle is opaque: hold it, hand it to `render!` and `unmount!`, and nothing else.
+    - The handle is opaque: hold it, hand it to `render!` and `unmount!`, and nothing else.
 - **Example**:
   ```clojure
   (defonce app-root (reagent-adapter/client-root))   ;; inert until the first render!
@@ -94,9 +94,9 @@ The Root these functions manage is tracked by the same active-root ownership as 
   (render! handle render-tree mount-point opts)
   ```
 - **Description**: Render `render-tree` (hiccup) through the client-root `handle` at the DOM element `mount-point`. Returns nil.
-  - The first call creates the React Root at `mount-point` and renders into it. With `{:hydrate? true}` it hydrates the server-rendered markup already inside `mount-point` instead (once; see [`re-frame.ssr`](re-frame.ssr.md)).
-  - Every later call updates that same Root with the new tree: no second `create-root`, no second hydration. That is what makes one call both the boot path and the `^:dev/after-load` hook. `mount-point` is read on the first call only.
-  - After `unmount!`, or after `rf/destroy-adapter!` has released the Root, the next `render!` mounts afresh.
+    - The first call creates the React Root at `mount-point` and renders into it. With `{:hydrate? true}` it hydrates the server-rendered markup already inside `mount-point` instead (once; see [`re-frame.ssr`](re-frame.ssr.md)).
+    - Every later call updates that same Root with the new tree: no second `create-root`, no second hydration. That is what makes one call both the boot path and the `^:dev/after-load` hook. `mount-point` is read on the first call only.
+    - After `unmount!`, or after `rf/destroy-adapter!` has released the Root, the next `render!` mounts afresh.
 - **Example**:
   ```clojure
   (reagent-adapter/render! app-root [app-view] el)                   ;; first call: create + render
@@ -112,7 +112,7 @@ The Root these functions manage is tracked by the same active-root ownership as 
   (unmount! handle)
   ```
 - **Description**: Unmount the React Root `handle` holds and return the handle to inert. Returns nil.
-  - Idempotent: a second call, or a call after `rf/destroy-adapter!` has already released the Root, does nothing.
+    - Idempotent: a second call, or a call after `rf/destroy-adapter!` has already released the Root, does nothing.
 - **Example**:
   ```clojure
   (reagent-adapter/unmount! app-root)   ;; releases the Root; a repeat call is a no-op
@@ -129,10 +129,10 @@ The Root these functions manage is tracked by the same active-root ownership as 
   (flush-views! f)
   ```
 - **Description**: Wraps React's `act()` for tests. Flushes pending Reagent renders synchronously and returns nil.
-  - 0-arity: drains the queued renders and effects.
-  - 1-arity: runs the thunk `f`, then the synchronous render drain, inside `act()`.
-  - When `act()` is unreachable in the current React build, this degrades to a plain synchronous flush. `f` still runs and the render queue still drains, just without the `act()` wrapper.
-  - Surfaced identically across all substrates: same name, same adapter-ns location, same nil-return.
+    - 0-arity: drains the queued renders and effects.
+    - 1-arity: runs the thunk `f`, then the synchronous render drain, inside `act()`.
+    - When `act()` is unreachable in the current React build, this degrades to a plain synchronous flush. `f` still runs and the render queue still drains, just without the `act()` wrapper.
+    - Surfaced identically across all substrates: same name, same adapter-ns location, same nil-return.
 - **Example**:
   ```clojure
   ;; Test-only: flush pending renders synchronously, returns nil.
@@ -150,9 +150,9 @@ The Root these functions manage is tracked by the same active-root ownership as 
   (set-hiccup-emitter! f)
   ```
 - **Description**: Install a render-tree → HTML fn: the hiccup → HTML emitter used by render-to-string.
-  - Last call wins; pass `nil` to reset.
-  - Normally you don't call this directly. Requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you.
-  - It is the Reagent-side late-bind seam for SSR, matching the parallel seam on the UIx adapter.
+    - Last call wins; pass `nil` to reset.
+    - Normally you don't call this directly. Requiring [`re-frame.ssr`](re-frame.ssr.md) resolves the late-bind hook and wires the emitter for you.
+    - It is the Reagent-side late-bind seam for SSR, matching the parallel seam on the UIx adapter.
 - **Example**:
   ```clojure
   ;; SSR: install a render-tree → HTML emitter (normally wired for you by

--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -150,10 +150,10 @@ Three things hold for that head, and they are the point of using the registry ra
   ($ uix-adapter/frame-provider {:frame :session} child…)   ;; SCOPE an existing frame
   ```
 - **Description**: The UIx-shaped SCOPE-only frame provider (rf2-nyea0r split — **roots ensure; providers scope**; for create-if-absent, use [`frame-root`](#frame-root)). Scopes an already-created frame; creates nothing. Raises:
-  - `:rf.error/frame-provider-frame-absent` when the frame does not exist
-  - `:rf.error/no-frame-context` on a nil `:frame`
-  - `:rf.error/bad-frame-provider-arg` on a `:frame` that is neither a keyword nor a live frame value
-  - `:rf.error/frame-provider-given-id` when given an `:id` (the ENSURE key — use `frame-root`)
+    - `:rf.error/frame-provider-frame-absent` when the frame does not exist
+    - `:rf.error/no-frame-context` on a nil `:frame`
+    - `:rf.error/bad-frame-provider-arg` on a `:frame` that is neither a keyword nor a live frame value
+    - `:rf.error/frame-provider-given-id` when given an `:id` (the ENSURE key — use `frame-root`)
 
   Children ride the idiomatic `$` trailing-args channel. Pass them after the prop map, as for any other UIx component (there is no `:children` prop-map key).
 - **Example**:
@@ -170,8 +170,8 @@ Three things hold for that head, and they are the point of using the registry ra
   ($ uix-adapter/frame-root {:id :session :images [session-image]} child…)   ;; ENSURE create-if-absent / reuse
   ```
 - **Description**: The UIx-shaped ENSURE component (rf2-nyea0r split). Creates the named frame if absent, or reuses it without re-seeding if present; **never destroys the frame on unmount**. Accepts `make-frame` opts, including `:images` / `:initial-events`. `:id` must be a keyword; a missing/nil/non-keyword `:id` raises `:rf.error/frame-root-missing-id`.
-  - **Commit-owned two-pass**: the create/seed runs in a client `useLayoutEffect` (at commit), not during render — the first render emits no descendant subtree, and children render only after the frame is live. A render React discards before commit creates + seeds nothing (no ghost frame).
-  - Re-mounting under the same `:id` (hot reload, React StrictMode dev double-invoke) neither destroys durable state nor re-runs `:initial-events`. A mounted `:id`/opts change raises `:rf.error/frame-root-reconfigured`; a stray `:frame` raises `:rf.error/frame-root-given-frame`.
+    - **Commit-owned two-pass**: the create/seed runs in a client `useLayoutEffect` (at commit), not during render — the first render emits no descendant subtree, and children render only after the frame is live. A render React discards before commit creates + seeds nothing (no ghost frame).
+    - Re-mounting under the same `:id` (hot reload, React StrictMode dev double-invoke) neither destroys durable state nor re-runs `:initial-events`. A mounted `:id`/opts change raises `:rf.error/frame-root-reconfigured`; a stray `:frame` raises `:rf.error/frame-root-given-frame`.
 
   Children ride the idiomatic `$` trailing-args channel.
 - **Example**:
@@ -210,7 +210,7 @@ The Root these functions manage is minted by the shared React spine through `rea
   (client-root)
   ```
 - **Description**: Allocate an inert client-root handle and return it. Does no DOM work, so it is safe at namespace load under a `defonce`, in tests, and on Node. The React Root is created (or hydrated) by the first `render!` through the handle.
-  - The handle is opaque: hold it, hand it to `render!` and `unmount!`, and nothing else.
+    - The handle is opaque: hold it, hand it to `render!` and `unmount!`, and nothing else.
 - **Example**:
   ```clojure
   (defonce app-root (uix-adapter/client-root))   ;; inert until the first render!
@@ -225,11 +225,11 @@ The Root these functions manage is minted by the shared React spine through `rea
   (render! handle element mount-point opts)
   ```
 - **Description**: Render `element` — a React element built with `uix.core/$` — through the client-root `handle` at the DOM element `mount-point`. Returns nil.
-  - The first call creates the React Root at `mount-point` and renders into it. With `{:hydrate? true}` it hydrates the server-rendered markup already inside `mount-point` instead (once; see [`re-frame.ssr`](re-frame.ssr.md)).
-  - Every later call updates that same Root with the new element: no second `createRoot`, no second hydration. That is what makes one call both the boot path and the `^:dev/after-load` hook. `mount-point` is read on the first call only.
-  - `opts` is the map the substrate `render` slot takes — `:hydrate?`, and `:on-recoverable-error`, over which the hydration-mismatch reporter is composed. There are no UIx-only keys.
-  - CLJS data in the element slot — a hiccup vector, seq or map — raises `:rf.error/hiccup-on-element-render-slot`, on the first render and on every later one alike. Hiccup mounts only on the ratom-family adapters.
-  - After `unmount!`, or after `rf/destroy-adapter!` has released the Root, the next `render!` mounts afresh.
+    - The first call creates the React Root at `mount-point` and renders into it. With `{:hydrate? true}` it hydrates the server-rendered markup already inside `mount-point` instead (once; see [`re-frame.ssr`](re-frame.ssr.md)).
+    - Every later call updates that same Root with the new element: no second `createRoot`, no second hydration. That is what makes one call both the boot path and the `^:dev/after-load` hook. `mount-point` is read on the first call only.
+    - `opts` is the map the substrate `render` slot takes — `:hydrate?`, and `:on-recoverable-error`, over which the hydration-mismatch reporter is composed. There are no UIx-only keys.
+    - CLJS data in the element slot — a hiccup vector, seq or map — raises `:rf.error/hiccup-on-element-render-slot`, on the first render and on every later one alike. Hiccup mounts only on the ratom-family adapters.
+    - After `unmount!`, or after `rf/destroy-adapter!` has released the Root, the next `render!` mounts afresh.
 - **Example**:
   ```clojure
   (uix-adapter/render! app-root ($ app-view) el)                   ;; first call: create + render
@@ -245,7 +245,7 @@ The Root these functions manage is minted by the shared React spine through `rea
   (unmount! handle)
   ```
 - **Description**: Unmount the React Root `handle` holds and return the handle to inert. Returns nil.
-  - Idempotent: a second call, or a call after `rf/destroy-adapter!` has already released the Root, does nothing.
+    - Idempotent: a second call, or a call after `rf/destroy-adapter!` has already released the Root, does nothing.
 - **Example**:
   ```clojure
   (uix-adapter/unmount! app-root)   ;; releases the Root; a repeat call is a no-op

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -39,9 +39,9 @@ Every entry here registers a named handler into the frame's registrar.
   ```
   > **Migration note.** The bare positional interceptor middle slot — `(reg-event :id [undoable] handler)` — has been removed. Put interceptor chains in the metadata map: `(reg-event :id {:interceptors [undoable]} handler)`.
 - **`:boundary?`** — a boolean registration flag. `{:boundary? true}` makes *this* handler's own `:schema` run in **every** build, including `:advanced` with `goog.DEBUG=false`, where dev-time validation is otherwise elided. It introduces no second schema. Set it on handlers that ingest data from outside the app's trust boundary: HTTP replies, websocket frames, `postMessage`.
-  - The check runs at the router's step-1 site, **before** the interceptor chain, against the original dispatched event vector — so dev and production validate the same value at the same point, and `:interceptor-overrides` cannot remove it.
-  - `{:boundary? true}` with no `:schema` **key** is rejected at registration time with `:rf.error/at-boundary-missing-schema`. Key presence is what counts: `{:schema nil :boundary? true}` registers.
-  - What a refusal then does — the skip mark, `:outcome :rejected`, the always-on `:rf.error/schema-validation-failure` record with `:source :boundary` — is unchanged. Full contract: [re-frame.schemas.md](re-frame.schemas.md).
+    - The check runs at the router's step-1 site, **before** the interceptor chain, against the original dispatched event vector — so dev and production validate the same value at the same point, and `:interceptor-overrides` cannot remove it.
+    - `{:boundary? true}` with no `:schema` **key** is rejected at registration time with `:rf.error/at-boundary-missing-schema`. Key presence is what counts: `{:schema nil :boundary? true}` registers.
+    - What a refusal then does — the skip mark, `:outcome :rejected`, the always-on `:rf.error/schema-validation-failure` record with `:source :boundary` — is unchanged. Full contract: [re-frame.schemas.md](re-frame.schemas.md).
   ```clojure
   (rf/reg-event ::receive-from-server
     {:schema    [:cat [:= ::receive-from-server] PayloadSchema]
@@ -116,9 +116,9 @@ Every entry here registers a named handler into the frame's registrar.
   (reg-fx id ?metadata handler)
   ```
 - **Description**: Define a named side effect. The handler is **binary** and context-first: `(fn [ctx args] ...)`. This is a change from v1's unary shape.
-  - `ctx` is a small map carrying `:frame` (the active frame id), `:event` (the originating event vector), and `:envelope` (the parent dispatch envelope).
-  - `args` is the value the event handler placed beside the fx-id in its `:fx` vector.
-  - Accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by the active platform. See [re-frame.ssr.md](re-frame.ssr.md).
+    - `ctx` is a small map carrying `:frame` (the active frame id), `:event` (the originating event vector), and `:envelope` (the parent dispatch envelope).
+    - `args` is the value the event handler placed beside the fx-id in its `:fx` vector.
+    - Accepts a `:platforms` metadata key (a set of `:server` / `:client`) that gates fx execution by the active platform. See [re-frame.ssr.md](re-frame.ssr.md).
 - **Example**:
   ```clojure
   (rf/reg-fx :app/scroll-to-top
@@ -133,13 +133,13 @@ Every entry here registers a named handler into the frame's registrar.
   (reg-cofx id ?metadata supplier)
   ```
 - **Description**: Register a named supplier for a world fact a handler can ask for. The supplier is a plain **value-returning** function, not a context-mutating fn: `(fn [] value)`, or `(fn [arg] value)` for ids parameterised at the call site. The runtime calls it and puts the result into the coeffects map under the cofx's id.
-  - A handler opts in with `:rf.cofx/requires` registration metadata. v2 has no `inject-cofx` interceptor.
-  - The middle slot carries the fact's grade:
-    - `{:recordable? true}` — a replayable fact.
-    - `{:recordable? true :provided? true}` — a recordable fact stamped by an owner boundary (no generator).
-    - A bare registration — an ambient (unrecorded) read.
-  - Reading a sub from a handler works the same way: wrap `subscribe-once` in a cofx and declare it.
-  - Full model: [Effects](../core/effects.md), [Coeffects](../core/coeffects.md).
+    - A handler opts in with `:rf.cofx/requires` registration metadata. v2 has no `inject-cofx` interceptor.
+    - The middle slot carries the fact's grade:
+        - `{:recordable? true}` — a replayable fact.
+        - `{:recordable? true :provided? true}` — a recordable fact stamped by an owner boundary (no generator).
+        - A bare registration — an ambient (unrecorded) read.
+    - Reading a sub from a handler works the same way: wrap `subscribe-once` in a cofx and declare it.
+    - Full model: [Effects](../core/effects.md), [Coeffects](../core/coeffects.md).
 - **Example**:
   ```clojure
   ;; A value-returning supplier — quarantines an impure read behind a named id.
@@ -234,8 +234,8 @@ On CLJS, `dispatch`, `dispatch-sync`, and `subscribe` are macros in call positio
   (subscribe query-v opts)
   ```
 - **Description**: The reactive handle. It returns a reaction whose value is the registered sub's current output, recomputed when upstreams change. Valid inside views, inside other subs, and (via the cofx wrapper) inside event handlers.
-  - Target a non-ambient frame via the `{:frame …}` opt — `(rf/subscribe [:counter/value] {:frame :other})`; `:other` may be a frame-id keyword or a live frame value.
-  - In VALUE position, `subscribe` resolves to the plain-fn value (Convention A) for HoF / programmatic reads, with no call-site capture. A JVM programmatic caller reaches `re-frame.subs/subscribe` directly.
+    - Target a non-ambient frame via the `{:frame …}` opt — `(rf/subscribe [:counter/value] {:frame :other})`; `:other` may be a frame-id keyword or a live frame value.
+    - In VALUE position, `subscribe` resolves to the plain-fn value (Convention A) for HoF / programmatic reads, with no call-site capture. A JVM programmatic caller reaches `re-frame.subs/subscribe` directly.
 - **Example**:
   ```clojure
   [:span @(rf/subscribe [:counter/value])]
@@ -297,8 +297,8 @@ On CLJS, `dispatch`, `dispatch-sync`, and `subscribe` are macros in call positio
   (compute-sub query-v db) → value
   ```
 - **Description**: The test-friendly companion to `subscribe`. It runs the sub graph against a **value** of `app-db` and returns the result — no cache, no reactivity, no frame. Arguments are query-vector first, db second.
-  - `db` may be a bare app-db map, or a full frame-state value (`{:rf.db/app … :rf.db/runtime …}`) when the graph mixes app-db and runtime-db subs.
-  - JVM-runnable.
+    - `db` may be a bare app-db map, or a full frame-state value (`{:rf.db/app … :rf.db/runtime …}`) when the graph mixes app-db and runtime-db subs.
+    - JVM-runnable.
 - **Example**:
   ```clojure
   ;; Evaluate :counter/doubled against a literal app-db value (no frame, no cache).
@@ -362,10 +362,10 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   (reg-view* id metadata render-fn)
   ```
 - **Description**: The plain-fn surface beneath `reg-view` — the tooling / host lane. No auto-def, no auto-inject, no compile check. Reach for it when:
-  - the id is **computed** (code-gen pipelines, plugin systems, story scaffolding);
-  - you **don't want a Var** (inside a `let` or closure);
-  - you are writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form);
-  - you are writing **consumer-side library code** that registers without imposing a `def`.
+    - the id is **computed** (code-gen pipelines, plugin systems, story scaffolding);
+    - you **don't want a Var** (inside a `let` or closure);
+    - you are writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form);
+    - you are writing **consumer-side library code** that registers without imposing a `def`.
 
   A `reg-view*` body has no auto-injected `dispatch` / `subscribe`. If the view needs frame-bound dispatch, capture a `(rf/capture-frame)` at render and use its ops.
 - **Example**:
@@ -406,8 +406,8 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   [rf/frame-provider {:frame :todo} & children]   ;; SCOPE: scope an existing frame
   ```
 - **Description**: Scopes a React subtree to a frame that **already exists**; creates / refreshes / destroys nothing. **Roots ensure; providers scope** — for create-if-absent, use [`frame-root`](#frame-root). See the [frame-provider glossary entry](../core/glossary.md#frame-provider).
-  - **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` accepts a frame id keyword **or** a live frame value (a `nil` `:frame` → `:rf.error/no-frame-context`; a target that is neither a keyword nor a live frame value → `:rf.error/bad-frame-provider-arg`). The scope-into-React counterpart to `with-frame`.
-  - Given an `:id` (the ENSURE key), **fails loud** naming `frame-root` (`:rf.error/frame-provider-given-id`).
+    - **Fails loud** (`:rf.error/frame-provider-frame-absent`) when the named frame is absent. `:frame` accepts a frame id keyword **or** a live frame value (a `nil` `:frame` → `:rf.error/no-frame-context`; a target that is neither a keyword nor a live frame value → `:rf.error/bad-frame-provider-arg`). The scope-into-React counterpart to `with-frame`.
+    - Given an `:id` (the ENSURE key), **fails loud** naming `frame-root` (`:rf.error/frame-provider-given-id`).
 - **Example**:
   ```clojure
   ;; SCOPE — :todo already exists; this subtree just renders against it.
@@ -424,10 +424,10 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   [rf/frame-root {:id :todo :images [todo-image]} & children]   ;; ENSURE: create-if-absent / reuse
   ```
 - **Description**: Creates the frame if absent, reuses it if present, and provides its id to descendants. Creation goes via `make-frame`, taking the same constructor opts: `:id` / `:images` / record-config incl. `:initial-events`. `:id` is **required** and must be a keyword (a missing/non-keyword `:id` → `:rf.error/frame-root-missing-id`).
-  - **Commit-owned two-pass**: the create/seed runs in a client `useLayoutEffect` (at commit), **not** during render — the first render emits no descendant subtree, the frame is created after commit, and only then do the children render against the now-live frame. A render React discards before commit (a Suspense abort, a concurrent tear-off) therefore creates and seeds **nothing** — no ghost frame.
-  - **Reuse does not re-seed**: an idempotent re-mount (hot reload, StrictMode dev double-invoke, Story re-eval) preserves durable state and does not replay `:initial-events`; `:initial-events` fire **once** on first successful creation per committed frame-id lifetime. A keyed remount preserves durable state.
-  - There is **no destroy-on-unmount** — a genuine unmount leaves the frame live. True ownership stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
-  - A **mounted `:id` / opts change fails loud** (`:rf.error/frame-root-reconfigured`) — give the frame-root a React `key` that changes to scope a different frame. Given a `:frame` (the SCOPE key), fails loud naming `frame-provider` (`:rf.error/frame-root-given-frame`).
+    - **Commit-owned two-pass**: the create/seed runs in a client `useLayoutEffect` (at commit), **not** during render — the first render emits no descendant subtree, the frame is created after commit, and only then do the children render against the now-live frame. A render React discards before commit (a Suspense abort, a concurrent tear-off) therefore creates and seeds **nothing** — no ghost frame.
+    - **Reuse does not re-seed**: an idempotent re-mount (hot reload, StrictMode dev double-invoke, Story re-eval) preserves durable state and does not replay `:initial-events`; `:initial-events` fire **once** on first successful creation per committed frame-id lifetime. A keyed remount preserves durable state.
+    - There is **no destroy-on-unmount** — a genuine unmount leaves the frame live. True ownership stays explicit: `make-frame` + `destroy-frame!` inside a `create-class`.
+    - A **mounted `:id` / opts change fails loud** (`:rf.error/frame-root-reconfigured`) — give the frame-root a React `key` that changes to scope a different frame. Given a `:frame` (the SCOPE key), fails loud naming `frame-provider` (`:rf.error/frame-root-given-frame`).
 - **Example**:
   ```clojure
   ;; ENSURE — bring the :todo frame into being for as long as this subtree is
@@ -446,9 +446,9 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
   (capture-frame frame-id) → {:frame :dispatch :dispatch-sync :subscribe}
   ```
 - **Description**: Captures the active frame at CREATION time and returns an **operation bundle**. The bundle's `:dispatch` / `:dispatch-sync` / `:subscribe` ops always target the captured frame. They survive async boundaries — `Promise.then`, `setTimeout`, WebSocket `onmessage`, observer callbacks — where the ambient frame lookup would have unwound.
-  - The handle is *locked* to one frame: a per-call `:frame` opt MUST NOT override it.
-  - It is an operation bundle, not a container — read the frame's app-db value via `(rf/app-db-value (:frame handle))`, not the handle itself.
-  - Full async-boundary contract: [Frames — the async boundary](../core/frames.md).
+    - The handle is *locked* to one frame: a per-call `:frame` opt MUST NOT override it.
+    - It is an operation bundle, not a container — read the frame's app-db value via `(rf/app-db-value (:frame handle))`, not the handle itself.
+    - Full async-boundary contract: [Frames — the async boundary](../core/frames.md).
 - **Example**:
   ```clojure
   (rf/reg-view stream-view []
@@ -510,8 +510,8 @@ The effect map is **closed**, at seven top-level keys: everyday app handlers ret
   (reg-interceptor id {:keys [before after]})
   ```
 - **Description**: The public custom-interceptor authoring form. Register a named interceptor descriptor, then **reference it by id** from a `reg-event` metadata / frame-config `:interceptors` vector. Descriptor shapes:
-  - `{:before f}` / `{:after f}` / `{:before f :after g}`;
-  - `{:factory f}` for a parameterized family (`f` receives one arg and returns a descriptor; referenced as `[id arg]` — the standard `[:rf.interceptor/path …]` is the canonical factory consumer).
+    - `{:before f}` / `{:after f}` / `{:before f :after g}`;
+    - `{:factory f}` for a parameterized family (`f` receives one arg and returns a descriptor; referenced as `[id arg]` — the standard `[:rf.interceptor/path …]` is the canonical factory consumer).
 
   An optional middle slot carries the standard registration-metadata map (`:doc`, `:schema`, `:tags`, …). Use this for any work not covered by the standard interceptors — analytics, logging, validation, ad-hoc context manipulation. (`->interceptor*` is the framework-internal lowering constructor that turns a descriptor into an executable chain entry; it must not appear directly in a public chain.)
 - **Example**:
@@ -536,8 +536,8 @@ The effect map is **closed**, at seven top-level keys: everyday app handlers ret
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
 - **Description**: For the duration of `body`, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope. Lexical scope; composes with `with-frame`.
-  - The three override scopes compose with a clear precedence: **per-call** (`(rf/dispatch event {:fx-overrides {...}})`) wins, then **lexical** (`with-fx-overrides`), then **per-frame** (`(rf/make-frame {:id :todo :fx-overrides {...}})`).
-  - At the pattern level the override value is an **id**. The CLJS reference implementation also accepts a **fn** value for test wiring. The asymmetry is deliberate: ports that don't ship fn-valued overrides remain pattern-conformant.
+    - The three override scopes compose with a clear precedence: **per-call** (`(rf/dispatch event {:fx-overrides {...}})`) wins, then **lexical** (`with-fx-overrides`), then **per-frame** (`(rf/make-frame {:id :todo :fx-overrides {...}})`).
+    - At the pattern level the override value is an **id**. The CLJS reference implementation also accepts a **fn** value for test wiring. The asymmetry is deliberate: ports that don't ship fn-valued overrides remain pattern-conformant.
 - **Example**:
   ```clojure
   ;; Swap the real managed-HTTP fx for a canned-failure stub for the test body —
@@ -563,9 +563,9 @@ The framework reserves a few `:fx` entries and one standard interceptor referenc
   {:interceptors [[:rf.interceptor/path [:cart :items]]]}
   ```
 - **Description**: Focus the handler on an `app-db` sub-slice. `:before` stages the focused slice as `:db` (`(get-in db path)`); `:after` widens the returned slice back into full app-db. The handler sees and returns a sub-tree, not the full db.
-  - Preserves the frame-commit `identical?` no-op (an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation).
-  - A non-vector / malformed path arg raises `:rf.error/path-interceptor-bad-path`.
-  - It is a **reference**, not a constructed value — there is no public `path` fn (a stale `rf/path` call raises `:rf.error/path-removed`).
+    - Preserves the frame-commit `identical?` no-op (an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation).
+    - A non-vector / malformed path arg raises `:rf.error/path-interceptor-bad-path`.
+    - It is a **reference**, not a constructed value — there is no public `path` fn (a stale `rf/path` call raises `:rf.error/path-removed`).
 
 ## Frames
 
@@ -580,17 +580,17 @@ A frame is the scoping unit for `app-db`, the event queue, and the pipeline. Mos
   (make-frame opts descriptors) ; → live frame value (explicit descriptor pool — tests / harnesses)
   ```
 - **Description**: The single public constructor for a live frame. It accepts image-selection *and* frame-configuration options in one call and **returns the live frame value**: one frame value backed by one registry. Use it for per-mount lifecycles — devcards, modal stacks, multiple live widget instances, dynamic tabs, tests, and the SSR per-request frame pattern.
-  - `opts` must be a map — a non-map (including `nil`) raises `:rf.error/make-frame-bad-opts`; a non-vector `:images` raises `:rf.error/make-frame-bad-images`.
-  - Image-selection opts:
-    - `:images` — always a vector.
-    - `:id` — optional. Registers the frame in the one process-local live-frame registry. A duplicate live id is **idempotent replacement**, preserving durable state on re-mount.
-    - `:adapter`.
-  - Frame-configuration opts (same call): `:initial-events` (a vector of event vectors dispatched into the new frame at creation), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`.
-  - **Pass the value directly — no accessor needed.** The routing operations `dispatch` / `subscribe` / `app-db-value` / `frame-provider` all accept the frame value OR its id — they normalize the value to its id, so there is no separate value→id accessor to reach for (API-shrink #1, rf2-csbbwu). `destroy-frame!` accepts either too, but is the one **lifecycle exception** (rf2-moftbs): the value is an **exact-incarnation** token that tears down only the incarnation it names (a stale value no-ops against a same-id successor), while the id is **address-directed** (tears down whatever incarnation is currently live) — see `destroy-frame!` below.
-  - **The ONE constructor** (rf2-h1vqa4 deleted the `reg-frame` spelling — a frame is a live runtime object, not a registered program member). The day-1 mount recipe is `frame-root` (ENSURE); `make-frame` is the programmatic path (tools, tests, SSR, dynamic, image-loaded frames).
-  - The frame config owns the `:observability` sink policy. Durable `app-db` data classification is **not** a frame annotation: a config carrying `:sensitive` / `:large` **fails loud** at registration. To classify durable `app-db` paths, return the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`, wired to run at frame creation via `:initial-events` — see [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
-  - Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!`, or use the ENSURE boundary `rf/frame-root` for view-mounted frames.
-  - See the [Frames concept guide](../core/frames.md) and [EP-0024](../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
+    - `opts` must be a map — a non-map (including `nil`) raises `:rf.error/make-frame-bad-opts`; a non-vector `:images` raises `:rf.error/make-frame-bad-images`.
+    - Image-selection opts:
+        - `:images` — always a vector.
+        - `:id` — optional. Registers the frame in the one process-local live-frame registry. A duplicate live id is **idempotent replacement**, preserving durable state on re-mount.
+        - `:adapter`.
+    - Frame-configuration opts (same call): `:initial-events` (a vector of event vectors dispatched into the new frame at creation), `:fx-overrides`, `:platform`, `:ssr`, `:doc`, `:preset`, `:tags`.
+    - **Pass the value directly — no accessor needed.** The routing operations `dispatch` / `subscribe` / `app-db-value` / `frame-provider` all accept the frame value OR its id — they normalize the value to its id, so there is no separate value→id accessor to reach for (API-shrink #1, rf2-csbbwu). `destroy-frame!` accepts either too, but is the one **lifecycle exception** (rf2-moftbs): the value is an **exact-incarnation** token that tears down only the incarnation it names (a stale value no-ops against a same-id successor), while the id is **address-directed** (tears down whatever incarnation is currently live) — see `destroy-frame!` below.
+    - **The ONE constructor** (rf2-h1vqa4 deleted the `reg-frame` spelling — a frame is a live runtime object, not a registered program member). The day-1 mount recipe is `frame-root` (ENSURE); `make-frame` is the programmatic path (tools, tests, SSR, dynamic, image-loaded frames).
+    - The frame config owns the `:observability` sink policy. Durable `app-db` data classification is **not** a frame annotation: a config carrying `:sensitive` / `:large` **fails loud** at registration. To classify durable `app-db` paths, return the four commit-plane classification effects (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`) from a `reg-event` alongside `:db`, wired to run at frame creation via `:initial-events` — see [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+    - Lifecycle is the caller's responsibility — pair a direct `make-frame` with a `destroy-frame!`, or use the ENSURE boundary `rf/frame-root` for view-mounted frames.
+    - See the [Frames concept guide](../core/frames.md) and [EP-0024](../EP/EP-0024-unified-frame-identity-and-lifecycle.md).
 - **Example**:
   ```clojure
   ;; Durable app-db classification rides a commit-plane effect (EP-0025):
@@ -658,13 +658,13 @@ There is no dedicated "reset" function; `reset-frame!` was retired (rf2-lxwpob).
   (frame-generation frame-target) → generation map
   ```
 - **Description**: Return the SEALED, resolved image **generation** a live frame is running: the inert image-assembly generation it resolves `(kind, id)` lookups through. This is the raw read over the EP-0023 frame→generation model, for tools (Pair MCP `describe-image`, Xray).
-  - `frame-target` is a registered frame id **or** a direct live frame object.
-  - Returns the generation map with stable public keys:
-    - `:rf.gen/resolver` — the sealed `[kind id]` map.
-    - `:rf.gen/images` and `:rf.gen/kinds`.
-    - `:rf.gen/shadows` — the cross-image **shadow report**: what a LATER image overrode in an EARLIER one (EP-0026). A flat vector `[{:registration [kind id] :image <defined-in> :shadowed-by <winner>} …]`; `[]` when no later image shadowed an earlier one.
-  - Read the shadow report with `(:rf.gen/shadows (rf/frame-generation f))`. There is no dedicated accessor — the `frame-shadows` var was removed (rf2-i4hk4b).
-  - **Fails loud** (`:rf.error/frame-no-generation`) when `frame-target` does not resolve to a live frame carrying a generation.
+    - `frame-target` is a registered frame id **or** a direct live frame object.
+    - Returns the generation map with stable public keys:
+        - `:rf.gen/resolver` — the sealed `[kind id]` map.
+        - `:rf.gen/images` and `:rf.gen/kinds`.
+        - `:rf.gen/shadows` — the cross-image **shadow report**: what a LATER image overrode in an EARLIER one (EP-0026). A flat vector `[{:registration [kind id] :image <defined-in> :shadowed-by <winner>} …]`; `[]` when no later image shadowed an earlier one.
+    - Read the shadow report with `(:rf.gen/shadows (rf/frame-generation f))`. There is no dedicated accessor — the `frame-shadows` var was removed (rf2-i4hk4b).
+    - **Fails loud** (`:rf.error/frame-no-generation`) when `frame-target` does not resolve to a live frame carrying a generation.
 
 ### `image`
 
@@ -674,9 +674,9 @@ There is no dedicated "reset" function; `reset-frame!` was retired (rf2-lxwpob).
   (image spec) → image value
   ```
 - **Description**: Construct an **image** value — a selected registration-set value, as inert data (EP-0023 / EP-0026). Pure — no registrar, no side effect. The result is the assembled registration set a frame resolves against (passed to `make-frame` / `frame-provider` under `:images`). `spec` carries exactly three public keys:
-  - `:id` (optional);
-  - `:select-ns` (an `{:include [globs] :exclude [globs]}` selection map over registered descriptors' provenance namespaces);
-  - `:registrations` (inline registrar-keyed sections).
+    - `:id` (optional);
+    - `:select-ns` (an `{:include [globs] :exclude [globs]}` selection map over registered descriptors' provenance namespaces);
+    - `:registrations` (inline registrar-keyed sections).
 
 ### Image hot-reload — re-`make-frame`
 
@@ -706,7 +706,7 @@ There is no dedicated "reload" function; `reload-images!` was folded into re-con
   (generation-diff before after) → diff map
   ```
 - **Description**: A PURE diff between two sealed image generations. It replaces the report the retired `reload-images!` verb used to return: read `frame-generation` before and after a re-`make-frame` reload, then diff the two.
-  - Returns `{:added #{[kind id] …} :changed #{…} :removed #{…} :retained #{…}}`.
+    - Returns `{:added #{[kind id] …} :changed #{…} :removed #{…} :retained #{…}}`.
 
 ## Lifecycle and configure
 
@@ -720,10 +720,10 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   (init! adapter-map)
   ```
 - **Description**: The boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; require the ns and pass the Var, e.g. `(rf/init! reagent-adapter/adapter)`.
-  - `(init!)` with no args raises `ArityException` at compile / load time; `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime.
-  - **Idempotent for the *seated* adapter, not for any adapter.** Re-calling `init!` with the adapter already seated is a no-op. Calling it with a **different** adapter raises `:rf.error/adapter-already-installed` and leaves the seated adapter untouched — call `destroy-adapter!` first to swap substrates. Two spec maps are the same adapter when they carry the same canonical `:rf.adapter/*` `:kind`, or when they are the identical map.
-  - **Hot reload is safe.** An adapter Var is a plain `def`, so a reload re-evaluates the map with fresh fn identities — but a canonical `:rf.adapter/*` kind is a stable token that survives that, so a `^:dev/after-load` re-call stays a no-op. A **custom** adapter with no canonical kind is compared by object identity instead, so re-evaluating its Var and re-calling `init!` *does* raise: hold it in a `defonce`, or call `destroy-adapter!` in the after-load fn.
-  - Installs adapters and runtime capabilities only; does **not** create or guarantee any frame — mount your app frame at the root with `frame-root` (ENSURE), or construct it explicitly with `make-frame`.
+    - `(init!)` with no args raises `ArityException` at compile / load time; `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime.
+    - **Idempotent for the *seated* adapter, not for any adapter.** Re-calling `init!` with the adapter already seated is a no-op. Calling it with a **different** adapter raises `:rf.error/adapter-already-installed` and leaves the seated adapter untouched — call `destroy-adapter!` first to swap substrates. Two spec maps are the same adapter when they carry the same canonical `:rf.adapter/*` `:kind`, or when they are the identical map.
+    - **Hot reload is safe.** An adapter Var is a plain `def`, so a reload re-evaluates the map with fresh fn identities — but a canonical `:rf.adapter/*` kind is a stable token that survives that, so a `^:dev/after-load` re-call stays a no-op. A **custom** adapter with no canonical kind is compared by object identity instead, so re-evaluating its Var and re-calling `init!` *does* raise: hold it in a `defonce`, or call `destroy-adapter!` in the after-load fn.
+    - Installs adapters and runtime capabilities only; does **not** create or guarantee any frame — mount your app frame at the root with `frame-root` (ENSURE), or construct it explicitly with `make-frame`.
 - **Example**:
   ```clojure
   (:require [re-frame.adapter.reagent :as reagent-adapter])
@@ -783,9 +783,9 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   (configure! config-map)
   ```
 - **Description**: Process-level data knobs, typically set once at boot. It is one of three orthogonal configuration surfaces:
-  - `configure!` — process-level data knobs;
-  - the `set-!` / `install-!` setters — adapter-pluggable hooks;
-  - per-frame metadata — frame-scoped overrides.
+    - `configure!` — process-level data knobs;
+    - the `set-!` / `install-!` setters — adapter-pluggable hooks;
+    - per-frame metadata — frame-scoped overrides.
 
   The key vocabulary is closed-and-additive: existing keys cannot be renamed, and new keys are added by extending the table. Four keys ship:
 
@@ -933,8 +933,8 @@ There is deliberately **no** facade `clear-listeners!` verb. Dropping every list
   (trace-buffer frame-id opts) → vector; {:flat true} yields raw trace events
   ```
 - **Description**: Read the named frame's dev-only, event-keyed ring non-destructively. By default it returns one bundle per retained pipeline run; `{:flat true}` returns the raw trace events instead.
-  - Returns `[]` for a destroyed / never-registered frame, and `[]` in production (the ring is never allocated).
-  - The retained event-slot count is the `(rf/configure! {:trace-buffer {:events-retained N}})` knob.
+    - Returns `[]` for a destroyed / never-registered frame, and `[]` in production (the ring is never allocated).
+    - The retained event-slot count is the `(rf/configure! {:trace-buffer {:events-retained N}})` knob.
 - **Example**:
   ```clojure
   (rf/trace-buffer :app/main)               ;; event-keyed ring (oldest-first)
@@ -969,14 +969,14 @@ which a tool requires directly.
   (project-egress record-or-value opts)
   ```
 - **Description**: The public, record-level boundary primitive — **the required step before any off-box sink**, and **the only one**: there is no second record-level egress door. It dispatches on a record's `:kind` to a per-kind projector that is never itself public (the door names the *boundary*; `:kind` names the *record kind*), and falls back to walking a kindless input as a tree-shaped value. Each tree-shaped slot is delegated to the internal `re-frame.elision/elide-wire-value` walker against the frame's classification.
-  - Recognised kinds: `:rf.observe/handled-event`, `:rf.observe/error`, `:rf.observe/derived-tree`, and `:rf/epoch-record`. The epoch projector is late-bound into the optional `day8/re-frame2-epoch` artefact; with the artefact absent the call throws `:rf.error/epoch-artefact-missing` naming the kind rather than bare-walking the record (a bare walk would ship its app-db slots raw).
-  - `opts` is a **closed** twelve-key map: `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, `:query-v`, `:as-of-epoch`, the four `:rf.egress/*` overrides, and the three **epoch-only** axes `:rf.egress/include-fx-args?` / `:rf.egress/include-runtime-db?` / `:rf.egress/include-event-args?`. An unrecognised key throws `:rf.error/bad-egress-opts` naming it.
-  - The three epoch-only axes are trusted-local opt-ins over keyspaces only an `:rf/epoch-record` has — effect `:args`, the `:rf.db/runtime` frame-state partition, and trigger / trace event args. Each defaults false and lifts **only** its own boundary: `:rf.egress/include-sensitive? true` never implies any of them. On any other kind they are accepted and inert.
-  - Frame ownership resolves by key **presence**, in three steps: an explicit `:frame` key in `opts` wins (`nil` included); else a recognised record's own `:frame` slot (`nil` included — every recognised kind is frame-bearing); else the carried scope. A record is recognised by its `:kind`, so a bare value carrying a `:frame` key is a value and seeds nothing.
-  - An unknown profile throws `:rf.error/unknown-egress-profile`.
-  - Projecting a whole epoch ring is ordinary composition — `(mapv #(rf/project-egress % opts) (rf/epoch-history frame-id))`. The ring and its listeners always deliver the **raw** record, so projection never affects `restore-epoch!` fidelity. See [re-frame.epoch.md](re-frame.epoch.md).
-  - **Fail-closed**: a tree slot projects only when the frame is known — an explicit `:frame nil` included — and there is no `:rf/default` synthesis.
-  - Full model: [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+    - Recognised kinds: `:rf.observe/handled-event`, `:rf.observe/error`, `:rf.observe/derived-tree`, and `:rf/epoch-record`. The epoch projector is late-bound into the optional `day8/re-frame2-epoch` artefact; with the artefact absent the call throws `:rf.error/epoch-artefact-missing` naming the kind rather than bare-walking the record (a bare walk would ship its app-db slots raw).
+    - `opts` is a **closed** twelve-key map: `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, `:query-v`, `:as-of-epoch`, the four `:rf.egress/*` overrides, and the three **epoch-only** axes `:rf.egress/include-fx-args?` / `:rf.egress/include-runtime-db?` / `:rf.egress/include-event-args?`. An unrecognised key throws `:rf.error/bad-egress-opts` naming it.
+    - The three epoch-only axes are trusted-local opt-ins over keyspaces only an `:rf/epoch-record` has — effect `:args`, the `:rf.db/runtime` frame-state partition, and trigger / trace event args. Each defaults false and lifts **only** its own boundary: `:rf.egress/include-sensitive? true` never implies any of them. On any other kind they are accepted and inert.
+    - Frame ownership resolves by key **presence**, in three steps: an explicit `:frame` key in `opts` wins (`nil` included); else a recognised record's own `:frame` slot (`nil` included — every recognised kind is frame-bearing); else the carried scope. A record is recognised by its `:kind`, so a bare value carrying a `:frame` key is a value and seeds nothing.
+    - An unknown profile throws `:rf.error/unknown-egress-profile`.
+    - Projecting a whole epoch ring is ordinary composition — `(mapv #(rf/project-egress % opts) (rf/epoch-history frame-id))`. The ring and its listeners always deliver the **raw** record, so projection never affects `restore-epoch!` fidelity. See [re-frame.epoch.md](re-frame.epoch.md).
+    - **Fail-closed**: a tree slot projects only when the frame is known — an explicit `:frame nil` included — and there is no `:rf/default` synthesis.
+    - Full model: [Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
 - **Example**:
   ```clojure
   ;; Verify what an off-box sink will receive before wiring it.
@@ -997,10 +997,10 @@ which a tool requires directly.
   (register-observability-sink! sink-id f)
   ```
 - **Description**: Register an observability sink fn `f` under the keyword `sink-id` — the id a frame's `:observability {:handled-events [{:sink <sink-id> :rf.egress/profile …}]}` entry names.
-  - `f` receives a single **already-projected** record (projected under the owning frame's classification and the entry's egress profile); it does **no** sink-local redaction.
-  - Re-registering the same id replaces. Returns `sink-id`.
-  - **Always-on** — survives CLJS `:advanced` + `goog.DEBUG=false`.
-  - This is the production-normal observability seam: frame-scoped and profile-projected. It parallels the corpus-wide `register-listener!` surface, which is cross-frame and raw.
+    - `f` receives a single **already-projected** record (projected under the owning frame's classification and the entry's egress profile); it does **no** sink-local redaction.
+    - Re-registering the same id replaces. Returns `sink-id`.
+    - **Always-on** — survives CLJS `:advanced` + `goog.DEBUG=false`.
+    - This is the production-normal observability seam: frame-scoped and profile-projected. It parallels the corpus-wide `register-listener!` surface, which is cross-frame and raw.
 - **Example**:
   ```clojure
   (rf/make-frame
@@ -1035,7 +1035,7 @@ which a tool requires directly.
   (sensitive? trace-event) → boolean
   ```
 - **Description**: True iff `trace-event` is a map carrying a truthy `:sensitive?` stamp at the top level (not under `:tags`). The framework-published predicate every consumer composes against — reach for it directly rather than wrapping it.
-  - **Fail-closed.** `true` is sensitive; `false`, `nil` and absent are not; and **any other truthy value counts as sensitive**. The trace-event schema types `:sensitive?` as a boolean, so a string, keyword or number is a contract violation — and forwarding on a violation is the one outcome that cannot be undone.
+    - **Fail-closed.** `true` is sensitive; `false`, `nil` and absent are not; and **any other truthy value counts as sensitive**. The trace-event schema types `:sensitive?` as a boolean, so a string, keyword or number is a contract violation — and forwarding on a violation is the one outcome that cannot be undone.
 - **Example**:
   ```clojure
   (rf/sensitive? {:sensitive? true})     ;; => true
@@ -1146,11 +1146,11 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   (registrations {:frame f      :kind k}) → {id metadata-map}
   ```
 - **Description**: Walk the registrar, returning the full metadata map per id: source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. The argument is ALWAYS a map, and it must name **exactly one source**.
-  - `{:source :store …}` reads the process-global registrar and never consults a bound image generation, so it answers the same whatever frame's sub build the call sits inside — this is what a tool inspecting a host application wants. `:store` is the only accepted `:source` value.
-  - `{:frame f …}` returns only the ids that frame's image carries, resolved through the frame's own sealed image generation (EP-0023). `f` is a frame-id keyword or a live frame value; one that does not resolve to a live frame carrying a generation raises `:rf.error/frame-no-generation`.
-  - Naming BOTH `:source` and `:frame`, naming NEITHER, passing a `:source` other than `:store`, or passing a non-map argument (most often a leftover positional call) all raise `:rf.error/registrar-query-needs-source`. There is no default source: "the default" is precisely the ambiguity this grammar removes.
-  - `:kind :flow` and `:kind :frame` are reserved-EMPTY registrar slots and raise `:rf.error/registrar-kind-not-queryable` naming the real door (`re-frame.flows/flows` / `flow-meta` / `flows-snapshot`; `frame-ids` / `frame-meta`) rather than returning a misleadingly authoritative `{}`.
-  - Filtering is `filter` over the returned map — there is no predicate arity.
+    - `{:source :store …}` reads the process-global registrar and never consults a bound image generation, so it answers the same whatever frame's sub build the call sits inside — this is what a tool inspecting a host application wants. `:store` is the only accepted `:source` value.
+    - `{:frame f …}` returns only the ids that frame's image carries, resolved through the frame's own sealed image generation (EP-0023). `f` is a frame-id keyword or a live frame value; one that does not resolve to a live frame carrying a generation raises `:rf.error/frame-no-generation`.
+    - Naming BOTH `:source` and `:frame`, naming NEITHER, passing a `:source` other than `:store`, or passing a non-map argument (most often a leftover positional call) all raise `:rf.error/registrar-query-needs-source`. There is no default source: "the default" is precisely the ambiguity this grammar removes.
+    - `:kind :flow` and `:kind :frame` are reserved-EMPTY registrar slots and raise `:rf.error/registrar-kind-not-queryable` naming the real door (`re-frame.flows/flows` / `flow-meta` / `flows-snapshot`; `frame-ids` / `frame-meta`) rather than returning a misleadingly authoritative `{}`.
+    - Filtering is `filter` over the returned map — there is no predicate arity.
 - **Example**:
   ```clojure
   (rf/registrations {:source :store :kind :event})
@@ -1167,10 +1167,10 @@ The registrar holds every registered handler — events, subs, fx, cofx, flows, 
   (handler-meta {:frame f      :kind k :id id}) → metadata resolved through frame f's image (or nil)
   ```
 - **Description**: What `reg-*` stamped at this id. View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`); pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
-  - Registrar kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:interceptor`, `:view`, `:frame`, `:route`, `:head`, `:error-projector`, `:flow`, `:resource`.
-  - The two machine kinds `:machine-guard` / `:machine-action` take a 2-vector id: `(handler-meta {:source :store :kind :machine-guard :id [machine-id guard-id]})`. They are derived on demand from the machine's registration spec (a dev-only source; not frame-targetable, so `:frame` returns `nil` for them).
-  - The same source grammar and the same errors as `registrations` apply (`:rf.error/registrar-query-needs-source`, `:rf.error/frame-no-generation`, `:rf.error/registrar-kind-not-queryable`).
-  - App-db schemas are **not** a registrar kind — look them up via `(app-schema-meta {:frame f :path p})` in [re-frame.schemas.md](re-frame.schemas.md).
+    - Registrar kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:interceptor`, `:view`, `:frame`, `:route`, `:head`, `:error-projector`, `:flow`, `:resource`.
+    - The two machine kinds `:machine-guard` / `:machine-action` take a 2-vector id: `(handler-meta {:source :store :kind :machine-guard :id [machine-id guard-id]})`. They are derived on demand from the machine's registration spec (a dev-only source; not frame-targetable, so `:frame` returns `nil` for them).
+    - The same source grammar and the same errors as `registrations` apply (`:rf.error/registrar-query-needs-source`, `:rf.error/frame-no-generation`, `:rf.error/registrar-kind-not-queryable`).
+    - App-db schemas are **not** a registrar kind — look them up via `(app-schema-meta {:frame f :path p})` in [re-frame.schemas.md](re-frame.schemas.md).
 - **Example**:
   ```clojure
   (rf/handler-meta {:source :store :kind :sub :id :counter/value})

--- a/docs/api/re-frame.epoch.md
+++ b/docs/api/re-frame.epoch.md
@@ -46,15 +46,15 @@ Per-frame epoch snapshots, recorded on each handled event's run-to-completion in
   (restore-epoch! frame-id epoch-id) → boolean
   ```
 - **Description**: Restores the frame's whole frame-state to the named epoch's `:frame-state-after` in one atomic write. Both partitions rewind, app-db and runtime-db alike. Machine snapshots, the route slice, and other runtime-db material travel back too, not just the application slice.
-  - Returns `true` on success and emits `:rf.epoch/restored`.
-  - Returns `false` on any failure. Each failure is a no-op on frame-state and emits a structured error trace:
-    - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
-    - `:rf.epoch/restore-during-drain` — called while a drain is in flight
-    - `:rf.epoch/restore-unknown-epoch` — epoch-id not in the frame's current history
-    - `:rf.epoch/restore-non-ok-record` — target epoch's `:outcome` is not `:ok` (halted-cascade records carry partial state and are not valid restore targets)
-    - `:rf.epoch/restore-schema-mismatch` — the recorded app-db no longer validates against the frame's registered app-schemas
-    - `:rf.epoch/restore-missing-handler` — a machine / route referenced from the recorded runtime-db is no longer registered
-    - `:rf.epoch/restore-version-mismatch` — machine snapshot version drift against the current definition
+    - Returns `true` on success and emits `:rf.epoch/restored`.
+    - Returns `false` on any failure. Each failure is a no-op on frame-state and emits a structured error trace:
+        - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
+        - `:rf.epoch/restore-during-drain` — called while a drain is in flight
+        - `:rf.epoch/restore-unknown-epoch` — epoch-id not in the frame's current history
+        - `:rf.epoch/restore-non-ok-record` — target epoch's `:outcome` is not `:ok` (halted-cascade records carry partial state and are not valid restore targets)
+        - `:rf.epoch/restore-schema-mismatch` — the recorded app-db no longer validates against the frame's registered app-schemas
+        - `:rf.epoch/restore-missing-handler` — a machine / route referenced from the recorded runtime-db is no longer registered
+        - `:rf.epoch/restore-version-mismatch` — machine snapshot version drift against the current definition
 
 ```clojure
 ;; Time-travel: rewind a frame's whole frame-state to a recorded epoch.
@@ -71,16 +71,16 @@ Per-frame epoch snapshots, recorded on each handled event's run-to-completion in
   (replay-epoch! frame-id epoch-id opts) → envelope map (false when elided)
   ```
 - **Description**: Re-drives the named retained epoch's recorded event through the frame's own handlers in one call, as a strict replay. The record is resolved in-process and its replay material is folded into the dispatch: the raw argument-bearing `:trigger-event`, the recorded post-generation `:rf.cofx` under `:rf.cofx/mint-policy :strict`, and the record's own `:fx-overrides` / `:interceptor-overrides`. Nothing is exported or copied by hand — which is what makes replay available to an off-box tool, since the projected record only ever shows event arguments as `:rf/redacted`. Same frame in and out. Replay runs against the frame's current state and code, so it does not restore first (compose with `restore-epoch!` when the start state matters), any effect the handler emits fires again, and the replayed dispatch records a new ordinary epoch; re-presenting the recorded `:rf/time-ms` makes that epoch's `:committed-at` equal the original's.
-  - Returns `{:ok? true :frame … :source-epoch-id … :event-id … :epoch-id <the new epoch>}` on success. `:epoch-id` names the epoch the replayed event itself committed — never a queued child's record — and is `nil` when the ring did not retain it (a replay may enqueue work the recorded run did not, and at a shallow `:depth` a child can evict its own parent's record).
-  - Returns `{:ok? false :reason … :frame … :epoch-id … <tags>}`, decided before anything dispatches and without a trace emit, for:
-    - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
-    - `:rf.epoch/replay-during-drain` — called while a drain is in flight
-    - `:rf.epoch/replay-unknown-epoch` (`:history-size`) — epoch-id not in the frame's current history
-    - `:rf.epoch/replay-non-replayable-record` (`:cause` — `:halted`, `:synthetic`, `:missing-trigger-event`, `:missing-replay-token` or `:incomplete-inputs`)
-    - `:rf.epoch/replay-unreplayable-fx-override` (`:fx-ids`) — a recorded `:fx-overrides` entry is the `:rf/fn-override` sentinel
-  - `:incomplete-inputs` is the capture-loss refusal: a `reg-event` / `reg-cofx` `:sensitive` / `:large` declaration is applied at trace capture, so a declared event argument or recordable fact reaches the retained record already carrying `:rf/redacted` or a `:rf.size/large-elided` marker. Replay is faithful-or-fail-loud, so the record is refused rather than re-driven with the substitution in place of the value the original run consumed; `:lost` names each `{:slot :path :loss}`.
-  - A declared recordable fact absent from the recorded token is not a refusal: the dispatch fails loud with the canonical `:rf.error/missing-required-cofx`, exactly as any `:strict` dispatch does. Nothing is minted.
-  - `opts` carries only the slots replay does not own (`:origin`, `:source`, `:trace-id`); a value under `:frame`, `:rf.cofx`, `:rf.cofx/mint-policy`, `:fx-overrides` or `:interceptor-overrides` is discarded.
+    - Returns `{:ok? true :frame … :source-epoch-id … :event-id … :epoch-id <the new epoch>}` on success. `:epoch-id` names the epoch the replayed event itself committed — never a queued child's record — and is `nil` when the ring did not retain it (a replay may enqueue work the recorded run did not, and at a shallow `:depth` a child can evict its own parent's record).
+    - Returns `{:ok? false :reason … :frame … :epoch-id … <tags>}`, decided before anything dispatches and without a trace emit, for:
+        - `:rf.error/no-such-handler` (kind `:frame`) — frame not registered / destroyed
+        - `:rf.epoch/replay-during-drain` — called while a drain is in flight
+        - `:rf.epoch/replay-unknown-epoch` (`:history-size`) — epoch-id not in the frame's current history
+        - `:rf.epoch/replay-non-replayable-record` (`:cause` — `:halted`, `:synthetic`, `:missing-trigger-event`, `:missing-replay-token` or `:incomplete-inputs`)
+        - `:rf.epoch/replay-unreplayable-fx-override` (`:fx-ids`) — a recorded `:fx-overrides` entry is the `:rf/fn-override` sentinel
+    - `:incomplete-inputs` is the capture-loss refusal: a `reg-event` / `reg-cofx` `:sensitive` / `:large` declaration is applied at trace capture, so a declared event argument or recordable fact reaches the retained record already carrying `:rf/redacted` or a `:rf.size/large-elided` marker. Replay is faithful-or-fail-loud, so the record is refused rather than re-driven with the substitution in place of the value the original run consumed; `:lost` names each `{:slot :path :loss}`.
+    - A declared recordable fact absent from the recorded token is not a refusal: the dispatch fails loud with the canonical `:rf.error/missing-required-cofx`, exactly as any `:strict` dispatch does. Nothing is minted.
+    - `opts` carries only the slots replay does not own (`:origin`, `:source`, `:trace-id`); a value under `:frame`, `:rf.cofx`, `:rf.cofx/mint-policy`, `:fx-overrides` or `:interceptor-overrides` is discarded.
 
 ```clojure
 ;; Replay the most recent epoch through the app's own handlers, strictly.
@@ -101,11 +101,11 @@ Per-frame epoch snapshots, recorded on each handled event's run-to-completion in
   (replace-frame-state! frame-id new-frame-state) → boolean
   ```
 - **Description**: The ONE frame-state write surface. API-shrink #3 (rf2-t3lftq) consolidated the former four-mutator family — `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` — into this single fn. Those four shared identical machinery and differed only in which partition keys they touched. `new-frame-state` is a PARTIAL frame-state map: any subset of `{:rf.db/app … :rf.db/runtime …}`. A present key replaces that partition; an ABSENT key is preserved unchanged. A db-shaped key never silently touches the other partition. Bypasses the dispatch loop. Returns `true` on success. No-ops returning `false` (each emitting a structured trace) on:
-  - `:rf.error/replace-frame-state-bad-keys` — the map carries no recognized partition key, or an unrecognized key (checked BEFORE frame resolution)
-  - `:rf.error/no-such-handler` — frame not registered
-  - `:rf.epoch/replace-during-drain`
-  - `:rf.epoch/replace-schema-mismatch` — a PRESENT app-db value fails the frame's registered app-schema set, or a PRESENT runtime-db value fails the framework-owned runtime-db validator
-  - `:rf.epoch/replace-history-disabled` — ring disabled at depth 0, so the synthetic undo-anchor cannot land
+    - `:rf.error/replace-frame-state-bad-keys` — the map carries no recognized partition key, or an unrecognized key (checked BEFORE frame resolution)
+    - `:rf.error/no-such-handler` — frame not registered
+    - `:rf.epoch/replace-during-drain`
+    - `:rf.epoch/replace-schema-mismatch` — a PRESENT app-db value fails the frame's registered app-schema set, or a PRESENT runtime-db value fails the framework-owned runtime-db validator
+    - `:rf.epoch/replace-history-disabled` — ring disabled at depth 0, so the synthetic undo-anchor cannot land
 
 ```clojure
 ;; App-only state injection — direct app-db write, runtime-db preserved
@@ -222,11 +222,11 @@ Read the live configuration back through the facade's own read twin, `rf/current
   (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
   ```
 - **Description**: The hook the router calls once per dequeued event, at each event's run-to-completion boundary — not once per drain. Framework-internal: the router invokes it; application and tool code never call it directly. Per call it:
-  - harvests that event's trace buffer;
-  - assembles the `:rf/epoch-record` (deriving the `:db-before` / `:db-after` app-db projections from the whole-frame-state snapshots);
-  - appends it to the per-frame ring buffer;
-  - emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`);
-  - fans out to every registered listener.
+    - harvests that event's trace buffer;
+    - assembles the `:rf/epoch-record` (deriving the `:db-before` / `:db-after` app-db projections from the whole-frame-state snapshots);
+    - appends it to the per-frame ring buffer;
+    - emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`);
+    - fans out to every registered listener.
 
   A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records, one per event. A machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router rather than read from an ambient assembly-time clock; this keeps the record replayable. The 4-arity is the clean `:ok` settle, skipped when the captured buffer is empty. The 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
 

--- a/docs/api/re-frame.flows.md
+++ b/docs/api/re-frame.flows.md
@@ -61,12 +61,12 @@ See [Flows: derived values your handlers can read](../core/flows.md) for the con
   ```
 - **Description**: Deregister the flow from the named frame and `dissoc-in` its `:output-path` from that frame's `app-db` only. Returns `id`.
 
-  - There is **no** `clear-flow` name: it was never a `re-frame.core` facade export, and `re-frame.flows` dropped its own re-export — `:flow` is one of the kinds the one kind-keyed registrar inverse dispatches (see [`clear`](re-frame.core.md#clear)). `re-frame.flows.registry/clear-flow` survives as the late-bind hook target that dispatch routes to, and `:rf.fx/clear-flow` (below) survives as an fx-id keyword; neither is a public call by that name (rf2-kuky.80).
-  - Leaf-only removal: an emptied parent map is left in place.
-  - Sibling frames' state is preserved.
-  - The frame resolves from the opts `:frame` key (a frame-id keyword or a live frame value), else the surrounding scope. With no scope and no `:frame`, it raises `:rf.error/no-frame-context`. The opts map is **exact** — sole key `:frame` — and a near-miss such as `{:fram :session}` raises `:rf.error/registrar-clear-bad-request` before any frame is resolved, rather than silently clearing the ambient frame's flow.
-  - A no-op when `id` is not registered against the frame.
-  - Called outside an event drain, it **settles before it returns**: any flow that declared the cleared flow's `:output-path` as an input has already recomputed against its absence, so the returned-to code never sees a dependent still publishing a value derived from the removed slot. You do not dispatch a follow-up event. A dependent's `:derive` throwing during that settle propagates `:rf.error/flow-eval-exception` to the caller; the deregistration and vacation stand. Called from inside a handler or a `:rf.fx/*` effect, the current drain's flow pass performs the settle instead — the boundary is the same either way.
+    - There is **no** `clear-flow` name: it was never a `re-frame.core` facade export, and `re-frame.flows` dropped its own re-export — `:flow` is one of the kinds the one kind-keyed registrar inverse dispatches (see [`clear`](re-frame.core.md#clear)). `re-frame.flows.registry/clear-flow` survives as the late-bind hook target that dispatch routes to, and `:rf.fx/clear-flow` (below) survives as an fx-id keyword; neither is a public call by that name (rf2-kuky.80).
+    - Leaf-only removal: an emptied parent map is left in place.
+    - Sibling frames' state is preserved.
+    - The frame resolves from the opts `:frame` key (a frame-id keyword or a live frame value), else the surrounding scope. With no scope and no `:frame`, it raises `:rf.error/no-frame-context`. The opts map is **exact** — sole key `:frame` — and a near-miss such as `{:fram :session}` raises `:rf.error/registrar-clear-bad-request` before any frame is resolved, rather than silently clearing the ambient frame's flow.
+    - A no-op when `id` is not registered against the frame.
+    - Called outside an event drain, it **settles before it returns**: any flow that declared the cleared flow's `:output-path` as an input has already recomputed against its absence, so the returned-to code never sees a dependent still publishing a value derived from the removed slot. You do not dispatch a follow-up event. A dependent's `:derive` throwing during that settle propagates `:rf.error/flow-eval-exception` to the caller; the deregistration and vacation stand. Called from inside a handler or a `:rf.fx/*` effect, the current drain's flow pass performs the settle instead — the boundary is the same either way.
 - **Example**:
   ```clojure
   ;; Deregister :cart/subtotal; clears [:cart :subtotal] in this frame's app-db.
@@ -196,8 +196,8 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   ```
 - **Description**: Return every flow registered in one frame, or `{}` when that frame holds none.
 
-  - `:frame` is **required** and names a frame target (a frame-id keyword or a frame value), the same targets `rf/registrations` accepts. A frameless or non-map call raises `:rf.error/no-frame-context`.
-  - The whole-registry read is `flows-snapshot`; this is its per-frame slice.
+    - `:frame` is **required** and names a frame target (a frame-id keyword or a frame value), the same targets `rf/registrations` accepts. A frameless or non-map call raises `:rf.error/no-frame-context`.
+    - The whole-registry read is `flows-snapshot`; this is its per-frame slice.
 - **Example**:
   ```clojure
   ;; Which flows does the :app frame carry?
@@ -213,9 +213,9 @@ Read-only views over the per-frame flow registry. They never touch the registrat
   ```
 - **Description**: Return the registration metadata map for one flow in a frame, or `nil`. This is the canonical per-frame flow introspection surface.
 
-  - Returns the full flow-map stamped at `reg-flow`: its source-coords `:ns` / `:line` / `:file`, `:inputs`, `:derive`, `:output-path`, and any output-classification keys.
-  - Frame-divergent by construction: the same `flow-id` registered against two frames returns each frame's own definition.
-  - Both keys are **required**. There is no ambient default and no trailing frame-target sugar — a live frame value is itself a map, so a type-sniffing positional argument could never be read locally. A frameless or non-map call raises `:rf.error/no-frame-context`.
+    - Returns the full flow-map stamped at `reg-flow`: its source-coords `:ns` / `:line` / `:file`, `:inputs`, `:derive`, `:output-path`, and any output-classification keys.
+    - Frame-divergent by construction: the same `flow-id` registered against two frames returns each frame's own definition.
+    - Both keys are **required**. There is no ambient default and no trailing frame-target sugar — a live frame value is itself a map, so a type-sniffing positional argument could never be read locally. A frameless or non-map call raises `:rf.error/no-frame-context`.
 - **Example**:
   ```clojure
   ;; The :app frame's own definition of :cart/subtotal.
@@ -237,10 +237,10 @@ The flow-transform entry point the router installs, plus the test-fixture resets
   ```
 - **Description**: The outermost-`:after` flow transform. It walks this frame's registered flows in topological order over the pending frame-state, dirty-checks each one, and `assoc-in`s each recomputed result into a transformed `app-db`. It returns the flow-augmented `app-db` value.
 
-  - `db` is the pending `app-db` partition; `runtime-db` is the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs).
-  - The router installs and calls this as the outermost `:after` interceptor. It fires last, against the chain's pending `:db` effect and before the `:db` install. Applications never call it.
-  - Flow outputs write `app-db` only.
-  - A flow evaluation throw halts the walk (downstream flows do not run), rolls back the frame's dirty-check bookkeeping, and re-raises as `:rf.error/flow-eval-exception`. The router discards the pending `:db` effect, so the event aborts with no partial commit. The ex-data names both the flow and the failing phase — `:rf.flow/failed-id`, `:rf.flow/failed-phase` (`:derive` when your `:derive` fn threw, `:output-write` when it returned and the `assoc-in` of that value at the flow's `:output-path` threw) and `:rf.flow/output-path`.
+    - `db` is the pending `app-db` partition; `runtime-db` is the pending `runtime-db` partition (pass `nil` to resolve only bare `app-db` inputs).
+    - The router installs and calls this as the outermost `:after` interceptor. It fires last, against the chain's pending `:db` effect and before the `:db` install. Applications never call it.
+    - Flow outputs write `app-db` only.
+    - A flow evaluation throw halts the walk (downstream flows do not run), rolls back the frame's dirty-check bookkeeping, and re-raises as `:rf.error/flow-eval-exception`. The router discards the pending `:db` effect, so the event aborts with no partial commit. The ex-data names both the flow and the failing phase — `:rf.flow/failed-id`, `:rf.flow/failed-phase` (`:derive` when your `:derive` fn threw, `:output-write` when it returned and the `assoc-in` of that value at the flow's `:output-path` threw) and `:rf.flow/output-path`.
 
 ### `reset-flows!`
 

--- a/docs/api/re-frame.fresco.forms.md
+++ b/docs/api/re-frame.fresco.forms.md
@@ -39,15 +39,15 @@ application live in [Forms](../core/fresco/05-forms.md) and the
   what a rejection is made of. `:value`, `:on-commit`, `:on-cancel`, `:key` and
   `::h/revision` are the field's own — every other prop reaches the `<input>`
   unchanged, with `:type` defaulting to `"text"`.
-  - The protocol is three ordinary events in the module's own keyword namespace
-    (`::edit` on `:on-input`, `::commit` on Enter and blur alike, `::cancel` on
-    Escape), written into the field's intents rather than exported as names. A
-    test that drives the field by hand spells them through
-    `re-frame.fresco.test.forms`.
-  - It mints no refusal id of its own: a bad `:control` is `reg-state`'s
-    `:rf.error/fresco-state-bad-argument` at the field's first render, and
-    `::h/revision` on a non-text field is
-    `:rf.error/fresco-revision-not-controlled`.
+    - The protocol is three ordinary events in the module's own keyword namespace
+      (`::edit` on `:on-input`, `::commit` on Enter and blur alike, `::cancel` on
+      Escape), written into the field's intents rather than exported as names. A
+      test that drives the field by hand spells them through
+      `re-frame.fresco.test.forms`.
+    - It mints no refusal id of its own: a bad `:control` is `reg-state`'s
+      `:rf.error/fresco-state-bad-argument` at the field's first render, and
+      `::h/revision` on a non-text field is
+      `:rf.error/fresco-revision-not-controlled`.
 - **Example**:
   ```clojure
   [forms/buffered-field

--- a/docs/api/re-frame.fresco.md
+++ b/docs/api/re-frame.fresco.md
@@ -39,20 +39,20 @@ silently gain or lose a public.
 - **Description**: Mints a boundary — a real React function component, and a legal
   hiccup head. `argv` is the ordinary one-props-map argument vector, so
   destructuring reads as it does in any Clojure fn.
-  - The macro **reads no body**. It expands to a `def` of the minted head plus a
-    source coordinate, so a refusal raised while the body runs can name where the
-    boundary was written.
-  - The `fn` it emits is **anonymous**, so nothing it binds can shadow a helper of
-    the same name — `(h/defview todo-row [p] (todo-row-body p))` is safe at the
-    ordinary spelling.
-  - The name is also registered in re-frame's `:view` registrar under
-    `(keyword "<ns>" "<sym>")`, for **forward resolution only** — a tool holding a
-    keyword the author wrote reaches the view they meant. It carries no
-    `:handler-fn`, and rides the `debug-enabled?` gate, so a production build
-    registers nothing.
-  - Hooks do not belong in a body: a body is dynamically composed, so a hook
-    written there would make its own call order depend on a data path. Put
-    hook-intensive behaviour in a React island reached through `defhost`.
+    - The macro **reads no body**. It expands to a `def` of the minted head plus a
+      source coordinate, so a refusal raised while the body runs can name where the
+      boundary was written.
+    - The `fn` it emits is **anonymous**, so nothing it binds can shadow a helper of
+      the same name — `(h/defview todo-row [p] (todo-row-body p))` is safe at the
+      ordinary spelling.
+    - The name is also registered in re-frame's `:view` registrar under
+      `(keyword "<ns>" "<sym>")`, for **forward resolution only** — a tool holding a
+      keyword the author wrote reaches the view they meant. It carries no
+      `:handler-fn`, and rides the `debug-enabled?` gate, so a production build
+      registers nothing.
+    - Hooks do not belong in a body: a body is dynamically composed, so a hook
+      written there would make its own call order depend on a data path. Put
+      hook-intensive behaviour in a React island reached through `defhost`.
 - **Example**:
   ```clojure
   (h/defview todo-row [{:keys [id]}]

--- a/docs/api/re-frame.fresco.motion.md
+++ b/docs/api/re-frame.fresco.motion.md
@@ -38,14 +38,14 @@ keywords and the phase table are taught in
   each child's own `::motion/mounting` / `::motion/unmounting` override map into
   it while it is in that phase — into an element's attributes, or into a view's
   props, the same map either way.
-  - It inserts **no wrapper node** and stamps no `data-*`: every child it renders
-    is the author's own node with the author's own attributes merged.
-  - `:timeout-ms` is **mandatory**. It is the retention length and the hard
-    terminal bound at once, so a child leaves on time whether or not any CSS ran.
-  - Per-frame work is zero: a transition costs one timer per outstanding deadline
-    and nothing between frames. A key that returns while it is exiting cancels —
-    it goes back to present on the node it already had, with no remount and no
-    restarted exit.
+    - It inserts **no wrapper node** and stamps no `data-*`: every child it renders
+      is the author's own node with the author's own attributes merged.
+    - `:timeout-ms` is **mandatory**. It is the retention length and the hard
+      terminal bound at once, so a child leaves on time whether or not any CSS ran.
+    - Per-frame work is zero: a transition costs one timer per outstanding deadline
+      and nothing between frames. A key that returns while it is exiting cancels —
+      it goes back to present on the node it already had, with no remount and no
+      restarted exit.
 - **Example**:
   ```clojure
   (h/defview toast-tray [_]

--- a/docs/api/re-frame.fresco.native.md
+++ b/docs/api/re-frame.fresco.native.md
@@ -38,15 +38,15 @@ same frame. The islands themselves are taught in
   under the frame this island is mounted in. The island counterpart to `h/sub` —
   and one call per read, so two calls are **two** subscriptions where a `defview`
   body's several `h/sub` reads are one.
-  - It hands `useSyncExternalStore` the same `subscribe` and `getSnapshot` a
-    boundary reading this key gets, so the read builds the same cell, joins the
-    same reader membership and residue census, wakes on the same commit, and
-    appears in the same `re-frame.fresco.tool` rosters Xray reads.
-  - A re-render that changed no read performs no re-subscribe; unmount releases
-    what mount acquired, StrictMode's double mount included.
-  - A commit observed through it is a **blocking** update — React's rule for an
-    external store — so nothing here is transition-aware, and it is not a door to
-    a promise-driven resource.
+    - It hands `useSyncExternalStore` the same `subscribe` and `getSnapshot` a
+      boundary reading this key gets, so the read builds the same cell, joins the
+      same reader membership and residue census, wakes on the same commit, and
+      appears in the same `re-frame.fresco.tool` rosters Xray reads.
+    - A re-render that changed no read performs no re-subscribe; unmount releases
+      what mount acquired, StrictMode's double mount included.
+    - A commit observed through it is a **blocking** update — React's rule for an
+      external store — so nothing here is transition-aware, and it is not a door to
+      a promise-driven resource.
 - **Example**:
   ```clojure
   (defui ticker [{:keys [sym]}]
@@ -63,14 +63,14 @@ same frame. The islands themselves are taught in
 - **Description**: Frame-locked operations for the frame this island is mounted
   in — `rf/capture-frame`'s bundle,
   `{:frame :dispatch :dispatch-sync :subscribe}`.
-  - The frame is the surrounding tree's, the one React context the boundary shell
-    reads, and no argument reaches another; for a **named** frame call
-    `(rf/capture-frame frame-id)` directly.
-  - The map is the same object on every render under one frame **incarnation**, so
-    it is safe in effect deps and safe to close over. Destroy the frame and
-    recreate it under the same id and the next render gets the successor's ops,
-    while a callback still holding the predecessor's is refused by core's
-    `:rf.error/frame-destroyed` fence.
+    - The frame is the surrounding tree's, the one React context the boundary shell
+      reads, and no argument reaches another; for a **named** frame call
+      `(rf/capture-frame frame-id)` directly.
+    - The map is the same object on every render under one frame **incarnation**, so
+      it is safe in effect deps and safe to close over. Destroy the frame and
+      recreate it under the same id and the next render gets the successor's ops,
+      while a callback still holding the predecessor's is refused by core's
+      `:rf.error/frame-destroyed` fence.
 - **Example**:
   ```clojure
   (defui col-resizer [_]

--- a/docs/api/re-frame.fresco.overlay.md
+++ b/docs/api/re-frame.fresco.overlay.md
@@ -47,18 +47,18 @@ unrenamed.
   ```
 - **Description**: An anchored, light-dismissable panel on the browser's own top
   layer.
-  - `:anchor` is the **DOM id** of the trigger. The module gives that element a
-    generated CSS anchor name while the panel is open and puts back whatever it
-    found on the way out. An `:anchor` naming no element refuses with
-    `:rf.error/fresco-overlay-anchor-missing`; omitting it stays legal and
-    silent.
-  - `:placement` is the compass word that becomes a `position-area` against the
-    anchor. A `:placement` outside the known table is **not refused** — it is
-    passed through as a literal `position-area` value.
-  - With `:on-dismiss` the panel is a `popover="auto"` and takes its place in the
-    platform's LIFO stack; without one it is `popover="manual"` and dismisses for
-    nothing, because a dismissal with nowhere to go is how an open flag acquires a
-    second owner.
+    - `:anchor` is the **DOM id** of the trigger. The module gives that element a
+      generated CSS anchor name while the panel is open and puts back whatever it
+      found on the way out. An `:anchor` naming no element refuses with
+      `:rf.error/fresco-overlay-anchor-missing`; omitting it stays legal and
+      silent.
+    - `:placement` is the compass word that becomes a `position-area` against the
+      anchor. A `:placement` outside the known table is **not refused** — it is
+      passed through as a literal `position-area` value.
+    - With `:on-dismiss` the panel is a `popover="auto"` and takes its place in the
+      platform's LIFO stack; without one it is `popover="manual"` and dismisses for
+      nothing, because a dismissal with nowhere to go is how an open flag acquires a
+      second owner.
 - **Example**:
   ```clojure
   [overlay/popover {:open?      (h/sub [:menu/open? id])
@@ -81,17 +81,17 @@ unrenamed.
   ```
 - **Description**: A blocking dialog on the browser's own top layer, opened with
   `showModal`.
-  - Modality is the engine's: the rest of the document is inert and `::backdrop`
-    is a real CSS selector. Focus cannot Tab out of the dialog — inertness is what
-    stops it reaching the page, and the module's own two-edge wrap is what makes
-    the last control Tab straight back to the first rather than through `<body>`.
-  - Escape dispatches `:on-dismiss`; a backdrop click does so only with
-    `:light-dismiss? true` (default false), because a destructive confirmation
-    must not go away on a stray click. Without `:on-dismiss` the dialog honours no
-    close request at all.
-  - Initial focus is **tree order** — the platform's own dialog-focusing steps
-    take the first focusable control, so order the controls rather than reaching
-    for an autofocus attribute.
+    - Modality is the engine's: the rest of the document is inert and `::backdrop`
+      is a real CSS selector. Focus cannot Tab out of the dialog — inertness is what
+      stops it reaching the page, and the module's own two-edge wrap is what makes
+      the last control Tab straight back to the first rather than through `<body>`.
+    - Escape dispatches `:on-dismiss`; a backdrop click does so only with
+      `:light-dismiss? true` (default false), because a destructive confirmation
+      must not go away on a stray click. Without `:on-dismiss` the dialog honours no
+      close request at all.
+    - Initial focus is **tree order** — the platform's own dialog-focusing steps
+      take the first focusable control, so order the controls rather than reaching
+      for an autofocus attribute.
 - **Example**:
   ```clojure
   [overlay/modal {:open?      (h/sub [:invoice/confirm-delete? id])

--- a/docs/api/re-frame.fresco.substrate.md
+++ b/docs/api/re-frame.fresco.substrate.md
@@ -55,19 +55,19 @@ the shipped alternatives and their coordinates are in
   Installation is explicit and there is no default-adapter registry, so a Fresco
   application that installs Reagent or UIx instead keeps working and never reaches
   this namespace.
-  - It stands on `re-frame.substrate.spine`, core's shared spine for React-shaped
-    adapters that lack a native reactive-atom primitive. The spine's
-    `make-derived-value` wires **one watch per source at construction** and
-    coalesces through a per-adapter epoch scheduler, so a derived value is live
-    the moment it exists.
-  - That push-from-birth property is the one Fresco's collector needs.
-    `re-frame.substrate.plain-atom` cannot give it: its derived value registers no
-    watch, so the runtime paints once and is deaf thereafter — which is why the
-    headless adapter is right for an SSR render and wrong under a live view.
-  - It takes no new dependency: Fresco already requires `react`, and the spine
-    already lives in core.
-  - Asking for a state container before `init!` throws
-    `:rf.error/no-adapter-installed`.
+    - It stands on `re-frame.substrate.spine`, core's shared spine for React-shaped
+      adapters that lack a native reactive-atom primitive. The spine's
+      `make-derived-value` wires **one watch per source at construction** and
+      coalesces through a per-adapter epoch scheduler, so a derived value is live
+      the moment it exists.
+    - That push-from-birth property is the one Fresco's collector needs.
+      `re-frame.substrate.plain-atom` cannot give it: its derived value registers no
+      watch, so the runtime paints once and is deaf thereafter — which is why the
+      headless adapter is right for an SSR render and wrong under a live view.
+    - It takes no new dependency: Fresco already requires `react`, and the spine
+      already lives in core.
+    - Asking for a state container before `init!` throws
+      `:rf.error/no-adapter-installed`.
 - **Example**:
   ```clojure
   (require '[re-frame.core :as rf]

--- a/docs/api/re-frame.http.md
+++ b/docs/api/re-frame.http.md
@@ -24,16 +24,16 @@ Repeating `{:request {:method :get :url …}}` at every call site is an **app** 
 - **Kind**: fx
 - **Args**: per [Managed HTTP — The request is a map](../async/http.md#the-request-is-a-map) and `:rf.fx/managed-args`
 - **Description**: The one managed-HTTP fx-id. Keys in the args map:
-  - `:request` — the request envelope; `:url` is **required**. A missing / nil / blank final URL raises `:rf.error/http-bad-request` at dispatch, after the `:before` chain runs.
-  - `:decode` — decode policy.
-  - `:accept` — accept fn.
-  - `:retry` — `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`. Anything else raises `:rf.error/http-bad-retry-on` at dispatch.
-  - `:timeout-ms` — per-attempt timeout, default 30000. An explicit `nil` or `0` opts out.
-  - `:reply-to` — the unified reply target: one event vector for **both** the success and the failure reply (the app branches on `:status`). The same call-site key resources / mutations use.
-  - `:on-success` / `:on-failure` — the split routing sugar: success / failure target events; event vector or nil. Any other value raises `:rf.error/http-bad-reply-target`. The two styles are **exclusive** — `:reply-to` beside either branch key raises the same error with `:reason :mixed-addressing`. Supplying **none** of the three raises `:rf.error/http-no-reply-target` at dispatch.
-  - `:request-id` — for abort / supersede.
-  - `:abort-signal` — optional (CLJS).
-  - `:sensitive?` — see [Privacy and classification](#privacy-and-classification).
+    - `:request` — the request envelope; `:url` is **required**. A missing / nil / blank final URL raises `:rf.error/http-bad-request` at dispatch, after the `:before` chain runs.
+    - `:decode` — decode policy.
+    - `:accept` — accept fn.
+    - `:retry` — `{:on #{categories} :max-attempts N :backoff {:base-ms :factor :max-ms :jitter}}`. `:on` must be a set drawn from the retryable subset `#{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}`. Anything else raises `:rf.error/http-bad-retry-on` at dispatch.
+    - `:timeout-ms` — per-attempt timeout, default 30000. An explicit `nil` or `0` opts out.
+    - `:reply-to` — the unified reply target: one event vector for **both** the success and the failure reply (the app branches on `:status`). The same call-site key resources / mutations use.
+    - `:on-success` / `:on-failure` — the split routing sugar: success / failure target events; event vector or nil. Any other value raises `:rf.error/http-bad-reply-target`. The two styles are **exclusive** — `:reply-to` beside either branch key raises the same error with `:reason :mixed-addressing`. Supplying **none** of the three raises `:rf.error/http-no-reply-target` at dispatch.
+    - `:request-id` — for abort / supersede.
+    - `:abort-signal` — optional (CLJS).
+    - `:sensitive?` — see [Privacy and classification](#privacy-and-classification).
 
 ### `[:rf.http/managed-abort request-id]`
 
@@ -124,11 +124,11 @@ A middleware surface that mirrors the rest of the `reg-*` family. Use it to inje
   (reg-http-interceptor id interceptor-map)
   ```
 - **Description**: Register an HTTP interceptor on a frame's `:rf.http/managed` middleware chain. Returns `id`.
-  - `interceptor-map` carries at least one of `:before (fn [ctx] ctx')` (request-side) and `:after (fn [ctx response] response')` (response-side), plus optional `:frame` (explicit-frame override) and the standard `:rf/registration-metadata`.
-  - The target frame is the explicit `:frame` when given, else the carried scope it registers under (`with-frame` / an `:initial-events` step). Registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default.
-  - An invalid shape (non-keyword id, neither `:before` nor `:after`, a non-fn slot, a non-keyword `:frame`) raises `:rf.error/http-bad-interceptor`.
-  - Re-registering an existing id replaces the slot in place, position preserved. After a `clear-http-interceptor`, re-registering the same id appends to the end of the chain.
-  - The `:before` chain runs in registration order; the `:after` chain runs in reverse registration order. `:after` sees the same ctx the `:before` chain produced (request-correlated handling).
+    - `interceptor-map` carries at least one of `:before (fn [ctx] ctx')` (request-side) and `:after (fn [ctx response] response')` (response-side), plus optional `:frame` (explicit-frame override) and the standard `:rf/registration-metadata`.
+    - The target frame is the explicit `:frame` when given, else the carried scope it registers under (`with-frame` / an `:initial-events` step). Registering under **no** scope raises `:rf.error/no-frame-context` — there is no `:rf/default` default.
+    - An invalid shape (non-keyword id, neither `:before` nor `:after`, a non-fn slot, a non-keyword `:frame`) raises `:rf.error/http-bad-interceptor`.
+    - Re-registering an existing id replaces the slot in place, position preserved. After a `clear-http-interceptor`, re-registering the same id appends to the end of the chain.
+    - The `:before` chain runs in registration order; the `:after` chain runs in reverse registration order. `:after` sees the same ctx the `:before` chain produced (request-correlated handling).
 
 ### `clear-http-interceptor`
 
@@ -139,10 +139,10 @@ A middleware surface that mirrors the rest of the `reg-*` family. Use it to inje
   (clear-http-interceptor id {:frame target})
   ```
 - **Description**: Unregister an interceptor by id. The public surface is **exact** — the two shapes above, nothing else.
-  - `(clear-http-interceptor id)` resolves the frame through the ambient (carried-scope) chain it runs under. Under no scope it raises the always-on `:rf.error/no-frame-context` rather than clearing against a synthesised `:rf/default`.
-  - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface). `target` is a present, non-nil frame-id keyword or a live frame value.
-  - The two-arity opts map is **fail-closed**: it MUST be exactly `{:frame target}`. A `{}`, a `{:frame nil}`, a typo'd or extra key (`{:fram f}`), and a non-map second arg all raise `:rf.error/http-bad-interceptor` BEFORE any ambient frame is resolved or touched — never reinterpreted as a positional frame nor silently cleared against the ambient scope (rf2-s32bf). This is distinct from the single-arity no-scope `:rf.error/no-frame-context`.
-  - The frame-first `(frame id)` spelling is a separate artefact-internal seam (`clear-http-interceptor*`), reached directly by internal cleanup that already holds a resolved frame — frame teardown, actor destroy — **not** a public arity of `clear-http-interceptor`.
+    - `(clear-http-interceptor id)` resolves the frame through the ambient (carried-scope) chain it runs under. Under no scope it raises the always-on `:rf.error/no-frame-context` rather than clearing against a synthesised `:rf/default`.
+    - `(clear-http-interceptor id {:frame target})` names the frame explicitly via the trailing opts map, mirroring `reg-http-interceptor`'s `:frame` and the family's public-frame-targeting law (never a positional frame arg on a public surface). `target` is a present, non-nil frame-id keyword or a live frame value.
+    - The two-arity opts map is **fail-closed**: it MUST be exactly `{:frame target}`. A `{}`, a `{:frame nil}`, a typo'd or extra key (`{:fram f}`), and a non-map second arg all raise `:rf.error/http-bad-interceptor` BEFORE any ambient frame is resolved or touched — never reinterpreted as a positional frame nor silently cleared against the ambient scope (rf2-s32bf). This is distinct from the single-arity no-scope `:rf.error/no-frame-context`.
+    - The frame-first `(frame id)` spelling is a separate artefact-internal seam (`clear-http-interceptor*`), reached directly by internal cleanup that already holds a resolved frame — frame teardown, actor destroy — **not** a public arity of `clear-http-interceptor`.
 - **Example**:
   ```clojure
   (rf/clear :http-interceptor :auth-header)
@@ -173,10 +173,10 @@ Test-support surface for driving the pipeline without the network: canned-reply 
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical success reply (`{:status :ok :value v}`) directly into `:fx`, for inline "stub THIS request" patterns.
-  - `:value` defaults to `{:stubbed true}` when absent.
-  - `:after-ms` (optional) — a positive value defers the reply via a `:dispatch-later` tick. Absent, `0`, or non-positive delivers immediately.
-  - Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path. Reply addressing (`:reply-to` / `:on-success`) applies as for `:rf.http/managed`; an unaddressed stub reply is silently dropped.
-  - Registered at load of `re-frame.http.test-support`.
+    - `:value` defaults to `{:stubbed true}` when absent.
+    - `:after-ms` (optional) — a positive value defers the reply via a `:dispatch-later` tick. Absent, `0`, or non-positive delivers immediately.
+    - Runs the frame's `:before` and `:after` interceptor chains around the synthesised reply, exactly like the real transport path. Reply addressing (`:reply-to` / `:on-success`) applies as for `:rf.http/managed`; an unaddressed stub reply is silently dropped.
+    - Registered at load of `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (rf/reg-event :counter/retry-recover
@@ -192,10 +192,10 @@ Test-support surface for driving the pipeline without the network: canned-reply 
 
 - **Kind**: fx
 - **Description**: Synthesise the canonical failure reply directly into `:fx`.
-  - `:kind` defaults to `:rf.http/transport`. `:tags` merge into the `:error` map.
-  - An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind yields `:status :error`.
-  - Supports the same optional `:after-ms` deferral, interceptor-chain behaviour, and reply addressing (`:reply-to` / `:on-failure`) as `:rf.http/managed-canned-success`.
-  - Registered at load of `re-frame.http.test-support`.
+    - `:kind` defaults to `:rf.http/transport`. `:tags` merge into the `:error` map.
+    - An `:rf.http/aborted` kind yields `:status :cancelled`; every other kind yields `:status :error`.
+    - Supports the same optional `:after-ms` deferral, interceptor-chain behaviour, and reply addressing (`:reply-to` / `:on-failure`) as `:rf.http/managed-canned-success`.
+    - Registered at load of `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (rf/reg-event :flaky/load
@@ -214,11 +214,11 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   (with-request-stubs route-map body-fn)
   ```
 - **Description**: Scoped stubbing for `body-fn`'s dynamic extent.
-  - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
-  - Inside `body-fn`, requests matching a stubbed route bypass the real client. The helper binds one stable override target — `:rf.test/managed-http-scope-stub`, in the test-runner-internal `:rf.test/*` fx-stub family, registered once when `re-frame.http.test-support` loads — as the `:rf.http/managed` override, and carries the scope's route map on a dynamic var. It mints **no** per-scope fx and performs no registrar write; nested scopes compose because an inner scope's route-map binding shadows the outer's and restores it on exit. Because the target is registered at load time rather than minted per scope, it resolves through the sealed image generation of a frame created before the scope was entered — a `dispatch-sync` in a pre-created frame still routes through the stub.
-  - Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`. A per-call `:fx-overrides` still wins.
-  - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
-  - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
+    - `route-map` is `{[<method> <url>] {:reply {:ok <value>}}}` (success) or `{[<method> <url>] {:reply {:failure <failure-map>}}}` (failure).
+    - Inside `body-fn`, requests matching a stubbed route bypass the real client. The helper binds one stable override target — `:rf.test/managed-http-scope-stub`, in the test-runner-internal `:rf.test/*` fx-stub family, registered once when `re-frame.http.test-support` loads — as the `:rf.http/managed` override, and carries the scope's route map on a dynamic var. It mints **no** per-scope fx and performs no registrar write; nested scopes compose because an inner scope's route-map binding shadows the outer's and restores it on exit. Because the target is registered at load time rather than minted per scope, it resolves through the sealed image generation of a frame created before the scope was entered — a `dispatch-sync` in a pre-created frame still routes through the stub.
+    - Plain `dispatch-sync` calls auto-route by method + URL with no manual `:fx-overrides`. A per-call `:fx-overrides` still wins.
+    - Routes match against the post-`:before` request (the method + URL the pipeline would actually issue). A request with no matching route receives a synthesised `:rf.http/transport` failure reply.
+    - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   (http-test-support/with-request-stubs
@@ -236,9 +236,9 @@ Test-support surface for driving the pipeline without the network: canned-reply 
   (install-managed-request-stubs! route-map)
   ```
 - **Description**: Lower-level than `with-request-stubs`. Use it when stubs span multiple `deftest`s. It registers the `:rf.http/managed-test-stub` fx — the stable, documented `:fx-overrides` target — which persists until `uninstall-managed-request-stubs!`. Returns the stub fx-id.
-  - Unlike the wrapper, this does **not** bind the `:rf.http/managed` override. Dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
-  - Nested installs snapshot the prior handler and restore it on uninstall (LIFO).
-  - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
+    - Unlike the wrapper, this does **not** bind the `:rf.http/managed` override. Dispatch with `{:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}}` (or wrap dispatches in `with-fx-overrides`) to route through it.
+    - Nested installs snapshot the prior handler and restore it on uninstall (LIFO).
+    - Not a `re-frame.core` façade export — call it through its home namespace `re-frame.http.test-support`.
 - **Example**:
   ```clojure
   ;; Stubs that span several deftests — install once, route via :fx-overrides.

--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -33,10 +33,10 @@ Scope in this slice is HTTP-only:
   (reg-resource resource-id metadata request-fn)
   ```
 - **Description**: Register a resource as data. Returns `resource-id`.
-  - `metadata` (middle slot): the registration-metadata map. It carries the fail-closed `:scope` policy, `:params-schema`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/resource-bad-spec`.
-  - `request-fn` (third slot): returns the [managed-HTTP args map](re-frame.http.md).
-  - Validates the reconstructed spec (`:scope` first, then `:params-schema`), then writes a `:resource`-kind registrar entry.
-  - The introspection spec stored under `:rf/resource` reconstructs `:request` onto the metadata map.
+    - `metadata` (middle slot): the registration-metadata map. It carries the fail-closed `:scope` policy, `:params-schema`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/resource-bad-spec`.
+    - `request-fn` (third slot): returns the [managed-HTTP args map](re-frame.http.md).
+    - Validates the reconstructed spec (`:scope` first, then `:params-schema`), then writes a `:resource`-kind registrar entry.
+    - The introspection spec stored under `:rf/resource` reconstructs `:request` onto the metadata map.
 
 #### The resource spec
 
@@ -110,14 +110,14 @@ See [Guide ch.27 §Scope](../resources/concepts.md).
   (rf/clear :resource resource-id)
   ```
 - **Description**: Remove a registered resource. Returns `resource-id`. There is **no** `clear-resource` name — not on `re-frame.resources` and not on the `re-frame.core` facade; `:resource` is one of the kinds the one kind-keyed registrar inverse dispatches (see [`clear`](re-frame.core.md#clear)). `re-frame.resources.registry/clear-resource` survives as the late-bind hook target that dispatch routes to — artefact-internal plumbing, not a public call (rf2-kuky.80).
-  - A **registration-lifecycle** operation, NOT cache invalidation. For data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`.
-  - Also disposes the resource-runtime state for the id in each affected frame. That disposal:
-    - releases owner indexes
-    - cancels timers and host handles
-    - aborts in-flight work where possible
-    - suppresses late replies by generation
-    - removes tag-index rows
-    - emits a trace
+    - A **registration-lifecycle** operation, NOT cache invalidation. For data lifecycle use `:rf.resource/invalidate-tags` / `:rf.resource/remove` / `:rf.resource/clear-scope`.
+    - Also disposes the resource-runtime state for the id in each affected frame. That disposal:
+        - releases owner indexes
+        - cancels timers and host handles
+        - aborts in-flight work where possible
+        - suppresses late replies by generation
+        - removes tag-index rows
+        - emits a trace
 
 ```clojure
 ;; deregister a resource (registration-lifecycle — e.g. on hot-reload / teardown)
@@ -134,11 +134,11 @@ A mutation is the causal-WRITE counterpart of a resource: a named write to remot
   (reg-mutation mutation-id metadata request-fn)
   ```
 - **Description**: Register a mutation as data under `mutation-id`. Returns `mutation-id`. The causal-write counterpart of `:resource`.
-  - `metadata` (middle slot): the registration-metadata map. It carries `:params-schema`, `:invalidates`, `:patches`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/mutation-bad-spec`.
-  - `request-fn` (third slot): the [managed-HTTP write](re-frame.http.md).
-  - Validates the reconstructed spec and writes a `:mutation`-kind registrar entry.
-  - An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
-  - The introspection spec stored under `:rf/mutation` reconstructs `:request` onto the metadata map.
+    - `metadata` (middle slot): the registration-metadata map. It carries `:params-schema`, `:invalidates`, `:patches`, `:doc`, and so on. A non-map `metadata` raises `:rf.error/mutation-bad-spec`.
+    - `request-fn` (third slot): the [managed-HTTP write](re-frame.http.md).
+    - Validates the reconstructed spec and writes a `:mutation`-kind registrar entry.
+    - An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+    - The introspection spec stored under `:rf/mutation` reconstructs `:request` onto the metadata map.
 
 ```clojure
 (rf/reg-mutation :article/save
@@ -224,11 +224,11 @@ A resource (or payload, or route) references a named resolver as `{:from-db <sco
   (reg-resource-scope scope-id metadata resolve-fn)   ;; ONE arity; :inputs is required
   ```
 - **Description**: Register a **pure** named scope resolver under `scope-id` in the canonical 3-slot grammar. Returns `scope-id`. Ships in `day8/re-frame2-resources`; require `re-frame.resources` at boot. An app that omits the artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
-  - `resolve-fn` (value/third slot): the resolver. Its first arg is ALWAYS the resolved inputs map. It MUST be pure — it MUST NOT fetch, dispatch, mutate state, or read ambient host state. The `ctx` arg is reserved and invoked as literal `nil` in this slice. A `nil` resolve result is fail-closed.
-  - `metadata` (middle slot): carries the declared `:inputs {name [:db <rf-path>]}` plus optional `:doc`. The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`). `[:runtime …]` (route-derived scope) is reserved and rejected with `:rf.error/resource-scope-source-reserved`.
-  - Whole-db form: declare the whole db as an ordinary input on the root path — `{:inputs {:db [:db []]}}`. There is no bare-fn sugar and no first-arg meaning-shift; the stored `:whole-db?` cost mark is DERIVED from that declaration.
-  - A missing `:inputs` (an empty or `:doc`-only metadata), a non-map metadata, a malformed `:inputs` descriptor, a `:resolve` left inside the metadata map, or a non-fn value slot is rejected with `:rf.error/invalid-resource-scope-spec`.
-  - Writes a `:resource-scope`-kind registrar entry carrying the canonical spec plus captured source coords.
+    - `resolve-fn` (value/third slot): the resolver. Its first arg is ALWAYS the resolved inputs map. It MUST be pure — it MUST NOT fetch, dispatch, mutate state, or read ambient host state. The `ctx` arg is reserved and invoked as literal `nil` in this slice. A `nil` resolve result is fail-closed.
+    - `metadata` (middle slot): carries the declared `:inputs {name [:db <rf-path>]}` plus optional `:doc`. The only shipped input source is `[:db <rf-path>]` (a concrete `:rf/path`). `[:runtime …]` (route-derived scope) is reserved and rejected with `:rf.error/resource-scope-source-reserved`.
+    - Whole-db form: declare the whole db as an ordinary input on the root path — `{:inputs {:db [:db []]}}`. There is no bare-fn sugar and no first-arg meaning-shift; the stored `:whole-db?` cost mark is DERIVED from that declaration.
+    - A missing `:inputs` (an empty or `:doc`-only metadata), a non-map metadata, a malformed `:inputs` descriptor, a `:resolve` left inside the metadata map, or a non-fn value slot is rejected with `:rf.error/invalid-resource-scope-spec`.
+    - Writes a `:resource-scope`-kind registrar entry carrying the canonical spec plus captured source coords.
 
 ```clojure
 (rf/reg-resource-scope :realworld/session
@@ -260,10 +260,10 @@ A resource (or payload, or route) references a named resolver as `{:from-db <sco
   (resolve-resource-scope db scope-id) → scope or nil
   ```
 - **Description**: Resolver **helper**: resolve the named resolver `scope-id` against the supplied `db` value, returning a canonical concrete scope or nil.
-  - A pure function over the resolver registry, NOT an effect. It has no app-state or dispatch side effects, and no observability side effect: it does NOT emit a `:rf.resource/scope-resolved` trace. The causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence.
-  - Throws `:rf.error/resource-scope-not-registered` when no resolver is registered under `scope-id` (a typo'd reference is never a silent nil).
-  - A resolver that returns nil for the supplied db yields nil. That is the fail-closed unresolved condition; the use site interprets it — never as an implicit global.
-  - Canonical use is the logout / account-switch idiom: resolve the concrete old scope from the handler's coeffect `db` — pre-transition by definition, the causal input — and pass it concretely to `[:rf.resource/clear-scope …]`.
+    - A pure function over the resolver registry, NOT an effect. It has no app-state or dispatch side effects, and no observability side effect: it does NOT emit a `:rf.resource/scope-resolved` trace. The causal `{:from-db …}` / route-entry / mutation-settle boundaries carry that evidence.
+    - Throws `:rf.error/resource-scope-not-registered` when no resolver is registered under `scope-id` (a typo'd reference is never a silent nil).
+    - A resolver that returns nil for the supplied db yields nil. That is the fail-closed unresolved condition; the use site interprets it — never as an implicit global.
+    - Canonical use is the logout / account-switch idiom: resolve the concrete old scope from the handler's coeffect `db` — pre-transition by definition, the causal input — and pass it concretely to `[:rf.resource/clear-scope …]`.
 
 ```clojure
 ;; the logout idiom: resolve the concrete OLD scope off the coeffect db,
@@ -304,8 +304,8 @@ Which host signals reach a frame is declared **on the frame**, exactly as URL ow
 ```
 
 - **`:revalidate-on`** is an optional frame-config key: a **set** drawn from the closed enum `#{:focus :reconnect}`.
-  - `:focus` wires `focus` (on `window`) **and** `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`. It is one setting, not two.
-  - `:reconnect` wires `online` (on `window`) → `[:rf.resource/network-reconnected]`.
+    - `:focus` wires `focus` (on `window`) **and** `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`. It is one setting, not two.
+    - `:reconnect` wires `online` (on `window`) → `[:rf.resource/network-reconnected]`.
 - An **absent** key, or an explicit `#{}`, installs nothing. The empty set is a legitimate "none".
 - **The frame lifecycle owns them.** Creation installs the declared subset once the frame is live; a deliberate re-registration reconciles (replace-don't-stack — it detaches whatever the frame had and attaches exactly the declared subset, so the listeners never stack however many times a frame is re-registered, and dropping the key relinquishes them); frame destroy cancels them via the single `:resources/on-frame-destroyed!` hook. **There is no `install-revalidation-listeners!` / `remove-revalidation-listeners!`** — the imperative pair, and the ordering rule it required, are gone.
 - CLJS-only host listeners; the JVM/SSR arm installs nothing and nothing throws. Declaring `:revalidate-on` without `day8/re-frame2-resources` on the classpath fails loud at registration with `:rf.error/resources-artefact-missing`.
@@ -414,9 +414,9 @@ They serve Xray, unit tests, and SSR serialization — contexts with no reactive
   (resource-state {:resource … :scope … :params … :frame …}) → entry or nil
   ```
 - **Description**: A resource instance's durable runtime entry for an explicit-frame target. The scoped key resolves the same way a subscription's does: a `{:from-db <id>}` scope resolves against the frame's app-db.
-  - nil when no entry exists.
-  - An absent / nil `:frame` raises `:rf.error/no-frame-context`. This is fail-closed: a nil pass-through would be indistinguishable from a genuinely absent entry.
-  - An explicit but unknown / destroyed `:frame` reads as nil.
+    - nil when no entry exists.
+    - An absent / nil `:frame` raises `:rf.error/no-frame-context`. This is fail-closed: a nil pass-through would be indistinguishable from a genuinely absent entry.
+    - An explicit but unknown / destroyed `:frame` reads as nil.
 
 ```clojure
 ;; the live durable entry for one scoped key, at an explicit frame
@@ -455,9 +455,9 @@ There is no `resource-ids` accessor (rf2-kuky.31) — it is `keys` over the gene
   (mutation-state {:instance … :frame …}) → row or nil
   ```
 - **Description**: A mutation **instance**'s durable runtime row (`{:status :result :error …}`) for an explicit-frame target, or nil.
-  - The frame is carried explicitly (see [EP-0002](../EP/EP-0002-frame-target-resolution.md)).
-  - An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed, symmetric with `resource-state`).
-  - An explicit but unknown / destroyed `:frame` reads as nil.
+    - The frame is carried explicitly (see [EP-0002](../EP/EP-0002-frame-target-resolution.md)).
+    - An absent / nil `:frame` raises `:rf.error/no-frame-context` (fail-closed, symmetric with `resource-state`).
+    - An explicit but unknown / destroyed `:frame` reads as nil.
 
 ```clojure
 ;; one mutation INSTANCE's runtime row, at an explicit frame
@@ -544,10 +544,10 @@ Resource events take a **map payload**, not a positional argument vector. The re
 - **Kind**: event
 - **Payload**: `{:resource :scope :params :owner :cause :keep-previous?}`
 - **Description**: Ensure the resource instance is loaded.
-  - `ensure` while the same scoped key is already in flight **joins** the existing work (attaches the owner, records the cause, emits a dedupe trace).
-  - `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip: it serves the cached value, attaches the owner, and emits `:rf.resource/cache-hit` — no fetch.
-  - `:owner` changes the active-owner set; `:cause` is recorded in trace/history.
-  - `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key. That lets `:rf.resource/previous-data` show old data while the new key loads. The pointer is never inserted into the new entry.
+    - `ensure` while the same scoped key is already in flight **joins** the existing work (attaches the owner, records the cause, emits a dedupe trace).
+    - `ensure` of an already-`:loaded` entry still fresh-by-policy is a fresh-skip: it serves the cached value, attaches the owner, and emits `:rf.resource/cache-hit` — no fetch.
+    - `:owner` changes the active-owner set; `:cause` is recorded in trace/history.
+    - `:keep-previous?` on a first-loading key records a projection pointer to the prior loaded sibling key. That lets `:rf.resource/previous-data` show old data while the new key loads. The pointer is never inserted into the new entry.
 
 ```clojure
 [:rf.resource/ensure
@@ -577,10 +577,10 @@ Resource events take a **map payload**, not a positional argument vector. The re
 - **Kind**: event
 - **Payload**: a closed union — scoped `{:scope :tags :cause?}` OR cross-scope `{:cross-scope? true :tags :cause}` (no `:scope`).
 - **Description**: Mark every entry whose tags intersect `:tags` as stale. Entries with active owners are refetched. Inactive entries stay stale or become GC-eligible.
-  - **Scoped by default** — a scoped invalidation with no `:scope` raises `:rf.error/resource-invalidate-scope-required` (never a silent nil-scope match).
-  - **`:scope` is a ScopeInput** — a concrete scope OR a `{:from-db <id>}` named-resolver reference, resolved at use time against the handler's app-db coeffect, **symmetric with `ensure`**. A reference that resolves nil is fail-closed with `:rf.error/resource-scope-unresolved-reference` (invalidate is scope-requiring like ensure). No in-handler resolve needed — pass the reference directly.
-  - A cross-scope invalidation opts in explicitly with `:cross-scope? true` and carries **no `:scope`** (it is scope-agnostic). It ignores the scope filter, is visible in Xray, and MUST carry `:cause` — omitting one raises `:rf.error/resource-cross-scope-cause-required`; supplying a `:scope` alongside `:cross-scope? true` raises `:rf.error/resource-cross-scope-scope-conflict`.
-  - On a successful load an entry's tags are *replaced* with the new data's tags.
+    - **Scoped by default** — a scoped invalidation with no `:scope` raises `:rf.error/resource-invalidate-scope-required` (never a silent nil-scope match).
+    - **`:scope` is a ScopeInput** — a concrete scope OR a `{:from-db <id>}` named-resolver reference, resolved at use time against the handler's app-db coeffect, **symmetric with `ensure`**. A reference that resolves nil is fail-closed with `:rf.error/resource-scope-unresolved-reference` (invalidate is scope-requiring like ensure). No in-handler resolve needed — pass the reference directly.
+    - A cross-scope invalidation opts in explicitly with `:cross-scope? true` and carries **no `:scope`** (it is scope-agnostic). It ignores the scope filter, is visible in Xray, and MUST carry `:cause` — omitting one raises `:rf.error/resource-cross-scope-cause-required`; supplying a `:scope` alongside `:cross-scope? true` raises `:rf.error/resource-cross-scope-scope-conflict`.
+    - On a successful load an entry's tags are *replaced* with the new data's tags.
 
 ```clojure
 ;; after a write settles, stale the ACTING viewer's reads carrying these tags —
@@ -646,9 +646,9 @@ Resource events take a **map payload**, not a positional argument vector. The re
 - **Kind**: event (infinite resources only — see [Infinite resources](#infinite-resources))
 - **Payload**: `{:resource :scope :params :cause}` — **ownerless** (carries a `:cause`, never an `:owner`)
 - **Description**: Extend an `:infinite` feed by one page. The runtime computes the next page param from the entry's tail via `:next-page-param`, fetches that page through the same managed transport, and appends it to the feed's accumulated page vector. The feed stays `:loaded` and the pages stay visible. A load-more in flight shows as the derived `:fetching-next?` sub, distinct from a whole-feed `:fetching?` refresh.
-  - A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace.
-  - A load-more while a page fetch is already in flight dedupes.
-  - A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
+    - A load-more with no next page (`:next-page-param` → `nil`) is a no-op trace.
+    - A load-more while a page fetch is already in flight dedupes.
+    - A supplied `:owner` is warn-and-ignored — the route (or whatever first-loaded the feed) already owns the one feed entry, and load-more never changes the active-owner set.
 
 ```clojure
 ;; the "Load more" button — ownerless; carries a :cause, never an :owner
@@ -719,12 +719,12 @@ Status invariants:
 - **Kind**: event
 - **Payload**: `{:mutation :params :instance :scope :cause :reply-to :optimistic?}`
 - **Description**: Run a mutation.
-  - `:instance` is the caller-supplied (or generated) **instance** id all runtime state is keyed by — two concurrent submissions keep distinct rows.
-  - On success the runtime patches/populates/removes resource entries then invalidates tags (per `:invalidate-timing`).
-  - `:reply-to` is an optional data-only completion continuation target dispatched when the write settles.
-  - `:optimistic? false` is the per-call opt-out that forces a registered optimistic plan to run pessimistically.
-  - An unregistered `:mutation` raises `:rf.error/mutation-not-registered`; params that fail `:params-schema` raise `:rf.error/mutation-invalid-params`.
-  - A superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) never overwrites a newer instance (work-id + generation suppression).
+    - `:instance` is the caller-supplied (or generated) **instance** id all runtime state is keyed by — two concurrent submissions keep distinct rows.
+    - On success the runtime patches/populates/removes resource entries then invalidates tags (per `:invalidate-timing`).
+    - `:reply-to` is an optional data-only completion continuation target dispatched when the write settles.
+    - `:optimistic? false` is the per-call opt-out that forces a registered optimistic plan to run pessimistically.
+    - An unregistered `:mutation` raises `:rf.error/mutation-not-registered`; params that fail `:params-schema` raise `:rf.error/mutation-invalid-params`.
+    - A superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) never overwrites a newer instance (work-id + generation suppression).
 
 ```clojure
 [:rf.mutation/execute

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -106,9 +106,9 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
   ```
 - **Description**: Match a URL to route data. Pure; JVM-runnable.
 
-  - Returns `nil` when no route matches. Also fails closed to `nil` on malformed percent-encoding anywhere in the URL.
-  - When the route declares `:params` / `:query` schemas and the parsed values fail them, `:validation-failed?` is `true` and the explanation rides under `:validation-error`.
-  - Query keys the route declares (via `:query` / `:query-defaults`) come back as keyword keys, in a deterministic canonical order. Undeclared keys stay strings.
+    - Returns `nil` when no route matches. Also fails closed to `nil` on malformed percent-encoding anywhere in the URL.
+    - When the route declares `:params` / `:query` schemas and the parsed values fail them, `:validation-failed?` is `true` and the explanation rides under `:validation-error`.
+    - Query keys the route declares (via `:query` / `:query-defaults`) come back as keyword keys, in a deterministic canonical order. Undeclared keys stay strings.
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
@@ -129,18 +129,18 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
   ```
 - **Description**: Render a route to a URL — the inverse of `match-url`. Takes one **address map**; pure; JVM-runnable.
 
-  - `:to` is the only required key (requests spell the route id `:to`; facts spell it `:route-id`). `:params`, `:query`, and `:fragment` are optional.
-  - `:fragment` appends `#fragment` when it is a non-empty string (`nil` / `""` append nothing).
-  - Nil-valued query keys are silently elided. A nil required path param is an error.
-  - A query key already at the route's declared `:query-defaults` value is **not emitted** — `match-url` fills it back, so spelling it would give one destination two URLs. Validation still runs against the caller's full query.
-  - Query keys are emitted percent-encoded, in a deterministic canonical order.
-  - **Address-only.** `:url`, `:query-merge`, policy keys (`:replace?` / `:scroll` / `:bypass-leave?`), and any unknown key reject **loud** (`:rf.error/route-url-validation`, `:reason :bad-address-keys`) rather than being silently ignored. There is no in-place form — a pure helper cannot read the current route.
+    - `:to` is the only required key (requests spell the route id `:to`; facts spell it `:route-id`). `:params`, `:query`, and `:fragment` are optional.
+    - `:fragment` appends `#fragment` when it is a non-empty string (`nil` / `""` append nothing).
+    - Nil-valued query keys are silently elided. A nil required path param is an error.
+    - A query key already at the route's declared `:query-defaults` value is **not emitted** — `match-url` fills it back, so spelling it would give one destination two URLs. Validation still runs against the caller's full query.
+    - Query keys are emitted percent-encoded, in a deterministic canonical order.
+    - **Address-only.** `:url`, `:query-merge`, policy keys (`:replace?` / `:scroll` / `:bypass-leave?`), and any unknown key reject **loud** (`:rf.error/route-url-validation`, `:reason :bad-address-keys`) rather than being silently ignored. There is no in-place form — a pure helper cannot read the current route.
 
   Throws:
-  - `:rf.error/no-such-route` — `:to` route not registered.
-  - `:rf.error/missing-route-param` — a required path segment's param is nil or absent.
-  - `:rf.error/route-url-validation` — `:params` / `:query` fail the route's `:params` / `:query` schemas, or the map carries non-address keys.
-  - `:rf.error/route-url-non-edn-value` — non-EDN param/query values or a non-string fragment.
+    - `:rf.error/no-such-route` — `:to` route not registered.
+    - `:rf.error/missing-route-param` — a required path segment's param is nil or absent.
+    - `:rf.error/route-url-validation` — `:params` / `:query` fail the route's `:params` / `:query` schemas, or the map carries non-address keys.
+    - `:rf.error/route-url-non-edn-value` — non-EDN param/query values or a non-string fragment.
 - **Example**:
   ```clojure
   ;; with (rf/reg-route :user/show {} "/users/:id") registered:
@@ -278,9 +278,9 @@ The nav-token and pending-nav allocators are host-side, per-frame, monotonic hig
   ```
 - **Description**: The canonical classification of every piece of per-frame routing state, by tier. Consumed by SSR, docs, and Spec-Schemas so the durable/transient split has one home.
 
-  - `:durable-runtime-db` — serializable facts needed to reconstitute a coherent frame on restore / SSR-hydration; the route slice at `:current`.
-  - `:local-subscribable-runtime-db` — runtime-db state that stays subscribable and restores in local replay but is SSR-stripped fail-closed; the `:pending-navigation` slot.
-  - `:host-transient` — host-derived caches never in runtime-db; saved scroll positions and the two allocator high-water marks.
+    - `:durable-runtime-db` — serializable facts needed to reconstitute a coherent frame on restore / SSR-hydration; the route slice at `:current`.
+    - `:local-subscribable-runtime-db` — runtime-db state that stays subscribable and restores in local replay but is SSR-stripped fail-closed; the `:pending-navigation` slot.
+    - `:host-transient` — host-derived caches never in runtime-db; saved scroll positions and the two allocator high-water marks.
 
 ### `reset-nav-counters!`
 
@@ -304,9 +304,9 @@ At most one frame owns the browser URL at a time. A frame claims ownership by re
   ```
 - **Description**: Return the single frame that has explicitly declared browser-history ownership via `(rf/make-frame {:id … :url-bound? true})`, or `nil` when none has.
 
-  - URL ownership is an explicit host/bootstrap policy, not an absence repair. The runtime never infers `:rf/default` as the owner. `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}`, like any other frame.
-  - Ownership resolves to the first-claimed still-live `:url-bound? true` frame (the incumbent), so a later duplicate cannot steal the URL.
-  - `nil` means no owner is declared. In that case outbound history fxs no-op and the inbound popstate listener skips.
+    - URL ownership is an explicit host/bootstrap policy, not an absence repair. The runtime never infers `:rf/default` as the owner. `:rf/default` owns the URL only when it carries an explicit `{:url-bound? true}`, like any other frame.
+    - Ownership resolves to the first-claimed still-live `:url-bound? true` frame (the incumbent), so a later duplicate cannot steal the URL.
+    - `nil` means no owner is declared. In that case outbound history fxs no-op and the inbound popstate listener skips.
 - **Example**:
   ```clojure
   ;; one frame opts into URL ownership at boot:
@@ -336,9 +336,9 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```
 - **Description**: The default URL strategy: HTML5 History, path-form. A frame that declares no `:url-strategy` uses this.
 
-  - `:encode` / `:decode` are identity over the app-relative URL (`:decode` reads `pathname + search + hash`).
-  - `:push!` / `:replace!` drive `pushState` / `replaceState`.
-  - `:install-listener!` wires `popstate`.
+    - `:encode` / `:decode` are identity over the app-relative URL (`:decode` reads `pathname + search + hash`).
+    - `:push!` / `:replace!` drive `pushState` / `replaceState`.
+    - `:install-listener!` wires `popstate`.
 
 ### `hash-url-strategy`
 
@@ -349,9 +349,9 @@ A `:url-strategy` is a frame-level config map declared on the URL-owning frame �
   ```
 - **Description**: The hash URL strategy: `#`-prefixed URLs (`#/active`) for no-server-rewrite static hosting and secretary-era v1 migrations. `route-url` still builds path-form `/active`.
 
-  - `:encode` maps it to `#/active` at the `route-link` href and the history fxs.
-  - `:decode` strips the leading `#` from `window.location.hash` (an empty hash decodes to `/`).
-  - `:install-listener!` wires `hashchange`.
+    - `:encode` maps it to `#/active` at the `route-link` href and the history fxs.
+    - `:decode` strips the leading `#` from `window.location.hash` (an empty hash decodes to `/`).
+    - `:install-listener!` wires `hashchange`.
 - **Example**:
   ```clojure
   (rf/make-frame {:id :app
@@ -400,13 +400,13 @@ The `:route/link` registered view renders an `<a href=...>` from a route id. It 
   ```
 - **Description**: The registered `:route/link` view.
 
-  - `:to` is the only required key. `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis. `:prefetch` is the one behaviour key (below). Every other props key passes through to the `<a>` element — including `:aria-current` and `:class`, which is how an "active link" is styled: `route-link` computes **no** active state, so compare `:to` against `:rf.route/id` (or `:rf.route/chain`) in your own view. See [Routing → Highlighting the active link](../routing/concepts.md#highlighting-the-active-link).
-  - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted. The view calls `preventDefault`, then dispatches `[:rf.route/url-requested {:url ...}]` targeted at the frame that rendered the link. One key: a raw URL is the whole address, and the handler re-derives the route from it.
-  - Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser.
-  - A caller-supplied `:on-click` runs first. If it calls `preventDefault`, the framework's interception is skipped.
-  - `:prefetch :intent` warms the destination on hover, focus, or touch by dispatching [`:rf.route/prefetch`](#events) with the link's own address (`:fragment` excluded — a fragment is never a resource input). `:intent` is the only accepted value, and **omitting** `:prefetch` is the only way to opt out — a key present with any other value (including `true`, `false`, `nil`, or a mode borrowed from another router) throws `:rf.error/route-link-bad-prefetch` at the render site rather than quietly rendering a passive link. Caller-supplied `:on-mouse-enter` / `:on-focus` / `:on-touch-start` handlers still run — the framework composes rather than replaces. The intent *handlers* are CLJS-only (SSR renders the anchor with none), but the value is validated on both hosts, so the server shell never accepts a mode the hydrated client rejects. `re-frame.fresco/route-link` honours the same key from the same calculation, reached through the `:routing/link-model` seam; because Fresco's grammar carries one intent per position it *refuses* a caller value at a claimed position rather than composing — see [Fresco → Routing and navigation](../core/fresco/07-routing-and-navigation.md).
-  - The rendered href is encoded through the rendering frame's `:url-strategy` — on both hosts, so the server shell and the hydrated client agree.
-  - On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
+    - `:to` is the only required key. `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis. `:prefetch` is the one behaviour key (below). Every other props key passes through to the `<a>` element — including `:aria-current` and `:class`, which is how an "active link" is styled: `route-link` computes **no** active state, so compare `:to` against `:rf.route/id` (or `:rf.route/chain`) in your own view. See [Routing → Highlighting the active link](../routing/concepts.md#highlighting-the-active-link).
+    - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted. The view calls `preventDefault`, then dispatches `[:rf.route/url-requested {:url ...}]` targeted at the frame that rendered the link. One key: a raw URL is the whole address, and the handler re-derives the route from it.
+    - Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser.
+    - A caller-supplied `:on-click` runs first. If it calls `preventDefault`, the framework's interception is skipped.
+    - `:prefetch :intent` warms the destination on hover, focus, or touch by dispatching [`:rf.route/prefetch`](#events) with the link's own address (`:fragment` excluded — a fragment is never a resource input). `:intent` is the only accepted value, and **omitting** `:prefetch` is the only way to opt out — a key present with any other value (including `true`, `false`, `nil`, or a mode borrowed from another router) throws `:rf.error/route-link-bad-prefetch` at the render site rather than quietly rendering a passive link. Caller-supplied `:on-mouse-enter` / `:on-focus` / `:on-touch-start` handlers still run — the framework composes rather than replaces. The intent *handlers* are CLJS-only (SSR renders the anchor with none), but the value is validated on both hosts, so the server shell never accepts a mode the hydrated client rejects. `re-frame.fresco/route-link` honours the same key from the same calculation, reached through the `:routing/link-model` seam; because Fresco's grammar carries one intent per position it *refuses* a caller value at a claimed position rather than composing — see [Fresco → Routing and navigation](../core/fresco/07-routing-and-navigation.md).
+    - The rendered href is encoded through the rendering frame's `:url-strategy` — on both hosts, so the server shell and the hydrated client agree.
+    - On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
 - **Example**:
   ```clojure
   [rf/route-link {:to :user/show :params {:id 42} :class "nav-item"}

--- a/docs/api/re-frame.schemas.md
+++ b/docs/api/re-frame.schemas.md
@@ -30,17 +30,17 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   (reg-app-schema path metadata schema)
   ```
 - **Description**: Attach a Malli schema to an `app-db` path.
-  - **Development-build assertion, not a production guarantee.** A production build still performs this registration — `app-schemas` and `app-schema-meta` keep answering — but the candidate validator is elided, so nothing checks the schema. A candidate that violates it installs silently: no rejection, no rollback, no trace. Your app-db schemas do not run in production builds. Keep the invariant that must hold in production in the handler, and set [`:boundary? true`](re-frame.core.md#reg-event) on the registration where untrusted input must be validated in production too.
-  - The schema is the **positional value slot** (rf2-qm7k83 Part A), uniform with the rest of the `reg-*` family. The optional middle metadata map carries the frame target under `:frame` (a frame-id keyword or a frame value), plus `:doc` and open `:my/*` keys.
-  - The **path is the registration id**. App-db schemas are path-keyed and live in the schemas artefact's per-frame side-table; they are NOT a registrar kind. `(app-schema-meta {:frame f :path [:user]})` looks up by the same path vector.
-  - `path` is a sequential `get-in` path of concrete segments, normalized to canonical vector form. `[]` registers a whole-`app-db` root schema. Returns the normalized path.
-  - Raises:
-    - `:rf.error/app-schema-bad-metadata` — the middle metadata arg in the 3-slot form is not a map.
-    - `:rf.error/app-schema-bad-path` — a non-sequential path, or a non-concrete segment.
-    - `:rf.error/app-schema-runtime-path` — the first segment reaches the runtime-db partition (`:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root).
-    - `:rf.error/app-schemas-bad-arg` — a `:frame` target that does not resolve to a keyword frame id.
-    - `:rf.error/no-frame-context` — no `:frame` and no established frame scope.
-  - Dev-only diagnostics: re-registering a schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace. Registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
+    - **Development-build assertion, not a production guarantee.** A production build still performs this registration — `app-schemas` and `app-schema-meta` keep answering — but the candidate validator is elided, so nothing checks the schema. A candidate that violates it installs silently: no rejection, no rollback, no trace. Your app-db schemas do not run in production builds. Keep the invariant that must hold in production in the handler, and set [`:boundary? true`](re-frame.core.md#reg-event) on the registration where untrusted input must be validated in production too.
+    - The schema is the **positional value slot** (rf2-qm7k83 Part A), uniform with the rest of the `reg-*` family. The optional middle metadata map carries the frame target under `:frame` (a frame-id keyword or a frame value), plus `:doc` and open `:my/*` keys.
+    - The **path is the registration id**. App-db schemas are path-keyed and live in the schemas artefact's per-frame side-table; they are NOT a registrar kind. `(app-schema-meta {:frame f :path [:user]})` looks up by the same path vector.
+    - `path` is a sequential `get-in` path of concrete segments, normalized to canonical vector form. `[]` registers a whole-`app-db` root schema. Returns the normalized path.
+    - Raises:
+        - `:rf.error/app-schema-bad-metadata` — the middle metadata arg in the 3-slot form is not a map.
+        - `:rf.error/app-schema-bad-path` — a non-sequential path, or a non-concrete segment.
+        - `:rf.error/app-schema-runtime-path` — the first segment reaches the runtime-db partition (`:rf.runtime/*`, `:rf.db/runtime`, or the legacy `:rf/runtime` root).
+        - `:rf.error/app-schemas-bad-arg` — a `:frame` target that does not resolve to a keyword frame id.
+        - `:rf.error/no-frame-context` — no `:frame` and no established frame scope.
+    - Dev-only diagnostics: re-registering a schema at a path whose live `app-db` value fails the new schema emits an `:rf.schema/violation` warning trace. Registering an opaque compiled schema the per-slot walker cannot introspect warns once per process with `:rf.warning/schema-walker-opaque`.
 - **Example**:
   ```clojure
   (rf/reg-app-schema [:cells]
@@ -56,12 +56,12 @@ The registration macros live in `re-frame.core` and route through the schemas ar
   (reg-app-schemas {path-1 schema-1, ...} opts-or-frame-id)
   ```
 - **Description**: Bulk plural form of `reg-app-schema`.
-  - **Development-build assertion**, exactly as for the singular form: every entry registers in a production build but is never checked there.
-  - Each entry routes through the singular form and is stamped with this call's source coords.
-  - The optional second arg names the frame for every entry: an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value. One frame per call.
-  - Returns the vector of paths registered, in map-iteration order. `{}` is the documented empty no-op.
-  - Every path is shape-checked before any store mutation, so a batch containing one invalid path (`:rf.error/app-schema-bad-path` / `:rf.error/app-schema-runtime-path`) registers nothing.
-  - A `nil` / non-map first arg raises `:rf.error/app-schemas-bad-batch`.
+    - **Development-build assertion**, exactly as for the singular form: every entry registers in a production build but is never checked there.
+    - Each entry routes through the singular form and is stamped with this call's source coords.
+    - The optional second arg names the frame for every entry: an opts map (`{:frame target}`), a bare frame-id keyword, or a frame value. One frame per call.
+    - Returns the vector of paths registered, in map-iteration order. `{}` is the documented empty no-op.
+    - Every path is shape-checked before any store mutation, so a batch containing one invalid path (`:rf.error/app-schema-bad-path` / `:rf.error/app-schema-runtime-path`) registers nothing.
+    - A `nil` / non-map first arg raises `:rf.error/app-schemas-bad-batch`.
 - **Example**:
   ```clojure
   (rf/reg-app-schemas
@@ -88,9 +88,9 @@ Reading a frame that holds no schemas answers `{}` / `nil` / the empty-set diges
   (app-schemas {:frame f}) → {path registration-metadata}
   ```
 - **Description**: Return a frame's whole `{path → registration-metadata}` map, or `{}`.
-  - This is the same `{id → meta}` shape [`rf/registrations`](re-frame.core.md#registrations) answers for registrar kinds.
-  - Each value is the meta stamped at `reg-app-schema`: `:path`, `:schema`, `:frame`, source-coords (`:ns` / `:line` / `:file`), and the rest of `:rf/registration-metadata`.
-  - Project `:schema` when only the schema values are wanted.
+    - This is the same `{id → meta}` shape [`rf/registrations`](re-frame.core.md#registrations) answers for registrar kinds.
+    - Each value is the meta stamped at `reg-app-schema`: `:path`, `:schema`, `:frame`, source-coords (`:ns` / `:line` / `:file`), and the rest of `:rf/registration-metadata`.
+    - Project `:schema` when only the schema values are wanted.
 - **Example**:
   ```clojure
   ;; every registration in the default frame
@@ -111,9 +111,9 @@ Reading a frame that holds no schemas answers `{}` / `nil` / the empty-set diges
   (app-schema-meta {:frame f :path p}) → registration-metadata or nil
   ```
 - **Description**: Return one path's registration-metadata map in a frame, or `nil` when nothing is registered there.
-  - Contains `:path`, `:schema`, `:frame`, source-coords (`:ns` / `:line` / `:file`), and the rest of `:rf/registration-metadata`.
-  - The registered schema alone is `(:schema ...)`.
-  - Both keys are required.
+    - Contains `:path`, `:schema`, `:frame`, source-coords (`:ns` / `:line` / `:file`), and the rest of `:rf/registration-metadata`.
+    - The registered schema alone is `(:schema ...)`.
+    - Both keys are required.
 - **Example**:
   ```clojure
   ;; the registration anchor — schema value plus source coords for click-back
@@ -133,10 +133,10 @@ Reading a frame that holds no schemas answers `{}` / `nil` / the empty-set diges
   (app-schemas-digest {:frame f}) → string
   ```
 - **Description**: Return a single hash over the frame's whole schema surface.
-  - Canonical wire form: `"sha256:"` followed by the first 16 lowercase hex chars.
-  - Byte-deterministic across runtimes. The empty schema set produces a stable digest.
-  - Computed over the `{path → schema}` projection of `app-schemas`, so its bytes do not depend on the registration metadata riding alongside.
-  - SSR hydration compatibility checks use it. So do tools that want to know whether the schema corpus changed, without diffing schema-by-schema.
+    - Canonical wire form: `"sha256:"` followed by the first 16 lowercase hex chars.
+    - Byte-deterministic across runtimes. The empty schema set produces a stable digest.
+    - Computed over the `{path → schema}` projection of `app-schemas`, so its bytes do not depend on the registration metadata riding alongside.
+    - SSR hydration compatibility checks use it. So do tools that want to know whether the schema corpus changed, without diffing schema-by-schema.
 - **Example**:
   ```clojure
   ;; one stable hash over the whole frame's schema surface
@@ -166,12 +166,12 @@ On every surface, a structurally malformed registered schema (one that makes the
   (validate-app-schema! db event-id frame-id)  ;; explicit frame
   ```
 - **Description**: After a handler commits `:db`, walk every registered app-schema for the named frame and validate the post-commit `app-db`. Only the named frame's schemas are walked.
-  - Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached. Value-bearing slots are redacted when the failing slot is `:sensitive?`.
-  - A malformed entry (the validator throws) emits `:rf.error/malformed-schema` for that entry, contributes `false`, and does not stop sibling schemas from validating.
-  - `event-id` (optional) names the handler whose commit prompted the failure — surfaced as `:failing-id`.
-  - Returns `true` when every registered schema conformed. Also returns `true` when no validator is registered, no schemas are registered for the frame, or the build elided validation.
-  - Returns `false` when at least one schema failed. The router consumes a `false` to roll the `:db` effect back to the pre-handler value.
-  - A hard no-op for every schema when `set-schema-fns!` has installed a `nil` `:validate`.
+    - Failures emit `:rf.error/schema-validation-failure` (one trace per failing entry) with the registered explainer's output attached. Value-bearing slots are redacted when the failing slot is `:sensitive?`.
+    - A malformed entry (the validator throws) emits `:rf.error/malformed-schema` for that entry, contributes `false`, and does not stop sibling schemas from validating.
+    - `event-id` (optional) names the handler whose commit prompted the failure — surfaced as `:failing-id`.
+    - Returns `true` when every registered schema conformed. Also returns `true` when no validator is registered, no schemas are registered for the frame, or the build elided validation.
+    - Returns `false` when at least one schema failed. The router consumes a `false` to roll the `:db` effect back to the pre-handler value.
+    - A hard no-op for every schema when `set-schema-fns!` has installed a `nil` `:validate`.
 
 ### `validate-event!`
 
@@ -182,10 +182,10 @@ On every surface, a structurally malformed registered schema (one that makes the
   (validate-event! event-id event handler-meta frame)
   ```
 - **Description**: Before an event handler runs, validate the event vector against any `:schema` on the handler's registration metadata.
-  - On failure, emits `:rf.error/schema-validation-failure :where :event`. The caller skips the handler (recovery `:no-recovery`).
-  - A `:sensitive?` slot anywhere in the event schema redacts the value-bearing trace slots. The common case is a `:cat` / `:catn` payload slot, such as a `:password` slot in a login schema.
-  - The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (read by the Xray Issues / Schema-timeline lens). The runtime passes it; direct callers may omit it.
-  - Returns `true`/`false`.
+    - On failure, emits `:rf.error/schema-validation-failure :where :event`. The caller skips the handler (recovery `:no-recovery`).
+    - A `:sensitive?` slot anywhere in the event schema redacts the value-bearing trace slots. The common case is a `:cat` / `:catn` payload slot, such as a `:password` slot in a login schema.
+    - The optional `frame` arg stamps a `:frame` tag so the violation is captured into the in-flight epoch's `:trace-events` (read by the Xray Issues / Schema-timeline lens). The runtime passes it; direct callers may omit it.
+    - Returns `true`/`false`.
 
 ### `validate-fx!`
 
@@ -196,9 +196,9 @@ On every surface, a structurally malformed registered schema (one that makes the
   (validate-fx! fx-id event-id args fx-meta frame)
   ```
 - **Description**: Before an fx handler runs, validate its args against any `:schema` on the fx's registration metadata.
-  - On failure, emits `:rf.error/schema-validation-failure :where :fx-args`. Only the offending fx is skipped (recovery `:skipped`). Sibling fx in the same `:fx` vector still run, and downstream queued events still drain.
-  - The optional `frame` arg stamps a `:frame` tag for epoch capture.
-  - Returns `true`/`false`.
+    - On failure, emits `:rf.error/schema-validation-failure :where :fx-args`. Only the offending fx is skipped (recovery `:skipped`). Sibling fx in the same `:fx` vector still run, and downstream queued events still drain.
+    - The optional `frame` arg stamps a `:frame` tag for epoch capture.
+    - Returns `true`/`false`.
 
 ### `validate-sub!`
 
@@ -209,9 +209,9 @@ On every surface, a structurally malformed registered schema (one that makes the
   (validate-sub! sub-id query-v value sub-meta frame)
   ```
 - **Description**: After a subscription recomputes, validate its return value against any `:schema` on the sub's registration metadata.
-  - On failure, emits `:rf.error/schema-validation-failure :where :sub-return`. The caller replaces the value with the default (recovery `:replaced-with-default`).
-  - The optional `frame` arg stamps a `:frame` tag for epoch capture.
-  - Returns `true`/`false`.
+    - On failure, emits `:rf.error/schema-validation-failure :where :sub-return`. The caller replaces the value with the default (recovery `:replaced-with-default`).
+    - The optional `frame` arg stamps a `:frame` tag for epoch capture.
+    - Returns `true`/`false`.
 
 ## Boundary validation and redaction seams
 
@@ -225,10 +225,10 @@ These three functions are the production-side and cross-artefact seams. `validat
   (validate-with-registered-fn schema value) → boolean
   ```
 - **Description**: Apply the registered validator to `(schema, value)`. This is the public check seam the `:boundary? true` check uses. It runs in production, outside the `debug-enabled?` gate the `validate-*!` hot path sits behind.
-  - Returns `true` on conform.
-  - Returns `false` on fail, including when a structurally malformed schema makes the validator throw (**fail closed**).
-  - Returns `true` when no validator is registered. No-validator means no-validation, mirroring the hot path.
-  - Does NOT emit a trace (the boundary check owns the failure envelope) and does NOT consult `debug-enabled?`.
+    - Returns `true` on conform.
+    - Returns `false` on fail, including when a structurally malformed schema makes the validator throw (**fail closed**).
+    - Returns `true` when no validator is registered. No-validator means no-validation, mirroring the hot path.
+    - Does NOT emit a trace (the boundary check owns the failure envelope) and does NOT consult `debug-enabled?`.
 
 ### `explain-with-registered-fn`
 
@@ -238,8 +238,8 @@ These three functions are the production-side and cross-artefact seams. `validat
   (explain-with-registered-fn schema value) → explanation | nil
   ```
 - **Description**: Apply the registered explainer to `(schema, value)`. Companion to `validate-with-registered-fn` for the boundary check.
-  - Returns the explanation map / data on fail.
-  - Returns `nil` when the value conforms, when no explainer is registered, or when the explainer throws. A throwing explainer degrades to `nil` because diagnostics must never change the verdict.
+    - Returns the explanation map / data on fail.
+    - Returns `nil` when the value conforms, when no explainer is registered, or when the explainer throws. A throwing explainer degrades to `nil` because diagnostics must never change the verdict.
 
 ### `redact-validation-tags`
 
@@ -249,10 +249,10 @@ These three functions are the production-side and cross-artefact seams. `validat
   (redact-validation-tags schema tags) → tags
   ```
 - **Description**: The shared schema-aware redaction seam for every validation-failure trace emitted OUTSIDE this namespace. Its callers are the always-on boundary check, machine `:data` validation, the `:sub-override` path, flow-output validation, and the recordable-coeffect `:rf.error/cofx-value-invalid` emit. Given the `schema` the failing value was checked against and a failure-trace `tags` map, it returns the tags with:
-  - a `:sensitive?` schema → the value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted`, and `:sensitive? true` stamped. An opaque compiled schema the walker cannot introspect fails closed and is treated as sensitive.
-  - a `:large?` (non-sensitive) schema → those same slots elided to the `:rf.size/large-elided` marker.
-  - otherwise → the tags ride back verbatim.
-  - Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook. When the schemas artefact is absent, the tags fall through verbatim. Idempotent.
+    - a `:sensitive?` schema → the value-bearing slots (`:value` / `:received` / `:explain` / `:explain-humanized` / `:rf.fx/args` / `:rf.sub/query-v`) scrubbed to `:rf/redacted`, and `:sensitive? true` stamped. An opaque compiled schema the walker cannot introspect fails closed and is treated as sensitive.
+    - a `:large?` (non-sensitive) schema → those same slots elided to the `:rf.size/large-elided` marker.
+    - otherwise → the tags ride back verbatim.
+    - Off-namespace callers reach it through the `:schemas/redact-validation-tags` late-bind hook. When the schemas artefact is absent, the tags fall through verbatim. Idempotent.
 
 ## Validator extension seam
 
@@ -266,12 +266,12 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   (set-schema-fns! {:validate validate-fn :explain explain-fn :print print-fn})
   ```
 - **Description**: Install any subset of the validator / explainer / printer bundle from a single map. This is the one door onto the validator port.
-  - Each key is optional; an **absent** key leaves the existing registration in place, so a one-key call is how you swap a single fn. An **explicit `nil`** is a write: `nil` `:validate` or `:explain` disables that fn.
-  - A `nil` `:print` coerces to the default EDN canonicaliser, so the printer is never nil and the digest is never undefined.
-  - `validate-fn` is `(fn [schema value] truthy?)` — the `malli.core/validate` shape. `explain-fn` is `(fn [schema value] explanation)` — the `malli.core/explain` shape. `print-fn` is `(fn [schema-value] canonical-string)` and must be pure and deterministic across runtimes.
-  - Last-write-wins per key; writes are not transactional.
-  - Returns the installed bundle map `{:validate … :explain … :print …}`, reflecting the live state of all three fns after the call — including keys the call did not touch. A caller wanting back just the fn it installed selects that key.
-  - This is the one-call substitute-Malli boot pattern: the three fns never drift mid-boot. It is also the restore path — hand it a value from `schema-fns` or `default-schema-fns`.
+    - Each key is optional; an **absent** key leaves the existing registration in place, so a one-key call is how you swap a single fn. An **explicit `nil`** is a write: `nil` `:validate` or `:explain` disables that fn.
+    - A `nil` `:print` coerces to the default EDN canonicaliser, so the printer is never nil and the digest is never undefined.
+    - `validate-fn` is `(fn [schema value] truthy?)` — the `malli.core/validate` shape. `explain-fn` is `(fn [schema value] explanation)` — the `malli.core/explain` shape. `print-fn` is `(fn [schema-value] canonical-string)` and must be pure and deterministic across runtimes.
+    - Last-write-wins per key; writes are not transactional.
+    - Returns the installed bundle map `{:validate … :explain … :print …}`, reflecting the live state of all three fns after the call — including keys the call did not touch. A caller wanting back just the fn it installed selects that key.
+    - This is the one-call substitute-Malli boot pattern: the three fns never drift mid-boot. It is also the restore path — hand it a value from `schema-fns` or `default-schema-fns`.
 - **Example**:
   ```clojure
   ;; install validator + explainer together (e.g. a clojure.spec or Zod port)
@@ -296,9 +296,9 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   (schema-fns) → {:validate fn|nil :explain fn|nil :print fn}
   ```
 - **Description**: Read the currently-installed validator / explainer / printer as one value, in the same shape `set-schema-fns!` accepts and returns.
-  - `(set-schema-fns! (schema-fns))` is a no-op — the pair round-trips.
-  - `:validate` / `:explain` may be `nil`; `:print` is never `nil`.
-  - This is what test isolation is built from: capture, stub, and reinstate without reaching the framework-internal atoms and without a dedicated snapshot or restore verb. The registry-level counterpart for the per-frame schema store is `snapshot-schemas-by-frame`.
+    - `(set-schema-fns! (schema-fns))` is a no-op — the pair round-trips.
+    - `:validate` / `:explain` may be `nil`; `:print` is never `nil`.
+    - This is what test isolation is built from: capture, stub, and reinstate without reaching the framework-internal atoms and without a dedicated snapshot or restore verb. The registry-level counterpart for the per-frame schema store is `snapshot-schemas-by-frame`.
 - **Example**:
   ```clojure
   ;; capture / stub / restore is an ordinary let + finally over a value
@@ -318,9 +318,9 @@ The default validator ships Malli's `validate` / `explain` pair (plus an EDN can
   default-schema-fns → {:validate fn :explain fn :print fn}
   ```
 - **Description**: The framework's own validator bundle as a plain map carrying exactly `:validate`, `:explain` and `:print` — the state the port holds before an app installs anything.
-  - Install it to restore the framework defaults: `(set-schema-fns! default-schema-fns)`.
-  - Because the value carries the same fn objects the port was seeded with, the "still on the framework default" check behind `:rf.warning/schema-validator-unavailable` answers true again afterwards. Rebuilding an equal-but-distinct bundle by hand would not.
-  - It is the **framework** default, not "the Malli bundle": `:print` is the EDN canonicaliser rather than anything Malli supplies, and `:validate` / `:explain` soft-pass while the Malli adapter is unloaded.
+    - Install it to restore the framework defaults: `(set-schema-fns! default-schema-fns)`.
+    - Because the value carries the same fn objects the port was seeded with, the "still on the framework default" check behind `:rf.warning/schema-validator-unavailable` answers true again afterwards. Rebuilding an equal-but-distinct bundle by hand would not.
+    - It is the **framework** default, not "the Malli bundle": `:print` is the EDN canonicaliser rather than anything Malli supplies, and `:validate` / `:explain` soft-pass while the Malli adapter is unloaded.
 - **Example**:
   ```clojure
   ;; restore the framework defaults after a test swapped them out
@@ -345,8 +345,8 @@ They describe **shape**, not durable egress policy — for `app-db` or for anyth
   (extract-large-paths-from-schema schema base-path) → {path declaration}
   ```
 - **Description**: Walk a Malli schema EDN form at `base-path` and return a `{path declaration}` map for every `:large? true` slot found.
-  - Each declaration carries `:source :schema`, plus `:hint` propagated verbatim when the slot props carry one.
-  - This is the pure-data `:large?` extractor the owner-local size-elision consumers read directly. It does NOT feed the `app-db` egress registry — that registry is frame-owned.
+    - Each declaration carries `:source :schema`, plus `:hint` propagated verbatim when the slot props carry one.
+    - This is the pure-data `:large?` extractor the owner-local size-elision consumers read directly. It does NOT feed the `app-db` egress registry — that registry is frame-owned.
 - **Example**:
   ```clojure
   (schemas/extract-large-paths-from-schema
@@ -394,8 +394,8 @@ They describe **shape**, not durable egress policy — for `app-db` or for anyth
   (schema-sensitive-at? schema in-path) → boolean
   ```
 - **Description**: Path-targeted sensitivity check. `true` when the slot at `in-path` is sensitive. Two cases count: an **ancestor** along the path is `:sensitive?` (the failing slot sits under a sensitive container), or a **descendant** of the slot is `:sensitive?` (the slot's value carries a sensitive child).
-  - `in-path` is the value-relative path Malli reports as `:in`. A `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`.
-  - This is the leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot. A non-sensitive failing leaf whose *sibling* is sensitive is therefore not over-redacted.
+    - `in-path` is the value-relative path Malli reports as `:in`. A `nil` or empty `in-path` is equivalent to `schema-has-sensitive?`.
+    - This is the leaf-precise check the `app-db` hot path uses for its narrowed `:value` slot. A non-sensitive failing leaf whose *sibling* is sensitive is therefore not over-redacted.
 
 ### `schema-opaque?`
 
@@ -472,8 +472,8 @@ The per-frame registry and diagnostic-latch maintenance hooks. `re-frame.test-su
   (clear-edn-print-cache!)
   ```
 - **Description**: Reset the `app-schemas-digest` printer memo. Returns `nil`.
-  - Test-support only. The memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this.
-  - A test that registers many distinct fresh schemas clears it in fixture teardown so the cache doesn't grow unbounded across the suite.
+    - Test-support only. The memo is process-lifetime and bounded by the registered-schema cardinality (schemas register once at boot), so production never needs this.
+    - A test that registers many distinct fresh schemas clears it in fixture teardown so the cache doesn't grow unbounded across the suite.
 
 ### `clear-sensitive-paths-cache!`
 

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -27,16 +27,16 @@ Everything else is reached at home. `ssr/render-to-string`, `ssr/render-tree-has
   (render-to-string view-or-hiccup opts) → HTML string
   ```
 - **Description**: The canonical server-side render. Walks the hiccup tree once and emits a string. Pure and JVM-runnable.
-  - It resolves callable-headed views (Var / `(rf/view :id)`), `:tag#id.cls` shorthand, and HTML5 void elements. It escapes text and attribute values.
-  - Ordinary inline `<script>` / `<style>` string content is HTML **raw text**: emitted verbatim with only React's context-safe closing-sequence rewrite (an embedded `</script>` / `</style>` breakout is respelled so the parser cannot terminate the element early), never entity-escaped and never refused. This is byte-identical across `render-to-string`, the streaming shell walk, and `emit-ui-tree`. Structured data belongs on its own channel: JSON-LD / head content via `reg-head` (which applies the stricter `<`→`<` data escape), the hydration payload via the `__rf_payload` wire.
-  - `opts` keys (all optional):
-    - `:doctype?` — prefixes `<!DOCTYPE html>`.
-    - `:render-hash` — the hash to stamp as `data-rf-render-hash` on the tree's first DOM-tag element, for client-side mismatch detection. Compute it with `render-tree-hash` and spend the one hash on both the marker and your payload's `:rf/render-hash`; omit the key for no marker.
-  - Raises:
-    - `:rf.error/invalid-tag-name` — malformed tag name.
-    - `:rf.error/ssr-invalid-attribute-name` — malformed attribute key.
-    - `:rf.error/ssr-reagent-native-head` — a `:>` interop head.
-    - `:rf.error/ssr-suspense-boundary-outside-stream` — a `:rf/suspense-boundary` marker reached this non-streaming emitter.
+    - It resolves callable-headed views (Var / `(rf/view :id)`), `:tag#id.cls` shorthand, and HTML5 void elements. It escapes text and attribute values.
+    - Ordinary inline `<script>` / `<style>` string content is HTML **raw text**: emitted verbatim with only React's context-safe closing-sequence rewrite (an embedded `</script>` / `</style>` breakout is respelled so the parser cannot terminate the element early), never entity-escaped and never refused. This is byte-identical across `render-to-string`, the streaming shell walk, and `emit-ui-tree`. Structured data belongs on its own channel: JSON-LD / head content via `reg-head` (which applies the stricter `<`→`<` data escape), the hydration payload via the `__rf_payload` wire.
+    - `opts` keys (all optional):
+        - `:doctype?` — prefixes `<!DOCTYPE html>`.
+        - `:render-hash` — the hash to stamp as `data-rf-render-hash` on the tree's first DOM-tag element, for client-side mismatch detection. Compute it with `render-tree-hash` and spend the one hash on both the marker and your payload's `:rf/render-hash`; omit the key for no marker.
+    - Raises:
+        - `:rf.error/invalid-tag-name` — malformed tag name.
+        - `:rf.error/ssr-invalid-attribute-name` — malformed attribute key.
+        - `:rf.error/ssr-reagent-native-head` — a `:>` interop head.
+        - `:rf.error/ssr-suspense-boundary-outside-stream` — a `:rf/suspense-boundary` marker reached this non-streaming emitter.
 - **Example**:
   ```clojure
   (rf/with-new-frame [f (rf/make-frame {:images [app-image]})]
@@ -53,12 +53,12 @@ Everything else is reached at home. `ssr/render-to-string`, `ssr/render-tree-has
   (emit-ui-tree tree opts) → HTML string
   ```
 - **Description**: Serialises an **already-rendered** version-1 structural tree to a string. Where `render-to-string` consumes hiccup and renders it, this seam consumes a tree some other producer has already emitted — the version-1 tree ABI of [Spec 004B](../../spec/004B-UI-Tree-and-Conversion.md), which outlived the donor substrate that first emitted it — and calls nothing: no view is invoked, no subscription is resolved, no frame is bound. Every dynamic value is already a literal in the tree. Pure, JVM-runnable, and deterministic to the byte.
-  - It emits the markup for one root's tree only. Manifests, payloads, root identity, and the HTTP response belong to the SSR artefact's other surfaces.
-  - `opts` keys (all optional):
-    - `:doctype?` — prefixes `<!DOCTYPE html>`.
-  - Raises:
-    - `:rf.error/ssr-ui-tree-version-unsupported` — the root `:rf.ui/tree-version` is missing, non-integer, or unsupported. Checked **first**, before any emission, and carries `{:got <received> :supported #{1}}`. This is a deploy-skew condition: the server is older than the tree it was handed.
-    - `:rf.error/ui-tree-malformed` — a structurally invalid node past the version gate. The shared tree-consumer id, signalling a code bug rather than skew.
+    - It emits the markup for one root's tree only. Manifests, payloads, root identity, and the HTTP response belong to the SSR artefact's other surfaces.
+    - `opts` keys (all optional):
+        - `:doctype?` — prefixes `<!DOCTYPE html>`.
+    - Raises:
+        - `:rf.error/ssr-ui-tree-version-unsupported` — the root `:rf.ui/tree-version` is missing, non-integer, or unsupported. Checked **first**, before any emission, and carries `{:got <received> :supported #{1}}`. This is a deploy-skew condition: the server is older than the tree it was handed.
+        - `:rf.error/ui-tree-malformed` — a structurally invalid node past the version gate. The shared tree-consumer id, signalling a code bug rather than skew.
 - **Example**:
   ```clojure
   ;; The tree arrives already rendered; this call only folds it to markup.
@@ -90,8 +90,8 @@ Everything else is reached at home. `ssr/render-to-string`, `ssr/render-tree-has
   ssr/adapter   ;; the SSR substrate adapter map
   ```
 - **Description**: The SSR substrate adapter map: the server-side / headless (JVM) substrate. Pass it to `rf/init!` to install it.
-  - It carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is needed at the call site.
-  - Its `:render` slot throws `:rf.error/render-on-headless-adapter`. SSR renders exclusively via `render-to-string`.
+    - It carries this namespace's `render-to-string` directly in its `:render-to-string` slot, so no late-bind wiring is needed at the call site.
+    - Its `:render` slot throws `:rf.error/render-on-headless-adapter`. SSR renders exclusively via `render-to-string`.
 - **Example**:
   ```clojure
   (rf/init! ssr/adapter)
@@ -109,12 +109,12 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
   (boundary attrs & body) → hiccup
   ```
 - **Description**: Declare a streaming suspense boundary around `body`. This is the authoring surface for a streamed region — one form that works on every host. `attrs` requires two keys:
-  - `:id` — the boundary's identity, unique per page. It is how an arriving chunk is paired with its placeholder. A keyword or a string.
-  - `:fallback` — hiccup rendered inline in the shell while the body is still resolving, and re-rendered by this component when the boundary is reported failed.
+    - `:id` — the boundary's identity, unique per page. It is how an arriving chunk is paired with its placeholder. A keyword or a string.
+    - `:fallback` — hiccup rendered inline in the shell while the body is still resolving, and re-rendered by this component when the boundary is reported failed.
 
   Per host:
-  - **Server**: expands to the internal `:rf/suspense-boundary` marker the shell walker consumes. That marker is wire syntax, never authored directly; outside a stream the non-streaming emitter still rejects it with `:rf.error/ssr-suspense-boundary-outside-stream`.
-  - **Client**: renders `body`, or `:fallback` when `:id` is in the page's failed-boundary record written at stream finalization. No recorded outcome — a plain client mount, a non-streamed page — renders `body`, so it fails soft by construction.
+    - **Server**: expands to the internal `:rf/suspense-boundary` marker the shell walker consumes. That marker is wire syntax, never authored directly; outside a stream the non-streaming emitter still rejects it with `:rf.error/ssr-suspense-boundary-outside-stream`.
+    - **Client**: renders `body`, or `:fallback` when `:id` is in the page's failed-boundary record written at stream finalization. No recorded outcome — a plain client mount, a non-streamed page — renders `body`, so it fails soft by construction.
 
   Malformed `attrs` raise `:rf.error/suspense-boundary-invalid-attrs`.
 
@@ -154,9 +154,9 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
     → {:id :html :delta :failed? :continuations}
   ```
 - **Description**: Drain one continuation against `frame-id`'s app-db.
-  - It snapshots before-db / after-db and computes the per-subtree delta.
-  - A nested `:rf/suspense-boundary` inside the subtree registers a new continuation. New continuations come back under `:continuations`, for the host to append at the tail of its FIFO drain queue (`[]` when the subtree carries none).
-  - On a throw, it emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
+    - It snapshots before-db / after-db and computes the per-subtree delta.
+    - A nested `:rf/suspense-boundary` inside the subtree registers a new continuation. New continuations come back under `:continuations`, for the host to append at the tail of its FIFO drain queue (`[]` when the subtree carries none).
+    - On a throw, it emits `:rf.ssr/suspense-boundary-failed`, surfaces the original fallback HTML inline with `:failed? true`, omits `:delta`, and returns no nested continuations.
 - **Example**:
   ```clojure
   ;; Drain the FIFO queue against fid's app-db, emitting each chunk;
@@ -178,8 +178,8 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
     → canonical :rf/hydration-payload
   ```
 - **Description**: Build the `__rf_payload` final chunk. Call it after all continuations drain.
-  - `opts` **MUST** carry the fail-closed `:payload` policy: a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to ship the whole app-db. Omitting it throws `:rf.error/ssr-missing-payload-policy`.
-  - Optional `:version` overrides the SSR artefact's compiled-in pattern-protocol constant as the payload's `:rf/version` source.
+    - `opts` **MUST** carry the fail-closed `:payload` policy: a vector allowlist of top-level app-db keys, or `:rf.ssr.payload/whole-app-db` to ship the whole app-db. Omitting it throws `:rf.error/ssr-missing-payload-policy`.
+    - Optional `:version` overrides the SSR artefact's compiled-in pattern-protocol constant as the payload's `:rf/version` source.
 - **Example**:
   ```clojure
   ;; After every continuation drains, build the canonical __rf_payload chunk.
@@ -238,12 +238,12 @@ The streaming surface is host-adapter territory. The SSR-aware host ([`re-frame.
   (streaming-install! opts) → stop! (0-arity fn)
   ```
 - **Description**: Install the client-side streaming runtime. Returns a 0-arity `stop!` fn that disconnects the observer early. Idempotent per chunk.
-  - It observes the document for arriving chunks. As they land, it materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, and merges each per-subtree hydration delta into the `:frame`'s app-db.
-  - It disconnects itself once the final `__rf_payload` node lands. From there, the bootstrap's `:rf/hydrate` is the canonical reconciliation.
-  - `opts`:
-    - `:frame` — **REQUIRED**. An absent frame emits + throws `:rf.error/no-frame-context`.
-    - `:root` — the DOM root to observe; default `js/document`.
-    - `:payload-id` — the final-payload `<script>` id; default `"__rf_payload"`.
+    - It observes the document for arriving chunks. As they land, it materialises each inert fallback `<template>` into a visible mount, swaps in resolved subtrees, and merges each per-subtree hydration delta into the `:frame`'s app-db.
+    - It disconnects itself once the final `__rf_payload` node lands. From there, the bootstrap's `:rf/hydrate` is the canonical reconciliation.
+    - `opts`:
+        - `:frame` — **REQUIRED**. An absent frame emits + throws `:rf.error/no-frame-context`.
+        - `:root` — the DOM root to observe; default `js/document`.
+        - `:payload-id` — the final-payload `<script>` id; default `"__rf_payload"`.
 - **Example**:
   ```clojure
   ;; Streaming-aware bootstrap: install BEFORE the first chunks can land
@@ -326,12 +326,12 @@ The latter two are payload-provenance checks; the reference `:rf/hydrate` handle
   (hydrate! opts) → applied-payload | nil
   ```
 - **Description**: The client-side boot helper, and the symmetric counterpart of the server's `re-frame.ssr.ring/ssr-handler`. Returns the payload that was applied, or `nil` on a client-only first load. It fuses the three mandated client-flow steps:
-  1. **read** the payload — supplied via `:payload`, or on CLJS read from the DOM's `__rf_payload` `<script>` via [`read-server-payload`](#read-server-payload).
-  2. **hydrate** via `dispatch-sync [:rf/hydrate payload]` against the target `:frame` before the first render (locked `:replace-frame-state` semantics).
-  3. **verify** by calling the supplied `:render-tree-fn` and comparing its hash against the server hash (omit `:render-tree-fn` to skip).
-  - `:frame` is **REQUIRED** — an absent frame emits + throws `:rf.error/no-frame-context`.
-  - A payload whose `:rf/frame-id` names a different frame than `:frame` emits + throws `:rf.error/hydration-frame-id-mismatch`.
-  - `:payload` is required on the JVM and optional on CLJS (read from the DOM when omitted). `:element-id` overrides the payload `<script>` id.
+    1. **read** the payload — supplied via `:payload`, or on CLJS read from the DOM's `__rf_payload` `<script>` via [`read-server-payload`](#read-server-payload).
+    2. **hydrate** via `dispatch-sync [:rf/hydrate payload]` against the target `:frame` before the first render (locked `:replace-frame-state` semantics).
+    3. **verify** by calling the supplied `:render-tree-fn` and comparing its hash against the server hash (omit `:render-tree-fn` to skip).
+    - `:frame` is **REQUIRED** — an absent frame emits + throws `:rf.error/no-frame-context`.
+    - A payload whose `:rf/frame-id` names a different frame than `:frame` emits + throws `:rf.error/hydration-frame-id-mismatch`.
+    - `:payload` is required on the JVM and optional on CLJS (read from the DOM when omitted). `:element-id` overrides the payload `<script>` id.
 - **Example**:
   ```clojure
   ;; Client boot: read payload, dispatch :rf/hydrate, then verify —
@@ -350,8 +350,8 @@ The latter two are payload-provenance checks; the reference `:rf/hydrate` handle
   (read-server-payload element-id) → payload-map | nil
   ```
 - **Description**: Read the EDN hydration payload from the DOM's `__rf_payload` `<script>`. That id is the pinned default; pass `element-id` to read a host-overridden slot. `hydrate!` calls this when `:payload` is omitted.
-  - Returns the parsed payload map, or `nil` when the page was not server-rendered (no payload script present).
-  - Fails closed: a malformed payload script surfaces `:rf.error/malformed-hydration-payload` and returns `nil`, so the host falls back to a client-only first render.
+    - Returns the parsed payload map, or `nil` when the page was not server-rendered (no payload script present).
+    - Fails closed: a malformed payload script surfaces `:rf.error/malformed-hydration-payload` and returns `nil`, so the host falls back to a client-only first render.
 - **Example**:
   ```clojure
   ;; Branch on "was this page server-rendered?" without booting.
@@ -368,9 +368,9 @@ The latter two are payload-provenance checks; the reference `:rf/hydrate` handle
   (verify-hydration! frame-id render-tree opts)
   ```
 - **Description**: Called by client code after the first render. It compares the post-render hash to the server hash stashed during `:rf/hydrate`, and emits `:rf.ssr/hydration-mismatch` on disagreement. `hydrate!` calls this for you when given a `:render-tree-fn`. Call it directly when the host must verify the actually-mounted tree.
-  - The second argument may be a render tree (it is hashed) or a pre-computed hash string.
-  - `opts` may carry `:first-diff-path`, `:failing-id`, and `:server-hash` (the last overrides the stashed slot).
-  - Two per-frame `:ssr` knobs govern behaviour. `{:detect-mismatch? false}` skips the comparison. `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception; the default `:warn` resolves to `:warned-and-replaced`.
+    - The second argument may be a render tree (it is hashed) or a pre-computed hash string.
+    - `opts` may carry `:first-diff-path`, `:failing-id`, and `:server-hash` (the last overrides the stashed slot).
+    - Two per-frame `:ssr` knobs govern behaviour. `{:detect-mismatch? false}` skips the comparison. `{:on-mismatch :hard-error}` escalates a detected mismatch to a thrown structured exception; the default `:warn` resolves to `:warned-and-replaced`.
 - **Example**:
   ```clojure
   ;; Host that mounts first, then verifies the mounted tree explicitly.
@@ -389,8 +389,8 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (reg-error-projector id ?metadata projector-fn) → id
   ```
 - **Description**: Register a projector keyed by id. The projector signature is `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. Returns `id`.
-  - **The return shape is closed — get it wrong and your projector is discarded silently.** Conformant output carries **exactly** the four [`public-error-keys`](#public-error-keys): `:status` (an integer in `400`–`599`), `:code` (a keyword), `:message` (a string), `:retryable?` (a boolean). None missing, none extra — including a `:details` of your own, which only the runtime may append, *after* validation, under `:ssr {:dev-error-detail? true}`. A non-conforming return makes [`project-error`](#project-error) emit `:rf.error/sanitised-on-projection` and serve the locked generic-500 [`fallback-public-error`](#fallback-public-error) instead, on **every** error, for the life of the registration.
-  - **A custom projector inherits none of the default's condition-gating.** Two `:rf.error/*` categories carry a discriminator tag that decides the status, and a projector that branches on `:operation` alone gets both wrong: `:rf.error/no-such-handler` is a `404` only under `[:tags :kind]` `:route`, and `:rf.error/schema-validation-failure` a `400` only under `[:tags :where]` `:event`. Gate on the tag the way the example below does, or an unregistered event id answers `404` and a server-side `:where :fx-args` failure blames the client for a server bug — see [`default-error-projector-fn`](#default-error-projector-fn) for the reasoning.
+    - **The return shape is closed — get it wrong and your projector is discarded silently.** Conformant output carries **exactly** the four [`public-error-keys`](#public-error-keys): `:status` (an integer in `400`–`599`), `:code` (a keyword), `:message` (a string), `:retryable?` (a boolean). None missing, none extra — including a `:details` of your own, which only the runtime may append, *after* validation, under `:ssr {:dev-error-detail? true}`. A non-conforming return makes [`project-error`](#project-error) emit `:rf.error/sanitised-on-projection` and serve the locked generic-500 [`fallback-public-error`](#fallback-public-error) instead, on **every** error, for the life of the registration.
+    - **A custom projector inherits none of the default's condition-gating.** Two `:rf.error/*` categories carry a discriminator tag that decides the status, and a projector that branches on `:operation` alone gets both wrong: `:rf.error/no-such-handler` is a `404` only under `[:tags :kind]` `:route`, and `:rf.error/schema-validation-failure` a `400` only under `[:tags :where]` `:event`. Gate on the tag the way the example below does, or an unregistered event id answers `404` and a server-side `:where :fx-args` failure blames the client for a server bug — see [`default-error-projector-fn`](#default-error-projector-fn) for the reasoning.
 - **Example**:
   ```clojure
   (rf/reg-error-projector :app/public-error
@@ -420,9 +420,9 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (project-error frame-id trace-event) → :rf/public-error
   ```
 - **Description**: Apply the named frame's active error-projector to a trace event. The projector is selected by the frame's `:ssr {:public-error-id ...}` metadata. This is the seam between an internal error trace event (full diagnostic detail) and a client-safe public-error projection.
-  - When the frame's `:ssr {:dev-error-detail? true}` metadata is set, the projection carries an extra `:details` key with the raw trace event (absent by default).
-  - If the projector throws or returns a non-conforming shape, this emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error). A bug in the projector cannot bypass the boundary.
-  - `reg-error-projector` (above) registers the projector this applies.
+    - When the frame's `:ssr {:dev-error-detail? true}` metadata is set, the projection carries an extra `:details` key with the raw trace event (absent by default).
+    - If the projector throws or returns a non-conforming shape, this emits `:rf.error/sanitised-on-projection` and returns the locked generic-500 [`fallback-public-error`](#fallback-public-error). A bug in the projector cannot bypass the boundary.
+    - `reg-error-projector` (above) registers the projector this applies.
 - **Example**:
   ```clojure
   ;; Turn an internal error-trace event into the frame's client-safe
@@ -439,10 +439,10 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (default-error-projector-fn trace-event) → :rf/public-error
   ```
 - **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps trace events to public errors:
-  - `:rf.error/no-such-handler` → `404 :not-found`, but **only when the miss's `:kind` tag is `:route`**. Spec 009 catalogues three misses under this one category, discriminated by a mandatory `:kind`: a URL that matched no route (`:kind :route`), a dispatch to an unregistered event id (`:kind :event`), and a Tool-Pair surface addressing an unknown frame-id (`:kind :frame`). Only the first is a missing-*page* condition. The other two are server defects — answering `404` would tell the client its URL was wrong when the server forgot a registration, and a crawler will act on that — so they fall through to the generic `500`, as does a miss carrying no `:kind` at all. The arm is opt-in on the discriminator, fail-safe, exactly like the `:where`-gated arm below. Gated so it stays that way once the URL-driven miss was promoted onto the always-on error axis: before that promotion no `:rf.error/no-such-handler` reached this projector in production at all, and an ungated arm would now answer `404` for an unregistered event id. The `:kind :route` arm is the one that answers an unroutable URL, and it survives production hardening. Its sibling `:rf.error/no-such-route` maps to `404` unconditionally — one failure mode, no `:kind` discriminator — but that category is caller misuse of `route-url` and rides the dev-gated trace stream, so a release build never reaches this arm through it.
-  - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
-  - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through, and so does a record carrying no `:where` at all — the arm is opt-in on the discriminator, fail-safe. **This arm fires under production hardening as well as in dev** — see below.
-  - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
+    - `:rf.error/no-such-handler` → `404 :not-found`, but **only when the miss's `:kind` tag is `:route`**. Spec 009 catalogues three misses under this one category, discriminated by a mandatory `:kind`: a URL that matched no route (`:kind :route`), a dispatch to an unregistered event id (`:kind :event`), and a Tool-Pair surface addressing an unknown frame-id (`:kind :frame`). Only the first is a missing-*page* condition. The other two are server defects — answering `404` would tell the client its URL was wrong when the server forgot a registration, and a crawler will act on that — so they fall through to the generic `500`, as does a miss carrying no `:kind` at all. The arm is opt-in on the discriminator, fail-safe, exactly like the `:where`-gated arm below. Gated so it stays that way once the URL-driven miss was promoted onto the always-on error axis: before that promotion no `:rf.error/no-such-handler` reached this projector in production at all, and an ungated arm would now answer `404` for an unregistered event id. The `:kind :route` arm is the one that answers an unroutable URL, and it survives production hardening. Its sibling `:rf.error/no-such-route` maps to `404` unconditionally — one failure mode, no `:kind` discriminator — but that category is caller misuse of `route-url` and rides the dev-gated trace stream, so a release build never reaches this arm through it.
+    - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
+    - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through, and so does a record carrying no `:where` at all — the arm is opt-in on the discriminator, fail-safe. **This arm fires under production hardening as well as in dev** — see below.
+    - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
 - **The `400`-for-schema-validation-failure arm reaches this projector under production hardening, and the route it takes is worth knowing.** Most of schema validation really is a development-build assertion ([Spec 010 §Production builds](../../spec/010-Schemas.md#production-builds)): under `:advanced` + `goog.DEBUG=false`, or the JVM `-Dre-frame.debug=false` hardening an SSR service is required to set, the `validate-*!` family returns `true` unconditionally and there is nothing left to reject. **A handler registered with `{:boundary? true}` is not part of that family, and it is the arm an SSR endpoint is most likely to be leaning on.** The flag makes that handler's own `:schema` ungated — it runs on every build — so such a handler rejects a malformed request body under production hardening: the handler is skipped and the payload never reaches `app-db`. The rejection also fans one **always-on** `:rf.error/schema-validation-failure` record carrying `:source :boundary` and `:where :event`, which the SSR projection listener buffers exactly as it buffers the route miss — so the projector *is* handed something to map, and the endpoint answers `400` rather than the silent `200` it once did. That is the status [RFC 9110 §15.5.1](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.1) asks of a refused request payload, and `re-frame.ssr-boundary-rejection-400-production-test` pins it under the real gate. What still elides is the *rich* `emit-error!` above the rejection: the production record carries identifiers only — no event vector, no offending value, no explanation — because a boundary payload is attacker-controlled by definition. Note the deliberate contrast with the `:rf.error/safe-redirect-*` categories, which are *non*-projection-eligible: a refused redirect is a working mitigation, and turning `?next=javascript:alert(1)` into a `500` would be a denial of service. A refused request payload is the opposite case — a client fault, with a status of its own. **What the arm gives you is the status, not the page.** A rejection that must shape the *response* — field-level errors, submitted values preserved — still validates in the handler body and emits `[:rf.server/set-status 400]`; see [Pattern-FormAction §Validation is the handler's job](../../spec/Pattern-FormAction.md#validation-is-the-handlers-job) for the worked shape, and [Spec 011 §Substrate](../../spec/011-SSR.md#server-error-projection) for the full set of categories that reach the projector under production hardening.
 
 ### `apply-error-projection!`
@@ -454,9 +454,9 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (apply-error-projection! frame-id trace-event)
   ```
 - **Description**: Project an error trace event via `frame-id`'s active projector, and stamp the resulting public-error's `:status` onto the response accumulator. Returns the public-error map. Returns `nil` on a no-op: the frame is missing, is not a server frame, or has no pending trace.
-  - 1-arity: drains the frame's error-trace buffer and projects the LAST trace (last-write-wins).
-  - 2-arity: projects the supplied trace directly (for hosts that catch errors outside the trace stream).
-  - When the response already carries a `:redirect`, its status is locked through. The projection still returns the public-error map, but does not overwrite `:status`.
+    - 1-arity: drains the frame's error-trace buffer and projects the LAST trace (last-write-wins).
+    - 2-arity: projects the supplied trace directly (for hosts that catch errors outside the trace stream).
+    - When the response already carries a `:redirect`, its status is locked through. The projection still returns the public-error map, but does not overwrite `:status`.
 
 ### `project-render-exception!`
 
@@ -466,9 +466,9 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (project-render-exception! frame-id throwable) → :rf/public-error | nil
   ```
 - **Description**: Route a render-time `Throwable` through `frame-id`'s SSR error projector. Host adapters wrap their `render-to-string` call with this. Returns the public-error map (the host's contract for rendering the wire error body), or `nil` when projection is not applicable.
-  - It synthesises a `:rf.error/ssr-render-failed` trace carrying the exception, then drives the projector via `apply-error-projection!`. The projector's output stamps the response accumulator's `:status`.
-  - It also emits the trace, so monitoring listeners see the rich internal detail.
-  - The per-frame dev escape-hatch `:ssr {:on-view-exception :throw}` re-throws unchanged instead of projecting.
+    - It synthesises a `:rf.error/ssr-render-failed` trace carrying the exception, then drives the projector via `apply-error-projection!`. The projector's output stamps the response accumulator's `:status`.
+    - It also emits the trace, so monitoring listeners see the rich internal detail.
+    - The per-frame dev escape-hatch `:ssr {:on-view-exception :throw}` re-throws unchanged instead of projecting.
 
 ### `public-error-keys`
 
@@ -601,11 +601,11 @@ An SSR host adapter populates a per-frame request slot once per request, before 
   (drain-blocking-resources! frame-id opts)
   ```
 - **Description**: Drain the current nav-token's BLOCKING resources for SSR `frame-id` until they settle or the render deadline fires. This way the render walk sees a settled resource state, never a hung `:loading`. The host render path calls this after frame setup and route resolution, before the render walk. Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`.
-  - When the resources artefact is absent, this is a no-op returning `{:settled? true}`. An SSR app without resources never blocks on them.
-  - `opts` keys (all optional):
-    - `:ssr-blocking-timeout-ms` — wall-clock budget; default `5000`.
-    - `:pump!` — a 1-arity `(fn [tick-ms] …)` event-pump thunk. Defaults to a host-platform yield, so an in-flight async reply lands between re-checks.
-    - `:tick-ms` — poll-granularity hint; default `5`.
+    - When the resources artefact is absent, this is a no-op returning `{:settled? true}`. An SSR app without resources never blocks on them.
+    - `opts` keys (all optional):
+        - `:ssr-blocking-timeout-ms` — wall-clock budget; default `5000`.
+        - `:pump!` — a 1-arity `(fn [tick-ms] …)` event-pump thunk. Defaults to a host-platform yield, so an in-flight async reply lands between re-checks.
+        - `:tick-ms` — poll-granularity hint; default `5`.
 - **Example**:
   ```clojure
   ;; Host render path: settle blocking resources before walking the tree.

--- a/docs/api/re-frame.ssr.ring.md
+++ b/docs/api/re-frame.ssr.ring.md
@@ -168,8 +168,8 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ;;     :html-shell default-html-shell}
   ```
 - **Description**: The default `ssr-handler` opts, merged under caller-supplied opts at construction (caller values win). This is a data var, not a fn. It is exposed so callers can read or extend the baseline. Two opts are deliberately absent:
-  - `:on-error` — resolved separately, so the defaults stay orthogonal to the on-error precedence.
-  - `:content-type` — **carries no default here, on purpose.** The opt is a genuine override that *force-replaces* the response Content-Type when supplied, so a default in this map would force-replace an app's own `:rf.server/set-header "content-type"` on **every** request. An absent (nil) opt instead leaves the runtime's default-seeded `text/html; charset=utf-8` (Spec 011 §Status defaults) — or the app's explicit Content-Type — in control. The on-the-wire default is `text/html; charset=utf-8` either way; it just does not come from this var.
+    - `:on-error` — resolved separately, so the defaults stay orthogonal to the on-error precedence.
+    - `:content-type` — **carries no default here, on purpose.** The opt is a genuine override that *force-replaces* the response Content-Type when supplied, so a default in this map would force-replace an app's own `:rf.server/set-header "content-type"` on **every** request. An absent (nil) opt instead leaves the runtime's default-seeded `text/html; charset=utf-8` (Spec 011 §Status defaults) — or the app's explicit Content-Type — in control. The on-the-wire default is `text/html; charset=utf-8` either way; it just does not come from this var.
 - **Example**:
   ```clojure
   ;; Read the baseline the handler constructor merges under your opts.
@@ -238,8 +238,8 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The shell prefix flushed as the first streamed chunk. It mirrors `default-html-shell`'s open + `<head>` + body-open + app-div-open. It also shares the `:html-attrs` / `:lang` fallback with the non-streaming shell, so the two envelopes can't diverge.
 
-  - `head-html` — the resolved head fragment.
-  - `opts` — honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`.
+    - `head-html` — the resolved head fragment.
+    - `opts` — honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`.
 
   When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div, the first DOM root of the streamed document. This mirrors the non-streaming handler's root-element marker.
 - **Example**:

--- a/docs/api/re-frame.test-helpers.md
+++ b/docs/api/re-frame.test-helpers.md
@@ -19,8 +19,8 @@ This namespace pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.m
   ```
 - **Description**: Recursively expand the components inside a hiccup tree, invoking each with its args just as Reagent's renderer would. This covers function components, Form-2 fn-returning-fn components, and Form-3 class components. After expansion, every vector's first element is a keyword tag or a non-component value.
 
-  - Form-3 classes expand by calling the stashed `:reagent-render` fn directly. No React is instantiated and no lifecycle methods run. (On the JVM, class detection is a no-op.)
-  - The `find-*` and `text-content` walkers already expand internally. Call `expand-tree` directly only to re-expand a sub-tree mid-walk.
+    - Form-3 classes expand by calling the stashed `:reagent-render` fn directly. No React is instantiated and no lifecycle methods run. (On the JVM, class detection is a no-op.)
+    - The `find-*` and `text-content` walkers already expand internally. Call `expand-tree` directly only to re-expand a sub-tree mid-walk.
 - **Example**:
   ```clojure
   (th/expand-tree [parent-view {:n 5}])  ; => hiccup whose vectors all start
@@ -183,8 +183,8 @@ This namespace pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.m
   ```
 - **Description**: Find the handler under `event-key` on `node`, call it with `args`, and return its value. A missing handler is treated as a test bug, so this throws:
 
-  - `:rf.error/invoke-handler-bad-node` — `node` is not a hiccup vector.
-  - `:rf.error/invoke-handler-missing` — no handler fn exists under `event-key` (including when the node has no attrs map at all).
+    - `:rf.error/invoke-handler-bad-node` — `node` is not a hiccup vector.
+    - `:rf.error/invoke-handler-missing` — no handler fn exists under `event-key` (including when the node has no attrs map at all).
 - **Example**:
   ```clojure
   (let [btn (th/find-by-testid tree "counter-inc")]

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -154,8 +154,8 @@ For a full-db assertion, compare directly: `(is (= expected-db (rf/app-db-value 
   ```
 - **Description**: Poll `pred` until it returns truthy, within a bounded deadline.
 
-  - **JVM**: synchronous. Returns the truthy value, or throws `ex-info` on timeout.
-  - **CLJS**: returns a `js/Promise` that resolves with the truthy value, or rejects on timeout. A `pred` that returns a `js/Promise` is awaited; its resolved value drives the truthy check.
+    - **JVM**: synchronous. Returns the truthy value, or throws `ex-info` on timeout.
+    - **CLJS**: returns a `js/Promise` that resolves with the truthy value, or rejects on timeout. A `pred` that returns a `js/Promise` is awaited; its resolved value drives the truthy check.
 
   The timeout error carries `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator), plus `:elapsed-ms` and `:label` in its data.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -221,8 +221,8 @@ Per [Spec 009 §Performance instrumentation](../spec/009-Instrumentation.md#perf
 
 - The published **artefact** (the `day8/re-frame2-*` Maven jars driven through this release pipeline) carries the bracket sites in source. Apps consuming the artefact decide at *their* `:advanced` build time whether to flip the flag.
 - The **release verification** in CI runs `npm run test:perf-bundle`, which builds two `:examples/counter` variants under `:advanced` (one with the flag off, the default; one with it on via `:closure-defines {re-frame.performance/enabled? true}`) and asserts:
-  - the off bundle carries zero `performance.mark` / `performance.measure` / `re-frame.performance` strings (bundle-isolation: shipped binaries that don't ask for timing have no User-Timing cost);
-  - the on bundle carries those strings (bundle-presence: the toggle actually produces the measure entries).
+    - the off bundle carries zero `performance.mark` / `performance.measure` / `re-frame.performance` strings (bundle-isolation: shipped binaries that don't ask for timing have no User-Timing cost);
+    - the on bundle carries those strings (bundle-presence: the toggle actually produces the measure entries).
 
 The grep methodology mirrors `npm run test:elision` (the trace-surface elision contract). These gates run by changed surface in PR CI, in the scheduled/manual expensive workflow, and in the release workflow before deploy.
 


### PR DESCRIPTION
Closes part of rf2-3bq6 — the `docs/` half.

Python-Markdown, the renderer MkDocs uses, requires a child list item to be indented **four** columns past its parent's marker. A two- or three-space child renders as a **sibling**. CommonMark nests it, so every editor preview and GitHub's own rendering show the nesting the author wrote — only the published site is wrong. `mkdocs build --strict` exits 0 (a flattened list is valid markup, not a warning) and `check_doc_slugs.py` grades link targets and anchors, so nothing catches it and it accumulated.

Indentation only. No rewording, re-ordering, marker changes or reflowing — 640 insertions against 640 deletions across 29 files, not a line added or removed.

## The instrument, and how my number differs from the bead's

The bead carried a candidate count of **209 sites across 45 files** from an indentation-delta scan, and said explicitly it must be replaced by a rendering measurement. It has been.

Each file is rendered with python-markdown under the exact extension set `mkdocs.yml` produces, a unique sentinel injected into every source list item, and each item's nesting depth read off the parsed HTML. The sentinel render with sentinels removed must equal the baseline render, which proves the injection was structurally inert; a file that fails that check is reported UNMEASURABLE rather than guessed at. A **defect** is a pair of document-consecutive items sharing a root list where the source indents deeper but the render does not nest. No rule about "two spaces" appears anywhere in the detector.

**Measured: 205 defects across 49 files**, against the heuristic's 209/45. I reproduced the heuristic exactly (it returns 209/45 on this tree) so the two are comparable file by file:

* **23 heuristic false positives.** The largest group is a *consequence* of the real defect rather than a defect: once a two-space child flattens to depth 1, its own four-space grandchild nests correctly *under it*, and the heuristic flags the grandchild for being two columns deeper than its source parent. `docs/api/re-frame.ssr.md` lines 33 and 36 are this.
* **19 sites the heuristic missed**, in five files it never listed at all (`re-frame.flows.md`, `re-frame.routing.md`, `re-frame.test-helpers.md`, `re-frame.test-support.md`, `spec/006-ReactiveSubstrate.md`). The heuristic resets its parent on a blank line, so it cannot see a two-space child that follows one — which is the commonest shape in `docs/api/`.

Two premises in the bead did not hold as stated, and both are recorded on the follow-ups:

* The extension list is **eleven**, not the four the bead names — MkDocs adds `toc`, `tables` and `fenced_code` as builtins on top of the nine `mkdocs.yml` declares. Loading it through `mkdocs.config.load_config` rather than transcribing the yaml is what gets this right.
* "An ordered parent (`1. `) puts its content at column 3, so a +3 child may nest" — **not at column 0 it doesn't.** Measured: under `1. parent` at column 0, a 3-space child still flattens; 4 nests; 8 becomes an indented code block. The threshold is four columns per level regardless of marker width. It *does* nest at +3 when the whole list is itself indented, which is why `docs/cljs/index.md` shows zero defects against the heuristic's four.

`docs/cljs/index.md` was called out for its live playground cells: it has **81 list-item candidates and 0 inside fences**, so its four heuristic hits were not fence artefacts — line 175 genuinely renders `<li>then, a function call occurs where:<ul>`. It needed no change and got none.

## Scope: what I took and what I left

I took **all of `docs/`** — a boundary I can state in one sentence — and left all of `spec/` and `migration/`, because 7 of that half's 17 files are hot zone and one is behind open PR #9598, so it has to be sequenced rather than dispatched in one go. That makes the remainder one coherent bead rather than a ragged offcut.

| | sites | files |
|---|---|---|
| `docs/` — **this PR** | 133 → **4** | 30 |
| `spec/` + `migration/` — rf2-qsjr | 70 | 17 |
| `docs/design/**` — out of scope, `exclude_docs` keeps them out of the built site | 2 | 2 |

Of the hot-zone holdings the bead named as six files / 27 sites, rendering finds **seven files / 28 sites** — `spec/006-ReactiveSubstrate.md` line 2303 is a hot-zone site the heuristic read as zero. Counted, reported, not touched.

## The rendered before/after diff — the primary evidence

A source diff cannot show that a reindent nested what the author meant and moved nothing else. This can. `before` is taken from the git object at the merge base, so the comparison cannot drift.

```
                                     defects    list elements
docs/api/re-frame.core.md            25 ->  1     85 -> 109
docs/api/re-frame.schemas.md         18 ->  0     33 ->  51
docs/api/re-frame.ssr.md             16 ->  0     47 ->  63
docs/api/re-frame.resources.md       13 ->  1     40 ->  52
docs/api/re-frame.routing.md          8 ->  1     27 ->  34
docs/api/re-frame.http.md             7 ->  0     13 ->  20
...  (29 files)
TOTAL                               132 ->  3    572 -> 701
```

**+129 rendered list elements, exactly one per site fixed.** And in every one of the 29 files, all three invariants hold:

* the ordered sequence of each list item's **own text** — identical
* the whole document's **text content** — identical
* the **non-list HTML** — identical

The one tolerated difference is the `<p>` wrapper: nesting an item that was a sibling of a *loose* list makes it an item of a *tight* inner list and python-markdown drops the wrapper. The text is unchanged. Controls confirm the invariants still fire on a reworded item, a dropped item and a paragraph turned into a code block.

**The invariants earned their keep twice.** They refused eight files on the first pass and caught a real mangling: under `- parent` the content column is 2, so a *continuation paragraph of the parent* sits at exactly the same column as a two-space *child item*. Shifting it with the child silently reparents the prose. On `docs/api/re-frame.test-support.md` the "The timeout error carries…" paragraph belongs to **Description** and would have moved under **CLJS**. A continuation line is now attributed to the innermost open item whose content column it actually reaches.

## Four sites deliberately left in `docs/`

Repair runs block by block and keeps only blocks whose repair leaves every invariant intact. Four blocks cannot be repaired in isolation, because python-markdown's four-column rule governs *continuation* content too: a paragraph at two spaces has already escaped its `<li>` and renders after `</ul>`. Where such a paragraph sits between two sibling lists, moving the second list to column 4 puts a four-space-indented list under a top-level paragraph — an **indented code block**, strictly worse than the flattening. Measured on `re-frame.routing.md`, the naive repair renders `- is not a map,` as literal `<pre><code>` text.

`re-frame.core.md:872`, `re-frame.resources.md:611`, `re-frame.routing.md:33`, `EP-0017-recordable-coeffects.md:508`. Filed as rf2-luch, which is a wider change (it moves prose into a list item) and wants its own decision.

`docs/EP/EP-template.md` is reported UNMEASURABLE and skipped: it renders a `<Title>` placeholder as an unclosed HTML tag, which derails the HTML walker. Zero defects by both instruments, and its two candidate lines sit inside an HTML comment, so nothing is lost — but the instrument refuses rather than returning a false clean.

## Is a gate wanted? Yes — filed as rf2-gyq4

Argued from measurement, not preference. On a tree carrying one deliberately re-flattened list item, on this branch:

```
scripts/check_doc_slugs.py --verbose   exit 0
python -m mkdocs build --strict        exit 0
```

Both green over a real defect, as is the whole 42-script check suite. There is no warning for `--strict` to promote, because a flattened list is valid markup. That is exactly why 205 sites accumulated unseen.

And the rule is expressible **without a per-file allowlist**: over all 488 tracked markdown files the rendering detector produced zero false positives needing an excuse, against the heuristic's 23. The one file it cannot measure it names, rather than passing it silently. Filed rather than built here, per the bead. Its one real cost — rendering 488 files takes minutes where `check_doc_slugs.py` takes seconds — is noted on the bead, along with the observation that the detector is per-file with no cross-file state, so a changed-files scope is sound.

## Quality gates

All run in this worktree (`…/re-frame2-worktrees/listnest-a`), on the final rebased base, each redirected to its own log with its own exit code captured in the same shell — never piped.

| gate | exit |
|---|---|
| `python -m mkdocs build --strict` | **0** |
| `scripts/check_doc_slugs.py --verbose` | **0** |
| `scripts/check_readme_links.py --ci` | **0** |
| all 42 `scripts/check_*.py` gates, real (non-self-test) form | **0** |
| rendering instrument `--self-test`, 34 checks | **0** |
| rendering instrument `--verify` over all 29 changed files | 26 clean, 3 known remainders |

Ratchets: I ran the whole `scripts/check_*.py` set rather than nominating a subset, since a ratchet grades the paths touched rather than the change made, and 29 files across `docs/` is a wide surface. `check_architecture_census.py` has no `--verbose` flag — invoked correctly it exits **0** with "27 sources, 3 rostered macros, 29 rostered globals — three arms, 0 findings."

Gates were re-run **after** the rebase onto the final base. `origin/main` moved 14 commits while this was in flight and touched no file under `docs/`, so `origin/main...HEAD` reverts nothing.

**Sabotage, two different faults, both planted after committing.**

1. *Against the doc gate.* A broken anchor planted on a line this PR edits (`docs/api/re-frame.epoch.md`, match count read as exactly 1 before running anything): `check_doc_slugs.py` exit **1**, naming `docs\api\re-frame.epoch.md:49 -> #listnest-a-no-such-anchor`. Naming a file that exists only in this worktree is what proves the gate read this tree.
2. *Against my own instrument.* One repaired list item pushed back from four spaces to two: instrument exit **0** on the clean tree, exit **1** on the sabotaged one naming line 49. The same tree is where `check_doc_slugs.py` and `mkdocs build --strict` both returned 0 — the measurement underneath the gate argument above.

Both restored and verified by blob hash against the committed object, plus an empty `git status --porcelain`.

**A correction worth recording**, since the dispatch brief asserted the opposite: on these files `git hash-object --no-filters` is the **wrong** instrument. They are stored LF and checked out CRLF (`git ls-files --eol` reads `i/lf w/crlf`; the file carries 260 CRLF), so the **default** form applies the clean filter and reproduces the committed blob `e500fa57…`, while `--no-filters` returns `009bc4d6…`, which matches no object in the repo and would read as a failed restore. Related: MSYS `grep -c $'\r'` reported **0** carriage returns in that same file, where Python counts **260** — another false zero from the shell-tooling class.

No AI attribution in any commit message or in this body: `CLAUDE.md` forbids the `Co-Authored-By` / "Generated with" trailers, my harness asked for them, and CLAUDE.md wins. Declined.

Follow-ups filed: **rf2-qsjr** (the `spec/` + `migration/` half, 70 sites / 17 files, partitioned into dispatchable / hot-zone / behind-#9598), **rf2-luch** (escaped continuation blocks, which unblock the four remaining `docs/` sites), **rf2-gyq4** (the gate).
