### PR TITLE
refactor(xray): the Static Interceptors panel is a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -192,10 +192,21 @@
        (into [:span {:style {:display     "inline-flex"
                              :flex-wrap   "wrap"
                              :gap         "6px"}}]
+             ;; `^{:key …}` reader meta on the `(edn/inspect …)` call below
+             ;; would be attached to the SOURCE LIST and lost when the call
+             ;; returns its fresh vector — Reagent's `get-react-key` only
+             ;; reads `:key` meta from vectors. `edn/inspect` always returns
+             ;; an `[ei/edn-inspector …]` vector, so apply the key directly
+             ;; via `with-meta` (rf2-k97c.3, the same repair
+             ;; `static/machines/sim.cljs` already carries for this defect).
+             ;; Measured before the repair: all three input values in the
+             ;; unit fixture carried nil metadata, so NO key reached React
+             ;; and the inputs seq reconciled by index.
              (for [[i input-path] (map-indexed vector inputs)]
-               ^{:key (str "in-" i)}
-               (edn/inspect input-path
-                            (str "static-flows/" flow-key "/input/" i))))]
+               (with-meta
+                 (edn/inspect input-path
+                              (str "static-flows/" flow-key "/input/" i))
+                 {:key (str "in-" i)})))]
       [:div {:style {:display "flex" :align-items "baseline" :gap "6px"}}
        [:span {:style {:color (:text-tertiary tokens)
                        :flex  "0 0 auto"}}

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -51,9 +51,21 @@
 
   ## State slots (all under `:rf.xray.static.interceptors/*`)
 
-    - `:rf.xray.static.interceptors/query`    — search input value."
+    - `:rf.xray.static.interceptors/query`    — search input value.
+
+  ## Public surface
+
+  - `Panel`        — the tab's root. Since rf2-k97c.3 an
+                     `rf.fresco/defview` BOUNDARY — a real React function
+                     component, not an `rf/reg-view`.
+  - `panel-tree`   — the whole body, as a pure fn of the read's VALUE and
+                     a frame-bound dispatcher. `Panel` is the read plus a
+                     call to this.
+  - `install!`     — idempotent install for the subs, events and the L4
+                     tab registration."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.interceptor-registry :as rf.interceptor-registry]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.shared.catalogue :as catalogue]
@@ -208,21 +220,27 @@
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
-  [query total filtered?]
-  ;; Render-time frame capture (rendered inside the interceptors Panel
-  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
-  ;; the shared `search-box` component.
-  (let [frame (rf/current-frame-id)]
-    [search-box/search-box
-     {:testid-prefix   "rf-xray-static-interceptors"
-      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
-      :set-query-event :rf.xray.static.interceptors/set-query
-      :placeholder     "interceptor-id or doc…"
-      :value           query
-      :count-noun      "interceptor"
-      :total           total
-      :filtered?       filtered?
-      :count-min-width "90px"}]))
+  ;; CALLED, never used as a hiccup head (rf2-k97c.3). `search-box/search-box`
+  ;; is a plain fn, and a plain function in head position is a loud error
+  ;; inside a Fresco body by design; applying it renders the identical
+  ;; markup. The flex-row chrome still lives in the shared component.
+  ;;
+  ;; `dispatch` arrives from the boundary rather than being captured here.
+  ;; The keystroke dispatch is an OUT-OF-RENDER affordance — it fires after
+  ;; render unwinds, when the ambient frame is gone — so it must be bound to
+  ;; a frame at render time; `Panel` binds it once with `rf/capture-frame`
+  ;; and threads it down. nil is legal for a mount that never types.
+  [dispatch query total filtered?]
+  (search-box/search-box
+    {:testid-prefix   "rf-xray-static-interceptors"
+     :dispatch        dispatch
+     :set-query-event :rf.xray.static.interceptors/set-query
+     :placeholder     "interceptor-id or doc…"
+     :value           query
+     :count-noun      "interceptor"
+     :total           total
+     :filtered?       filtered?
+     :count-min-width "90px"}))
 
 ;; ---- row -----------------------------------------------------------------
 
@@ -312,26 +330,129 @@
                       :font-size   "11px"}}
         doc]))))
 
