### PR TITLE
fix(xray): give the edn-inspector's root node a testid of its own (rf2-o7p7)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -2848,7 +2848,23 @@
                            ;; Use the mini renderer for compact prior;
                            ;; fall back to a type-summary when it
                            ;; would overflow.
-                           [mini prior 40])]]
+                           ;;
+                           ;; rf2-qhoj — CALLED, never placed in head
+                           ;; position. `mini` is a plain function (this
+                           ;; ns's docstring says so), and under Fresco a
+                           ;; plain fn head is a loud error by design
+                           ;; (HD-016, `:rf.error/fresco-bad-head`). This
+                           ;; branch is on `edn-inspector-view`'s render
+                           ;; path, so wrapping this call in a hiccup
+                           ;; vector throws out of the boundary with no
+                           ;; error boundary above it, and React unmounts
+                           ;; the whole Xray root.
+                           ;;
+                           ;; The offending form is deliberately NOT
+                           ;; written out anywhere in this file: a census
+                           ;; for it greps the source, and a comment
+                           ;; quoting it reads as the defect itself.
+                           (mini prior 40))]]
                        :else
                        (change-annotation
                          (if projection

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector.cljs
@@ -1578,12 +1578,45 @@
     false))
 
 (defn- testid-for
-  "Compose a stable data-testid for a node — `[panel-id mount-id path]`."
+  "Compose a stable data-testid for a NODE — `[panel-id mount-id path]`.
+
+  The path separator is UNCONDITIONAL, so the root node at `[]` reads
+  `…-<mount-id>-` with a trailing separator and an empty path after it.
+  That is deliberate and is the whole of rf2-o7p7.
+
+  A node's name is `[panel-id mount-id path]`; the widget's outer container
+  has a name of its own, `[panel-id mount-id]`, composed at the render site
+  as `container-id`. Two names for two different things. Appending the
+  separator only `(when (seq path))` collapsed them: the root node at `[]`
+  composed the container's string exactly, so ONE MOUNT PUT ONE TESTID ON
+  TWO NODES — the container carrying the widget chrome, the measurement
+  `:ref` and `data-rf-mount-id`, and the render-node carrying the rendered
+  tree.
+
+  It failed in the direction that reassures, which is why it went unseen for
+  as long as it existed: `querySelector` always returned something, so a
+  helper resolving \"the container\" got a node and carried on, and which of
+  the two it got was document order. A count is the first instrument that
+  has to care, and the first one written duly read 4 panels for 2 (rf2-d2aj,
+  PR #9597's W5).
+
+  The separator, rather than a word like `-root`, is what makes the node
+  namespace TOTAL: every path composes a suffix, no path composes the empty
+  one, and no path can collide with the container. A word could — `pr-str`
+  of the SYMBOL `root` is the bare string `root`, so a value keyed by it
+  would put a node at `…-<mount-id>-root` beside the root's own, which is
+  the very defect this repairs, reintroduced one level along.
+
+  This MOVES the root node's testid (and the `-toggle` / `-body` derived
+  from it) and leaves the container's ALONE — the direction that matters,
+  because the container's is the public handle every existing DOM-level
+  consumer reaches for. Under the reverse repair those consumers would keep
+  resolving, silently, to the render-node."
   [panel-id mount-id path]
   (str "rf-xray-edn-inspector-"
        (name (or panel-id :anon))
        "-" mount-id
-       (when (seq path) (str "-" (str/join "/" (map pr-str path))))))
+       "-" (str/join "/" (map pr-str path))))
 
 ;; rf2-tzvk9 — triangle expand/collapse glyph carries an explicit
 ;; ≥24×24 click target. The padding inside the existing key-column

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_cljs_test.cljs
@@ -54,15 +54,23 @@
       (walk tree))
     @out))
 
