### PR TITLE
fix(xray): let the caller name two app-db Panels in one frame (rf2-t3fz)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -112,8 +112,15 @@
   annotation (rf2-fyd8u), and the added/removed colouring (rf2-9d4j8)
   together give FULL+DIFF the density `:diff` used to provide and the
   comparison-context `:full` lacked, so the three-mode toggle (and its
-  sub/event/slot trio) is gone."
-  [section-model selected-epoch-id]
+  sub/event/slot trio) is gone.
+
+  rf2-t3fz — the 3-arity takes `Panel`'s optional `:instance-id` and
+  hands it to `state-body`, which composes it into every section's
+  edn-inspector `:mount-id` and `:site-id`. The 2-arity is the
+  single-mount call and is unchanged in every id it produces."
+  ([section-model selected-epoch-id]
+   (panel-tree section-model selected-epoch-id nil))
+  ([section-model selected-epoch-id instance-id]
   [:section {:data-testid "rf-xray-app-db-diff"
              ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis on
              ;; the enclosing section. FULL+DIFF is the single mode
@@ -149,7 +156,7 @@
     ;; no DOM node, so the per-epoch clean remount this comment describes
     ;; survives the migration intact.
     [:<> {:key selected-epoch-id}
-     (state/state-body section-model)]]])
+     (state/state-body section-model instance-id)]]]))
 
 (rf.fresco/defview Panel
   "The app-db tab's root — a current-state inspector sectioned by
@@ -172,12 +179,39 @@
   READING BOTH HERE, which is why the two reads stay together in this body
   rather than moving down into the projection.
 
-  The argument is the ordinary one-props-map vector every `defview`
-  takes. This panel reads nothing from props — the L4 registry and the
-  standalone embed both mount it with none — so it is destructured away."
-  [_props]
+  ## `:instance-id` — OPTIONAL, and it names ONE LIVE MOUNT (rf2-t3fz)
+
+  This panel reads no DATA from props: the value it renders comes from
+  the two subs below and from nothing else, and the L4 registry and the
+  standalone embed both mount it with no props at all. The one prop it
+  takes is an IDENTITY.
+
+  Every id the sections compose — the edn-inspector's `:mount-id`, the
+  expansion/zoom `:site-id` — names a logical SURFACE and is deliberately
+  stable, so two `Panel`s on screen at once present the same ones.
+  rf2-d2aj qualified the widget's per-mount store by the FRAME, which
+  separates two panels under two `frame-provider`s; two panels under ONE
+  frame it cannot separate, and nothing inside the widget can — a Fresco
+  boundary is a React function component with no per-instance storage its
+  body may use, so there is no id for it to mint. Left unnamed the two
+  share one store entry, one ResizeObserver, one projection cache and one
+  width slot, and detaching either releases the survivor's state.
+
+  So the distinction is the caller's to make, and this prop is how:
+
+      [Panel {:instance-id \"left\"}]
+      [Panel {:instance-id \"right\"}]
+
+  A non-blank string or a keyword. It must be STABLE across that
+  instance's renders — it is an identity, not a per-render nonce — and
+  `app-db-diff-state`'s `instance-token` refuses, loudly, the shapes that
+  could not be. OMIT IT when only one app-db Panel renders in this frame,
+  which is every call site in this tree today: the ids are then
+  byte-for-byte what they were."
+  [{:keys [instance-id]}]
   (panel-tree (rf.fresco/sub [:rf.xray/app-db-state])
-              (:epoch-id (rf.fresco/sub [:rf.xray/app-db-current+diff]))))
+              (:epoch-id (rf.fresco/sub [:rf.xray/app-db-current+diff]))
+              instance-id))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;
@@ -211,9 +245,26 @@
   `:rf/xray` in React context for it.
 
   PUBLIC because the standalone `mount-*!` facade in `panels.cljs` passes
-  it by name — unlike the L4-only panels, whose bridge can stay private."
-  []
-  [:> Panel-component {}])
+  it by name — unlike the L4-only panels, whose bridge can stay private.
+
+  rf2-t3fz — the 1-arity is how a REAGENT parent names an instance when
+  it renders two of these under one `frame-provider`:
+
+      [Panel-bridge {:instance-id \"left\"}]
+
+  The 0-arity stays because that is how the shell mounts an L4 tab
+  (`[(:panel tab)]`) and how `render-panel!` mounts the standalone embed
+  (`[panel-view]`) — one panel per frame, no instance to name. The prop
+  crosses `[:>]` as a STRING either way: Reagent converts a prop value
+  before React sees it, so a keyword written here arrives at the boundary
+  as its name (`Panel`'s own `:instance-id` note, and `instance-token`
+  accepts both spellings for exactly that reason)."
+  ([] (Panel-bridge nil))
+  ([props]
+   [:> Panel-component
+    (if-let [instance-id (:instance-id props)]
+      {:instance-id instance-id}
+      {})]))
 
 (defn install!
   "Idempotent install for the app-db tab's Xray-side registrations.

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -181,10 +181,90 @@
   [:div {:style empty-body-style}
    label])
 
+;; ---- panel-instance identity (rf2-t3fz) ---------------------------------
+;;
+;; Every id below — the widget's `:mount-id`, the expansion/zoom
+;; `:site-id` — names a LOGICAL SURFACE of the app-db panel, and is
+;; deliberately stable so a tab-switch round-trip comes back to the same
+;; expansion, the same zoom and the same measured column. That stability
+;; is the whole point, and it is also why a surface name cannot double as
+;; a LIVE-MOUNT identity: two `Panel`s on screen at once present the same
+;; surface names.
+;;
+;; rf2-d2aj fixed HALF of that. The widget's per-mount store — the
+;; ResizeObserver, the width debounce, the Editscript projection cache —
+;; is keyed by `[frame-id mount-id]`, so two panels under two DIFFERENT
+;; `frame-provider`s no longer collide. Two panels under ONE frame still
+;; do, and nothing inside the widget can separate them: a Fresco boundary
+;; is a real React function component with no per-instance storage its
+;; body may use (hooks do not belong in a body, and `rf.fresco/reg-state`
+;; consumes an instance key rather than minting one). rf2-d2aj's closing
+;; ruling named that case the CALLER's to name, which is what this is.
+;;
+;; So `Panel` takes an optional `:instance-id` prop and it is threaded
+;; down to here. When the caller names one it qualifies BOTH ids, and
+;; that pair is deliberate rather than belt-and-braces: qualifying the
+;; store key alone would leave both instances writing the SAME width
+;; slot, which is keyed by the logical `mount-id` inside the frame — a
+;; wrong number rather than a missing one. When no instance is named
+;; every id is byte-for-byte what it was, so the single-mount callers
+;; (the L4 tab, the standalone `mount-app-db-diff!` facade) are
+;; untouched.
+;;
+;; `:site-id` is qualified too because a caller who has bothered to name
+;; two instances wants them independent: unqualified, expanding a node in
+;; one expands it in the other and zooming one zooms both. It stays
+;; stable across THAT instance's remounts, which is all rf2-pvsxs asked
+;; of it, because a caller-supplied instance id is an identity and not a
+;; per-render nonce — see [[instance-token]] for what is refused to keep
+;; it that way.
+
+(defn- instance-token
+  "Normalise `Panel`'s optional `:instance-id` prop to the string that
+  qualifies one instance's section ids, or nil when the caller named no
+  instance (the single-mount default — every composed id is then exactly
+  what it was before rf2-t3fz).
+
+  A KEYWORD is accepted alongside a string because the two doors into
+  `Panel` disagree about what survives the crossing: mounted from a
+  Fresco body a keyword arrives as a keyword, while a Reagent parent's
+  `[:>]` converts a prop VALUE first and it arrives as its name (Fresco's
+  `as-component` puts it in terms — names round-trip across a crossing,
+  values do not). Refusing one here would make one call site behave two
+  ways depending on which head mounted it.
+
+  Anything else is REFUSED rather than `str`-ed, and that is the point of
+  the fn. The token has to be stable across the instance's renders; a
+  value whose printed form is minted per render — a map, a JS object —
+  would compose a fresh `:mount-id` and `:site-id` on every pass and
+  silently throw away expansion, zoom and the measured column width each
+  time. That is the same failure `edn-inspector-view`'s own `:mount-id`
+  refusal exists to prevent, one level up."
+  [instance-id]
+  (cond
+    (nil? instance-id)     nil
+    (keyword? instance-id) (subs (str instance-id) 1)
+    (string? instance-id)  (when (seq instance-id) instance-id)
+    :else
+    (throw (ex-info
+             (str "The app-db Panel's :instance-id must be a non-blank string "
+                  "or a keyword naming ONE live mount of the panel; it was "
+                  (pr-str instance-id) ". It is composed into the "
+                  "edn-inspector's :mount-id and :site-id, so it must be "
+                  "stable across that mount's renders — a value minted per "
+                  "render would lose expansion, zoom and the measured column "
+                  "width on every pass. Omit it entirely when only one "
+                  "app-db Panel is on screen in this frame.")
+             {:instance-id instance-id}))))
+
 (defn- value-body
   "Render a current-state VALUE, with the inline `← changed` diff
   annotation when a pre-image is supplied (spec/021 §4.3). `render-id`
   keeps adjacent renders' testids independent across the panel.
+
+  The 5-arity's `instance-id` is `Panel`'s optional per-instance name;
+  see the block comment above for what it separates and why. The 4-arity
+  is the single-mount call and composes exactly the ids it always did.
 
   `f/display-value` runs first so giant string leaves collapse to the
   `:rf.size/large-elided` display marker before rendering — the same
@@ -216,8 +296,14 @@
   slice rendered identically to an unchanged one and the per-event diff
   was near-invisible — the focused epoch's actual change (a new instance
   appearing) carried no visual marker at all."
-  [value before render-id title]
-  (let [;; rf2-k97c.3 — `:mount-id` is REQUIRED by the Fresco head and must
+  ([value before render-id title]
+   (value-body value before render-id title nil))
+  ([value before render-id title instance-id]
+  (let [;; rf2-t3fz — the caller's per-instance name, or nil for the
+        ;; single-mount default. Normalised (and type-refused) ONCE here so
+        ;; the two compositions below can never disagree about it.
+        instance (instance-token instance-id)
+        ;; rf2-k97c.3 — `:mount-id` is REQUIRED by the Fresco head and must
         ;; be a stable string: a boundary is a React function component with
         ;; no form-2 outer body, so an id minted in the body would be fresh
         ;; every render and the widget would lose its expansion state each
@@ -236,14 +322,30 @@
         ;; would take `:site-id` with it and lose expansion and zoom on
         ;; every pass, which is the trade the widget's split exists to
         ;; avoid.
-        mount-id  (str "app-db-state/" render-id)
+        ;;
+        ;; rf2-t3fz — the frame qualifier does not reach two panels in ONE
+        ;; frame, and the caller's `instance` is what does. It is a stable
+        ;; NAME and not a per-render nonce (`instance-token` refuses the
+        ;; shapes that would not be), so this stays exactly the stable
+        ;; string the paragraph above requires — it now names one live
+        ;; instance's surface rather than every instance's at once.
+        mount-id  (if instance
+                    (str "app-db-state/" instance "/" render-id)
+                    (str "app-db-state/" render-id))
         ;; rf2-pvsxs — stable `:site-id` so expansion overrides survive
         ;; a tab-switch round-trip. `render-id` already identifies the
         ;; logical surface (e.g. "top" for the user-domain section, an
         ;; area name for the per-:rf/* sections), so passing it AS the
         ;; site-id reuses the existing per-surface key without
         ;; introducing a new namespace.
-        site-id [:rf.xray/app-db render-id]
+        ;;
+        ;; rf2-t3fz — qualified by the same instance name when the caller
+        ;; supplies one, so two named instances expand and zoom
+        ;; independently. Unqualified it is unchanged, which is every
+        ;; single-mount call site.
+        site-id (if instance
+                  [:rf.xray/app-db instance render-id]
+                  [:rf.xray/app-db render-id])
         ;; rf2-227cz — three before-states: `no-diff` (render plain),
         ;; `added` (this whole slice is new this epoch → `:added? true`),
         ;; or a real pre-image (diff against it → `:before`).
@@ -292,7 +394,7 @@
                   ;; `:added?` path so the entire subtree washes `:added`
                   ;; (green) rather than rendering as plain unchanged state.
                   added?
-                  (assoc :added? true))}]))
+                  (assoc :added? true))}])))
 
 ;; ---- top (user-domain) section ------------------------------------------
 
@@ -307,9 +409,13 @@
   the panel's anchor; an empty user-domain app-db is itself meaningful
   operator information). Empty reserved-area sections are filtered at
   projection time and never reach the renderer; only the TOP carries
-  an empty-state body."
+  an empty-state body.
+
+  rf2-t3fz — the 3-arity carries `Panel`'s optional `:instance-id` down
+  to the value body; see the block comment above [[instance-token]]."
   ([top] (top-section top h/no-diff))
-  ([top before]
+  ([top before] (top-section top before nil))
+  ([top before instance-id]
    (let [title  [:span "app-db"]
          empty? (and (map? top) (empty? top))]
      (section-shell
@@ -318,7 +424,7 @@
         :hide-header? (not empty?)
         :body         (if empty?
                         (empty-body "app-db has no user-domain keys yet.")
-                        (value-body top before "top" title))}))))
+                        (value-body top before "top" title instance-id))}))))
 
 ;; ---- reserved-area sections ---------------------------------------------
 
@@ -335,22 +441,26 @@
   (`:rf/machines`) and per parent (`:rf/spawned`). The instance carries
   its own `:before` pre-image so the body diff-annotates the changed
   snapshot in place. The section-shell H3 is suppressed — the
-  edn-inspector card's own header ribbon carries the title."
-  [area {:keys [id value] :as inst}]
-  (let [title [:span
-               (area-label area)
-               [:span {:style instance-section-separator-style}
-                "›"]
-               [:span {:style instance-section-id-style}
-                (pr-str id)]]]
-    (section-shell
-      {:testid       (str "rf-xray-app-db-state-instance-"
-                          (pr-str area) "-" (pr-str id))
-       :title        title
-       :hide-header? true
-       :body         (value-body value (get inst :before h/no-diff)
-                                 (str (pr-str area) "/" (pr-str id))
-                                 title)})))
+  edn-inspector card's own header ribbon carries the title.
+
+  rf2-t3fz — the 3-arity carries `Panel`'s optional `:instance-id`."
+  ([area inst] (instance-section area inst nil))
+  ([area {:keys [id value] :as inst} instance-id]
+   (let [title [:span
+                (area-label area)
+                [:span {:style instance-section-separator-style}
+                 "›"]
+                [:span {:style instance-section-id-style}
+                 (pr-str id)]]]
+     (section-shell
+       {:testid       (str "rf-xray-app-db-state-instance-"
+                           (pr-str area) "-" (pr-str id))
+        :title        title
+        :hide-header? true
+        :body         (value-body value (get inst :before h/no-diff)
+                                  (str (pr-str area) "/" (pr-str id))
+                                  title
+                                  instance-id)}))))
 
 (defn instances-area
   "Render a map-of-instances reserved area (`:rf/machines`,
@@ -358,8 +468,11 @@
 
   rf2-jcdvo — empty registries are filtered at projection time
   (`current-state-sections` omits `:empty?` entries) so this fn is
-  only invoked for populated registries; no empty-state branch."
-  [{:keys [area instances]}]
+  only invoked for populated registries; no empty-state branch.
+
+  rf2-t3fz — the 2-arity carries `Panel`'s optional `:instance-id`."
+  ([area-entry] (instances-area area-entry nil))
+  ([{:keys [area instances]} instance-id]
   (into [:div {:data-testid (str "rf-xray-app-db-state-area-" (pr-str area))}]
         (for [{:keys [id] :as inst} instances]
           ;; rf2-k97c.3 — the sequence key rides on a keyed FRAGMENT rather
@@ -376,7 +489,7 @@
           ;; answers hiccup of no fixed shape, so there is no one attribute
           ;; map to write into; `[:<> …]` takes the key and adds no DOM node.
           [:<> {:key (pr-str id)}
-           (instance-section area inst)])))
+           (instance-section area inst instance-id)]))))
 
 (defn singleton-area
   "Render a singleton-slice reserved area (`:rf/route`,
@@ -387,29 +500,36 @@
   (`current-state-sections` omits `:empty?` entries) so this fn is
   only invoked for populated slices; no empty-state branch. The
   section-shell H3 is suppressed — the edn-inspector card's own header
-  ribbon carries the title."
-  [{:keys [area value] :as area-entry}]
-  (let [title (area-label area)]
-    (section-shell
-      {:testid       (str "rf-xray-app-db-state-area-" (pr-str area))
-       :title        title
-       :hide-header? true
-       :body         (value-body value (get area-entry :before h/no-diff)
-                                 (pr-str area)
-                                 title)})))
+  ribbon carries the title.
+
+  rf2-t3fz — the 2-arity carries `Panel`'s optional `:instance-id`."
+  ([area-entry] (singleton-area area-entry nil))
+  ([{:keys [area value] :as area-entry} instance-id]
+   (let [title (area-label area)]
+     (section-shell
+       {:testid       (str "rf-xray-app-db-state-area-" (pr-str area))
+        :title        title
+        :hide-header? true
+        :body         (value-body value (get area-entry :before h/no-diff)
+                                  (pr-str area)
+                                  title
+                                  instance-id)}))))
 
 (defn area-section
   "Dispatch one reserved-area section entry (from
   `current-state-sections`'s `:areas`) to the matching renderer based
   on its `:kind`. Only invoked for non-empty areas — empty entries are
-  filtered at projection time (rf2-jcdvo)."
-  [{:keys [kind] :as area-entry}]
-  (case kind
-    :instances (instances-area area-entry)
-    :singleton (singleton-area area-entry)
-    ;; Defensive — an unknown kind still renders the bare key so the
-    ;; area never silently vanishes.
-    (singleton-area area-entry)))
+  filtered at projection time (rf2-jcdvo).
+
+  rf2-t3fz — the 2-arity carries `Panel`'s optional `:instance-id`."
+  ([area-entry] (area-section area-entry nil))
+  ([{:keys [kind] :as area-entry} instance-id]
+   (case kind
+     :instances (instances-area area-entry instance-id)
+     :singleton (singleton-area area-entry instance-id)
+     ;; Defensive — an unknown kind still renders the bare key so the
+     ;; area never silently vanishes.
+     (singleton-area area-entry instance-id))))
 
 ;; ---- panel body ----------------------------------------------------------
 
@@ -425,12 +545,19 @@
   lens both retired with the toggle.
 
   Pure hiccup; nil-safe (a nil model degrades to an empty TOP + no
-  areas)."
-  [{:keys [top areas] :as model}]
-  (let [before-top (get model :before-top h/no-diff)]
-    (into [:div {:data-testid "rf-xray-app-db-state"}
-           (top-section top before-top)]
-          (for [{:keys [area] :as area-entry} areas]
-            ;; rf2-k97c.3 — keyed fragment; see `instances-area` above.
-            [:<> {:key (pr-str area)}
-             (area-section area-entry)]))))
+  areas).
+
+  rf2-t3fz — the 2-arity takes `Panel`'s optional `:instance-id` and
+  threads it to every section, which is what lets two `Panel`s under ONE
+  `frame-provider` own separate edn-inspector lifecycles. The 1-arity is
+  the single-mount call and composes exactly the ids it always did; see
+  the block comment above `instance-token`."
+  ([model] (state-body model nil))
+  ([{:keys [top areas] :as model} instance-id]
+   (let [before-top (get model :before-top h/no-diff)]
+     (into [:div {:data-testid "rf-xray-app-db-state"}
+            (top-section top before-top instance-id)]
+           (for [{:keys [area] :as area-entry} areas]
+             ;; rf2-k97c.3 — keyed fragment; see `instances-area` above.
+             [:<> {:key (pr-str area)}
+              (area-section area-entry instance-id)])))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -77,11 +77,17 @@
 
   Only the READS are reproduced here; the MARKUP stays in the panel, as
   `app-db-diff/panel-tree`, so these rows still fail when the panel's own
-  shape drifts."
-  []
-  (app-db-diff/panel-tree
-    @(rf/subscribe [:rf.xray/app-db-state])
-    (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff]))))
+  shape drifts.
+
+  rf2-t3fz — the 1-arity reproduces a `Panel` mounted with an
+  `:instance-id` prop, which is how a caller names ONE of two live panels
+  under one `frame-provider`."
+  ([] (panel-tree nil))
+  ([instance-id]
+   (app-db-diff/panel-tree
+     @(rf/subscribe [:rf.xray/app-db-state])
+     (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff]))
+     instance-id)))
 
 ;; ---- fixture data --------------------------------------------------------
 
@@ -742,3 +748,66 @@
         (is (= :cart-frame @(rf/subscribe [:rf.xray/observed-frame]))
             "observed-frame reflects the picker selection (rf2-fvplw —
              preserved post-rf2-ug1r6)")))))
+
+;; ---- (9) `:instance-id` — naming one of two live panels (rf2-t3fz) ------
+;;
+;; rf2-d2aj keyed the edn-inspector's per-mount store by `[frame-id
+;; mount-id]`, which separates two panels under two `frame-provider`s and
+;; cannot separate two under ONE — a Fresco boundary has no per-instance
+;; storage its body may use, so the distinction is the caller's to make.
+;; `Panel` takes an optional `:instance-id` prop for it and hands it to
+;; `panel-tree`; what the ids then compose to, and the lifecycle and width
+;; consequences of getting it wrong, are pinned in
+;; `app_db_diff_state_cljs_test`'s closing block (positive half plus the
+;; defect as an explicit negative control). These two rows pin the THREADING
+;; — that the prop reaches the sections at all, and that the two doors into
+;; the boundary both carry it.
+
+(deftest panel-tree-threads-instance-id-to-the-sections
+  (testing "rf2-t3fz — `panel-tree` hands its `:instance-id` down to
+            `state-body`, so two instances of the panel over one frame's
+            app-db render two disjoint sets of widget mount-ids. The
+            2-arity is the single-mount call and is unchanged."
+    (seed-host-frame! {:counter 5 :user {:name "ada"}})
+    (registry/register-xray-handlers!)
+    (rf/make-frame {:id :rf/xray})
+    (rf/with-frame :rf/xray
+      (let [mount-ids (fn [tree]
+                        (->> (hiccup-seq tree)
+                             (keep (fn [n]
+                                     (when (and (vector? n)
+                                                (fn? (first n))
+                                                (map? (second n)))
+                                       (:mount-id (second n)))))
+                             vec))
+            plain (mount-ids (panel-tree))
+            left  (mount-ids (panel-tree "left"))
+            right (mount-ids (panel-tree "right"))]
+        (is (seq plain)
+            "control: the panel mounts at least one edn-inspector widget, so
+             an empty intersection below means separation and not silence")
+        (is (= (count plain) (count left) (count right))
+            "naming an instance changes the ids, never the sections")
+        (is (nil? (some (set left) right))
+            "no mount-id survives from one named instance to the other")
+        (is (= plain
+               (mount-ids
+                 (app-db-diff/panel-tree
+                   @(rf/subscribe [:rf.xray/app-db-state])
+                   (:epoch-id @(rf/subscribe [:rf.xray/app-db-current+diff])))))
+            "and the 2-arity — every call site in this tree today — composes
+             exactly what it always did")))))
+
+(deftest panel-bridge-carries-the-instance-id-across-the-reagent-door
+  (testing "rf2-t3fz — the Reagent-facing bridge passes `:instance-id`
+            through to the React component, and its 0-arity — the shell's
+            `[(:panel tab)]` and `render-panel!`'s `[panel-view]` — still
+            mounts with no props at all."
+    (let [named   (app-db-diff/Panel-bridge {:instance-id "left"})
+          unnamed (app-db-diff/Panel-bridge)]
+      (is (= :> (first named))
+          "still an interop vector onto the boundary's React component")
+      (is (= "left" (:instance-id (nth named 2)))
+          "the caller's instance name reaches the component's props")
+      (is (= {} (nth unnamed 2))
+          "and the 0-arity mounts with no props, exactly as before"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -771,6 +771,14 @@
     (seed-host-frame! {:counter 5 :user {:name "ada"}})
     (registry/register-xray-handlers!)
     (rf/make-frame {:id :rf/xray})
+    ;; EP-0002 (rf2-bd4div) — the observed target no longer defaults, and
+    ;; without it the panel projects against nothing: the TOP section still
+    ;; renders (it is the panel's anchor) but with the EMPTY-STATE body, so
+    ;; no edn-inspector mounts at all. That is exactly the silence the
+    ;; control below is here to separate from real separation, and it caught
+    ;; this row's first draft.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
     (rf/with-frame :rf/xray
       (let [mount-ids (fn [tree]
                         (->> (hiccup-seq tree)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -10,13 +10,30 @@
   The section VALUE bodies render through the canonical EDN widget's
   cljs-devtools `inspect` path; these tests assert section structure +
   testids, not the inner cljs-devtools markup (that engine is covered
-  by `views.edn-widget.*` tests)."
+  by `views.edn-widget.*` tests).
+
+  ## rf2-t3fz — two panel instances under ONE frame
+
+  The last block in this file is the exception to \"no DOM mount\": it
+  drives the edn-inspector's per-mount store directly, with the mount-ids
+  READ OUT OF the hiccup the sections above render. That is the residual
+  rf2-d2aj deliberately left — its `[frame-id mount-id]` lifecycle key
+  separates two panels under two `frame-provider`s and cannot separate two
+  under one — and the block carries the defect as an explicit negative
+  control. See the banner comment there."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.test-support :as rf.test-support]
             [cljs.test :refer-macros [use-fixtures]]
             [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]
-            [day8.re-frame2-xray.panels.app-db-diff-state :as state]))
+            [day8.re-frame2-xray.panels.app-db-diff-state :as state]
+            ;; rf2-t3fz — READ-ONLY here, and only for the per-mount store's
+            ;; public test surface (`lifecycle-key`, `container-ref-for`,
+            ;; `mount-state-count`, `mount-state-held`). The widget's own
+            ;; rows live in `views/edn_inspector_mount_state_cljs_test`; what
+            ;; these assert is that the PANEL hands that store two distinct
+            ;; keys when the caller names two instances.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; `state-body` renders values through the EDN widget's pure `inspect`
 ;; path (cljs-devtools). A plain-atom runtime keeps any reactive read in
@@ -324,8 +341,14 @@
                 (vector? n)
                 (do (when (fn? (first n))
                       (let [props (when (>= (count n) 2) (nth n 1))]
-                        (swap! out conj {:value (:value props)
-                                         :opts  (:opts props)})))
+                        ;; rf2-t3fz — `:mount-id` is carried too. It is the
+                        ;; id the per-mount store is keyed by (qualified by
+                        ;; the frame), and the rows at the foot of this file
+                        ;; read it off the render rather than rebuilding the
+                        ;; panel's composition rule in the test.
+                        (swap! out conj {:mount-id (:mount-id props)
+                                         :value    (:value props)
+                                         :opts     (:opts props)})))
                     (doseq [c (rest n)] (walk c)))
                 (seq? n) (doseq [c n] (walk c))))]
       (walk tree))
@@ -560,3 +583,217 @@
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
       (is (seq diff-mts)
           "the changed-machine instance mount threads `:before`"))))
+
+;; ===========================================================================
+;; rf2-t3fz — TWO PANEL INSTANCES UNDER ONE FRAME PROVIDER
+;; ===========================================================================
+;;
+;; Every id these sections compose names a logical SURFACE — the widget's
+;; `:mount-id`, the expansion/zoom `:site-id` — and is deliberately the same
+;; string from every instance of the panel, because that stability is what
+;; survives a tab-switch round-trip. rf2-d2aj gave the widget's per-mount
+;; store a lifecycle key of `[frame-id mount-id]`, which separates two
+;; panels under two `frame-provider`s. It does not, and cannot, separate two
+;; panels under ONE: a Fresco boundary is a React function component with no
+;; per-instance storage its body may use, so nothing inside the widget can
+;; tell two structurally identical siblings apart. rf2-d2aj's closing ruling
+;; named that residual the CALLER's to name; `Panel`'s `:instance-id` prop is
+;; the naming, and these rows are what says it works.
+;;
+;; They follow R9 in `views/edn_inspector_mount_state_cljs_test` — no DOM,
+;; because the store is where the release actually happens and it is
+;; assertable in milliseconds against a browser lane's seconds — with two
+;; differences that carry the whole of this bead:
+;;
+;;   * ONE DISPATCHER, not two. Both instances render under one frame, so
+;;     the widths they measure land in ONE app-db. Folding both dispatches
+;;     into the slot they write is what exercises the SECOND half of the
+;;     defect: qualifying the store key alone would leave both instances
+;;     writing the same `mount-id`-keyed width slot, so the fix has to move
+;;     both or it is only half a fix.
+;;   * THE MOUNT-IDS ARE READ OFF THE PANEL'S OWN RENDER rather than written
+;;     here. A row that spelled them out would keep passing if the panel
+;;     stopped distinguishing two instances, which is precisely the claim.
+;;
+;; The negative control is the defect verbatim: the same two panels with no
+;; instance named at all.
+
+(def ^:private one-frame
+  "The single frame both instances render under — the case rf2-d2aj's
+  `[frame-id mount-id]` key cannot separate. A test-only id, so these rows
+  cannot collide with another namespace's entries in the module-global
+  store."
+  :rf.xray.test/samefrm)
+
+(defn- section-mount-ids
+  "The `:mount-id`s the panel composed for `tree`, in render order."
+  [tree]
+  (mapv :mount-id (find-edn-inspector-mounts tree)))
+
+(defn- section-site-ids
+  "The expansion/zoom `:site-id`s the panel composed for `tree`."
+  [tree]
+  (mapv #(get-in % [:opts :site-id]) (find-edn-inspector-mounts tree)))
+
+(defn- fake-el
+  "A stand-in container element. `measure-and-dispatch!` reads `clientWidth`
+  and nothing else, and `js/ResizeObserver` does not exist under Node."
+  [w]
+  #js {:clientWidth w})
+
+(defn- attach!
+  "Mount one section the way `edn-inspector-view` does: compose the lifecycle
+  key from the frame and the mount-id the PANEL rendered, take the memoised
+  ref for it, and hand it an element of `width`. Returns the ref callback."
+  [mount-id dispatch-fn width]
+  (let [ref-fn (ei/container-ref-for (ei/lifecycle-key one-frame mount-id)
+                                     mount-id
+                                     dispatch-fn)]
+    (ref-fn (fake-el width))
+    ref-fn))
+
+(defn- unmount!
+  "What React does at unmount: call the container ref with nil."
+  [ref-fn]
+  (ref-fn nil))
+
+(defn- widths-from
+  "Fold the dispatched width events into the app-db slot they write, which is
+  where the renderer reads a measured column back out of. Asserting on the
+  SLOT rather than on the event list is the point: two events that name one
+  key are one width, and that is the half of this defect a store-key-only
+  fix leaves standing."
+  [events]
+  (reduce (fn [acc [ev mount-id w]]
+            (case ev
+              :rf.xray.edn-inspector/set-width   (assoc acc mount-id w)
+              :rf.xray.edn-inspector/clear-width (dissoc acc mount-id)
+              acc))
+          {}
+          events))
+
+(deftest t3fz-named-instances-compose-distinct-ids
+  (testing "rf2-t3fz — two `:instance-id`s over the SAME section model
+            compose two disjoint sets of `:mount-id`s and `:site-id`s, and
+            naming no instance leaves every id exactly what it was."
+    (let [model  (sections {:counter 5} {:rf/route {:id :home}})
+          plain  (state/state-body model)
+          left   (state/state-body model "left")
+          right  (state/state-body model "right")
+          ids-p  (section-mount-ids plain)
+          ids-l  (section-mount-ids left)
+          ids-r  (section-mount-ids right)]
+      (is (< 1 (count ids-p))
+          "control: this model renders more than one widget mount, so the
+           rows below are about a SET of ids and not a single string")
+      (is (= (count ids-p) (count ids-l) (count ids-r))
+          "naming an instance changes the ids, never the sections")
+      (is (nil? (some (set ids-l) ids-r))
+          "no mount-id is shared between two named instances — the store key
+           and the width slot are both derived from this string, so a single
+           shared id is the whole defect")
+      (is (nil? (some (set (section-site-ids left)) (section-site-ids right)))
+          "and no site-id either, so the two expand and zoom independently
+           rather than moving in lockstep")
+      (is (= ["app-db-state/top" "app-db-state/:rf/route"] ids-p)
+          "UNNAMED IS UNCHANGED: the single-mount call sites (the L4 tab, the
+           standalone embed) compose the ids they always did")
+      (is (= ["app-db-state/left/top" "app-db-state/left/:rf/route"] ids-l)
+          "and a named instance qualifies them without disturbing the
+           surface name inside")))
+
+  (testing "rf2-t3fz — a keyword instance-id is accepted, because a Reagent
+            parent's `[:>]` crossing converts a prop value to its name while
+            a Fresco body hands it over as a keyword; refusing one here would
+            make one call site behave two ways."
+    (let [model (sections {:counter 5} {})]
+      (is (= (section-mount-ids (state/state-body model :left))
+             (section-mount-ids (state/state-body model "left")))
+          "`:left` and \"left\" name the same instance")))
+
+  (testing "rf2-t3fz — an instance-id that could not be stable across renders
+            is REFUSED rather than `str`-ed into a fresh id every pass."
+    (let [model (sections {:counter 5} {})]
+      (is (thrown-with-msg? js/Error #":instance-id"
+            (state/state-body model {:not "a name"}))
+          "a map is refused")
+      (is (= (section-mount-ids (state/state-body model))
+             (section-mount-ids (state/state-body model "")))
+          "and a blank string is simply no instance, not a `//` id"))))
+
+(deftest t3fz-two-named-instances-in-one-frame-stay-independent
+  (testing "rf2-t3fz — two app-db Panels under ONE frame provider, each named
+            by the caller, get two ref callbacks, two store entries and two
+            width slots, and detaching one leaves the other whole."
+    (let [model    (sections {:counter 5} {})
+          left-id  (first (section-mount-ids (state/state-body model "left")))
+          right-id (first (section-mount-ids (state/state-body model "right")))
+          sink     (atom [])
+          ;; ONE frame ⇒ ONE dispatcher. Both instances write into the same
+          ;; app-db, which is why the width slot has to separate them.
+          dispatch #(swap! sink conj %)
+          before   (ei/mount-state-count)
+          ref-l    (attach! left-id dispatch 100)
+          ref-r    (attach! right-id dispatch 200)]
+      (is (not= left-id right-id)
+          "the panel composed two mount-ids for two named instances")
+      (is (not (identical? ref-l ref-r))
+          "two live mounts under one frame get two ref callbacks — sharing
+           one is what leaves the second element unobserved and never
+           measured")
+      (is (= (+ before 2) (ei/mount-state-count))
+          "and two store entries, not one")
+      (is (= {left-id 100 right-id 200} (widths-from @sink))
+          "each instance measured itself into its OWN width slot inside the
+           one frame they share")
+
+      (reset! sink [])
+      (unmount! ref-r)
+      (is (nil? (ei/mount-state-held (ei/lifecycle-key one-frame right-id)))
+          "the detached instance is gone")
+      (is (contains? (ei/mount-state-held (ei/lifecycle-key one-frame left-id))
+                     :ref)
+          "and the instance still on screen is untouched — releasing the
+           survivor is what the shared key did, and it disconnected an
+           observer of a node still in the document")
+      (is (= [[:rf.xray.edn-inspector/clear-width right-id]] @sink)
+          "the width clear named the LEAVING instance's slot and only it, so
+           the survivor's measured column is still there")
+
+      (unmount! ref-l)
+      (is (= before (ei/mount-state-count))
+          "both released, store back where it started"))))
+
+(deftest t3fz-negative-control-unnamed-instances-collide
+  (testing "rf2-t3fz — THE DEFECT VERBATIM, so this file cannot go green over
+            a half-repair. The same two panels with no instance named compose
+            ONE mount-id between them; under one frame that is one lifecycle
+            key AND one width slot, so they share a ref, the second
+            instance's measurement lands in the FIRST's slot — a wrong number
+            rather than a missing one — and detaching the second releases the
+            first."
+    (let [model    (sections {:counter 5} {})
+          id-a     (first (section-mount-ids (state/state-body model)))
+          id-b     (first (section-mount-ids (state/state-body model)))
+          sink     (atom [])
+          dispatch #(swap! sink conj %)
+          before   (ei/mount-state-count)]
+      (is (= id-a id-b)
+          "CONTROL BITES: two unnamed instances compose the SAME mount-id")
+      (let [ref-a (attach! id-a dispatch 100)
+            ref-b (attach! id-b dispatch 200)]
+        (is (identical? ref-a ref-b)
+            "one ref callback between two mounts")
+        (is (= (inc before) (ei/mount-state-count))
+            "and one store entry between them")
+        (is (= {id-a 200} (widths-from @sink))
+            "ONE width slot, holding the SECOND instance's measurement: the
+             first panel now lays itself out against a column it does not
+             have")
+        (unmount! ref-b)
+        (is (nil? (ei/mount-state-held (ei/lifecycle-key one-frame id-a)))
+            "detaching the SECOND released the shared entry, so the first —
+             still on screen — has lost its observer, its width debounce and
+             its projection cache together")
+        (is (= before (ei/mount-state-count))
+            "store back where it started")))))


### PR DESCRIPTION
Closes rf2-t3fz (P2). Filed by the merged-PR audit of #9597 as the residual rf2-d2aj deliberately left.

## The defect

rf2-d2aj keyed the edn-inspector's per-mount store by `[frame-id mount-id]`, which separates two panels under two `frame-provider`s. Two panels under **one** frame it did not reach, and its closing ruling said why: a Fresco boundary is a React function component with no per-instance storage its body may use — hooks do not belong in a body, and `rf.fresco/reg-state` consumes an instance key rather than minting one — so nothing inside the widget can tell two structurally identical siblings apart. *"That case is the CALLER's to name."*

The App-db panel could not name it. `Panel` took `[_props]` and its docstring said in as many words that it reads nothing from props, and `app-db-diff-state/value-body` derived `mount-id` from a `render-id` that repeats across same-frame mounts. So two App-db `Panel`s under one `frame-provider` shared one lifecycle key, one store entry, one ResizeObserver, one projection cache **and** one width slot; detaching either removed the survivor's state and cleared the shared width.

## The fix

`Panel` takes an optional `:instance-id` prop, threaded through `panel-tree` → `state-body` → the section renderers → `value-body`. When the caller names an instance it qualifies **both** composed ids:

- the edn-inspector `:mount-id` — the lifecycle key's second component **and** the width slot's key, which is why one qualification fixes both;
- the expansion/zoom `:site-id`, so two named instances expand and zoom independently rather than in lockstep. It stays stable across *that* instance's own remounts, which is all rf2-pvsxs asked of it, because a caller-supplied instance id is an identity and not a per-render nonce.

Qualifying the store key alone would have been half a repair: the widths are keyed by the logical `mount-id` *inside* the frame, so both instances would go on writing one slot — a wrong number rather than a missing one. Both had to move together, and they move as one because they are composed from one string.

Unnamed, every id is byte-for-byte what it was. That is every call site in this tree today: the L4 tab registry and `render-panel!`'s standalone embed each mount one panel per frame. Nothing existing changes shape — every prior arity is retained.

`instance-token` accepts a non-blank string or a keyword and refuses anything else loudly. The keyword is not indulgence: a Reagent parent's `[:>]` converts a prop value before React sees it, so a keyword written at a Reagent call site arrives at the boundary as its name while a Fresco body hands it over as a keyword — refusing one would make a single call site behave two ways depending on which head mounted it. What is refused is a shape that could not be stable across renders (a map, a JS object): its printed form would compose a fresh `:mount-id` and `:site-id` every pass and silently discard expansion, zoom and the measured column each time, which is the failure `edn-inspector-view`'s own `:mount-id` refusal exists to prevent, one level up.

## Evidence

Node lane, beside R9's precedent in `edn_inspector_mount_state_cljs_test` — the store is where the release actually happens, and it is assertable in milliseconds against a browser lane's seconds. Two differences from R9 carry this bead:

- **One dispatcher, not two.** Both instances render under one frame, so their measurements land in one app-db. The rows fold both dispatches into the width slot they write, which is what exercises the half a store-key-only fix leaves standing.
- **The mount-ids are read off the panel's own render** rather than written into the test, so a row goes red if the panel stops distinguishing two instances — which is the whole claim.

Three rows in `app_db_diff_state_cljs_test`:

1. two `:instance-id`s over one section model compose disjoint sets of `:mount-id`s and `:site-id`s; unnamed composes exactly `["app-db-state/top" "app-db-state/:rf/route"]` as before; a keyword and its name are the same instance; a map is refused; a blank string is simply no instance.
2. two named instances under **one** frame get two ref callbacks, two store entries and two width slots (100 and 200 in their own keys); detaching one leaves the survivor's entry holding its `:ref` and clears only the leaver's slot; both released, the store returns to its starting count.
3. **the negative control, which is the defect verbatim** — the same two panels unnamed compose one `mount-id`, so they share one ref and one entry, the second instance's 200 lands in the first's slot, and detaching the second releases the first's observer, debounce and projection cache together.

Two more in `app_db_diff_cljs_test` pin the threading itself: `panel-tree`'s 3-arity reaches the sections while its 2-arity is unchanged, and `Panel-bridge` carries `:instance-id` across the Reagent door while its 0-arity — the shell's `[(:panel tab)]` and `render-panel!`'s `[panel-view]` — still mounts with no props.

### Sabotage

With the instance qualification removed from `value-body` (the shared identity restored), the node lane went **exit 1 with 8 failures**, all in the new rows and each naming what it got: `"app-db-state/top"` shared between the two, one shared `site-id`, `(not (not true))` for the ref identity, `(not (= 5 4))` for the store count, and — the one that is the bug — `(contains? nil :ref)` for the survivor after the other detached. Test and assertion **counts were unchanged at 11555 / 58026**, so the plant crashed no namespace and the comparison is like-for-like.

The negative control (row 3) stayed **green** under the plant, which is the correct signature: it asserts the collision, so it is the row that must not move. `panel-bridge-carries-the-instance-id-across-the-reagent-door` also stayed green, correctly — it pins the prop crossing, not the id composition. Restored and verified by blob hash against `HEAD:` (this file is `i/lf`, so the default `git hash-object` is the matching form) plus `git diff --quiet HEAD` exit 0 as an independent second instrument.

## Scope, and one finding about the boundary

Four files, all inside this bead's slice. `views/edn_inspector.cljs` is **read only** here — another worker's surface, and the fix needed nothing from it, which is itself the finding: the affordance the caller needed already existed in the widget's `:mount-id`, and what was missing was a way for the App-db panel's caller to reach it. The cross-frame lifecycle key is untouched and not reopened.

**One residual is deliberately left and named rather than taken.** The standalone facade `panels/mount-app-db-diff!` passes `Panel-bridge` to `render-panel!`, which mounts `[panel-view]` with no props, so two standalone mounts sharing a `:frame` opt still cannot be told apart. Giving that door an instance name means adding an `:instance-id` key to `mount-app-db-diff!`'s opts in `panels.cljs`, which is another live worker's file. The Fresco and Reagent doors both carry the prop today; this one is a follow-on, not a gap in the fix.

Not absorbed: rf2-pb0l (the `inspect-view` one-arity) and rf2-o7p7 (duplicate testids) are different defects with their own owners.

Standing direction on rf2-k97c.3, reported including the zero: the `^{:key ...}`-on-a-call-form shape is **absent from both panels** — the grep exits 1 with no output on each, and the only `with-meta` hit is the word inside a comment explaining why the shape was retired. The control that says the instrument is live: both files carry keyed fragments (`[:<> {:key …}]`, 2 and 3 hits), the shape rf2-k97c.3 migrated *to*. No new sequence-keying was introduced.

## Quality gates

Every number below is a captured, unpiped exit code from a local run in the worker worktree, written to its own `.exit` file and read back — never a figure reported about the run by something else.

| Gate | Exit | Result |
|---|---|---|
| `compile-node-test.cjs node-test` | **0** | Build completed, 1933 files, 0 warnings |
| `node out/node-test.js` | **0** | 11555 tests / 58026 assertions, **0 failures, 0 errors** |
| Xray JVM (`clojure -M:test` in `tools/xray`) | **0** | 1276 tests / 6118 assertions, **0 failures, 0 errors** |
| `shadow-cljs compile browser-test` | **0** | Build completed, 1041 files, 5 warnings |
| `serve-and-run-browser-tests.cjs` | **0** | 887 tests / 4908 assertions, **0 failures, 0 errors** |
| `check-examples-compile.cjs` | **0** | all 58 swept builds compiled, zero warnings |
| Splint (4 changed files) | **0** | 3 style warnings, **identical on the base files** |
| clj-kondo (4 changed files) | **0** | 2 warnings, **both present on the base files** |
| `api-manifest.gen --check` | **0** | in sync, 471 public vars |
| `api-manifest.xray-spec-check` | **0** | in sync, 37 public-var references |
| every `scripts/check_*.py` (43 of them) | **0** | all pass |

Notes on the gate readings, because two of them are narrower than they look:

- The node lane's baseline before this branch was 11550 / 57996. The delta is exactly the 5 new deftests and 30 new assertions, so nothing was displaced.
- The 5 browser-compile warnings are pre-existing `:infer-warning`s in `implementation/fresco/test/re_frame/fresco/login_server_crossing_ssr_dom_cljs_test.cljs`, a file this branch does not touch. The browser numbers match the baseline exactly; this change adds no browser rows and the lane is a no-regression reading.
- `scripts/check_thrown_error_messages.py` passes, but its `DEFAULT_SCAN_DIRS` is `("implementation",)` — this branch's new `ex-info` is under `tools/`, outside that surface. Its green is honest but says nothing about this change, and it is recorded that way rather than counted as coverage.

The changed-surface classifier arms `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and `story_xray_browser` on these four paths. The first four are covered by local runs above. The last two were graded by CI on this exact head (`d17d9a60e0f3…`, full 40-character `headRefOid` re-queried rather than extended from a prefix): `Story/Xray browser gates (PR-smoke)` SUCCESS, `MCP conformance tools/story-mcp` SUCCESS, `MCP conformance wire-vocab` SUCCESS. Rollup read status-first — `total=87 pending=0 failed=0`, `runs=4 not_completed=0 bad=0` — gating on `.status == "COMPLETED"` before reading `.conclusion`, since a running check carries an empty-string conclusion rather than null.