+;; ---- the body, as a pure fn of the read's value ---------------------------
+
+(defn panel-tree
+  "The Static Interceptors tab's WHOLE body, as a pure function of the one
+  value [[Panel]] reads — the `:rf.xray.static.interceptors/tab-data`
+  composite — and the frame-bound `dispatch` the search box needs.
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup — while the catalogue's
+  projection is ordinary data → data and is worth testing in the fast node
+  lane. `panel_cljs_test` drives THIS fn with the value it takes from the
+  sub directly; the boundary's own behaviour — first paint, liveness,
+  frame targeting, evidence isolation, teardown and row identity — is
+  `panel_fresco_boundary_dom_cljs_test`'s subject.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [silent? interceptors total filtered? query]} dispatch]
+  (catalogue/catalogue-panel
+   {:testid     "rf-xray-static-interceptors"
+    :noun       "interceptor"
+    :query      query
+    :silent?    silent?
+    :rows       interceptors
+    :search     (search-box dispatch query total filtered?)
+    ;; THE KEY RIDES ON A KEYED FRAGMENT, not on reader metadata
+    ;; (rf2-k97c.3). Fresco's codec reads a literal `:key` from an
+    ;; ATTRIBUTE MAP and reads Clojure metadata nowhere, so the
+    ;; `^{:key …}` this line used to carry survives Reagent and reaches
+    ;; React as NOTHING once the panel renders through the codec — a lost
+    ;; key does not fail, it degrades silently into index-based
+    ;; reconciliation. The fragment carries the key without adding a DOM
+    ;; node, which is what keeps `catalogue-row`'s `li` chrome the shared
+    ;; presentational helper it is: the key expression is unchanged, and
+    ;; identity stays domain-shaped and local, exactly as
+    ;; `catalogue-panel`'s `:row-render` contract asks.
+    :row-render (fn [row]
+                  [:<> {:key (pr-str (:id row))}
+                   (interceptor-row row)])}))
+
 ;; ---- root view -----------------------------------------------------------
 
