### PR TITLE
docs+test(ssr): correct the attr-string gloss direction, pin the JSX source-coord strip class (rf2-w2ql, rf2-ounh)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -1029,12 +1029,14 @@
   single realisation point every SSR surface serialises through, and its
   docstring carries each class's reason and matching rule; this one names
   the classes only so a caller can see what `attr-string` will silently
-  discard without scrolling back. It is downstream of `strip-prop?` the
-  way Spec 011's enumeration is downstream of both, and the three of them
-  standing apart is a defect in whichever moved without the others. This
-  gloss demonstrates the cost: written 2026-05-21, it went short SIX DAYS
-  later when the JSX class landed 400 lines above it in this same file,
-  and was three classes behind by 2026-09-10."
+  discard without scrolling back. It is downstream of `strip-prop?`,
+  which is itself downstream of Spec 011's enumeration — that list is the
+  contract, and what an other-language port implements (011 §XSS at
+  output boundaries says so in terms). The three of them standing apart
+  is a defect in whichever moved without the others, and this gloss
+  demonstrates the cost: written 2026-05-21, it went short SIX DAYS later
+  when the JSX class landed 400 lines above it in this same file, and was
+  three classes behind by 2026-09-10."
   [attrs]
   ;; `keep` realises only the surviving attributes; the leading space is
   ;; added once, conditionally. A map that is non-empty but whose every

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -13,7 +13,13 @@
       live XSS hole the camelCase/kebab-only regex missed).
     - function-valued prop values,
     - reserved prototype-pollution keys (`__proto__` / `constructor` /
-      `prototype`), and
+      `prototype`),
+    - JSX source-coord props (`:_jsxFileName` / `:_jsxLineNumber` /
+      `:_jsxColumnNumber`, rf2-fa4ly) — React DevTools internals that
+      have no HTML wire representation. Matched CASE-SENSITIVELY against
+      exactly those three documented names rather than by a broad
+      underscore prefix, so an app's own underscore-led prop still
+      surfaces the grammar error (rf2-ounh), and
     - React's two STRUCTURAL SLOTS, `:key` and `:ref` (rf2-gw87) —
       reconciliation identity and an instance handle, consumed by React
       before the host sees them and serialised by react-dom/server as
@@ -129,6 +135,77 @@
     (testing "the match is case-insensitive on the normalised name"
       (is (= " id=\"x\""
              (rf.ssr.html-helpers/attr-string {(keyword "Constructor") "polluted" :id "x"}))))))