-(defn- find-attr
-  "Return the first node whose attribute-map key `k` equals `v`."
+(defn- nodes-with-attr
+  "Every node whose attribute-map key `k` equals `v`, in document order.
+
+  `find-attr` below takes the first of these, which is the right instrument
+  for \"is it rendered at all\" and the wrong one for \"how many answer this
+  name\" — the distinction rf2-o7p7 turns on."
   [tree k v]
   (->> (walk-hiccup tree)
        (filter (fn [n]
                  (and (vector? n)
                       (map? (second n))
-                      (= v (get (second n) k)))))
-       first))
+                      (= v (get (second n) k)))))))
+
+(defn- find-attr
+  "Return the first node whose attribute-map key `k` equals `v`."
+  [tree k v]
+  (first (nodes-with-attr tree k v)))
 
 (defn- collect-text
   "Flatten string leaves under `tree` into one big string."
@@ -583,6 +591,10 @@
     (is (not (re-find #"▾" text-collapsed)))))
 
 (deftest render-node-includes-data-testid
+  ;; The trailing separator is not a typo and is the pin for rf2-o7p7 (see
+  ;; the block below): a node's testid always carries its path component,
+  ;; and the root's path is empty, so the string ends at the separator. It
+  ;; is what keeps the root node's name off the container's.
   (let [h  (ei/render-node {:value {:a 1}
                             :panel-id :app-db
                             :mount-id "m-42"
@@ -591,7 +603,88 @@
                             :expansion-map {}
                             :opts {}})]
     (is (some? (find-attr h :data-testid
-                          "rf-xray-edn-inspector-app-db-m-42")))))
+                          "rf-xray-edn-inspector-app-db-m-42-")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-o7p7 — THE CONTAINER TESTID NAMES EXACTLY ONE NODE.
+;;
+;; Two names, for two different things. The widget's outer container is
+;; `[panel-id mount-id]`; a node inside its rendered tree is `[panel-id
+;; mount-id path]`. They used to compose the SAME STRING, because the path
+;; suffix was appended only for a NON-EMPTY path — so the root render-node
+;; at `[]` answered the container's name as well as its own, and one mount
+;; put one testid on two nodes.
+;;
+;; It failed in the direction that reassures. `querySelector` always returns
+;; something, so a helper resolving "the container" got a node and carried
+;; on; WHICH of the two it got was document order. They are not
+;; interchangeable — the container carries the widget chrome, the
+;; measurement `:ref` and `data-rf-mount-id`, the render-node carries the
+;; rendered tree — so a row asserting on geometry through that selector
+;; could pass while measuring the wrong element. A COUNT is the first
+;; instrument that has to care, and W5's first draft duly read 4 panels for
+;; 2 (rf2-d2aj).
+;;
+;; The row is written so that a node coming back is not enough to pass it.
+;; It counts, and it asks every answering node for an attribute only the
+;; container carries — the second assertion is independent of document
+;; order, so neither is carried by the other.
+;; ---------------------------------------------------------------------------
+
+(deftest container-testid-names-exactly-one-node
+  (testing "rf2-o7p7 — the widget's container testid is answered by ONE node,
+            and that node is the container."
+    (let [outer (ei/edn-inspector {:a 1 :b 2} {:panel-id :p})
+          tree  (outer {:a 1 :b 2} {:panel-id :p})
+          cid   (:data-testid (second tree))
+          hits  (nodes-with-attr tree :data-testid cid)]
+      (is (some? cid)
+          "PRECONDITION: the outer container carries a testid at all — the
+           two assertions below are vacuous against a nil name")
+      (is (= 1 (count hits))
+          (str "the container testid names exactly one node. TWO is the "
+               "defect: the root render-node at path [] composed the same "
+               "string, so every count keyed on this selector read double "
+               "and every querySelector took whichever came first. Got "
+               (count hits) " for " (pr-str cid)))
+      (is (every? #(some? (:data-rf-mount-id (second %))) hits)
+          (str "and the selector resolves to the CONTAINER — every node "
+               "answering it carries data-rf-mount-id, which no render-node "
+               "does. This half does not depend on document order, so a "
+               "container that merely happened to come first cannot carry "
+               "it. Kinds answering the name: "
+               (pr-str (mapv #(select-keys (second %)
+                                           [:data-rf-mount-id :data-rf-kind])
+                             hits)))))))
+
+(deftest container-testid-collision-negative-control
+  (testing "rf2-o7p7 — THE DEFECT WRITTEN OUT. Under the pre-fix rule the
+            path suffix was appended only for a non-empty path, so a node at
+            `[]` composed the container's name exactly — and only at `[]`,
+            which is why it survived as long as it did."
+    (let [pre-fix        (fn [panel-id mount-id path]
+                           (str "rf-xray-edn-inspector-"
+                                (name panel-id) "-" mount-id
+                                (when (seq path)
+                                  (str "-" (str/join "/" (map pr-str path))))))
+          container-name (str "rf-xray-edn-inspector-" (name :p) "-" "m")]
+      (is (= container-name (pre-fix :p "m" []))
+          "CONTROL BITES: the old rule gave the root render-node and the
+           container one name between them")
+      (is (not= container-name (pre-fix :p "m" [:a]))
+          "and every non-empty path was already distinct under it, so the
+           collision was the root's alone")
+      (let [shipped (:data-testid
+                       (second (ei/render-node {:value {:a 1}
+                                                :panel-id :p
+                                                :mount-id "m"
+                                                :path []
+                                                :depth 0
+                                                :expansion-map {}
+                                                :opts {}})))]
+        (is (not= container-name shipped)
+            (str "the shipped composer gives the root node a name of its "
+                 "own. Got " (pr-str shipped)))))))
 
 ;; ---- rf2-tzvk9 — triangle hit-box ≥24×24 ---------------------------------
 ;;
@@ -651,7 +744,7 @@
                              :expansion-map {}
                              :opts {:default-expanded-depth 1}})
         tog (find-attr h :data-testid
-                       "rf-xray-edn-inspector-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m--toggle")]
     (is (some? tog) "collapsed renders carry a toggle span")
     (let [s (-> tog second :style)]
       (is (= ei/triangle-style s)
@@ -666,7 +759,7 @@
                              :expansion-map {k0 {:expanded? true}}
                              :opts {:default-expanded-depth 0}})
         tog (find-attr h :data-testid
-                       "rf-xray-edn-inspector-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m--toggle")]
     (is (some? tog) "expanded renders carry a toggle span")
     (let [s (-> tog second :style)]
       (is (= ei/triangle-style s)
@@ -682,7 +775,7 @@
                              :expansion-map {}
                              :opts {:default-expanded-depth 5 :max-depth 1}})
         tog (find-attr h :data-testid
-                       "rf-xray-edn-inspector-test-m-toggle")]
+                       "rf-xray-edn-inspector-test-m--toggle")]
     (is (some? tog) "depth-capped renders still carry a toggle span")
     (let [s (-> tog second :style)]
       (is (= ei/triangle-style s)
@@ -721,7 +814,7 @@
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m--body")]
       (is (some? body) "expanded map renders a body container")
       (let [s (-> body second :style)]
         (is (= "grid" (:display s))
@@ -747,7 +840,7 @@
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m--body")
           key-cells   (->> (walk-hiccup body)
                            (filter #(= "key"   (get (second %) :data-rf-cell))))
           value-cells (->> (walk-hiccup body)
@@ -767,7 +860,7 @@
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m--body")]
       (is (some? body) "expanded vector renders a body container")
       (let [s (-> body second :style)]
         (is (not= "grid" (:display s))
@@ -825,7 +918,7 @@
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m--body")
           ;; Filter ONLY this body's direct cells, not the nested
           ;; map's cells.
           direct-children (rest (rest body))]
@@ -847,7 +940,7 @@
                               :path [] :depth 0
                               :expansion-map {k0 {:expanded? true}}
                               :opts {:default-expanded-depth 0}})
-          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m-body")]
+          body (find-attr h :data-testid "rf-xray-edn-inspector-p-m--body")]
       (is (= "0" (-> body second :style :row-gap))))))
 
 ;; ---- toggle handler shape ------------------------------------------------
@@ -905,7 +998,7 @@
                                               (reset! captured event-v))
                                :opts {:default-expanded-depth 2}})
           tog (find-attr h :data-testid
-                         "rf-xray-edn-inspector-test-m2-toggle")
+                         "rf-xray-edn-inspector-test-m2--toggle")
           on-click (-> tog second :on-click)]
       (is (fn? on-click) "toggle glyph must carry an :on-click")
       (when on-click (on-click nil))