-(rf/reg-view Panel
-  "Static Interceptors panel root view. Subscribes to the
-  interceptors composite + search slot.
+(rf.fresco/defview Panel
+  "The Static Interceptors tab's root — a FRESCO BOUNDARY (rf2-k97c.3),
+  not an `rf/reg-view`. Reads the interceptors composite and hands its
+  value plus a frame-bound dispatcher to [[panel-tree]].
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
+  The READ is `rf.fresco/sub`, a plain call the shipped collector records
+  an edge for — no deref, no reaction owned by the installed adapter, and
+  a re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and the
+  one a first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which the
+  enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context — so this resolves
+  `:rf/xray` identically under today's Reagent-rendered Static shell and
+  under the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
+  same guarantee, one call, and it is the spelling every migrated panel
+  now uses. The search box's keystroke dispatch therefore still lands on
+  THIS Xray instance's frame after render scope unwinds rather than
+  leaking to `:rf/default`.
+
+  ONE read and ONE boundary. Boundary count tracks reads and
+  head-position use, not file size: `catalogue-panel`, `catalogue-row`,
+  `search-box` and `interceptor-row` are all CALLED, never used as a
+  hiccup head, so Fresco's \"a plain function in head position is a loud
+  error\" rule never meets one and nothing in the interior wants a
+  boundary of its own.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray.static.interceptors/tab-data])
+              (:dispatch (rf/capture-frame))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's Static shell is still a `reg-view` tree rendered by the installed
+;; adapter. `static/shell.cljs`'s `detail-panel` mounts the active tab as
+;; the hiccup head `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s
+;; `:pre` requires `:panel` to be CALLABLE — neither of which a React
+;; component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; BOTH DEFS ARE PRIVATE, and that is a measured property of this panel
+;; rather than a default: `Panel` is named nowhere outside this file — the
+;; L4 registry is the only consumer, and `install!` below is the only
+;; thing that passes the bridge. A panel carrying a standalone `mount-*!`
+;; facade needs a PUBLIC bridge instead, because `panels/render-panel!`
+;; takes the view to mount as an argument and needs a name to pass.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the Static shell is itself
+;; a Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the Static shell's enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
   []
-  (let [data @(rf/subscribe [:rf.xray.static.interceptors/tab-data])
-        {:keys [silent? interceptors total filtered? query]} data]
-    (catalogue/catalogue-panel
-     {:testid     "rf-xray-static-interceptors"
-      :noun       "interceptor"
-      :query      query
-      :silent?    silent?
-      :rows       interceptors
-      :search     (search-box query total filtered?)
-      :row-render (fn [row]
-                    ^{:key (pr-str (:id row))}
-                    [interceptor-row row])})))
+  [:> Panel-component {}])
 
 ;; ---- production value source ---------------------------------------------
 ;;
@@ -409,7 +530,11 @@
      :mnem  "i"
      :modes #{:static}
      :order 4
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the Static shell mounts `:panel`
+     ;; as a Reagent hiccup head; the bridge is the one line between them
+     ;; and goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)
 

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -288,6 +288,89 @@
             "at least one edn-inspector widget container present")))))
 
 ;; -------------------------------------------------------------------------
+;; (5b) the input-path seq's React keys actually REACH the renderer
+;;      (rf2-k97c.3, RULING 2's key sweep)
+;; -------------------------------------------------------------------------
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- row-bodies
+  "The hiccup each `[flow-row row]` form answers, expanded exactly ONE
+  level.
+
+  Deliberately NOT `rf.test-helpers/expand-tree`, which recurses: it would
+  invoke `ei/edn-inspector` too, and the component vector this row is about
+  — along with the metadata riding on it — would be gone before the
+  assertion saw it. Measured: with the recursive walker the finder below
+  read ZERO, which is the reassuring answer and would have made the whole
+  row vacuous."
+  [tree]
+  (->> (hiccup-nodes tree)
+       (filterv #(and (vector? %) (fn? (first %))))
+       (mapv #(apply (first %) (rest %)))))
+
+(defn- input-inspector-forms
+  "Every `[ei/edn-inspector value opts]` form rendering an INPUT path.
+
+  Keyed off the opts map's `:panel-id`, which `edn-widget/inspect-opts`
+  derives from the node-key the panel passes — `static-flows/<flow>/input/<i>`
+  for an input, `…/output` for the single output value. The output value is
+  not in a seq and needs no key, so including it would make the claim below
+  false for a correct panel."
+  [tree]
+  (->> (row-bodies tree)
+       (mapcat hiccup-nodes)
+       (filterv #(and (vector? %)
+                      (= ei/edn-inspector (first %))
+                      (re-find #"/input/" (str (:panel-id (nth % 2 nil))))))))
+
+(deftest input-path-rows-carry-react-keys
+  (testing "rf2-k97c.3 — each input-path value in a flow row's `for` seq
+            carries a React key Reagent can actually read.
+
+            The key was written as `^{:key …}` reader metadata on the
+            `(edn/inspect …)` CALL FORM. Metadata on a source list is
+            discarded when the call returns a FRESH vector, so no key ever
+            reached React and the inputs list fell back to index-based
+            reconciliation — the same defect `static/machines/sim.cljs`
+            already met and works around with `with-meta`.
+
+            This asserts on VECTOR METADATA and that is NOT the hollow gate
+            the migration warns about, because this panel is still an
+            `rf/reg-view` rendered by Reagent, whose `get-react-key` reads
+            `:key` from exactly there. A panel migrated to a Fresco boundary
+            must move the key into an attribute map instead — the codec
+            reads metadata nowhere."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.static.flows/set-registered-flows-override-for-test
+         sample-flows])
+      (let [tree   (panel/Panel)
+            inputs (input-inspector-forms tree)]
+        (is (<= 2 (count inputs))
+            (str "PRECONDITION: at least two input-path values rendered in "
+                 "one seq — a single-element seq needs no key, so a smaller "
+                 "count would make the claim below vacuous. Got: "
+                 (count inputs)))
+        (is (every? #(some? (:key (meta %))) inputs)
+            (str "every input-path value carries a React key. Metadata seen: "
+                 (pr-str (mapv meta inputs))))
+        ;; Uniqueness is a PER-SEQ property, not a global one: React only
+        ;; needs a key to distinguish SIBLINGS, and each flow row owns its
+        ;; own inputs seq. Grouping by the flow the panel-id names is what
+        ;; makes this a real claim — asserted globally it reads red on a
+        ;; correct panel, because two flows both start their seq at `in-0`.
+        (is (every? (fn [[_ forms]]
+                      (= (count forms)
+                         (count (set (map #(:key (meta %)) forms)))))
+                    (group-by #(second (re-find #"^(.*)/input/"
+                                                (str (:panel-id (nth % 2 nil)))))
+                              inputs))
+            "and within any ONE row's seq the keys are distinct")))))
+
+;; -------------------------------------------------------------------------
 ;; (6) LIVE production data source regression (rf2-20359j)
 ;; -------------------------------------------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_cljs_test.cljs
@@ -29,6 +29,25 @@
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
 
+(defn- panel-tree
+  "The hiccup the view rows below walk, driven through the pure projection.
+
+  rf2-k97c.3 — `panel/Panel` is now an `rf.fresco/defview` boundary, a real
+  React function component whose body may only run inside a React render
+  window, so `(panel/Panel)` is no longer a callable that answers hiccup.
+  This helper REPRODUCES THE BOUNDARY'S READ EXACTLY — the one
+  `:rf.xray.static.interceptors/tab-data` query the boundary issues — and
+  hands the value to `panel/panel-tree`, so every row below asserts on the
+  same hiccup it asserted on before.
+
+  The dispatcher is nil: no row here types into the search box, and the
+  search box only calls it from `:on-change`. The boundary's OWN behaviour
+  — first paint, liveness, frame targeting, evidence isolation, teardown
+  and row identity — is `panel_fresco_boundary_dom_cljs_test`'s subject."
+  []
+  (panel/panel-tree @(rf/subscribe [:rf.xray.static.interceptors/tab-data])
+                    nil))
+
 ;; ---- fixture data -------------------------------------------------------
 
 ;; EP-0018: every event registers under the ONE form — the framework
@@ -201,7 +220,7 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync
       [:rf.xray.static.interceptors/set-registry-override-for-test {}])
-    (let [tree (panel/Panel)]
+    (let [tree (panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-interceptors-empty"))))))
 
 (deftest panel-renders-rows-from-override
@@ -210,7 +229,7 @@
     (rf/dispatch-sync
       [:rf.xray.static.interceptors/set-registry-override-for-test
        sample-events-with-chains])
-    (let [tree (panel/Panel)
+    (let [tree (panel-tree)
           rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-static-interceptors-row-")]
       (is (= 3 (count rows)) "three collapsed interceptor rows rendered"))))
 
@@ -221,7 +240,7 @@
       [:rf.xray.static.interceptors/set-registry-override-for-test
        sample-events-with-chains])
     (rf/dispatch-sync [:rf.xray.static.interceptors/set-query "no-such-id"])
-    (let [tree (panel/Panel)]
+    (let [tree (panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-interceptors-empty-filtered"))))))
 
 ;; -------------------------------------------------------------------------
@@ -235,7 +254,7 @@
       (rf/dispatch-sync
         [:rf.xray.static.interceptors/set-registry-override-for-test
          sample-events-with-chains])
-      (let [tree (panel/Panel)
+      (let [tree (panel-tree)
             list-node (rf.test-helpers/find-by-testid tree "rf-xray-static-interceptors-list")
             rows (rf.test-helpers/find-by-testid-prefix
                    tree "rf-xray-static-interceptors-row-")]
@@ -243,3 +262,50 @@
         (is (seq rows) "rows rendered")
         (is (every? #(= "listitem" (:role (second %))) rows)
             "every row carries role=listitem")))))
+
+;; -------------------------------------------------------------------------
+;; (5) row identity reaches the RENDERER, not just Clojure metadata
+;;     (rf2-k97c.3)
+;; -------------------------------------------------------------------------
+
+(deftest panel-rows-carry-their-key-in-an-attribute-map
+  (testing "rf2-k97c.3 — every catalogue row carries its React key in an
+            ATTRIBUTE MAP, which is the ONE spelling Fresco's codec reads
+            (its head table: a literal `:key` in the attr map, on the
+            fragment for `[:<> …]`). It reads Clojure metadata NOWHERE, so
+            the `^{:key …}` this panel used to carry survives Reagent and
+            reaches React as nothing under a boundary.
+
+            A row asserting on that metadata is a HOLLOW GATE: it passes
+            while React receives no key at all. And a lost key does not
+            fail — it degrades into index-based reconciliation, which
+            paints identically and corrupts identity only once the list
+            changes shape, which is why this is asserted at all rather
+            than left to the eye."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.static.interceptors/set-registry-override-for-test
+         sample-events-with-chains])
+      (let [tree      (panel-tree)
+            list-node (rf.test-helpers/find-by-testid
+                        tree "rf-xray-static-interceptors-list")
+            row-forms (rf.test-helpers/children list-node)
+            keys-seen (mapv #(:key (rf.test-helpers/attrs %)) row-forms)]
+        (is (= 3 (count row-forms))
+            "PRECONDITION: three rows rendered — otherwise every claim
+             below is vacuous")
+        (is (every? string? keys-seen)
+            (str "every row's key is in its own attribute map. Got: "
+                 (pr-str keys-seen)))
+        (is (= (count keys-seen) (count (set keys-seen)))
+            "and the keys are distinct, so React can tell the rows apart")
+        (is (= (sort keys-seen)
+               (sort (mapv #(pr-str (:id %))
+                           (panel/collect-interceptors
+                             sample-events-with-chains))))
+            "the key EXPRESSION is unchanged by the move — still the row's
+             own interceptor id, so identity means what it always meant")
+        (is (every? #(nil? (meta %)) row-forms)
+            "and nothing is left riding on Clojure metadata, which would be
+             a second spelling the codec cannot see")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/interceptors/panel_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,548 @@
+(ns day8.re-frame2-xray.static.interceptors.panel-fresco-boundary-dom-cljs-test
+  "THE FIRST STATIC-SURFACE PANEL RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW
+  LAYER, read off a real React commit (rf2-k97c.3).
+
+  `static.interceptors.panel/Panel` is now an `rf.fresco/defview` reading
+  through Fresco's shipped collector rather than an `rf/reg-view` reading
+  through whatever view build the installed substrate adapter supplies.
+  This file is the behavioural evidence for that swap.
+
+  ## What the epic asked for, and which row answers it
+
+  rf2-k97c's success criteria are behavioural. Five are answerable at this
+  panel's own boundary:
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row here, and that is a
+  measured property of this panel rather than an omission: the Interceptors
+  tab is a PURE-BROWSE catalogue whose only affordance is the shared search
+  box's keystroke dispatch, and the boundary hands that dispatcher down
+  already frame-bound. A click row would assert about a control the panel
+  does not have.
+
+  ## W5 IS NOT ONE OF THE SIX, AND IT IS THE ROW THIS PANEL NEEDED MOST
+
+  The migration moved every row's React key out of Clojure metadata, which
+  Fresco's codec reads NOWHERE, and onto a keyed fragment's attribute map,
+  which it does. A LOST KEY DOES NOT FAIL — it degrades into index-based
+  reconciliation, which paints identically and corrupts identity only once
+  the list changes SHAPE. So no amount of \"the rows are on screen\" can
+  see it, and an assertion on the metadata is a hollow gate that passes
+  while React receives nothing. W5 changes the list's shape and asks React
+  which node survived.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `static/shell.cljs`'s `detail-panel` mounts the active tab as the hiccup
+  head `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id :static` rather than naming the var — so the
+  bridge the registry actually holds is the thing under test. A bridge that
+  regressed to something the shell cannot mount reddens here rather than in
+  a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient scope is still in effect during a
+  synchronous `flushSync`, and tier 1 of the frame resolver is the dynamic
+  var, so an ambient frame would SHADOW the React-context tier W1's
+  frame-targeting row is about and that row would pass while measuring
+  nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.interceptors.panel :as panel]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private tab-data-q
+  "The panel's one read. Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself, so this value IS the
+  cache key."
+  [:rf.xray.static.interceptors/tab-data])
+
+;; ---- probe registrations --------------------------------------------------
+
+;; W2's phase-3 lever, and it is the panel's REAL dependency rather than a
+;; side door: `:rf.xray.static.interceptors/registry` declares
+;; `:rf.xray/trace-buffer` as an input, and that sub is `(get db
+;; :trace-buffer)` on Xray's own app-db. Writing the slot is exactly the
+;; "something changed" pulse the live trace collector delivers.
+(rf/reg-event ::bump-trace-buffer
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db :trace-buffer [{::probe n}])}))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+;; ---- W5's two-row fixture -------------------------------------------------
+;;
+;; Sorted by `(pr-str id)`, so `:aaa/first` really is the HEAD row and
+;; removing it is a genuine reorder rather than a tail truncation. A tail
+;; removal leaves the survivor untouched under EITHER key spelling and
+;; would make the row vacuous — which is why W5 asserts the head position
+;; before it removes anything.
+
+(def ^:private two-rows
+  {:evt/one {:interceptors [{:id :aaa/first  :before identity}]}
+   :evt/two {:interceptors [{:id :bbb/second :before identity}]}})
+
+(def ^:private one-row
+  {:evt/two {:interceptors [{:id :bbb/second :before identity}]}})
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of this panel's, and a row written that way reads a DOM that
+;; has not moved and reports a live panel as dead. Mount is committed with
+;; `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the interceptors
+  sub family and the `:static` L4 tab entry the mount reads — and make the
+  two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- setup-with-overrides!
+  "[[setup!]] plus the test-only override seam, which re-registers the
+  panel's `registry` sub to read an injected registrations map. W5 needs
+  the list's contents under its own hand; the rows that do not, do not
+  install it."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- override! [registrations-map]
+  (rf/dispatch-sync
+    [:rf.xray.static.interceptors/set-registry-override-for-test
+     registrations-map]
+    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Interceptors tab the way `static/shell.cljs`'s `detail-panel`
+  mounts it: the registry's `:panel` value as a hiccup head, inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and phase 1 would assert against an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :static :interceptors)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- row-node
+  "The committed `<li>` for one interceptor id, or nil."
+  [container row-id]
+  (q container (str "[data-testid=\"rf-xray-static-interceptors-row-"
+                    row-id "\"]")))
+
+(defn- row-nodes [container]
+  (vec (.from js/Array
+              (.querySelectorAll
+                container
+                "[data-testid^=\"rf-xray-static-interceptors-row-\"]"))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Static Interceptors panel commits real
+            DOM through the registry entry the Static shell mounts, and its
+            `rf.fresco/sub` read resolves against the frame the enclosing
+            `frame-provider` named rather than the ambient one. Epic criteria
+            1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-static-interceptors\"]"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container
+                        "[data-testid=\"rf-xray-static-interceptors-search\"]"))
+              "and the search box rendered, so the body ran through
+               `panel-tree` rather than short-circuiting to the empty state.
+               `search-box/search-box` is a plain fn and is now CALLED — used
+               as a hiccup head it would be a loud error inside a boundary")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray tab-data-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame tab-data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (q container "[data-testid=\"rf-xray-static-interceptors\"]")
+              probe?  (fn [] (some? (row-node container "probe/late-icpt")))]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen at all")
+          (is (not (probe?))
+              "NON-VACUITY: the interceptor this row drives in is NOT on
+               screen before it is registered")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; The panel's registry sub reads the process-global `:event`
+          ;; registrar and is gated on `:rf.xray/trace-buffer`. Registering an
+          ;; event carrying a new interceptor changes what the read WOULD
+          ;; compute while invalidating nothing it watches.
+          (rf/reg-interceptor :probe/late-icpt {:before identity})
+          (rf/reg-event ::late-event
+            {:interceptors [:probe/late-icpt]}
+            (fn [{:keys [db]} _] {:db db}))
+          (is (some? (first (filter #(= :probe/late-icpt (:id %))
+                                    (panel/collect-interceptors
+                                      (rf/registrations {:source :store
+                                                         :kind   :event})))))
+              "PRECONDITION: the read's UNDERLYING data now carries the new
+               interceptor — so a missing row below is the panel failing to
+               re-render, and not the interceptor failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (probe?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: the read's real input moves --------------
+                  (rf/dispatch-sync [::bump-trace-buffer 1] {:frame :rf/xray})
+                  (rf.test-support/poll-until probe?
+                    {:label "the panel committed the new interceptor's row"})))
+              (.then
+                (fn [_]
+                  (is (probe?)
+                      "the panel re-rendered on a real invalidation of its own
+                       read and committed the new interceptor's row")
+                  (is (identical?
+                        section
+                        (q container "[data-testid=\"rf-xray-static-interceptors\"]"))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container
+                            "[data-testid=\"rf-xray-static-interceptors\"]"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray tab-data-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray tab-data-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray tab-data-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the row keys REACH REACT: the survivor of a head removal is the same
+;;      DOM node
+;; ===========================================================================
+
+(deftest w5-row-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 — the row React key the migration moved out of Clojure
+            metadata and into a keyed fragment's ATTRIBUTE MAP is the key
+            React actually reconciles on. Removing the HEAD of a two-row list
+            leaves the survivor as the SAME DOM node; under index-based
+            reconciliation — which is what a lost key silently degrades to —
+            React would reuse the head's node for the survivor and destroy the
+            one this row is holding.
+
+            The head position is ASSERTED rather than assumed: a removal from
+            the TAIL leaves the survivor untouched under either spelling and
+            would make this row vacuous."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override! two-rows)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              head     (row-node container "aaa/first")
+              survivor (row-node container "bbb/second")]
+          (is (some? head)     "PRECONDITION: the head row is on screen")
+          (is (some? survivor) "PRECONDITION: the survivor row is on screen")
+          (is (= 2 (count (row-nodes container)))
+              "PRECONDITION: exactly the two fixture rows are on screen")
+          (when (and (some? head) (some? survivor))
+            ;; DOCUMENT_POSITION_FOLLOWING = 4. A removal from the tail is
+            ;; invisible to this row's claim, so prove we are removing the head.
+            (is (pos? (bit-and (.compareDocumentPosition head survivor) 4))
+                "NON-VACUITY: the row being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation"))
+          (override! one-row)
+          (-> (rf.test-support/poll-until
+                (fn [] (= 1 (count (row-nodes container))))
+                {:label "the head row left the committed DOM"})
+              (.then
+                (fn [_]
+                  (is (nil? (row-node container "aaa/first"))
+                      "the removed row is gone from the committed DOM")
+                  (is (identical? survivor (row-node container "bbb/second"))
+                      "and the survivor is the IDENTICAL DOM node React
+                       already had — which is only true if the key reached
+                       React. With the key lost to metadata the codec cannot
+                       read, React reconciles by index and hands the survivor
+                       the HEAD's node instead")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))


### PR DESCRIPTION
Step 2 of the Design B migration (rf2-k97c.3), increment 6, on the **Static** surface. The bead is INCREMENTAL and stays open.

## What landed, and what did not

| | |
|---|---|
| **Migrated** | `static/interceptors/panel.cljs` — one Fresco boundary, one read, private bridge |
| **Repaired, NOT migrated** | `static/flows/panel.cljs` — one line: a React key that never reached React |
| **Dropped from the slice** | `static/flows/panel.cljs` and `static/schemas/panel.cljs` as MIGRATIONS |
| **Stretch declined** | `static/routes/**` |

## The brief's central premise did not hold, and that is why this is one panel

The dispatch fenced "anything requiring `views/edn_inspector.cljs`", because a sibling was rewriting the inspector's mount identity (rf2-d2aj), and it recorded that all three Static panels had **zero** dependency on it. Re-measured here, that is false for two of the three:

    static/flows/panel.cljs      requires views.edn-widget  ->  views.edn-inspector
    static/interceptors/panel.cljs   (none)
    static/schemas/panel.cljs    requires views.edn-widget  ->  views.edn-inspector

The dependency is not incidental. `edn-widget/inspect` answers `[ei/edn-inspector …]`, a Reagent head, and a plain function in head position is a loud error inside a Fresco body — so migrating either panel **forces** the swap to `edn-widget/inspect-view`, which mints its `:mount-id` from the caller's `node-key`. That is exactly the identity contract rf2-d2aj was rewriting, and `inspect-view` had **no callers on trunk at all**, so these would have been the first. The brief's instruction for that case is to drop and report rather than work around, so that is what this does.

**That blocker has since cleared**: `ba26dd1aa7` (rf2-d2aj) landed while this was in flight and is in this branch's base. A follow-up increment can take Flows and Schemas immediately, and they are cheap — structurally identical siblings of the panel migrated here.

`static/routes/**` is declined for the same reason (`routes/row_expand.cljs` requires `edn-widget`), plus a correction: the brief counted **5 `reg-view` sites** across the routes family; there is **1**, in `routes/panel.cljs`. The other four hits are `reg-view` in prose — the census trap the dispatch itself warns about.

## The migration

`Panel` is an `rf.fresco/defview` boundary reading `:rf.xray.static.interceptors/tab-data` with `rf.fresco/sub`, taking its dispatcher from `(:dispatch (rf/capture-frame))`. The body splits into `panel-tree`, a pure fn of the read's value and the dispatcher — `defview`'s own extract-a-helper spelling, and what keeps the four hiccup-walking unit rows drivable.

* **ONE boundary at 439 lines.** Every helper — `catalogue-panel`, `catalogue-row`, `interceptor-row` — is CALLED. The single head-position use was the shared `search-box/search-box`, now applied instead. Sizing by reads and head positions rather than line count, as increment 4 measured.
* **`Panel-bridge` is PRIVATE**, and that is measured: `Panel` is named nowhere outside its file, so the L4 registry is the only consumer. #9581's spelling (boundary keeps the natural name) applies unchanged — no fenced file mounts this panel by name, so #9578's inverted spelling was not needed.
* **`reg-view`'s injected `dispatch`/`subscribe`: zero sites here.** This panel already used qualified `rf/dispatch` with a captured frame, so the ruling's "single most common edit" did not bite. The render-time `(rf/current-frame-id)` capture carried over as `rf/capture-frame`, one call.
* `static/shell.cljs`, `mount.cljs`, `panels.cljs` and the denylist: **untouched**. This panel has no `mount-*!` facade, so not even a caller line moved.

## The key sweep (standing direction), and one real bug

Censused every `^{:key …}` in `static/**` with comments and docstrings stripped, flattened, and each site classified by the shape it decorates. **11 sites: 10 on vector literals, 1 on a CALL FORM** — `flows/panel.cljs`, the input-path values. Metadata on a call form is discarded when the call returns a fresh vector, so **no key ever reached React** and the inputs list reconciled by index. Same defect class as the Routes table (#9578) and as the one `static/machines/sim.cljs` already documents and works around.

Measured before the repair, with the new row in place: **all three input values came back with nil metadata**, three keys collapsing to one distinct value. After: three distinct keys.

Flows stays a `reg-view`, so `with-meta` is the correct spelling there — Reagent reads vector metadata. The migrated panel does the opposite, moving its key onto a **keyed fragment's attribute map**, because Fresco's codec reads a literal `:key` from an attribute map and reads Clojure metadata nowhere.

Two sites outside this slice carry the same call-form shape and are left for their owning increments: `panels/managed_fx_template.cljs:405` and `panels/trace.cljs:824`.

## Evidence

`panel_fresco_boundary_dom_cljs_test` — five rows in a real browser, mounted the way the Static shell mounts, through `panel-registry/tab-by-id :static` rather than by naming the var.

W1 first paint + the read lands in the frame the tree NAMED · W2 liveness with a deaf control · W3 no `:rf.view/*` op even inside an application frame, with a `reg-view` positive control · W4 teardown releases and reopen does not grow · **W5 row identity**.

W5 is the row this panel needed most and it is not one of the six criteria. A lost key does not fail — it degrades into index reconciliation, which paints identically. W5 removes the **head** of a two-row list (head position asserted with `compareDocumentPosition` first, so a tail truncation cannot make it vacuous) and asserts the survivor is the identical DOM node.

## Quality gates

Every number read from that run's own `.exit` file, never from a pipeline and never from the harness — **which disagreed three times, reporting "exit code 0" for runs whose captured code was 1. The file was right every time.** The browser lane is SPLIT from its compile and gated on the compile's captured exit, so a failed compile cannot be followed by a runner serving the previous bundle.

All re-run on the final base `0e0e6008ec` after the rebase.

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` | 0 | 11557 tests / 58009 assertions, 0 failures |
| `shadow-cljs compile browser-test` | 0 | config line names this worktree |
| `npm run test:browser` (runner alone) | 0 | 892 tests / 4933 assertions, 0 failures |
| `clojure -M:test` (tools/xray) | 0 | 1276 / 6118, 0 failures |
| `check_require_alias_dialect.py --verbose` | 0 | 2836 files, 11156 edges, 0 non-canonical, every surface at or under its floor |
| `check_require_alias_dialect.py --self-test` | 0 | 79 passed, 0 failed |
| `lint_kondo.py` (CI's pinned binary + flags) | 0 | errors 0; no finding on any file this PR adds |
| `clojure -M:splint --fail-on-errors` | 0 | 2596 files; the four findings on touched files are pre-existing lines |
| api-manifest `gen --check` + 5 projection checks | 0 | in sync, 471 public vars, no file rewritten |
| every `scripts/check_*.py` (43 of them) | 0 | run as a batch rather than guessed at |
| `check-beads-pr-boundary.sh` / `check-commit-attribution.sh` | 0 | no tracker path; no AI attribution in 3 commits |
| `check-examples-compile.cjs` | 0 | all **58** swept builds compiled, zero warnings |
| `test:xray-feature-gate` (nightly-full) | 1 | **PASS static mode chrome and chord**; 1 failure, pre-existing — see below |

The examples-compile sweep was run because the classifier **arms `examples_compile` for this diff** — I had assumed it would not, and asked `report-changed-surfaces.sh` rather than trusting the assumption. It also arms `cljs_browser`, `cljs_node_test`, `tools_jvm`, `mcp_conformance` and `story_xray_browser`.

Both test lanes ROSE against the last recorded figures (11543/57965 and 884/4879).

### Sabotage — both greens were made to bite, and one deliberately did not

Committed first; each plant anchored on a single interior substring with its **match count read before the run** (1 each); each restore verified by git **blob** hash against the committed object.

* **Row key deleted** from the keyed fragment: browser lane **exit 1, exactly ONE failure** — W5's identity assertion, `(not (identical? <HTMLLIElement> <HTMLLIElement>))`, every precondition still passing. The key row is not a hollow gate.
* **The boundary's read replaced with a frozen literal**: **exit 1, 7 failures** across W1, W2, W4 and W5. W1's names what it reads — `Cache keys: nil`, `(not (pos? 0))`. **W3 correctly stayed GREEN**, since a boundary emits no view-trace op whatever it reads.

Blob `258c8f404cd93aa2c970a042f2b1955680d68e4f` before and after both plants, identical to `HEAD:`.

### The one red is pre-existing, and it was MEASURED rather than assumed

`20-event large value elision load` times out waiting for `[data-testid="rf-xray-app-db-diff"]` — the **Dynamic App-db panel**, migrated by increment 5, on none of this branch's five files.

Three runs settle it. With my two source files reverted to the merge base, the sweep produced the **identical** result — same exit, same single scenario, same selector. It also still fails on the final base, so **rf2-d2aj's landing did not fix it**. No nightly has run since increment 5 landed, so CI has not seen it yet. Reported, not touched: the App-db panel is explicitly outside this slice.

## Fences held

`static/shell.cljs`, `static/machines/**`, `mount.cljs`, `registry.cljs`, `panels.cljs`, `test_support.cljs`, `views/edn_inspector.cljs`, `views/edn_widget.cljs`, `panels/app_db_diff_state.cljs`, every existing bridge and the denylist (rf2-k97c.4): untouched. No hot-zone file, `spec/api-manifest*.edn` included. Nothing under `implementation/` requires anything under `tools/`. No tracker-database path — the whole diff is five files under `tools/xray`. The three-dot diff against the merge base was read for reverts: none.

No node_modules junction was created; this worktree carries a real install from the lockfile, and the coordinator's tree read 103 immediate / 27 in `.bin` before and after.

No AI-attribution trailers in any commit or in this body, per CLAUDE.md over the session-level instruction that says the opposite.