+
+(deftest attr-string-drops-jsx-source-coord-props
+  (testing "rf2-ounh — React DevTools' \"View source\" gesture reads
+            `_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber` off the
+            rendered element. The framework does not emit them, but user
+            code, JSX-compiled third-party libraries and hand-stamped
+            DevTools shims can, and they have no HTML wire representation.
+            The class landed with the reference stripper on 2026-05-27
+            (rf2-fa4ly) as a defensive rider on a DevTools commit, and
+            went untested until this deftest."
+    (testing "each of the three documented names is dropped"
+      (doseq [k ["_jsxFileName" "_jsxLineNumber" "_jsxColumnNumber"]]
+        (is (= " id=\"x\""
+               (rf.ssr.html-helpers/attr-string {(keyword k) "v" :id "x"}))
+            (str k " must not survive to wire output"))))
+
+    (testing "THE ORDERING PROPERTY, and it is the assertion with the real
+              value here. The filter sits UPSTREAM of the attribute-name
+              grammar gate, so a JSX source-coord prop is silently dropped
+              instead of surfacing as `:rf.error/ssr-invalid-attribute-name`
+              — the leading underscore fails the conservative HTML5 grammar
+              `[A-Za-z][A-Za-z0-9_:-]*`. If the filter ever moved BELOW
+              `validate-attr-name!` the behaviour would regress from
+              silently-clean to throwing, and nothing else in the lane
+              would notice."
+      (is (= "<div></div>"
+             (rf.ssr.emit/render-to-string
+               [:div {:_jsxFileName     "app.cljs"
+                      :_jsxLineNumber   12
+                      :_jsxColumnNumber 3}]
+               {}))
+          "a fully JSX-stamped element emits clean markup and does NOT throw")
+      (is (= "" (rf.ssr.html-helpers/attr-string {:_jsxFileName "app.cljs"}))
+          "a props map that is ONLY a source-coord prop yields the empty
+           string, not a stray leading space"))
+
+    (testing "surviving attributes on the same element are untouched"
+      (is (= " id=\"x\" class=\"c\""
+             (rf.ssr.html-helpers/attr-string
+               (array-map :_jsxFileName "app.cljs" :id "x" :class "c"))))
+      (is (= "<div id=\"a\">x</div>"
+             (rf.ssr.emit/render-to-string
+               [:div (array-map :_jsxLineNumber 12 :id "a") "x"] {}))))
+
+    (testing "the match is CASE-SENSITIVE against exactly those three
+              names, and that is the half pinning the design decision. The
+              matcher deliberately names the three documented spellings
+              (per `@babel/plugin-transform-react-jsx-source`) rather than
+              a broad underscore prefix, so an app's own underscore-led
+              prop is NOT swallowed here — it still reaches the grammar
+              gate and still surfaces the error, which is what tells the
+              author their attribute name is unservable."
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/ssr-invalid-attribute-name"
+            (rf.ssr.html-helpers/attr-string {:_JsxFileName "app.cljs"}))
+          "a case VARIANT of a rostered name is not in the set, so it falls
+           through to the grammar gate")
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/ssr-invalid-attribute-name"
+            (rf.ssr.html-helpers/attr-string {:_appPrivate "v"}))
+          "an app's own underscore-prefixed prop is not swallowed by a
+           prefix match"))
+
+    (testing "the filter does not over-reach onto grammar-legal names that
+              merely contain the word"
+      (doseq [[k expected] {:data-jsx-file "data-jsx-file=\"v\""
+                            :jsxFileName   "jsxFileName=\"v\""}]
+        (is (str/includes? (rf.ssr.html-helpers/attr-string {k "v"}) expected)
+            (str k " is an ordinary attribute and must round-trip"))))))
 
 (deftest attr-string-drops-reacts-structural-slots
   (testing "rf2-gw87 — `:key` and `:ref` are React's two STRUCTURAL SLOTS.


### PR DESCRIPTION
Two beads on one surface, touching different files within it, one commit each.

## rf2-w2ql — the attr-string gloss claimed the wrong direction

The sentence added at #9602 read:

> It is downstream of `strip-prop?` the way Spec 011's enumeration is downstream of both

which makes the spec's enumeration the most-derived of the three. At that same landing `spec/011-SSR.md` (§XSS at output boundaries) says the opposite: the enumeration "is the contract, and it is what an other-language port implements", and "**That fn is downstream of this list**".

The spec is the artefact and the code is downstream, so the spec is right and the docstring reversed it.

**Chosen repair: correct the comparison in place rather than omit it.** The bead allowed either. The sentence carries two useful things beyond its direction — the three-way chain (gloss, then `strip-prop?`, then Spec 011's enumeration) and the "standing apart is a defect in whichever moved without the others" clause that the gloss then demonstrates against itself. Only the direction was wrong, so only the direction moved. Omitting the comparison would have discarded a working piece of teaching to fix a one-clause error.

Documentation only. `strip-prop?`, its name sets, the accepted spec authority and the deliberately open drift-gate question (rf2-7ntc) are untouched. `spec/011-SSR.md` is not edited — it is the authority being aligned to.

## rf2-ounh — the JSX source-coord class had no SSR test anywhere

`strip-prop?` drops six classes. Five carried tests; the JSX source-coord class (`_jsxFileName` / `_jsxLineNumber` / `_jsxColumnNumber`) had none under `implementation/ssr/test`. It landed 2026-05-27 as a defensive rider on a React DevTools commit (rf2-fa4ly) — source only, no test — and stayed untested.

One deftest, shaped like `attr-string-drops-prototype-pollution-keys` next door. The assertion with the real value is the **ordering property**: the filter sits upstream of the attribute-name grammar gate, so a fully JSX-stamped element emits clean markup instead of throwing `:rf.error/ssr-invalid-attribute-name` on the leading underscore, which fails the conservative grammar `[A-Za-z][A-Za-z0-9_:-]*`. That is the behaviour that would regress silently if the filter ever moved below `validate-attr-name!`.

Also pinned: surviving attributes on the same element are untouched, and the match is case-sensitive against exactly those three documented names — a case variant of a rostered name **and** an app's own underscore-led prop both still surface the grammar error. That negative is the half pinning the design decision to name three spellings rather than match a broad underscore prefix.

**Judgement call, taken deliberately: no four-surface emitter sweep.** The two classes that landed 2026-09-10 got one because widening the shared roster changed *other* surfaces' output in ways worth recording as decisions (the head emitter dropping `key` off a `<meta>`). The JSX class has no such cross-surface consequence to pin, and the ordering property is fully reachable at the `attr-string` unit level plus one pass through the public emitter. A fourth full sweep would be gold-plating.

The test ns docstring's roster listed five of the six classes; the sixth is listed now too, since that file owns the roster.

No executable behaviour changes in this PR.

## Quality gates

Every number below is a locally captured, unpiped exit code and the runner's own summary line.

| Gate | Command | Result |
|---|---|---|
| SSR JVM suite (baseline, pre-change) | `clojure -M:test` in `implementation/ssr` | exit 0 — 672 tests / 4454 assertions, 0 failures 0 errors |
| SSR JVM suite (after both commits) | `clojure -M:test` in `implementation/ssr` | exit 0 — **673 tests / 4465 assertions**, 0 failures 0 errors |
| clj-kondo | `clj-kondo --fail-level error` over both touched files | exit 0 — 0 errors, 0 warnings |
| Splint | `clojure -M:splint --fail-on-errors` over both touched files | exit 0 — 3 style warnings, all pre-existing in `html_helpers.cljc` executable code (lines 298, 885, 886), none in the docstring edited here and none in the test file |

`mkdocs build --strict` is not a gate for a Clojure docstring. `check_doc_slugs.py` does not cover this change either — nothing here is under `docs/`, `spec/`, `skills/`, `migration/` or `tools/*/spec` — so it was not run, and its absence is absent coverage rather than evidence.

### Red-to-green

Real work was committed first, then the source was sabotaged to show the new rows failing against pre-fix behaviour, then restored and verified by blob hash.

**Plant B — narrow the name set** (drop `_jsxFileName` from `jsx-source-prop-names`). This is the isolating plant: delete the new deftest and the fault survives with nothing red.

- exit **1** — 673 tests containing **4465** assertions, 0 failures, **4 errors**.
- Test AND assertion counts both identical to green, so the plant crashed no namespace and aborted no deftest.
- All 4 errors in `attr-string-drops-jsx-source-coord-props`. **Zero collateral elsewhere in the suite.**
- The rows named what they got, e.g. `expected: (= "<div></div>" (rf.ssr.emit/render-to-string [:div {:_jsxFileName "app.cljs", ...}] {}))` / `actual: clojure.lang.ExceptionInfo: attribute name violates the HTML5 grammar [A-Za-z][A-Za-z0-9_:-]*; got "_jsxFileName"`.

**Plant A — move the filter below the grammar gate** (force `validate-attr-name!` ahead of the strip decision), the exact regression the ordering assertion exists to catch.

- exit **1** — 673 tests containing 4462 assertions, 0 failures, **11 errors**, 7 of them in the new deftest, naming the same grammar refusal.
- Test count unchanged at 673, so no namespace crashed. The 3-assertion shortfall against green is 4 unrelated deftests aborting where the throw escaped a `let` binding rather than being caught inside an `is`.
- Reported for completeness rather than as the isolating evidence: this plant also reddens `attr-string-drops-prototype-pollution-keys`, `attr-string-normal-attrs-still-emit`, `render-shell-strips-function-and-proto-props` and `render-to-string-drops-prototype-pollution-keys`, because `__proto__` is underscore-led too. It shows the ordering property is real; plant B is what shows this deftest is the thing carrying it.

**Restore verified by blob hash**, not by eye. Both files are `i/lf` on the index side per `git ls-files --eol`, so the default `git hash-object` form applies (no `--no-filters`); `git cat-file -t` returns `blob` for both. Worktree and committed hashes are identical: `eb2ec6816e8f97782f6e5d4fa459dfada439d9fe` for `html_helpers.cljc`, `10c7298b584c9fbbee5711625e74c63a5caa5ac1` for `ssr_attr_filter_test.clj`. `git status --porcelain` is empty, and the post-restore re-run is exit 0 at 673 / 4465.

## Tracker boundary

No `.beads` path is staged in either commit. Both beads are left open for the mayor to close after merge.