@@ -2535,7 +2628,7 @@
                                                 (reset! captured event-v))
                                  :opts {:default-expanded-depth 0}})
         tog     (find-attr h :data-testid
-                           "rf-xray-edn-inspector-app-db-m-toggle")
+                           "rf-xray-edn-inspector-app-db-m--toggle")
         on-click (-> tog second :on-click)]
     (is (fn? on-click))
     (when on-click (on-click nil))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -608,12 +608,21 @@
 (defn- panel-count
   "How many host panels are on screen.
 
-  COUNTED ON THE HOST PANEL, not on the widget's own container testid, and
-  the first draft of this row got that wrong in a way worth writing down:
-  `testid-for` composes the SAME string for the widget's outer container and
-  for its root render-node at path `[]`, so one mount answers that selector
-  TWICE. `container-node` above never noticed because `querySelector` takes
-  the first match — a count is the first instrument here that has to care."
+  Counted on the HOST PANEL, which is what this row is actually asking about
+  — how many panels are on screen — rather than on the widget nested inside
+  one.
+
+  The first draft counted the widget's container testid instead and read 4
+  for 2, which is worth keeping written down because the cause outlived the
+  draft: `testid-for` composed the SAME string for the widget's outer
+  container and for its root render-node at path `[]`, so one mount answered
+  that selector twice. `container-node` above never noticed, because
+  `querySelector` takes the first match — a count was the first instrument
+  here that had to care. Repaired under rf2-o7p7 (the node testid's path
+  separator is now unconditional, so the root node's name ends at the
+  separator and the container keeps its own), which is why `container-node`
+  can now be relied on to mean the container rather than whichever of the
+  two came first."
   [container]
   (.-length (.querySelectorAll
               container "[data-testid=\"rf-xray-host-panel\"]")))


