### PR TITLE
feat(xray): migrate the after-rings overlay to a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -82,13 +82,36 @@
   is below threshold. v1 ships at ~60fps with no skip-frame because
   the typical-app `:after`-timer count is small (1-3).
 
-  ## Pure hiccup
+  ## Substrate (rf2-k97c.3)
 
-  Same contract as every other Xray panel — the view is pure hiccup,
-  no Reagent / UIx references. Frame isolation comes from the
-  enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`."
+  [[AfterRingsOverlay]] is an `rf.fresco/defview` — a real React
+  function component whose four reads are `rf.fresco/sub`, recorded by
+  Fresco's own collector rather than by the installed adapter's
+  observer. That is the epic's coupling (3) OBSERVATION, severed for
+  this overlay. Frame isolation still comes from the enclosing
+  `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`, which the
+  boundary reads out of React context exactly as the `reg-view` did.
+
+  The overlay's markup is NOT pure hiccup, and it is the one panel in
+  the migration where that matters. Its whole job is to delegate to the
+  machines-viz `AfterRingsOverlay`, which is a **Reagent form-3 class**
+  (`chart/scaffold/make-resizing-overlay-class`) in a bundle-isolated
+  sibling artefact that knows nothing of Fresco. A plain function in
+  head position is a loud error under Fresco (HD-016), and CALLING it
+  is not the usual repair either — it answers a Reagent CLASS, not
+  hiccup. The door is Fresco's own ABI: *\"A React element is a legal
+  child anywhere\"* (`re-frame.fresco.impl.codec`'s component-ABI
+  table; `child-kind` classifies `react/isValidElement` as
+  `:react-element` and `as-element` passes it through untouched). So
+  [[overlay-tree]] takes an `:as-child` function — `identity` for a
+  hiccup caller, `reagent.core/as-element` for the boundary — and the
+  CLJS props map crosses to machines-viz BY IDENTITY, because
+  `as-element` carries the hiccup vector itself rather than converting
+  a props object. See [[overlay-tree]]."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.interop :as rf.interop]
+            [reagent.core :as r]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-machines-viz.chart.overlays.after-rings
@@ -385,7 +408,89 @@
                 :state      (:state spec)
                 :epoch      (:epoch spec)}])))
 
-(rf/reg-view AfterRingsOverlay
+(defn overlay-tree
+  "The overlay's markup, as a plain function of the values the boundary
+  READS. Split out of the view by rf2-k97c.3; it is `defview`'s own
+  documented extract-a-helper spelling and the same split
+  `routing/panel-tree` and `resources/panel-tree` already make. A
+  migrated view is a real React component and can no longer be CALLED,
+  so without this split every hiccup-walking row in
+  `machine_after_rings_cljs_test` would have to be rewritten; with it,
+  every one of them asserts on exactly the hiccup it did before.
+
+  Args (one map):
+
+    :timers         — `:rf.xray/active-timers-for-focused-machine`.
+    :live-now       — `:rf.xray/now-ms`, the rAF-bumped live clock.
+    :scrub          — `:rf.xray/machine-scrubber-position`.
+    :focused-detail — `:rf.xray/focused-event-bundle-detail`; the
+                      retro-mode anchor source (rf2-8i1tg3).
+    :frame          — the frame this tree renders in
+                      (`rf/current-frame-id`). It arms the off-render
+                      rAF clock through `kick-tick!` and is the frame
+                      the hover / leave dispatches CARRY (rf2-nesy9).
+    :as-child       — how to spell the delegated machines-viz child for
+                      the calling renderer. `identity` (the default)
+                      leaves it as hiccup, which is what a Reagent
+                      parent and the node-lane rows want;
+                      `reagent.core/as-element` answers a React element,
+                      which is what a Fresco body needs. The ns
+                      docstring records why neither of the migration's
+                      usual repairs — mount it as a head, or CALL it —
+                      is available for a Reagent class.
+
+  Returns nil when the projection has no active timers (the overlay
+  layer drops out so unrelated chart hover handlers aren't shadowed).
+
+  NOT side-effect free, deliberately: it kicks the single per-chart rAF
+  clock at exactly the point the `reg-view` body did (Lock #8). Moving
+  that out would change WHEN the clock arms, which is a behaviour
+  change wearing a tidy-up's clothes."
+  [{:keys [timers live-now scrub focused-detail frame as-child]
+    :or   {as-child identity}}]
+  (let [focused-ms (rings-h/focused-cascade-time-ms focused-detail)
+        now        (rings-h/resolve-now-ms scrub live-now focused-ms)
+        ;; rf2-k97c.3 — `reg-view` LEXICALLY INJECTED a frame-aware
+        ;; `dispatch` into the body; `defview` binds NO name inside a
+        ;; body, so the dispatcher is built here from the carried frame.
+        ;; Same target as before — the surrounding instance frame
+        ;; (rf2-nesy9), never a `{:frame :rf/xray}` literal.
+        dispatch   (fn [event-v] (rf/dispatch event-v {:frame frame}))
+        ;; Kick the rAF loop iff ticking is needed (live mode + at
+        ;; least one armed timer). Cheap to call per render — the
+        ;; `:running?` sentinel collapses duplicate kicks. Per Lock #8
+        ;; this is the SINGLE per-chart clock (O(charts), not
+        ;; O(rings × charts)); the machines-viz overlay runs no clock
+        ;; of its own — it just re-measures the DOM when `:tick` bumps.
+        _          (when (rings-h/needs-ticking? timers scrub)
+                     (kick-tick! frame))
+        specs      (rings-h/timers->ring-specs
+                     timers chart-layout/highlight-id now)]
+    (when (seq specs)
+      [:div {:data-rf-xray-after-rings-host ""
+             ;; rf2-e64drj — the React ref that clears `:mounted?` on unmount
+             ;; so the off-render rAF tick loop stops when this overlay leaves
+             ;; the screen (switch away from the Machine Inspector) even while
+             ;; an `:after` timer stays armed. Stable fn identity ⇒ React fires
+             ;; it only on mount (node) / unmount (nil), never per re-render.
+             ;; Fresco's codec passes `:ref` through untouched, so the
+             ;; lifecycle is the same one under either renderer.
+             :ref overlay-ref!
+             :style {:display "contents"}}
+       (as-child
+         [mv-after-rings/AfterRingsOverlay
+          {:ring-specs specs
+           ;; `now` is the rAF-bumped (or scrubber-pinned) instant —
+           ;; bumping it on every frame forces the overlay to re-measure
+           ;; the DOM + repaint the swept arcs (Lock #8 60Hz-when-visible
+           ;; cadence, driven by THIS ns's clock, not the overlay's).
+           :tick       now
+           :testid     "rf-xray-machine-inspector-after-rings-overlay"
+           :on-hover   (fn [node-id] (timer-hovered! dispatch specs node-id))
+           :on-leave   (fn [_node-id]
+                         (dispatch [:rf.xray/timer-hover nil]))}])])))
+
+(rf.fresco/defview AfterRingsOverlay
   "Mounts the focused machine's `:after` countdown rings over the
   xyflow chart. Subscribes to the active timers + now-ms + scrubber
   internally; projects each timer into a presentation-ready ring-spec
@@ -394,20 +499,34 @@
   rAF clock in live mode; then delegates positioning + paint to the
   machines-viz `AfterRingsOverlay`, which walks the xyflow node DOM.
 
-  rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
-  React-context frame tier carries the enclosing `:rf/xray` frame
+  rf2-m4xz1 — was a `reg-view` (and before that a plain `defn`) so the
+  React-context frame tier carried the enclosing `:rf/xray` frame
   through to the four subscribes inside. As a plain fn rendered under
   `[rf/frame-provider {:frame :rf/xray}]`, the subscribes routed to
   `:rf/default` (the host app's frame), which is a real frame-leak —
   xray-internal slots must be read via xray's own frame. Same surgery
   PR #2110 (rf2-uu3lp) applied to the rest of xray chrome.
 
-  Accepts an optional opts map (currently unused — reserved for a
-  future per-call testid override). Variadic to preserve the prior
-  0-arg + 1-arg call shapes (the hiccup mount carries one arg, tests
-  call with zero or one). The legacy positioned-graph / viewport-
-  transform args are GONE (xyflow owns positions; the overlay reads
-  them off the DOM).
+  rf2-k97c.3 — now an `rf.fresco/defview`. The frame reasoning above is
+  UNCHANGED and still the reason this is a component rather than a fn:
+  a boundary reads its frame from the same `re-frame.adapter.context`
+  React context that `rf/frame-provider` writes, so the four reads
+  still resolve through `:rf/xray`. What changed is the OBSERVER — the
+  reads are `rf.fresco/sub`, recorded by Fresco's collector rather than
+  by the installed adapter's, which is the epic's coupling (3).
+
+  Two consequences of `defview`'s contract, both load-bearing here:
+
+    * It binds NO name inside the body, so `reg-view`'s lexically
+      injected `dispatch` is gone. [[overlay-tree]] builds one from the
+      carried frame instead — same target, same behaviour.
+    * It takes ONE props map, so the old `[& _opts]` variadic (and with
+      it the 0-arg / 1-arg call shapes the node rows used) is gone. The
+      opts map was never read. Node-lane rows drive [[overlay-tree]]
+      directly now.
+
+  The legacy positioned-graph / viewport-transform args are GONE
+  (xyflow owns positions; the overlay reads them off the DOM).
 
   Returns nil when the projection has no active timers (the overlay
   layer drops out so unrelated chart hover handlers aren't shadowed).
@@ -427,61 +546,76 @@
   overlay queries to measure node rects is unchanged because a
   `display: contents` element is not a positioning context). Same
   pattern as `shell.cljs` (rf2-uu3lp)."
-  [& _opts]
-  (let [timers     @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
-        live-now   @(rf/subscribe [:rf.xray/now-ms])
-        scrub      @(rf/subscribe [:rf.xray/machine-scrubber-position])
-        ;; rf2-8i1tg3 — xray/003 §M.2: in RETRO mode ('scrubber-
-        ;; driven') the ring must freeze at the elapsed-fraction the
-        ;; timer had reached at the FOCUSED CASCADE's timestamp, not
-        ;; wherever the live clock last sat when the tick loop
-        ;; stopped. `needs-ticking?` already suspends the rAF loop when
-        ;; `scrub` leaves `:present`, so `live-now` simply goes stale —
-        ;; nothing was plumbing the scrubbed anchor into the ring
-        ;; projection below. `:rf.xray/focused-event-bundle-detail` is
-        ;; the same cross-panel primitive the Epoch / App-db-diff
-        ;; panels read to find "the event-bundle the spine is pointing
-        ;; at"; referenced by keyword (no ns require — re-frame's
-        ;; registrar resolves subs at runtime, not compile-time,
-        ;; keeping this ns out of the `registry.cljs` require cycle).
-        focused-ms (rings-h/focused-cascade-time-ms
-                     @(rf/subscribe [:rf.xray/focused-event-bundle-detail]))
-        now        (rings-h/resolve-now-ms scrub live-now focused-ms)
-        ;; rf2-nesy9 — capture the surrounding instance frame so the
-        ;; off-render rAF clock + the hover/leave callbacks dispatch
-        ;; into it (not a `:rf/xray` literal). `frame` arms the rAF loop
-        ;; via kick-tick!; `dispatch` is the reg-view-injected dispatcher.
-        frame  (rf/current-frame-id)
-        ;; Kick the rAF loop iff ticking is needed (live mode + at
-        ;; least one armed timer). Cheap to call per render — the
-        ;; `:running?` sentinel collapses duplicate kicks. Per Lock #8
-        ;; this is the SINGLE per-chart clock (O(charts), not
-        ;; O(rings × charts)); the machines-viz overlay runs no clock
-        ;; of its own — it just re-measures the DOM when `:tick` bumps.
-        _      (when (rings-h/needs-ticking? timers scrub)
-                 (kick-tick! frame))
-        specs  (rings-h/timers->ring-specs
-                 timers chart-layout/highlight-id now)]
-    (when (seq specs)
-      [:div {:data-rf-xray-after-rings-host ""
-             ;; rf2-e64drj — the React ref that clears `:mounted?` on unmount
-             ;; so the off-render rAF tick loop stops when this overlay leaves
-             ;; the screen (switch away from the Machine Inspector) even while
-             ;; an `:after` timer stays armed. Stable fn identity ⇒ React fires
-             ;; it only on mount (node) / unmount (nil), never per re-render.
-             :ref overlay-ref!
-             :style {:display "contents"}}
-       [mv-after-rings/AfterRingsOverlay
-        {:ring-specs specs
-         ;; `now` is the rAF-bumped (or scrubber-pinned) instant —
-         ;; bumping it on every frame forces the overlay to re-measure
-         ;; the DOM + repaint the swept arcs (Lock #8 60Hz-when-visible
-         ;; cadence, driven by THIS ns's clock, not the overlay's).
-         :tick       now
-         :testid     "rf-xray-machine-inspector-after-rings-overlay"
-         :on-hover   (fn [node-id] (timer-hovered! dispatch specs node-id))
-         :on-leave   (fn [_node-id]
-                       (dispatch [:rf.xray/timer-hover nil]))}]])))
+  [_props]
+  ;; The four reads, unchanged in identity and unconditional as before —
+  ;; only the OBSERVER moved, from the installed adapter's to Fresco's
+  ;; collector. `rf.fresco/sub` records its edge WHERE THE READ HAPPENS,
+  ;; so keeping all four here keeps the dependency set exactly what the
+  ;; `reg-view` had.
+  ;;
+  ;; rf2-8i1tg3 — xray/003 §M.2: in RETRO mode ('scrubber-driven') the
+  ;; ring must freeze at the elapsed-fraction the timer had reached at
+  ;; the FOCUSED CASCADE's timestamp, not wherever the live clock last
+  ;; sat when the tick loop stopped. `:rf.xray/focused-event-bundle-detail`
+  ;; is the same cross-panel primitive the Epoch / App-db-diff panels
+  ;; read to find "the event-bundle the spine is pointing at"; referenced
+  ;; by keyword (no ns require — re-frame's registrar resolves subs at
+  ;; runtime, not compile-time, keeping this ns out of the
+  ;; `registry.cljs` require cycle).
+  ;;
+  ;; rf2-nesy9 — `rf/current-frame-id` is one of core's PURE frame doors,
+  ;; which `impl.intent/with-frame` answers with the boundary's DECLARED
+  ;; frame precisely because it neither reads nor dispatches. So the
+  ;; surrounding instance frame still reaches the off-render rAF clock
+  ;; and the hover / leave dispatches, and it is still not a `:rf/xray`
+  ;; literal.
+  (overlay-tree
+    {:timers         (rf.fresco/sub [:rf.xray/active-timers-for-focused-machine])
+     :live-now       (rf.fresco/sub [:rf.xray/now-ms])
+     :scrub          (rf.fresco/sub [:rf.xray/machine-scrubber-position])
+     :focused-detail (rf.fresco/sub [:rf.xray/focused-event-bundle-detail])
+     :frame          (rf/current-frame-id)
+     ;; The machines-viz overlay is a Reagent class, so it reaches React
+     ;; as a finished React ELEMENT — a legal child anywhere per Fresco's
+     ;; component ABI — rather than as a hiccup head. `r/as-element`
+     ;; carries the hiccup vector itself, so the CLJS props map crosses
+     ;; BY IDENTITY; see the ns docstring.
+     :as-child       r/as-element}))
+
+;; ---- the migration bridge (rf2-k97c.3) ----------------------------------
+;;
+;; MIGRATION SCAFFOLDING WITH A DEFINED END. `Chart` in
+;; `panels/machine_canvas.cljs` is still a `reg-view`, so it mounts this
+;; overlay from a REAGENT tree, and a boundary is not a Reagent render
+;; fn. `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; that; the crossing is an EMPTY props map, which is the only shape that
+;; survives a Reagent parent's `convert-prop-value` (increment 2 measured
+;; that a payload does not). The overlay never had a payload to cross —
+;; its one call site passed `nil` opts — so nothing is given up here.
+;;
+;; When the shell chain is itself a Fresco tree (step 3), `Chart` mounts
+;; `AfterRingsOverlay` directly and both of these go in that commit.
+;;
+;; Naming follows the mayor's 2026-09-10 ruling: the boundary keeps the
+;; NATURAL name and the caller is handed a PUBLIC bridge (the #9581
+;; spelling). The constraint that forced #9578's opposite spelling — a
+;; fenced `shell.cljs` mounting the var by name — does not exist here:
+;; the sole caller is `machine_canvas/Chart`, which this slice owns.
+
+(def ^:private AfterRingsOverlay-component
+  "The React component [[AfterRingsOverlay]] presents as, for a
+  non-Fresco parent. Declared ONCE at top level, as
+  `rf.fresco/as-component`'s own docstring requires — a fresh one per
+  render is a fresh element type and would remount the subtree on every
+  pass, taking the machines-viz overlay's measured state with it."
+  (rf.fresco/as-component AfterRingsOverlay))
+
+(defn AfterRingsOverlay-bridge
+  "Mount [[AfterRingsOverlay]] from a Reagent hiccup tree. Public
+  because its one consumer is `panels/machine_canvas.cljs`'s `Chart`,
+  a different namespace. Deleted at step 3 with the component above."
+  []
+  [:> AfterRingsOverlay-component {}])
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -380,7 +380,16 @@
      ;; The overlay walks the chart's node DOM by data-testid to find
      ;; bbox positions; no positioned-graph prop is needed
      ;; post-migration (xyflow owns positions internally).
