### PR TITLE
fix(lint): make the :rf/default floor scan constant-stack (rf2-ep7u)

### DIFF
--- a/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
+++ b/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
@@ -91,9 +91,35 @@
   (let [idx (.indexOf line ";")]
     (if (neg? idx) line (subs line 0 idx))))
 
+;; POSSESSIVE ON PURPOSE (rf2-ep7u) — do not "simplify" this back to the
+;; natural greedy spelling #"\"(?:\\.|[^\"\\])*\"".
+;;
+;; THE DEFECT. Java compiles a quantified group to a `Loop` node and matches a
+;; greedy loop by RECURSING once per iteration, so scanning an N-character
+;; quoted span costs N stack frames. Past a threshold set by the thread's stack
+;; size the greedy form throws `StackOverflowError` — and because the throw
+;; happens inside the `for` that builds `offenders`, it surfaces as
+;; `expected: (empty? offenders)` beneath this lint's own `:rf/default` prose,
+;; i.e. it reads exactly like a genuine floor finding on a PR that introduced
+;; none. It is DETERMINISTIC in span length; what varies between runs is the
+;; stack, which is why re-running "fixed" it and why re-running is not a remedy.
+;; This lint's step also runs FIRST in test.yml's `jvm-repo-source-walks` job,
+;; whose steps carry no `if:`, so the crash SKIPS the six walks behind it.
+;;
+;; THE REPAIR IS THE SAME LANGUAGE, not merely a faster one. The two branches
+;; are DISJOINT — `[^\"\\]` excludes both the backslash and the quote, `\\.`
+;; requires a backslash — so at most one applies at any position and the loop
+;; never has a choice to backtrack into. Undoing an iteration could only matter
+;; if it let the closing `\"` match, and it cannot: undoing a `\\.` leaves the
+;; cursor on a backslash, undoing a `[^\"\\]` leaves it on a non-quote
+;; character, and `\"` matches neither. Possessive quantifiers compile to a node
+;; that ITERATES, so the scan is constant-stack at any length. Checked
+;; empirically as well: over the 371,268 lines of the real corpus the two forms
+;; produce identical output on every line, with zero disagreements.
 (def ^:private string-literal-re
-  "A double-quoted Clojure string span, `\\\"`-escapes included."
-  #"\"(?:\\.|[^\"\\])*\"")
+  "A double-quoted Clojure string span, `\\\"`-escapes included. Possessive so
+  the scan cannot overflow the stack on a long line — see the comment above."
+  #"\"(?:[^\"\\]++|\\.)*+\"")
 
 (defn- strip-string-literals
   "Replace every double-quoted string span on the line with a space, so a
@@ -186,3 +212,61 @@
                "`:rf/default` is legal only as an EXPLICIT, registered + "
                "selected frame id):\n  "
                (str/join "\n  " offenders))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ep7u — rows that grade THE INSTRUMENT rather than the corpus.
+;;
+;; The lint above walks a corpus that changes under it, so it cannot pin its own
+;; scanner. These two do. The first is the crash; the second is the contract the
+;; crash fix must not buy its way out of.
+;; ---------------------------------------------------------------------------
+
+(defn- long-span
+  "`n` characters of string CONTENT — the thing whose length drove the old
+  pattern's recursion depth."
+  [n]
+  (str/join (repeat n "x")))
+
+(deftest string-literal-strip-is-constant-stack
+  (testing "a long quoted span is STRIPPED rather than overflowing the stack
+            (rf2-ep7u). The superseded greedy group recursed once per character
+            of span, so this threw `StackOverflowError` — and did it under
+            `expected: (empty? offenders)`, reading as a floor finding. 20000 is
+            an order of magnitude past the longest span in the real corpus and
+            far past any plausible thread stack, so restoring the greedy form
+            turns this row RED rather than leaving it a hollow pass."
+    (is (= "(def x  )"
+           (strip-string-literals (str "(def x \"" (long-span 20000) "\")")))))
+
+  (testing "the escape branch is constant-stack too — a long span made ENTIRELY
+            of `\\\\x` escapes exercises the other alternative of the group."
+    (is (= "(def x  )"
+           (strip-string-literals
+             (str "(def x \"" (str/join (repeat 10000 "\\x")) "\")"))))))
+
+(deftest string-literal-strip-preserves-the-lint-contract
+  (testing "`:rf/default` inside string DATA is stripped, so it is not read as a
+            live positional floor — the false positive the strip exists to
+            remove (rf2-wwt8a3 MCP descriptor prose)."
+    (is (empty? (offending-lines
+                  "(def hint \"-> {:frames [:rf/default :stories]}\")"))))
+
+  (testing "and it is still stripped when the span is LONG. A repair that bought
+            constant stack by declining to scan long lines would pass the crash
+            row above and let this false positive straight back in."
+    (is (empty? (offending-lines
+                  (str "(def hint \"" (long-span 3000)
+                       " [:rf/default :stories]\")")))))
+
+  (testing "a live floor is still REPORTED — all three banned shapes. The strip
+            may only reduce false positives, never mask a genuine floor."
+    (is (seq (offending-lines "(defwrapper foo ([id] [:rf/default id]))")))
+    (is (seq (offending-lines "(let [f (or (:frame opts) :rf/default)] f)")))
+    (is (seq (offending-lines
+               "(defn g [{:keys [frame-id] :or {frame-id :rf/default}}] frame-id)"))))
+
+  (testing "a live floor sitting AFTER a long string span on the same line is
+            still reported — the strip must run to completion and then leave the
+            code outside it intact."
+    (is (seq (offending-lines
+               (str "(def hint \"" (long-span 3000) "\") [:rf/default id]"))))))


### PR DESCRIPTION
Fixes rf2-ep7u.

`no-rf-default-floor-lint-test` could fail a PR with a `StackOverflowError` that
had nothing to do with the diff — and it presented as a real finding. The throw
happens inside the `for` that builds `offenders`, so it surfaces as
`expected: (empty? offenders)` beneath the lint's own `:rf/default` prose. A
worker had to rule that out by hand before it could report its PR green.

## It is not a flake

Java matches a greedy quantified group by recursing once per iteration, so
`strip-string-literals` cost one stack frame per character of quoted span. That
is deterministic in span length; what varies between runs is the thread's stack
size. Re-running the identical commit turning it green is a coin flip on stack
allocation, not a remedy.

Measured in this worktree, applying the old pattern to a quoted span of N
characters (Java 21, default stack):

| span | greedy | possessive |
|------|--------|------------|
| 1000 | ok | ok |
| 1500 | ok | ok |
| 2000 | **OVERFLOW** | ok |
| 4000 | **OVERFLOW** | ok |
| 10000 | **OVERFLOW** | ok |

The threshold landed between 1500 and 2000 here; it was measured between 1000
and 1500 on another box. It is a function of the stack, so no number is portable
and none is written into a test.

**The driver is the longest quoted SPAN, not the longest line** — a distinction
worth recording, because the corpus's longest line (2829) and its longest span
(2021) are different files. Post-comment-strip, the corpus carries 71 spans over
400 characters, 12 over 1000 and 3 over 1500, nearly all in
`implementation/core/src/re_frame/late_bind/directory.cljc`. That file is the
corpus, not the defect, and is untouched here.

Marginality is the whole story: across all 371,268 corpus lines the greedy form
threw **zero** overflows in this tree, while overflowing at 2000 in an isolated
probe. The corpus maximum sits right at the boundary, so a small change in call
depth or thread stack flips it.

## The repair is the same language, not merely a faster one

The scan is now possessive. The two branches are disjoint — `[^\"\\]` excludes
both the backslash and the quote, `\\.` requires a backslash — so at most one
applies at any position and the loop never has a choice to backtrack into.
Undoing an iteration could only matter if it let the closing `\"` match, and it
cannot: undoing a `\\.` leaves the cursor on a backslash, undoing a `[^\"\\]`
leaves it on a non-quote character, and `\"` matches neither.

Checked empirically as well as by that argument: over the 371,268 lines of the
real corpus the two forms produce identical output on **every** line, zero
disagreements.

## Evidence, and why it is not hollow

Two `deftest`s grade the instrument rather than the corpus.

* **The crash row** strips a 20000-character span and asserts the *result*, plus
  a 10000-escape span for the other branch of the alternation.
* **The contract rows** pin what the crash fix must not buy its way out of: a
  `:rf/default` inside a string span is still stripped — including a *long* one,
  which a skip-long-lines repair would have passed the crash row while letting
  that false positive back in — and all three banned floor shapes are still
  reported, including one sitting after a long span on the same line.

Sabotage run, greedy pattern restored on the committed tree: **exit 1, 4 errors,
every one `java.lang.StackOverflowError` from `java.util.regex.Pattern`.**
Restored and verified by blob hash against the committed object.

## The fail-open half, confirmed at source

`test.yml`'s `jvm-repo-source-walks` job runs seven steps and **none carries an
`if:`**, so default `success()` semantics apply: a failure in step one — this
lint — skips the six walks behind it. The claim is real.

It is worst exactly where it matters. That lane exists to schedule these walks
when `jvm-core` does not, and `jvm-core` is gated on `implementation_jvm`. On a
prose-only PR — which is what the original incident was — this lane is the *only*
place those six walks run, so the overflow removed them from the run entirely. A
green-after-re-run is therefore not evidence that the other six passed first time.

**No workflow change here:** `.github/workflows/*` is hot zone. All seven steps
were run locally on this branch and all seven are green.

## Quality gates

All exit codes captured unpiped to a file and quoted from that file.

| Gate | Exit |
|------|------|
| `clojure -M:test -n re-frame.no-rf-default-floor-lint-test` (3 tests / 9 assertions) | 0 |
| All seven `jvm-repo-source-walks` steps, run as CI runs them | 0 |
| `implementation/core` full JVM suite — 2307 tests / 11931 assertions | 0 |
| `scripts/test-jvm-implementation.sh` — 21 artefacts, all `0 failures, 0 errors` | 0 |
| clj-kondo over the touched file (0 errors, 0 warnings) | 0 |
| Splint `--fail-on-errors` over the touched file | 0 |
| Ratchets: test-lane-bijection, jvm-lane-rosters, gate-scheduling, thrown-error-messages, keyword-catalogue-drift, workflow-yaml, fast-pr-gap | 0 |

Sabotage control: greedy restored → exit 1, 4 `StackOverflowError`s. The rows
detect the fault they were written for.