### PR DESCRIPTION
Closes rf2-o7p7 and rf2-qhoj (the mayor closes both after merge).

**Two commits, one per bead**, deliberately kept apart so the audit trail reads
cleanly:

* `fbad75155f` — rf2-o7p7, the testid work this branch was dispatched for.
* `6d4753e09e` — rf2-qhoj (P1), a one-token fix that landed in the same file
  while this branch was open. Described in its own section near the end.

**The Quality gates table says, per row, whether the figure was taken on the head
carrying BOTH commits or only on the first.** Everything except the
examples-compile sweep was re-taken after the P1 fix landed; that row is marked,
with its reasoning.

## The defect, re-measured in this worktree

`testid-for` composes a NODE's testid from `[panel-id mount-id path]` and appended
the path suffix only `(when (seq path))`. The widget's outer container composes its
own name from `[panel-id mount-id]` (the `container-id` local at the render site).
Those two are different names for different things, and at path `[]` they were the
same string — so one mount put one `data-testid` on two nodes.

Measured here rather than taken on trust. The node lane, run against the unrepaired
source with the new row in place, reported:

```
the container testid names exactly one node. TWO is the defect ...
  Got 2 for "rf-xray-edn-inspector-p-26c16729-45e9-4ecc-b6c7-36b2e314ea3c"
Kinds answering the name:
  [{:data-rf-mount-id "26c16729-..."} {:data-rf-kind "map"}]
```

One container, one root render-node, one name between them.

### One correction to the bead, and it changes what a repair has to move

The bead and the brief both name lines 2435 and 2633 as the two colliding sites,
"one being the widget's outer CONTAINER and the other its ROOT RENDER-NODE".
Half of that holds.

2435 (inside `render-container`) is genuinely one of the two — it is what renders
the root node when the inspected value is a container kind, and it is the
`data-rf-kind "map"` node in the measurement above. But 2633 is inside
`render-protocol-node`, which is also a NODE renderer and an ALTERNATIVE to 2435
rather than a partner to it: the protocol renderer returns nil to fall through to
the built-in, so for any one node exactly one of the two runs. Neither is the
container.

The container's name is composed separately, as the `container-id` local at the
render site, and put on the outer `<section>` / `<div>`. So the collision is
`container-id` against `testid-for` at `[]` — and it holds only while `site-id` is
nil, because the root descent is handed `effective-id`, which is
`(or site-id mount-id)`. Nil `site-id` is the ordinary case.

This does not change the verdict — the duplication is real and the count above is
the proof — but it does change the repair. A fix aimed at reconciling 2435 with
2633 would have been aimed at two sites that never collide.