-     [after-rings/AfterRingsOverlay nil])])
+     ;;
+     ;; rf2-k97c.3 — `AfterRingsOverlay` is now an `rf.fresco/defview`,
+     ;; i.e. a real React component, and `Chart` here is still a
+     ;; `reg-view`, i.e. a Reagent tree. `AfterRingsOverlay-bridge` is
+     ;; the one line between them (`rf.fresco/as-component`, crossing an
+     ;; empty props map — the overlay's opts were never read, which is
+     ;; why the old `nil` argument is no loss). Both the bridge and this
+     ;; call go at step 3, when `Chart` is itself a Fresco body and can
+     ;; mount the boundary directly.
+     [after-rings/AfterRingsOverlay-bridge])])
 
 ;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
@@ -372,6 +372,32 @@
 
 ;; ---- (5c) the substrate seam (rf2-k97c.3) ------------------------------
 
+(defn- crossed-by-identity?
+  "True when `props` is reachable from React element `el`'s props object
+  WITHOUT conversion — as the same object, at a slot or inside a vector
+  or array at a slot.
+
+  Written to the QUESTION rather than to one Reagent version's field
+  layout, and that is the point: the first draft of this asserted
+  `(aget (.-argv (.-props el)) 1)`, copied from
+  `tools/machines-viz`'s `react_chart_cljs_test`, and read nil. The
+  copy was wrong in a way worth recording, because the two cases look
+  identical and are not — `react_chart.cljs` builds its bridge props by
+  hand as `#js {:argv #js [...]}`, a JS ARRAY, so `aget` is right there;
+  `reagent.core/as-element` carries the hiccup vector itself, a CLJS
+  PersistentVector, on which `aget` answers nil rather than erroring.
+  Probing for the object instead of for its address survives both."
+  [el props]
+  (let [p (.-props el)]
+    (boolean
+      (when (some? p)
+        (some (fn [v]
+                (or (identical? v props)
+                    (and (vector? v) (boolean (some #(identical? % props) v)))
+                    (and (array? v)
+                         (boolean (some #(identical? % props) (array-seq v))))))
+              (array-seq (js/Object.values p)))))))
+
 (deftest as-child-lifts-the-reagent-delegate-to-a-react-element
   (testing "rf2-k97c.3 — the machines-viz `AfterRingsOverlay` is a REAGENT
             component, so a Fresco body can neither take it as a hiccup
@@ -399,19 +425,28 @@
       (push-scheduled! 1000 :auth/login :idle 5000 0)
       (let [hiccup-child  (delegated-child (overlay-tree))
             props         (second hiccup-child)
-            element-child (delegated-child (overlay-tree {:as-child r/as-element}))]
+            ;; ONE tree, converted two ways. Two separate `overlay-tree`
+            ;; calls would answer two EQUAL but distinct props maps, and
+            ;; the identity claim below would be false for a reason that
+            ;; has nothing to do with the crossing.
+            element-child (r/as-element hiccup-child)
+            ;; ...and the parameter really is wired through `overlay-tree`,
+            ;; which is the half the boundary depends on.
+            via-param     (delegated-child (overlay-tree {:as-child r/as-element}))]
         (is (vector? hiccup-child)
             "the default :as-child leaves the delegate as hiccup")
         (is (= mv-after-rings/AfterRingsOverlay (first hiccup-child))
             "and it is the machines-viz overlay")
-        (is (not (vector? element-child))
-            ":as-child r/as-element answers a React element, not hiccup")
+        (is (not (vector? via-param))
+            ":as-child is threaded through overlay-tree, not ignored")
         (is (some? (.-props element-child))
-            "and it is a real element carrying React props")
-        (is (= props (aget (.-argv (.-props element-child)) 1))
-            "the CLJS props map rides at argv[1] — Reagent reads argv AS
-             IS and never touches the raw props object, so :ring-specs
-             stays a CLJS vector of CLJS maps across the crossing")))))
+            "as-element answers a real React element carrying React props")
+        (is (crossed-by-identity? element-child props)
+            "THE CLAIM: the CLJS props map reaches the element AS THE SAME
+             OBJECT. Reagent carries the hiccup vector itself and never
+             converts it, so :ring-specs stays a CLJS vector of CLJS maps.
+             A `[:> ...]` crossing would fail this — its host walk
+             camelCases the top-level key and `clj->js`es the value")))))
 
 ;; ---- (5d) deferred hover dispatch routing (rf2-nesy9 / rf2-k97c.3) -----
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_cljs_test.cljs
@@ -18,10 +18,12 @@
        timer-hover slot by node-id).
     6. The rAF tick loop's `needs-ticking?` gate stops the loop when
        no armed timers are present."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.registrar :as rf.registrar]
+            [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
@@ -38,7 +40,11 @@
   ;; init reset a SECOND time) into one owner; `:post-reset` stops any
   ;; armed rAF tick loop. (`trace-collector` stays required for seeding.)
   (xray-test-support/make-xray-runtime-fixture
-    {:post-reset (fn [] (after-rings/stop-tick!))}))
+    ;; `:async? true` is the map-form `cljs.test/async` shape, needed by
+    ;; `hover-dispatch-lands-on-the-render-frame` below (rf2-k97c.3),
+    ;; which polls a real async dispatch rather than racing the drain.
+    {:async?     true
+     :post-reset (fn [] (after-rings/stop-tick!))}))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
@@ -182,6 +188,35 @@
 ;; SVG-positioned-graph + viewport-transform tests are gone with the
 ;; elk renderer.)
 
+(defn- overlay-tree
+  "Drive `after-rings/overlay-tree` with EXACTLY the reads the
+  `AfterRingsOverlay` boundary makes — same four query vectors, same
+  order, and the frame taken the same way — so what these rows assert on
+  is the tree the mounted boundary actually renders.
+
+  rf2-k97c.3 — the rows below used to call `(overlay-tree)`
+  directly. A migrated view is a real React component and cannot be
+  called, so the markup moved into `overlay-tree`, which can. `:as-child`
+  is left at its `identity` default so the delegated machines-viz child
+  stays HICCUP here and every assertion below reads exactly what it read
+  before; the boundary passes `reagent.core/as-element` instead, and the
+  new `machine_after_rings_fresco_boundary_dom_cljs_test` is what proves
+  that half against a real React commit.
+
+  Call inside `(rf/with-frame :rf/xray ...)`, as every row here does.
+  `extra` is merged last, so a row can vary ONE input (`:as-child`)
+  without drifting the other five away from the boundary's."
+  ([] (overlay-tree nil))
+  ([extra]
+   (after-rings/overlay-tree
+     (merge
+       {:timers         @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
+        :live-now       @(rf/subscribe [:rf.xray/now-ms])
+        :scrub          @(rf/subscribe [:rf.xray/machine-scrubber-position])
+        :focused-detail @(rf/subscribe [:rf.xray/focused-event-bundle-detail])
+        :frame          (rf/current-frame-id)}
+       extra))))
+
 (defn- delegated-child
   "Pull the inner `[mv-after-rings/AfterRingsOverlay {...}]` hiccup
   past the `display: contents` wrapper `:div` (rf2-fkpuv)."
@@ -203,9 +238,7 @@
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 1000)
-    (is (nil? (after-rings/AfterRingsOverlay)))
-    (is (nil? (after-rings/AfterRingsOverlay nil))
-        "opts-arity also returns nil with no timers")))
+    (is (nil? (overlay-tree)))))
 
 (deftest overlay-delegates-one-ring-spec-per-active-timer
   (setup-xray-frame!)
@@ -214,7 +247,7 @@
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
-    (let [tree  (after-rings/AfterRingsOverlay)
+    (let [tree  (overlay-tree)
           child (delegated-child tree)
           props (delegated-props tree)
           specs (:ring-specs props)]
@@ -240,7 +273,7 @@
     (pin-now-ms! 7000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
     (push-fired!     6000 :auth/login :idle 0)
-    (is (nil? (after-rings/AfterRingsOverlay))
+    (is (nil? (overlay-tree))
         "fired timers are filtered out of the active projection — the
          whole overlay drops out")))
 
@@ -252,7 +285,7 @@
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle    5000 0)
     (push-scheduled! 1500 :auth/login :authing 3000 0)
-    (let [specs (-> (after-rings/AfterRingsOverlay) delegated-props :ring-specs)]
+    (let [specs (-> (overlay-tree) delegated-props :ring-specs)]
       (is (= 2 (count specs)))
       (is (= #{"idle" "authing"} (set (map :node-id specs)))))))
 
@@ -263,7 +296,7 @@
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
-    (let [props    (-> (after-rings/AfterRingsOverlay) delegated-props)
+    (let [props    (-> (overlay-tree) delegated-props)
           on-hover (:on-hover props)
           on-leave (:on-leave props)
           spec     (-> props :ring-specs first)]
@@ -326,16 +359,106 @@
       ;; the composite a known, non-live anchor timestamp.
       (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:some/event] 4242))
       (rf/dispatch-sync [:rf.xray/set-scrubber-position 3])
-      (let [props (-> (after-rings/AfterRingsOverlay) delegated-props)]
+      (let [props (-> (overlay-tree) delegated-props)]
         (is (= 4242 (:tick props))
             "RETRO tick anchors to the focused cascade's dispatched
              time (4242) — NOT the pinned live now-ms (9999), which is
              the exact rf2-8i1tg3 regression"))
       (rf/dispatch-sync [:rf.xray/set-scrubber-position :present])
-      (let [props (-> (after-rings/AfterRingsOverlay) delegated-props)]
+      (let [props (-> (overlay-tree) delegated-props)]
         (is (= 9999 (:tick props))
             "returning to :present restores the live clock as the tick
              anchor")))))
+
+;; ---- (5c) the substrate seam (rf2-k97c.3) ------------------------------
+
+(deftest as-child-lifts-the-reagent-delegate-to-a-react-element
+  (testing "rf2-k97c.3 — the machines-viz `AfterRingsOverlay` is a REAGENT
+            component, so a Fresco body can neither take it as a hiccup
+            head (a plain function in head position is a loud error,
+            HD-016) nor CALL it (it answers a Reagent CLASS, not hiccup —
+            which is why the migration's usual `(mini v 40)` repair does
+            not apply). `overlay-tree`'s `:as-child` is the seam:
+            `identity` leaves the delegate as hiccup for a Reagent parent
+            and for every row above, while `reagent.core/as-element`
+            answers a React element, which Fresco's component ABI admits
+            as a legal child anywhere.
+
+            The row that matters is the last one: `as-element` carries the
+            hiccup vector itself as Reagent's `argv`, so the CLJS props map
+            reaches machines-viz BY IDENTITY. That is the whole reason this
+            route was taken over `[:> ...]`, whose host walk camelCases the
+            top-level key and `clj->js`es a collection value — under which
+            `:ring-specs` would arrive as `:ringSpecs` holding a JS array
+            and the overlay would destructure nil."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (pin-now-ms! 2000)
+      (push-scheduled! 1000 :auth/login :idle 5000 0)
+      (let [hiccup-child  (delegated-child (overlay-tree))
+            props         (second hiccup-child)
+            element-child (delegated-child (overlay-tree {:as-child r/as-element}))]
+        (is (vector? hiccup-child)
+            "the default :as-child leaves the delegate as hiccup")
+        (is (= mv-after-rings/AfterRingsOverlay (first hiccup-child))
+            "and it is the machines-viz overlay")
+        (is (not (vector? element-child))
+            ":as-child r/as-element answers a React element, not hiccup")
+        (is (some? (.-props element-child))
+            "and it is a real element carrying React props")
+        (is (= props (aget (.-argv (.-props element-child)) 1))
+            "the CLJS props map rides at argv[1] — Reagent reads argv AS
+             IS and never touches the raw props object, so :ring-specs
+             stays a CLJS vector of CLJS maps across the crossing")))))
+
+;; ---- (5d) deferred hover dispatch routing (rf2-nesy9 / rf2-k97c.3) -----
+;;
+;; Sibling in shape to `reactive_panel_disclosure_dispatch_routing_cljs_test`:
+;; pluck the deferred handler off the rendered tree and fire it OUTSIDE any
+;; `with-frame`, reproducing the browser reality that a mouseenter fires
+;; AFTER render commits and the ambient frame scope has unwound.
+;;
+;; The rows in (5) above deliberately declined this claim — "the production
+;; callback dispatches async, so racing the router drain here would be
+;; flaky" — and asserted only that the callbacks are wired and don't throw.
+;; Polling rather than racing makes the claim available, and it is the one
+;; the migration most needs: `reg-view` used to INJECT a frame-aware
+;; `dispatch`, `defview` binds no name inside a body, and this row is what
+;; says the replacement targets the same frame.
+
+(deftest hover-dispatch-lands-on-the-render-frame
+  (testing "rf2-nesy9 — the hover dispatch lands on the frame the TREE
+            named, and does NOT leak to :rf/default, even though it fires
+            long after the render extent has unwound. That is the
+            'carrying' half of the boundary contract: the dispatcher holds
+            an explicit {:frame ...}, so it never has to resolve a frame
+            ambiently at click time."
+    (setup-xray-frame!)
+    (let [on-hover (rf/with-frame :rf/xray
+                     (override-machines!    [:auth/login])
+                     (override-definitions! {:auth/login fixture-definition})
+                     (pin-now-ms! 2000)
+                     (push-scheduled! 1000 :auth/login :idle 5000 0)
+                     (:on-hover (delegated-props (overlay-tree))))]
+      (is (fn? on-hover) "the delegate is handed an :on-hover callback")
+      ;; Frameless, exactly as a real mouseenter is.
+      (on-hover "idle")
+      (async done
+        (-> (rf.test-support/poll-until
+              #(some? (:rings/hover (rf.frame/frame-app-db-value :rf/xray)))
+              {:label      ":rings/hover appears on :rf/xray after a frameless hover"
+               :timeout-ms 1000})
+            (.then (fn [_]
+                     (is (= {:machine-id :auth/login :state :idle :epoch 0}
+                            (:rings/hover (rf.frame/frame-app-db-value :rf/xray)))
+                         "the deferred hover landed on :rf/xray carrying the
+                          full (machine-id, state, epoch) identity tuple")
+                     (is (nil? (:rings/hover (rf.frame/frame-app-db-value :rf/default)))
+                         ":rf/default was NOT polluted — no bare-dispatch leak")))
+            (.catch (fn [e] (is false (.-message e)) nil))
+            (.then (fn [_] (done))))))))
 
 ;; ---- (6) frame isolation ----------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,540 @@
+(ns day8.re-frame2-xray.panels.machine-after-rings-fresco-boundary-dom-cljs-test
+  "THE `:after`-RINGS OVERLAY RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW LAYER,
+  read off a real React commit (rf2-k97c.3).
+
+  `machine-after-rings/AfterRingsOverlay` is now an `rf.fresco/defview`
+  reading its four slots through Fresco's shipped collector rather than an
+  `rf/reg-view` reading through whatever view build the installed adapter
+  supplies. This file is the behavioural evidence, and it follows
+  `module_view_fresco_boundary_dom_cljs_test`'s four-row template.
+
+  ## What is DIFFERENT about this boundary, and why two rows here are new
+
+  Every panel migrated before this one rendered its own hiccup all the way
+  down. This one's whole job is to DELEGATE to the machines-viz
+  `AfterRingsOverlay`, which is a **Reagent component** living in a
+  bundle-isolated sibling artefact that knows nothing of Fresco. Fresco
+  admits neither spelling the migration has used so far:
+
+    * as a hiccup HEAD it is a plain function, which is a loud error
+      (HD-016);
+    * CALLED — the repair used for `mini`, `frame-row`, `code-block` and
+      Resources' 37 section helpers — it answers a Reagent CLASS rather
+      than hiccup, so calling it is a different bug rather than a fix.
+
+  The door taken is Fresco's own component ABI: *\"A React element is a
+  legal child anywhere\"* (`re-frame.fresco.impl.codec`; `child-kind`
+  classifies `react/isValidElement` as `:react-element` and `as-element`
+  passes it through untouched). `overlay-tree`'s `:as-child` is
+  `reagent.core/as-element` at the boundary, so Reagent's own renderer
+  builds the element and the CLJS props map crosses BY IDENTITY.
+
+  Two rows exist for that seam and would not appear in a template panel:
+
+    * W1 asserts the machines-viz overlay's OWN committed DOM
+      (`data-ring-count`), which exists only if the React element really
+      crossed the substrate seam and Reagent really rendered it. A
+      migration that broke the crossing paints nothing there.
+    * W5 asserts the rf2-e64drj MOUNT GATE still works — the overlay's
+      `:ref` callback clears the rAF tick loop's `:mounted?` liveness on
+      unmount. `:ref` is one of the two structural slots Fresco carries
+      untouched, and an off-render 60Hz loop that outlives its panel is
+      the exact regression that contract was written for.
+
+  ## Criterion 3 is answered in the NODE lane, deliberately
+
+  The overlay's interactions are `:on-hover` / `:on-leave`, which the
+  machines-viz overlay fires from ring `<g>` elements it only paints after
+  MEASURING a rendered xyflow chart. Standing a real chart up here to
+  produce a hover target would make the row about xyflow's layout rather
+  than about the boundary. `machine_after_rings_cljs_test`'s
+  `hover-dispatch-lands-on-the-render-frame` makes the claim instead, and
+  makes it in the sharper place: it fires the handler OUTSIDE any
+  `with-frame`, which is what a real mouseenter does, and asserts the
+  event landed in the frame the tree named and NOT in `:rf/default`.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's
+  `cljs-test$` regex also matches, so it LOADS under Node — where every
+  row short-circuits through [[browser?]] and reports the skip rather
+  than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. W1 reads it as
+  the negative half of the frame-targeting claim, and W3 mounts INSIDE it
+  so the evidence claim cannot be carried by `:rf/xray`'s trace-disabled
+  gate."
+  ::app)
+
+(def ^:private timers-q
+  "The overlay's primary read. Named once because three rows key off it —
+  the sub-cache is keyed by the query vector itself
+  (`re-frame.subs/cache-key` is identity), so this value IS the cache key."
+  [:rf.xray/active-timers-for-focused-machine])
+
+(def ^:private overlay-sel
+  "The machines-viz overlay's own committed root. Reaching for THIS rather
+  than for the Xray wrapper is the point of W1: the wrapper is emitted by
+  the boundary, but this node exists only if the React element crossed
+  into React and Reagent rendered the foreign component behind it."
+  "[data-testid=\"rf-xray-machine-inspector-after-rings-overlay\"]")
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on    {:start :authing}
+                       :after {5000 :timeout}}
+             :authing {:on {:ok :done}}
+             :timeout {:on {:retry :idle}}
+             :done    {:final? true}}})
+
+;; ---- a probe event, and the `reg-view` W3 measures the boundary against ----
+
+(rf/reg-event ::bump
+  (fn [{:keys [db]} [_ n]] {:db (assoc db ::n n)}))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the boundary — so the only variable between it and
+  the overlay is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"} (str @(rf/subscribe [::n]))])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     ;; `:ambient-frame nil` is load-bearing: the fixture's default ambient
+     ;; `:rf/default` scope would SHADOW the React-context tier W1 is about,
+     ;; and the frame-targeting row would pass while measuring nothing.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; The boundary kicks the single per-chart rAF clock
+                      ;; from its render, so a row that mounts leaves a loop
+                      ;; armed for the next one.
+                      (after-rings/stop-tick!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this overlay's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission — increment 1 measured it. A Fresco boundary is NOT in Reagent's
+;; render queue, so draining Reagent's queue commits nothing of this overlay's,
+;; and a row written that way reads a DOM that has not moved and reports a live
+;; panel as dead. Mount is committed with `flushSync` (React's own door) and
+;; everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after an event is
+  a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers, install the test-only `now-ms` override seam
+  (the rows pin a deterministic clock through it), and make both frames."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- seed-one-armed-timer!
+  "Put exactly one ARMED `:after` timer in front of the overlay, in
+  `frame`. Without this the projection is empty and the overlay returns
+  nil — so every row that asserts DOM depends on this having worked, and
+  W1 checks it did."
+  [frame]
+  (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
+                     [:auth/login]] {:frame frame})
+  (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test
+                     {:auth/login fixture-definition}] {:frame frame})
+  (rf/dispatch-sync [:rf.xray/set-now-ms-override-for-test 2000] {:frame frame})
+  ;; The trace buffer is the collector's, not a frame's, so this one seed
+  ;; is visible to whichever frame the overlay is mounted in.
+  (trace-collector/seed-trace-for-test!
+    {:id 1000 :time 1000
+     :operation :rf.machine.timer/scheduled
+     :tags {:machine-id :auth/login
+            :state :idle
+            :delay 5000
+            :delay-source :literal
+            :epoch 0}})
+  nil)
+
+(defn- mount-overlay!
+  "Mount the overlay the way `machine-canvas/Chart` mounts it: through
+  `AfterRingsOverlay-bridge`, the PUBLIC var the caller actually holds,
+  inside a `frame-provider` scoping `frame`. Reaching for the bridge
+  rather than for the boundary is deliberate — a bridge that regressed to
+  something a Reagent tree cannot mount reddens here rather than in a
+  browser. Committed synchronously; React 19's `root.render` is otherwise
+  async and W1 would assert against an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [after-rings/AfterRingsOverlay-bridge]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads and where the `:ref` callback
+  clears the tick loop's liveness — have RUN by the time the next line
+  reads them. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- tick-attr
+  "The `data-tick` the machines-viz overlay committed — the instant this
+  ns's clock handed it. Read off the DOM rather than off props, because
+  props are what the boundary SENT and this is what React received."
+  [container]
+  (some-> (q container overlay-sel) (.getAttribute "data-tick")))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent. The spike measured the rejected design by watching this
+  number climb across renders and never fall on unmount, so it is the
+  number the migration is answerable on."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- mounted-flag
+  "The rAF tick loop's `:mounted?` liveness (rf2-e64drj), owned by the
+  overlay's `:ref` callback. Private var, reached the same way
+  `machine_after_rings_tick_loop_cljs_test` reaches it."
+  []
+  (:mounted? @#'day8.re-frame2-xray.panels.machine-after-rings/tick-state))
+
+;; ===========================================================================
+;; W1 — first display, the foreign child really crossed, and the read lands
+;;      in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-overlay-paints-through-the-seam-and-reads-the-named-frame
+  (testing "rf2-k97c.3 — the migrated overlay commits real DOM through the
+            bridge its caller holds, the machines-viz Reagent component
+            behind the substrate seam paints its own root, and the
+            boundary's `rf.fresco/sub` reads resolve against the frame the
+            enclosing `frame-provider` named rather than the ambient one.
+            Epic criteria 1 and 4, plus the crossing."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            _ (seed-one-armed-timer! :rf/xray)
+            {:keys [container root]} (mount-overlay! :rf/xray)]
+        (try
+          (is (some? (q container "[data-rf-xray-after-rings-host]"))
+              "the boundary committed its `display: contents` wrapper — the
+               body ran rather than short-circuiting to nil")
+
+          ;; ---- the crossing: machines-viz painted its OWN root -------------
+          (let [overlay (q container overlay-sel)]
+            (is (some? overlay)
+                "THE SEAM: the machines-viz overlay — a REAGENT component a
+                 Fresco body can neither head nor call — committed its own
+                 DOM root. This node exists only if `r/as-element`'s React
+                 element crossed as a legal Fresco child and Reagent
+                 rendered the component behind it")
+            (is (= "1" (.getAttribute overlay "data-ring-count"))
+                "and it received the ONE ring-spec the projection produced,
+                 so the CLJS props map crossed by identity rather than
+                 arriving camelCased or `clj->js`ed into nil")
+            (is (= "2000" (.getAttribute overlay "data-tick"))
+                "and the pinned clock reached it as :tick"))
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray timers-q))
+              (str "the boundary's read holds a reference in :rf/xray's "
+                   "sub-cache — the frame the enclosing frame-provider "
+                   "named. Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame timers-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            ;; Release the imperative probe explicitly: `unsubscribe`'s own
+            ;; docstring says a Reagent view auto-disposes via the reaction
+            ;; lifecycle and an imperative subscriber must not rely on that.
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-overlay-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted overlay re-renders and commits new DOM
+            when its read's value really changes, and does NOT when the
+            underlying slot moves without moving the answer. Epic criterion
+            2, with the control that makes the update mean liveness rather
+            than a commit that simply had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-one-armed-timer! :rf/xray)
+        (let [{:keys [container root]} (mount-overlay! :rf/xray)]
+          (is (= "2000" (tick-attr container))
+              "PRECONDITION: the committed DOM carries the pinned clock, so
+               a later change to it is visible")
+
+          ;; ---- phase 2: the world moves, and the overlay is deaf ----------
+          ;; `:rf.xray/now-ms` reads `(or override live)`. Bumping the LIVE
+          ;; slot while the override is pinned moves a slot the read really
+          ;; touches — the sub recomputes — but leaves its ANSWER identical,
+          ;; so nothing downstream may move. A boundary that repainted here
+          ;; would make phase 3 pass for a reason that is not liveness.
+          (rf/dispatch-sync [:rf.xray/timer-tick 8888] {:frame :rf/xray})
+          (is (= 2000 (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/now-ms])))
+              "PRECONDITION: the override still wins, so the read's answer
+               genuinely did not move")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (= "2000" (tick-attr container))
+                      "CONTROL: given a full settling window the committed
+                       DOM still carries 2000 — the live-slot write moved
+                       data the read touches without moving what it answers")
+                  ;; ---- phase 3: the answer really changes, DOM follows ----
+                  (rf/dispatch-sync [:rf.xray/set-now-ms-override-for-test 5555]
+                                    {:frame :rf/xray})
+                  (rf.test-support/poll-until
+                    #(= "5555" (tick-attr container))
+                    {:label "the overlay committed the new clock as :tick"})))
+              (.then
+                (fn [_]
+                  (is (= "5555" (tick-attr container))
+                      "the overlay re-rendered on a real invalidation of its
+                       own read and pushed the new value through the
+                       substrate seam into the foreign component's DOM")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — tick: " (pr-str (tick-attr container))))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated overlay
+            contributes NOTHING to the substrate's view-trace stream, even
+            when it is mounted INSIDE an application frame. Epic criterion
+            5, proven structurally rather than by the `:rf/xray` frame
+            gate: a Fresco boundary is not a substrate view render, so
+            there is no event to gate. The control is an ordinary
+            `reg-view` in the same root, the same frame and the same
+            commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            _        (seed-one-armed-timer! app-frame)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the overlay, mounted in an APPLICATION frame --
+          (let [{:keys [container root]} (mount-overlay! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container overlay-sel))
+                  "precondition: the overlay really did render in this commit
+                   — an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the boundary's render put NO :rf.view/* op in the "
+                       "trace stream while rendering inside an application "
+                       "frame. Ops seen: "
+                       (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the "
+                         "same way DOES emit a :rf.view/* op, so the "
+                         "subject's zero is a property of the boundary and "
+                         "not of a dead instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released?
+  "The overlay's read is fully released from `:rf/xray`'s sub-cache."
+  []
+  (zero? (ref-count-of :rf/xray timers-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the overlay releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so a keyed
+            reorder that unmounts and remounts within a single turn reuses
+            the reaction instead of rebuilding it. A synchronous assertion
+            would report a LEAK against a collector behaving exactly as
+            documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-one-armed-timer! :rf/xray)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-overlay! :rf/xray)
+                      mounted (ref-count-of :rf/xray timers-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, "
+                                   "within the collector's grace macrotask. "
+                                   "Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ---
+                          (let [{c2 :container r2 :root} (mount-overlay! :rf/xray)
+                                remounted (ref-count-of :rf/xray timers-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the rf2-e64drj MOUNT GATE survives the migration
+;; ===========================================================================
+;;
+;; This row is NOT in the template, and it is the one this panel most needs.
+;; The overlay owns the single per-chart rAF tick loop, and `tick-loop!` is
+;; gated on a `:mounted?` liveness flag that the overlay's `:ref` callback
+;; clears. Pre-rf2-e64drj the loop was gated on app-db data ALONE, so
+;; switching away from the Machine Inspector while an `:after` timer stayed
+;; armed left it dispatching ~60x/s in the background for ever.
+;;
+;; `:ref` is one of the two structural slots Fresco carries untouched rather
+;; than emitting as an attribute, so the contract SHOULD survive — but
+;; "should" is what this file exists to replace. Nothing else in the suite
+;; can see it: `machine_after_rings_tick_loop_cljs_test` drives `overlay-ref!`
+;; by hand, which proves the flag's algebra and not that React still calls it.
+
+(deftest w5-unmount-clears-the-tick-loop-mount-gate
+  (testing "rf2-e64drj / rf2-k97c.3 — mounting the boundary arms the rAF
+            clock's `:mounted?` liveness and unmounting CLEARS it, because
+            Fresco carried the `:ref` callback through to React untouched.
+            Without this the off-render 60Hz loop outlives its panel."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            _ (seed-one-armed-timer! :rf/xray)]
+        (after-rings/stop-tick!)
+        (is (false? (boolean (mounted-flag)))
+            "PRECONDITION: nothing is holding the gate open before the mount")
+        (let [{:keys [container root]} (mount-overlay! :rf/xray)]
+          (is (some? (q container overlay-sel))
+              "precondition: the overlay really did mount, so the flag below
+               is about this mount")
+          (is (true? (boolean (mounted-flag)))
+              "the mounted overlay armed the tick loop's liveness")
+          (teardown! root container)
+          (is (false? (boolean (mounted-flag)))
+              "and the unmount CLEARED it — React invoked the `:ref` callback
+               with nil, which it only does if Fresco carried the ref slot
+               through to the committed element. A boundary that dropped
+               `:ref` would leave this true and strand the rAF loop"))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_after_rings_fresco_boundary_dom_cljs_test.cljs
@@ -175,18 +175,27 @@
   nil)
 
 (defn- seed-one-armed-timer!
-  "Put exactly one ARMED `:after` timer in front of the overlay, in
-  `frame`. Without this the projection is empty and the overlay returns
-  nil — so every row that asserts DOM depends on this having worked, and
-  W1 checks it did."
-  [frame]
+  "Put exactly one ARMED `:after` timer in front of the overlay. Without
+  this the projection is empty and the overlay returns nil, so every row
+  that asserts DOM depends on it — and W1 checks it worked.
+
+  TARGETS `:rf/xray` AND TAKES NO FRAME ARGUMENT, because it cannot
+  honestly offer one. `trace-collector/refresh-trace-rings!`, which
+  `seed-trace-for-test!` calls, snapshots the rings into **`:rf/xray`'s**
+  `:trace-buffer` slot and its own docstring says the dispatch is a
+  silent no-op when `:rf/xray` is not registered. Seeding \"into\" any
+  other frame would therefore leave `:rf.xray/trace-buffer` empty there,
+  the projection empty, and the overlay rendering nil — while the three
+  override dispatches above all appeared to succeed. An earlier draft of
+  W3 did exactly that and would have asserted a zero against a container
+  with nothing in it."
+  []
   (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
-                     [:auth/login]] {:frame frame})
+                     [:auth/login]] {:frame :rf/xray})
   (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test
-                     {:auth/login fixture-definition}] {:frame frame})
-  (rf/dispatch-sync [:rf.xray/set-now-ms-override-for-test 2000] {:frame frame})
-  ;; The trace buffer is the collector's, not a frame's, so this one seed
-  ;; is visible to whichever frame the overlay is mounted in.
+                     {:auth/login fixture-definition}] {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-now-ms-override-for-test 2000]
+                    {:frame :rf/xray})
   (trace-collector/seed-trace-for-test!
     {:id 1000 :time 1000
      :operation :rf.machine.timer/scheduled
@@ -251,9 +260,15 @@
 (defn- mounted-flag
   "The rAF tick loop's `:mounted?` liveness (rf2-e64drj), owned by the
   overlay's `:ref` callback. Private var, reached the same way
-  `machine_after_rings_tick_loop_cljs_test` reaches it."
+  `machine_after_rings_tick_loop_cljs_test` reaches it.
+
+  TWO derefs, and the count is load-bearing: `@#'v` unwraps the Var to
+  the ATOM, and the second reads the atom's map. With one deref every
+  key answers nil, which reads as `:mounted? false` — so the two
+  assertions W5 makes about the gate being CLOSED would both pass while
+  measuring nothing."
   []
-  (:mounted? @#'day8.re-frame2-xray.panels.machine-after-rings/tick-state))
+  (:mounted? @@#'day8.re-frame2-xray.panels.machine-after-rings/tick-state))
 
 ;; ===========================================================================
 ;; W1 — first display, the foreign child really crossed, and the read lands
@@ -274,7 +289,7 @@
             ;; targeting claim below is measured with an instrument that is
             ;; demonstrably able to see an entry in that frame's cache.
             _probe (rf/subscribe [::n] {:frame app-frame})
-            _ (seed-one-armed-timer! :rf/xray)
+            _ (seed-one-armed-timer!)
             {:keys [container root]} (mount-overlay! :rf/xray)]
         (try
           (is (some? (q container "[data-rf-xray-after-rings-host]"))
@@ -330,7 +345,7 @@
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
-        (seed-one-armed-timer! :rf/xray)
+        (seed-one-armed-timer!)
         (let [{:keys [container root]} (mount-overlay! :rf/xray)]
           (is (= "2000" (tick-attr container))
               "PRECONDITION: the committed DOM carries the pinned clock, so
@@ -343,9 +358,16 @@
           ;; so nothing downstream may move. A boundary that repainted here
           ;; would make phase 3 pass for a reason that is not liveness.
           (rf/dispatch-sync [:rf.xray/timer-tick 8888] {:frame :rf/xray})
-          (is (= 2000 (rf/with-frame :rf/xray @(rf/subscribe [:rf.xray/now-ms])))
-              "PRECONDITION: the override still wins, so the read's answer
-               genuinely did not move")
+          ;; Read the db directly rather than through `rf/subscribe`: an
+          ;; imperative subscription here would take a reference nothing
+          ;; releases, in the same frame and for a query W4 counts.
+          (let [db (rf.frame/frame-app-db-value :rf/xray)]
+            (is (= 8888 (:rings/now-ms db))
+                "PRECONDITION: the live slot really did move — otherwise the
+                 control below is asserting against an event that did nothing")
+            (is (= 2000 (:rings/now-ms-override db))
+                "PRECONDITION: and the override that shadows it is still in
+                 place, so the read RECOMPUTES and answers what it did before"))
           (-> (settle)
               (.then
                 (fn [_]
@@ -389,7 +411,16 @@
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (let [_        (setup!)
-            _        (seed-one-armed-timer! app-frame)
+            ;; Give the composite a DEFINED answer in the application
+            ;; frame — `active-timers-empty-when-no-selection` in the node
+            ;; suite pins that an empty machine override yields `[]` rather
+            ;; than throwing. No timer is seeded: the trace snapshot only
+            ;; ever lands in `:rf/xray`'s slot (see `seed-one-armed-timer!`),
+            ;; so there would be nothing to paint here in any case, and this
+            ;; row's precondition is the READ rather than the DOM.
+            _        (rf/dispatch-sync
+                       [:rf.xray/set-registered-machines-override-for-test []]
+                       {:frame app-frame})
             traces   (atom [])
             view-op? #(and (keyword? (:operation %))
                            (= "rf.view" (namespace (:operation %))))]
@@ -399,9 +430,28 @@
           (let [{:keys [container root]} (mount-overlay! app-frame)
                 subject-views (filterv view-op? @traces)]
             (try
-              (is (some? (q container overlay-sel))
-                  "precondition: the overlay really did render in this commit
-                   — an empty container would make the zero below vacuous")
+              ;; THE PRECONDITION IS THE READ, NOT THE DOM, and that is
+              ;; forced rather than chosen. The projection this overlay
+              ;; paints from is fed by `trace-collector`, which snapshots
+              ;; into `:rf/xray`'s slot ALONE — so inside an application
+              ;; frame there are no timers, and the boundary correctly
+              ;; renders nil. A DOM precondition is therefore unavailable
+              ;; HERE, and reaching for one would have made the zero below
+              ;; vacuous in the quietest possible way.
+              ;;
+              ;; A reference in this frame's sub-cache is the better
+              ;; evidence anyway: it says the BODY RAN in this commit,
+              ;; which is precisely the act that would have emitted a
+              ;; `:rf.view/*` op had this been a substrate view render.
+              ;; The DOM half of the claim is W1's, in the frame that has
+              ;; something to paint.
+              (is (pos? (ref-count-of app-frame timers-q))
+                  (str "precondition: the boundary's body really did RUN in "
+                       "this commit, inside an application frame — it took "
+                       "a reference in that frame's sub-cache. Without this "
+                       "the zero below would be the zero of a body that "
+                       "never executed. Cache keys: "
+                       (pr-str (keys (cache-of app-frame)))))
               (is (zero? (count subject-views))
                   (str "the boundary's render put NO :rf.view/* op in the "
                        "trace stream while rendering inside an application "
@@ -452,12 +502,23 @@
             reorder that unmounts and remounts within a single turn reuses
             the reaction instead of rebuilding it. A synchronous assertion
             would report a LEAK against a collector behaving exactly as
-            documented."
+            documented.
+
+            THIS ROW DELIBERATELY SEEDS NO TIMER, and that is a choice
+            rather than an oversight. The boundary reads all four of its
+            slots UNCONDITIONALLY, at the top of the body, so the
+            reference this row is about is taken whether or not the
+            projection has anything to paint — the DOM is nil here and
+            the ref-count is not. Seeding one would arm the rAF clock,
+            and `tick-loop!` then takes its own reads off-render through
+            the imperative `(rf/subscribe q {:frame f})` form. Whatever
+            those hold, they are not the boundary's, and the subject of
+            this row is precisely whether the BOUNDARY released. Leaving
+            the clock disarmed keeps it the only holder."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
-        (seed-one-armed-timer! :rf/xray)
         ;; The starting point is polled, not asserted: a neighbouring row's
         ;; teardown grace may still be in flight when this one begins.
         (-> (rf.test-support/poll-until released?
@@ -522,7 +583,7 @@
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (let [_ (setup!)
-            _ (seed-one-armed-timer! :rf/xray)]
+            _ (seed-one-armed-timer!)]
         (after-rings/stop-tick!)
         (is (false? (boolean (mounted-flag)))
             "PRECONDITION: nothing is holding the gate open before the mount")

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -20,6 +20,7 @@
             [re-frame.registrar :as rf.registrar]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
             [day8.re-frame2-xray.panels.machine-canvas :as mc]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -175,6 +176,49 @@
             "canvas host mounts")
         (is (nil? (find-by-testid tree "rf-xray-machine-canvas-view-mode-toggle"))
             "the retired view-mode toggle never renders")))))
+
+(deftest chart-mounts-the-after-rings-bridge-rf2-k97c-3
+  (testing "rf2-k97c.3 — `machine-after-rings/AfterRingsOverlay` is now an
+            `rf.fresco/defview`, i.e. a real React component, while `Chart`
+            here is still a `reg-view`, i.e. a Reagent tree. So `Chart` must
+            mount the `as-component` BRIDGE and not the boundary: handing
+            Reagent a React component where it expects a render fn is
+            exactly what `defview`'s contract forbids, and it would paint
+            nothing. The boundary's own end-to-end DOM evidence lives in
+            `machine_after_rings_fresco_boundary_dom_cljs_test`, which
+            mounts this same public var — this row is what says CHART is
+            the caller holding it, so the two cannot drift apart silently.
+
+            Both halves are asserted. The bridge being present is the claim;
+            the boundary being ABSENT is what would catch a well-meaning
+            revert to the pre-migration spelling, which type-checks fine and
+            fails only at first paint."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [tree  (mc/Chart {:definition fixture-definition :machine-id :m})
+            heads (into #{}
+                        (comp (filter vector?) (map first))
+                        (hiccup-seq tree))]
+        (is (contains? heads after-rings/AfterRingsOverlay-bridge)
+            "Chart mounts AfterRingsOverlay-bridge (:show-after-rings? defaults true)")
+        (is (not (contains? heads after-rings/AfterRingsOverlay))
+            "and NOT the boundary itself, which a Reagent tree cannot mount")))))
+
+(deftest chart-omits-the-after-rings-bridge-when-suppressed
+  (testing "the three Static / topology call sites pass `:show-after-rings?
+            false`; the bridge must then be absent altogether. This is the
+            NON-VACUITY control for the row above — without it, a `heads`
+            set that contained the bridge unconditionally would satisfy it."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [tree  (mc/Chart {:definition fixture-definition
+                             :machine-id :m
+                             :show-after-rings? false})
+            heads (into #{}
+                        (comp (filter vector?) (map first))
+                        (hiccup-seq tree))]
+        (is (not (contains? heads after-rings/AfterRingsOverlay-bridge))
+            ":show-after-rings? false drops the overlay mount entirely")))))
 
 ;; ---- 4. SnapshotDrillIn view (rf2-lxvn6 · spec/021 §10) --------------
 


### PR DESCRIPTION
Increment of the rf2-k97c.3 panel fan-out. One panel file family plus its
tests; the bead stays open and is NOT claimed and NOT closed.

`machine-after-rings/AfterRingsOverlay` is now an `rf.fresco/defview`. Its
four reads are `rf.fresco/sub`, recorded by Fresco's own collector rather
than by the installed adapter's observer — the epic's coupling (3)
OBSERVATION, severed for this overlay.

## THE SHAPE THE TEMPLATE DOES NOT COVER, AND IT BINDS THE REMAINING PANELS

This overlay's whole job is to delegate to the machines-viz
`AfterRingsOverlay`, a **Reagent component** in a bundle-isolated sibling
artefact (`tools/machines-viz`) that has zero knowledge of Fresco —
measured: `git grep -l 'fresco' tools/machines-viz` returns nothing.

**Both of the migration's established repairs are unavailable, and the
second one is the interesting one:**

* as a hiccup HEAD it is a plain function, which is a loud error (HD-016);
* **CALLED — the repair used for `mini`, `edn-inspector-diff`,
  `code-block`, `frame-row` and Resources' 37 section helpers — it answers
  a Reagent CLASS rather than hiccup.** So "call it rather than head it" is
  not a repair here; it is a different bug. Read at source:
  `chart/overlays/after_rings.cljs`'s `AfterRingsOverlay` is a form-2 fn
  whose body returns `overlay_scaffold/make-resizing-overlay-class`, i.e. a
  `reagent.core/create-class` product.

  **Generalisable rule for the remaining panels: the CALL repair works only
  for a helper that ANSWERS HICCUP. Check what a helper returns before
  reaching for it.**

**The door taken is Fresco's own component ABI**, and it is documented
rather than improvised — `re-frame.fresco.impl.codec`'s header table says
*"A React element is a legal child anywhere; a plain function in head
position is a loud error"*, and the implementation agrees: `child-kind`
classifies `react/isValidElement` as `:react-element` and `as-element`
returns it untouched.

So `overlay-tree` takes an `:as-child` function — `identity` for a hiccup
caller, `reagent.core/as-element` at the boundary. Reagent's own renderer
builds the element, and **the CLJS props map crosses BY IDENTITY**, because
`as-element` carries the hiccup vector itself rather than converting a props
object.

**Why not `[:> Component props]`, which is the door a reader reaches for
first:** its host walk camelCases the top-level key and `clj->js`es a
collection value (`codec.cljs`'s `host-prop-value`: `(coll? v) (clj->js v)`;
`slot/prop-name` maps `:ring-specs` to `"ringSpecs"`). `:ring-specs` would
arrive as `:ringSpecs` holding a JS array and the overlay would destructure
nil. It also would not mount this component at all, since a form-2 fn
returning a class is not a React element type.

**One consequence worth stating because it is reassuring rather than
alarming (inference, not measurement): the substrate boundary is exactly at
`r/as-element`. Everything below it is still Reagent's renderer, so
machines-viz's own `^{:key node-id}` vector metadata keeps working and
machines-viz needs no change.**

## `machine_canvas.cljs` GETS ONE LINE, AND IS NOT MIGRATED

`Chart` still mounts the overlay, so that one line now mounts
`AfterRingsOverlay-bridge` (`rf.fresco/as-component`, crossing an EMPTY
props map — the overlay's opts were never read, so the old `nil` argument
is no loss).

**The panel itself is NOT migrated and is not being put back on any
roster.** rf2-dp64 ruled on 2026-09-10 that `machine_canvas.cljs` stays on
Reagent, and that ruling holds. Re-measured independently here before the
bead was found: `Chart` performs **zero** reads (`rf/subscribe` 0 in the
whole file), and its four external mount sites pass a rich CLJS props map
(a definition MAP, a machine-id KEYWORD, two SETs of edge-ids, a FUNCTION
callback) which no Reagent-parent bridge can carry.

## THE `^{:key ...}` SWEEP (rf2-k97c.3 ruling 2): ZERO, BOTH FILES

`^{:key` 0 and `with-meta` 0 in both files; the `:key` hits are all
`{:keys [...]}` destructuring, and neither file contains a `for` or a
`map-indexed`. Agrees with rf2-truw's own reading for `machine_canvas`.

## EVIDENCE

New `machine_after_rings_fresco_boundary_dom_cljs_test`: W1-W4 from the
`module_view` template, plus **W5, which is new to the programme**.

* **W1** asserts the machines-viz overlay's OWN committed `data-ring-count`
  and `data-tick`. Those nodes exist only if the React element really
  crossed the seam and Reagent really rendered the foreign component — the
  renderer-level evidence the standing direction asks for, not a props
  assertion.
* **W2**'s deaf control moves a slot the read really touches
  (`:rings/now-ms`) while an override shadows it, so the read RECOMPUTES and
  answers what it did before. Both halves are asserted off the app-db.
* **W3**'s precondition is the READ, not the DOM, and that is forced:
  `trace-collector/refresh-trace-rings!` snapshots into `:rf/xray`'s slot
  ALONE, so inside an application frame there is nothing to paint. A
  reference in that frame's sub-cache says the BODY RAN, which is the act
  that would have emitted a `:rf.view/*` op. An earlier draft asserted a
  zero against an empty container; that is now written down in the row.
* **W5 asserts the rf2-e64drj MOUNT GATE survives**: React still invokes the
  `:ref` callback on unmount, so the off-render 60Hz rAF loop cannot outlive
  its panel. Nothing else in the suite can see this —
  `machine_after_rings_tick_loop_cljs_test` drives `overlay-ref!` by hand,
  which proves the flag's algebra and not that React still calls it.
* **Criterion 3 is answered in the NODE lane**, deliberately, by
  `hover-dispatch-lands-on-the-render-frame`: it fires the deferred handler
  OUTSIDE any `with-frame` — what a real mouseenter does — and asserts the
  event landed in the frame the tree named and NOT in `:rf/default`. The
  existing rows explicitly DECLINED this claim ("racing the router drain
  here would be flaky"); polling rather than racing makes it available.

**Twenty-one existing hiccup-walking assertions are unchanged.** The markup
moved into `overlay-tree`, which is still callable, so every row asserts on
exactly what it asserted before. The only row deleted is the one pinning the
`[& _opts]` variadic, which `defview`'s one-props-map contract removes.

## Quality gates

Every number below is read from that run's own `.exit` file, never from a
pipeline and never from the harness. Both compiles printed this worktree's
own `shadow-cljs.edn` path on their first line.

Every number below is read from that run's own `.exit` file, never from a
pipeline and never from the harness. Every compile printed this worktree's
own `shadow-cljs.edn` path on its first line.

The JVM/node/lint rows were run on **base `a46ba042aa`**; the branch was
then rebased onto trunk **`537cc6d917`** and the BROWSER rows were run on
that rebased tree. Each row says which.

| gate | tree | captured exit | result |
|---|---|---|---|
| `check_require_alias_dialect.py --verbose` | a46ba042aa | **0** | 2836 files, 11158 re-frame require edges, 0 non-canonical; `tools` floor 0 NOT touched |
| `check_require_alias_dialect.py --self-test` | a46ba042aa | **0** | 79 passed, 0 failed |
| clj-kondo (touched files) | a46ba042aa | **0** | errors 0; 2 warnings, both pre-existing |
| Splint (touched files) | a46ba042aa | **0** | 5 files, 11 style warnings; 2 new, 9 pre-existing |
| `npm run test:cljs` BASELINE | a46ba042aa | **0** | 11557 tests / 58009 assertions, 0 failures |
| `npm run test:cljs` first run | a46ba042aa | **1** | 11566 / 58030, **1 failure** |
| `npm run test:cljs` after fix | a46ba042aa | **0** | 11566 / 58030, **0 failures** |
| `clojure -M:test` in `tools/xray` | a46ba042aa | **0** | 1276 / 6118, 0 failures |
| `shadow-cljs compile browser-test` | 537cc6d917 | **0** | 1043 files, 60 compiled, 5 warnings (all pre-existing, in `implementation/fresco/test/.../login_server_crossing_ssr_dom_cljs_test.cljs`) |
| `serve-and-run-browser-tests.cjs` | 537cc6d917 | **0** | **897 tests / 4957 assertions, 0 failures, 0 errors** |

**The browser step is compile-gated**: the compile captures its own `.exit`
and the run fires only on a captured `0`, so a lane chained behind a failed
compile cannot serve the previous bundle and return a truthful zero over
stale code. Both halves are reported above, compile first.

## SABOTAGE — THE GREEN WAS MADE TO BITE

**The plant, and it is the one that matters:** `:as-child r/as-element` in
the boundary changed to `:as-child identity`, which turns the delegated
machines-viz component back into a plain fn in HEAD position — the exact
HD-016 shape. **The prediction was written down before the run**: W1, W2 and
W5 red (they paint), W3 and W4 GREEN (both deliberately seed no timer, so
`(when (seq specs))` is false and `as-child` is never reached), and the
total unchanged.

| | green | sabotaged |
|---|---|---|
| compile captured exit | 0 | **0** — the plant COMPILES; this is a paint-time error, which is what makes it a real delete-the-signal test |
| run captured exit | 0 | **1** |
| tests / assertions | 897 / 4957 | **897 / 4957 — UNCHANGED, so the plant crashed no namespace** |
| failures | 0 | 10 FAIL + 2 ERROR |

**Eleven of the twelve failing assertions are in this PR's own namespace,
in exactly W1, W2 and W5. W3 and W4 stayed green. The prediction held on
every row.** W1's ERROR names the mechanism directly:

    expected: (= "1" (.getAttribute overlay "data-ring-count"))
      actual: #object[TypeError TypeError: Cannot read properties of null
                      (reading 'getAttribute')]

— the overlay node is NULL. Nothing painted, which is precisely what an
unguarded plain-fn head does.

**The twelfth is outside this PR and is reported rather than explained
away:** `module_view_fresco_boundary_dom_cljs_test`'s W2 deaf control fired.
It PASSED on the identical restored tree in the green run above, so it is
not deterministic. It is consistent either with collateral from the
boundary throw (the `:browser-test` build runs every `-dom-cljs-test`
namespace in ONE page, and an unguarded boundary throw tears down more than
its own subtree — the same class as #9606) or with the process-global
`rf.frame/frames` bleed increment 1 already recorded for that suite.
**Not proven either way, and it does not touch the verdict for the rows
under test here.**

**Restored and verified by git BLOB hash, not by reading a diff:**
`39a018be8a80c5bb4bb2fe0bf2378dff46d3fd47` before the plant and after the
restore. The tree is therefore byte-identical to the one that ran the green
lane above, so that green needs no re-run.

**A second, accidental red-to-green on the node lane, same population:**
the first run after the migration was EXIT 1 with 1 failure at 11566 /
58030; after three test repairs the identical population reads EXIT 0 with
0 failures at 11566 / 58030. The failing row was the one asserting the
crossing, and it failed for two real reasons recorded in the second commit.

## A HARNESS DISAGREEMENT, OBSERVED THREE TIMES

The node run whose captured `.exit` read **1** was announced by the harness
as "exit code 0", and so was the sabotage run whose captured `.exit` read
**1**. The captured file was acted on every time. That is the disagreement
the method warns about, met twice in this PR.

## FENCES HELD

`shell.cljs`, `static/shell.cljs`, `mount.cljs`, `panels.cljs` (not one
line, `render-panel!` included), every existing `*-bridge`,
`views/edn_inspector.cljs`, `views/edn_widget.cljs`,
`panels/app_db_diff*.cljs`, `panels/managed_fx_template.cljs` and
`panels/trace.cljs` are all untouched. The element-shaped-adapter denylist
is untouched (rf2-k97c.4 stays fenced). No hot-zone file, `spec/API.md` and
both `spec/api-manifest*.edn` included. Nothing under `implementation/`
requires anything under `tools/`. `tools/machines-viz` is unchanged. The
branch carries no tracker-database path — its whole diff is five files under
`tools/xray`.

## LEFT DELIBERATELY, FOR STEP 3

`tools/xray/spec/Conventions.md`'s `display: contents` sample shows
`(rf/reg-view AfterRingsOverlay ...)`, which is now counterfactual for that
one var although the pattern it teaches is still correct for a `reg-view`.
Left alone for the same reason #9581 left `panel_enum.cljc` and
`tools/xray/spec/API.md`: it is a shared doc another slice may be in, and
step 3 rewrites this class of reference at once.

## A SMALL NOTE ON THE RULED BRIDGE SPELLING

`AfterRingsOverlay-component` / `-bridge` add **2** informational
`naming/lisp-case` warnings to Splint (which fails only on errors). This is
not avoidable while following the ruled #9581 spelling: `Panel-bridge`
escapes the rule only because `Panel` is a single capitalised word, and any
CamelCase view name trips it. Measured both ways — `resources.cljs` reads 0
warnings, and the pre-existing `SnapshotDrillIn` in `machine_canvas.cljs`
already carries the same warning on trunk today.

## AI attribution

No AI-attribution trailers were added to any commit or to this body, per
CLAUDE.md's Git Conventions over the session-level instruction that says the
opposite. Stating that in prose is deliberate and permitted — the guard
refuses a line that IS an attribution, never one that mentions it.
