### PR TITLE
ci(test.yml): let each repo-wide source walk run past a failed predecessor (rf2-gf3y)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3206,7 +3206,7 @@ jobs:
       # seven of those is a worse log than one honest one. (rf2-gf3y)
       - name: Absence-repair floor lint for :rf/default (implementation/** + tools/**)
         if: ${{ !cancelled() }}
-        run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test-TEMPORARY-rf2-gf3y-demo
+        run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test
 
       - name: Egress-chokepoint conformance (every implementation/ src root)
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3140,13 +3140,17 @@ jobs:
   # SILENT: measured on this tree, `-n <valid> -n <does-not-exist>` exits 0
   # having run only the valid one, with no warning. One combined step therefore
   # rests entirely on the quiet runner's TOTAL test-count floor, and these
-  # namespaces are lopsided — 1 / 3 / 27 / 1 / 2 / 8 / 5 tests. A total floor cannot tell
-  # "the 1-test floor lint stopped selecting" from "the 27-test catalogue
-  # gained a test", so the guard would silently stop guarding the moment the
-  # big suite grew. Run per namespace and each takes the runner's DEFAULT
+  # namespaces are lopsided — several carry a single test while the
+  # error-catalogue suite carries dozens. A total floor cannot tell "a
+  # single-test lint stopped selecting" from "the big catalogue suite gained
+  # a test", so the guard would silently stop guarding the moment that suite
+  # grew. Run per namespace and each takes the runner's DEFAULT
   # floor of 1 on its own: a namespace that disappears runs zero tests and
   # REDS (measured: exit 1). That also leaves no calibrated number to
-  # maintain, so there is no count here to go stale.
+  # maintain, so there is no count here to go stale. The per-namespace test
+  # counts this paragraph used to quote were illustrative only — nothing
+  # enforced them, and they had drifted unnoticed — so they were removed
+  # rather than corrected (rf2-gf3y). Please don't put them back.
   #
   # These also still run inside `jvm-core`, and that duplication is
   # deliberate: this lane exists to schedule them when `jvm-core` does not.
@@ -3183,25 +3187,49 @@ jobs:
             ${{ runner.os }}-clj-core-
             ${{ runner.os }}-clj-
 
+      # The seven walks below are INDEPENDENT — they share only the JDK and the
+      # Maven cache — so each carries `if: ${{ !cancelled() }}` and runs even
+      # when an earlier walk has failed. Without it, GitHub's default step
+      # condition (`success()`) makes the first failing walk SKIP the six behind
+      # it. That does not admit a bad merge — the job reds either way — but it
+      # is badly misread: "the lane is red because of step 1" hides that the six
+      # behind it were never EVALUATED, so the green after the fix is the first
+      # time they have run at all and looks identical to one that was passing
+      # all along. That is the incident behind rf2-ep7u. It bites hardest on a
+      # prose-only PR, where `implementation_jvm` is false, `jvm-core` never
+      # runs, and this lane is the only place those walks execute anywhere.
+      #
+      # `!cancelled()` rather than `always()`, so a cancelled run stops burning
+      # the lane instead of grinding through seven more walks. The three SETUP
+      # steps above are deliberately NOT guarded: a walk whose JDK never
+      # installed fails for a reason that has nothing to do with the walk, and
+      # seven of those is a worse log than one honest one. (rf2-gf3y)
       - name: Absence-repair floor lint for :rf/default (implementation/** + tools/**)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test
 
       - name: Egress-chokepoint conformance (every implementation/ src root)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.egress-chokepoint-conformance-test
 
       - name: Error-catalogue channel conformance (every implementation/ src root)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.error-catalogue-channel-conformance-test
 
       - name: Warn-once-clear governance (file-seq over implementation/)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.warn-once-clear-governance-test
 
       - name: Production-gate naming drift (every artefact's test/ tree)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.prod-gate-naming-drift-test
 
       - name: Late-bind directory drift (every implementation/ src root)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.late-bind-drift-test
 
       - name: Observation render-law drift (every tracked prose file, git ls-files)
+        if: ${{ !cancelled() }}
         run: clojure -M:test -n re-frame.observation-render-law-drift-test
 
   cljs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3206,7 +3206,7 @@ jobs:
       # seven of those is a worse log than one honest one. (rf2-gf3y)
       - name: Absence-repair floor lint for :rf/default (implementation/** + tools/**)
         if: ${{ !cancelled() }}
-        run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test
+        run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test-TEMPORARY-rf2-gf3y-demo
 
       - name: Egress-chokepoint conformance (every implementation/ src root)
         if: ${{ !cancelled() }}

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -493,12 +493,51 @@ test('the unconditional walk lane runs every namespace whose false arm it excuse
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
   const block = jobBlock(workflow, 'jvm-repo-source-walks');
 
+  // "Unconditional" means NO JOB-LEVEL `if:`. That is where a read-set model of
+  // what the walks walk would go, and it is the defect this lane exists to avoid
+  // rather than relocate. Job properties sit at four spaces and step properties
+  // at eight, so the two are told apart by indentation alone. This assertion read
+  // `/^\s+if:/m` until rf2-gf3y — any indentation, which also forbade the step
+  // guards below and made the two halves of that repair inseparable.
   assert.doesNotMatch(
     block,
-    /^\s+if:/m,
-    'jvm-repo-source-walks must stay UNCONDITIONAL — a condition here is a ' +
-      'read-set model of what the walks walk, which is the defect the lane exists ' +
-      'to avoid rather than relocate',
+    /^ {4}if:/m,
+    'jvm-repo-source-walks must stay UNCONDITIONAL — a job-level condition here is ' +
+      'a read-set model of what the walks walk, which is the defect the lane ' +
+      'exists to avoid rather than relocate',
+  );
+
+  // Step conditions are allowed for exactly ONE purpose (rf2-gf3y). The seven
+  // walks are independent of one another, so each carries `if: ${{ !cancelled() }}`
+  // and runs even when an earlier walk has failed. Without it GitHub's default
+  // step condition (`success()`) makes the first failing walk SKIP the six behind
+  // it. That never admitted a bad merge — the job reds either way — but it hid
+  // that the six were never EVALUATED, so the green after the fix was the first
+  // time they had run at all and looked identical to one that had always passed.
+  // Anything OTHER than that exact guard at step level is the same read-set model
+  // wearing a different indentation, so it is refused here.
+  //
+  // `\r` is stripped before the comparison: `jobBlock` preserves CRLF, and this
+  // file is checked out CRLF on Windows, so a trailing carriage return would sit
+  // inside the anchored match and defeat it.
+  const stepConditions = (block.match(/^ {8}if:[^\n]*/gm) || []).map((s) =>
+    s.replace(/\r$/, ''),
+  );
+  for (const cond of stepConditions) {
+    assert.match(
+      cond,
+      /^ {8}if: \$\{\{ !cancelled\(\) \}\}$/,
+      `"${cond.trim()}" is a step condition other than the permitted ` +
+        '`!cancelled()` failure-independence guard',
+    );
+  }
+  assert.equal(
+    stepConditions.length,
+    REPO_SOURCE_WALK_NAMESPACES.length,
+    'every walk step must carry `if: ${{ !cancelled() }}`, so a failing walk cannot ' +
+      'skip the walks behind it. The setup steps (checkout, JDK, Clojure CLI, ' +
+      'Maven cache) deliberately carry no guard: a walk whose JDK never installed ' +
+      'fails for a reason that is not about the walk',
   );
   assert.match(
     workflow,
@@ -520,8 +559,11 @@ test('the unconditional walk lane runs every namespace whose false arm it excuse
   // ONE STEP PER NAMESPACE, which is not decoration: a namespace missing from a
   // multi-`-n` selector is SILENT (exit 0, runs the rest, no warning), so a
   // combined step would rest entirely on a total test-count floor across suites
-  // of 1 / 3 / 27 / 1 / 2 tests. Per-namespace steps each take the runner's own
-  // default floor of 1 and red alone.
+  // that are lopsided — several carry a single test while the error-catalogue
+  // suite carries dozens. Per-namespace steps each take the runner's own
+  // default floor of 1 and red alone. (This comment quoted per-namespace counts
+  // until rf2-gf3y; nothing enforced them and they had gone stale, so they were
+  // removed rather than corrected. Please don't put them back.)
   const runs = block.match(/^\s+run: clojure -M:test[^\n]*/gm) || [];
   assert.equal(
     runs.length,


### PR DESCRIPTION
Rebased onto `631bf09b15` (#9608, the rf2-ep7u repair to the FIRST of these seven walks).

Closes rf2-gf3y (the mayor closes the bead after merge; this PR does not).

`test.yml`'s `jvm-repo-source-walks` job runs seven independent repo-wide walks as
seven steps. None of them carried an `if:`, so GitHub's default step condition
(`success()`) made the first failing walk skip the six behind it.

**This never admitted a bad merge.** The job reds either way and the merge criterion
blocks it honestly. What fails open is the *inference* a reader makes next -- "the lane
is red because of step 1; fix step 1 and this lane is clean" -- when the six behind it
were never **evaluated**. The green after the re-run is the first time they have run at
all, and it is indistinguishable from a green that had been passing all along. That is
the incident behind rf2-ep7u: a StackOverflowError in the first walk took the lane down
and the six behind it were silently skipped while the failure was read as being about
the one step named in the log.

It bites hardest on a **prose-only PR**, where `implementation_jvm` is false, the
job-level gate keeps `jvm-core` from running, and this lane is the only place those
walks execute anywhere.

## What changed

**`.github/workflows/test.yml`** — seven added `if: ${{ !cancelled() }}` guards, one per
walk, and **seven, not ten**. The three setup steps (JDK, Clojure CLI, Maven cache) and
the checkout stay unguarded on purpose: a walk whose JDK never installed fails for a
reason that has nothing to do with the walk, and seven such failures is a worse log than
one honest one. `!cancelled()` rather than `always()`, so a cancelled run stops burning
the lane. Verified by parsing the workflow rather than by eye: the seven walk steps carry
the guard, the four setup steps carry none, and the job still has no job-level `if:`.

**`implementation/scripts/_changed-surfaces.test.cjs`** — see the next section. This
half was not in the original scope and is unavoidable.

## The repair could not land alone — a pin forbade it

`_changed-surfaces.test.cjs` asserted `doesNotMatch(block, /^\s+if:/m)` — an `if:` at
**any** indentation anywhere in that job block. Its stated reason is about a *job-level*
condition: "a read-set model of what the walks walk, which is the defect the lane exists
to avoid rather than relocate." A step-level `!cancelled()` models nothing about the
walks' domain, but the regex could not tell the two apart, so the pin also forbade the
guards this PR adds. Measured: the workflow change alone fails that test (exit 1).

Job properties sit at four spaces and step properties at eight, so the two are separable
by indentation. The pin now refuses a job-level `if:` outright, allows a step condition
**only** when it is exactly `if: ${{ !cancelled() }}`, and requires one such guard per
walked namespace. The third assertion is **new coverage, not a relaxation** — the old pin
could not have caught a missing guard, because it forbade all of them.

**Read this as new coverage, not a loosened pin.** The old assertion could only ever forbid
guards from existing; it could never have caught a *missing* one, because it forbade all of
them. What replaces it is strictly stronger in the direction that matters: a job-level `if:`
is still refused outright, the only step condition permitted is the exact
`!cancelled()` guard, and the count assertion is a check the old pin could not express at
all. Exercised in both directions: 369 assertions pass on the repaired workflow, and
removing a single guard fails with `6 !== 7`.

**This is the one-toucher rule working as written, not scope creep.** CLAUDE.md holds this
pair one-toucher "for a change that alters what the classifier OUTPUTS or what the test PINS
about those outputs", precisely because such a change lands a tree where the suite
contradicts the script unless both halves move in ONE commit. That is this case exactly, so
both halves in one commit is required rather than optional. Exclusive ownership of both
halves was confirmed from the mayor checkout against every live worker's working tree and
branch diff and every open PR's file list: #9610 is the only PR touching the pair.

## The illustrative test counts: removed, not corrected

The paragraph above the job quoted per-namespace counts as `1 / 3 / 27 / 1 / 2 / 8 / 5`.
I re-measured every position with two instruments — a static `deftest` count and the
runner itself (`clojure -M:test -n <ns>`, JDK 21, this tree). Both agree on all seven:

| # | namespace | comment said | measured |
|---|---|---|---|
| 1 | `no-rf-default-floor-lint-test` | 1 | **3** (was 1 before #9608 merged) |
| 2 | `egress-chokepoint-conformance-test` | 3 | **3** |
| 3 | `error-catalogue-channel-conformance-test` | 27 | **30** |
| 4 | `warn-once-clear-governance-test` | 1 | **1** |
| 5 | `prod-gate-naming-drift-test` | 2 | **2** |
| 6 | `late-bind-drift-test` | 8 | **8** |
| 7 | `observation-render-law-drift-test` | 5 | **5** |

At my original base `974ff9ed45`, exactly one position had drifted (3: 27 -> 30), silently.
**Then #9608 merged while this PR was in flight, and position 1 moved 1 -> 3.** I measured it
at 1 with two instruments; it was 3 a few hours later. That is the decisive argument for
removing the vector rather than correcting it: a corrected vector would have gone stale again
the same day, and nothing would have said so.

**I removed the figures rather than correcting them.** Nothing enforces them: the enforced
floor is the runner's own **default of 1 per namespace**, which is the paragraph's entire
argument for one step per namespace instead of one `-n` list. The paragraph already ends
"there is no calibrated number to maintain, so there is no count here to go stale" —
true of the design, false of the paragraph, since the vector sat three lines above it.
Correcting it would have meant maintaining **three** number sites in that paragraph, not
one, plus **a fourth in a different file**: `_changed-surfaces.test.cjs` carried the same
vector, staler still at `1 / 3 / 27 / 1 / 2` — five positions for seven namespaces.

What the numbers were *doing* is carrying the lopsidedness argument — a total floor cannot
tell a one-test lint that stopped selecting from a big suite that gained a test. That is
kept, in words: "several carry a single test while the error-catalogue suite carries
dozens." The teaching survives; the maintenance surface does not. Both sites carry a short
note that they were removed deliberately, so nobody helpfully restores them.

## Behavioural evidence — the six behind a failed walk now run

A green run here would only prove the workflow parses; on this PR the first walk passes,
so it cannot show that a *failing* first walk lets the other six run. So I forced one.

Temporary commit `7e7266b01d` (pre-rebase; now `afca493936`) pointed the first walk at a namespace that does not exist,
so the runner discovers zero tests and exits 1 — the same shape of first-walk failure as
the rf2-ep7u incident. Run `34447291816`, job `JVM repo-wide source walks`:

```
 6  failure   Absence-repair floor lint for :rf/default (implementation/** + tools/**)
 7  success   Egress-chokepoint conformance (every implementation/ src root)
 8  success   Error-catalogue channel conformance (every implementation/ src root)
 9  success   Warn-once-clear governance (file-seq over implementation/)
10  success   Production-gate naming drift (every artefact's test/ tree)
11  success   Late-bind directory drift (every implementation/ src root)
12  success   Observation render-law drift (every tracked prose file, git ls-files)
```

Job conclusion: **failure** — the lane still reds honestly, which is the point. Under the
old behaviour steps 7-12 would have read `skipped`. Reverted in the commit that follows it; the restore
was verified by blob hash rather than by eye — `.github/workflows/test.yml` is `i/lf` on
the index side, so the default `git hash-object` form applies, and working tree and `HEAD`
both read `047084203b915172f587c7a4364a1cde0c00a87c`, matching the pre-demo blob, with
the diff between the pre-demo and post-revert commits empty.

## For the merge criterion

```
git diff 631bf09b15 HEAD -- .github/workflows/ | grep -cE '^\+  [a-z][a-z0-9_-]*:[[:space:]]*$'
0
```

**0 job keys added** — adding `if:` lines adds none — so the check-set band should not move
when this lands. The instrument is live rather than vacuously zero: the same discriminator
reads `1` on `366e4fca79`, a commit that genuinely added a job.

## Quality gates

| gate | exit | result |
|---|---|---|
| `scripts/check_workflow_yaml.py` | 0 | PASS — workflow YAML well-formed (11 files) |
| `scripts/check_workflow_job_timeouts.py` | 0 | PASS — 118 jobs across 11 files carry a job-level timeout |
| `scripts/check_ci_reproduce_commands.py` | 0 | reproduce-command contract clean, 47 checker steps in sync |
| `node --test implementation/scripts/_changed-surfaces.test.cjs` | 0 | 369 passed, 0 failed |
| negative control: one guard removed | 1 | fails `6 !== 7`, as intended |
| `sh scripts/assert-worker-worktree.sh` | 0 | `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/walkgate-a` |
| all 7 walk namespaces, run locally | 0 each | 1 / 3 / 30 / 1 / 2 / 8 / 5 tests, 0 failures 0 errors |
| behavioural demo, run `34447291816` | job failed as designed | steps 7-12 ran behind a failed step 6 |

Exit codes were captured directly from each runner, unpiped.

## Notes

No AI attribution trailers, per CLAUDE.md's Git Conventions, which outrank the harness
instruction to add them.

Tracker boundary respected: no `.beads` path is touched. Net diff is two files.