## The repair, and why not the obvious one

The path separator is now **unconditional**, so the root node reads
`...-<mount-id>-` and the container's name is UNCHANGED.

The brief flagged option (a) — suffix the container `-container` — as the one to
check hardest. It should not be taken, and the reason is stronger than the churn
count:

**(a) does not remove the failure mode, it makes it permanent for existing
consumers.** Under (a) the old string `rf-xray-edn-inspector-<panel>-<mount>` stays
live — on the root RENDER-NODE. So every consumer that means "the container" and
has not been updated keeps resolving, silently, to the other node. That is exactly
the reassuring-direction failure this bead exists to remove, preserved rather than
fixed.

Under this repair the old string belongs to the container ALONE. Consumers meaning
the container keep working and now resolve to exactly one node; consumers meaning
the root render-node get nothing, which is a loud miss.

### Call-site census (why the churn count is not the argument)

Repo-wide, `rf-xray-edn-inspector` appears in 15 tracked files outside the tracker
export — 81 hits on this branch, 79 before it. Classified by consumer shape:

| Consumer shape | Sites | Moved? |
| --- | --- | --- |
| Bare form meaning the CONTAINER (`container-node`, browser lane) | 1 helper, 3 uses | no |
| Bare form meaning the ROOT RENDER-NODE (`render-node-includes-data-testid`) | 1 | yes |
| Root-derived `-toggle` / `-body` at path `[]` | 11 | 10 (the 11th already carried the post-fix shape) |
| Non-root path forms (`-:a`, `-:x-toggle`, `-:parent-toggle`, `-:k`) | 4 | no |
| Prefix scans (`find-by-testid-prefix`, `startsWith`) — static flows/routes/schemas, trace rows, epoch view | 8 | no |
| Unrelated widget testids (`-redacted`, `-large`, `-popup-*`, `-mini`) | rest | no |

Eleven literals move, and the diff confirms it: 11 removed testid literals against
13 added (the two extra are the negative control's own strings).

So option (a) would have moved ONE helper and this repair moves eleven — **(a) is
the smaller diff.** It is still the wrong one, for the silent-misresolution reason
above; the churn count is not the argument and does not favour this repair.

No testbed, gallery selector or `feature_matrix/scenarios.cjs` selector reaches the
bare container form. The only `scenarios.cjs` hits are `rf-xray-edn-inspector-large`,
a different testid.

### Why a separator and not `-root`

`pr-str` of the SYMBOL `root` is the bare string `root`, so a value keyed by it
would put a node at `...-<mount-id>-root` beside the root node's own name — the
same defect one level along. The separator makes the node namespace total instead:
every path composes a suffix, no path composes the empty one, and none can reach
the container's name.

### Spec

No spec change needed. `tools/xray/spec/021-Dynamic-Panel-Designs.md` states the
node testid shape as "derived from `[panel-id mount-id path]`" (lines 4168, 4309)
and the container's as `container-id` (4724-4728). Both remain true, and no spec
line writes out the root node's literal form.

## Evidence

Two rows in the node lane, both discriminating — a node merely coming back does not
pass either, and neither is carried by the other:

* `container-testid-names-exactly-one-node` — takes the widget's own container
  testid off the rendered hiccup (composing no string of its own), COUNTS the nodes
  answering it, and asks every one of them for `data-rf-mount-id`, an attribute
  only the container carries. The count half catches the duplication; the
  attribute half states the "resolves to the container" claim and does not depend
  on document order, so a container that merely happened to come first cannot
  carry it.
* `container-testid-collision-negative-control` — writes the pre-fix rule out
  (R9's pattern from rf2-d2aj) and shows it collapsing the two names, then shows
  the shipped composer keeping them apart.

Also corrected: W5's `panel-count` docstring in the browser lane, which documented
this duplication as live.

`edn_inspector_protocol_cljs_test.cljs:226` asserted `nil?` against
`"rf-xray-edn-inspector-test-m1--body"` — a double-dash string that could not match
under the old rule, so the assertion was vacuous. It is now the real root-body
name, so that row became a genuine assertion without being touched.

## Quality gates

Every exit code below is the runner's own, captured with the redirect and the echo
on one command line in one shell. Not a harness-reported number. Every compound
gate was SPLIT into its phases so each phase's verdict is its own, and nothing was
piped through a filter.

The change classifies onto `cljs_node_test`, `cljs_browser`, `examples_compile`,
`tools_jvm`, `mcp_conformance` and `story_xray_browser`
(`.github/scripts/report-changed-surfaces.sh` over the three touched paths). The
first four were run locally; the last two are armed by the breadth of the
`tools/xray/**` rule rather than by anything this diff reaches — the only
`feature_matrix/scenarios.cjs` selector in this family is
`rf-xray-edn-inspector-large`, a fixed literal that `testid-for` does not compose.

| Gate | Command | Exit | Result | Head |
| --- | --- | --- | --- | --- |
| node-test compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | 1933 files, 0 warnings | both commits |
| `test:cljs` (node lane) | `node out/node-test.js` | 0 | 11552 tests / 58002 assertions, 0 failures, 0 errors | both commits |
| browser-test compile | `npx shadow-cljs compile browser-test` | 0 | 1041 files; no warning names a touched file | both commits |
| `test:browser` | `node scripts/serve-and-run-browser-tests.cjs` | 0 | 887 tests / 4908 assertions, 0 failures, 0 errors | both commits |
| Xray JVM suite | `clojure -M:test` in `tools/xray` | 0 | 1276 tests / 6118 assertions, 0 failures, 0 errors | both commits |
| clj-kondo | `--fail-level error` over the touched files | 0 | 2 warnings, BOTH pre-existing (verified against the base blob) | both commits |
| Splint | `clojure -M:splint --fail-on-errors` over the touched files | 0 | style warnings only, none on an added line | both commits |
| Ratchets | all 43 `scripts/check_*.py` | 0 each | 0 failures of 43 | both commits |
| PR guard — attribution (commits) | `scripts/check-commit-attribution.sh origin/main` | 0 | none in the 2 commits this branch introduces | both commits |
| PR guard — attribution (body) | `scripts/check-commit-attribution.sh --pr-body` on this text | 0 | none in the pull request body | both commits |
| PR guard — tracker boundary | `scripts/check-beads-pr-boundary.sh origin/main` | 0 | no beads-database paths in the diff | both commits |
| examples-compile sweep | `node implementation/scripts/check-examples-compile.cjs` | 0 | all 58 builds compiled, zero warnings (roster read from the tool's own `--list`, not from a grep for a build name) | **first commit only** |

The examples-compile sweep is the one row not re-taken, and it is a 58-build
COMPILE check. The second commit changes one form inside one function in one file,
and that file is compiled from scratch by both full compiles above — node-test
(1933 files) and browser-test (1041 files) — which WERE re-taken after it. CI runs
the sweep on the final head regardless.

The browser run was gated on the compile's CAPTURED exit code read back from its
own file, not chained behind it.

Local clj-kondo is v2025.10.23; CI pins v2026.04.15, so the kondo row is weaker
evidence than CI's will be.

### Which tree each gate read

Checked rather than assumed, because a gate invoked from the wrong directory pins
faithfully to a sibling worktree and reports its verdict as yours.

* All three shadow-cljs gates (node-test, browser-test, examples sweep) print their
  config path, and all three named THIS worktree's `implementation/shadow-cljs.edn`.
  The sweep was launched by ABSOLUTE script path for that reason.
* The Xray JVM suite prints no root, so it was checked directly:
  `clojure -Spath` from this worktree's `tools/xray` resolves 12 classpath entries
  inside this worktree.
* For the node lane the stronger proof is the RED under sabotage below — the fault
  existed only here, so a run that had wandered into a sibling would have come back
  green.

The JVM suite is a "nothing else broke" check rather than evidence for this change:
`tools/xray/test` holds 52 JVM test files and 156 CLJS ones, and the file changed
here is `.cljs`, which that lane never compiles.

### Sabotage

Committed first, then the duplication was planted back into `testid-for` — one
line, match count read before the run (1) rather than inferred afterwards.

* Recompiled (exit 0, 271 files recompiled — the plant was in the module graph and
  the runtime saw it), then ran the node lane: **exit 1, 27 failures, 0 errors**.
* Test and assertion totals were IDENTICAL to the green run (11552 / 58002), so no
  namespace was skipped and nothing crashed out.
* The new row named what it got: `Got 2 for "rf-xray-edn-inspector-p-b3310cea-..."`,
  with the two answering nodes reported as one carrying `data-rf-mount-id` and one
  carrying `data-rf-kind "map"`.
* Restored and verified two independent ways: `git hash-object` returned
  `6f3027285032b473ac1c2645212240a707978593`, equal to
  `git rev-parse "HEAD:<path>"`, and `git diff --quiet HEAD -- <path>` exited 0.

Which `hash-object` form reproduces the blob is a PER-FILE fact, set by the INDEX
side of `git ls-files --eol` — `i/lf` wants the default form, `i/crlf` wants
`--no-filters`, and both present the same `w/crlf`, so the working-tree half does
not discriminate. This file reads `i/lf w/crlf` (as do all 7 files in its
directory), so the default form is the right instrument here; `--no-filters`
returned `e68bc5b391...`, which matches no object and would have read as a failed
restore. `git diff --quiet HEAD` needs no hashing at all and is the check to lean
on.

## Hand verification

Table column counts in this body checked by hand; no anchors added.

## The second commit — rf2-qhoj (P1), `6d4753e09e`

One token, in the same file, folded in at the coordinator's request rather than
left for a second worker.

`render-leaf`'s `:modified` -> `type-change?` branch (the R7 "was <prior>" suffix)
put `mini` in HICCUP HEAD POSITION instead of calling it. This ns's own docstring
already states the rule: `mini` and every helper here are PLAIN FUNCTIONS, legal
as a Reagent head and a loud error by design under Fresco. Since `f05040ae9b`
switched `panels/app_db_diff_state.cljs` to `ei/edn-inspector-view`, that output
travels Fresco's codec, which refuses a plain fn head (HD-016,
`:rf.error/fresco-bad-head`). The throw escapes the boundary with no error
boundary above it, so React unmounts the entire Xray root.

Verified at source in this worktree, not taken on trust: the site is real, `mini`
is `declare`d near the top of the file and has a 2-arity `[value max-len]`
returning hiccup, so the call form is exactly what the vector was standing in for.

**Census for other plain-fn heads in this file: exactly one, this one.** Run over
the source with STRING LITERALS stripped first — docstrings are string literals,
and this file's prose describes the very construct being counted — then `;`
comments, with a positive control that fires on the known site. 25 candidate heads
before the fix, 24 after, and the one that disappeared is this. The remaining 24
are argument vectors, `get-in` paths and `subscribe` query vectors whose head
shares a name with a def. `[edn-inspector after ...]` in `edn-inspector-diff` is
NOT one: `edn-inspector` is a `reg-view`, not a plain function.

One thing worth flagging, because it bit the obvious probe. The comment left at
the site deliberately does NOT write the broken form out. The first version of it
quoted the vector, and the natural census — grep the pushed blob for the offending
literal — then reported the bug STILL PRESENT at a head that carried the fix,
against a live control. Measured at the pushed head both ways: with the form
quoted, bug-literal 1 / fix-literal 1 / control 13; reworded, bug-literal 0 /
fix-literal 1 / control 13. Prose describing a defect is not distinguishable from
the defect by a grep.

**The coverage gap is deliberately NOT addressed here.** rf2-qhoj names it — a
CLJS row rendering `edn-inspector-view` through Fresco over a nil-to-string pair,
or a smoke-tier scenario whose app-db diff carries a type change — and it is
being dispatched separately. No JVM or CLJS suite can currently observe an
HD-016, so this commit's evidence is the stated rule, the bead's A/B measurement,
the census above, and a green suite; there is no local witness that would have
gone red, and this PR does not claim one.

`panels/app_db_diff.cljs` and `panels/app_db_diff_state.cljs` are untouched.

## Out of scope, deliberately

Not folded in, per the brief: `edn_widget.cljs`'s `inspect-view` 1-arity minting a
constant mount-id (rf2-pb0l), and any wider testid audit of the inspector. One
duplicated string.

## Attribution

AI-attribution trailers were declined, per `CLAUDE.md`'s Git Conventions, which
outranks the harness reminder that asks for them.
