### PR TITLE
feat(xray): let a standalone app-db mount name its instance (rf2-2n8q)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -11,8 +11,10 @@
   **Status: internal-but-stable, not a host-facing v1.0 embed
   contract.** The mount fns are stable (the shell + tests depend on
   them; hosts MAY use them) but carry NO v1.0 host-facing-contract
-  guarantee — there is no per-panel props vocabulary beyond the single
-  `:frame` opt (defaulting to `:rf/xray`). The v1.0 host-facing embed
+  guarantee — the props vocabulary is two keys wide and one of them is
+  a single panel's: `:frame` (every mount fn, defaulting to `:rf/xray`)
+  and `:instance-id` (`mount-app-db-diff!` only — see §`:instance-id`
+  opt below). The v1.0 host-facing embed
   contract is the **full-shell** embed per
   `tools/xray/spec/008-Embedding-Contract.md` §Full-shell embed
   contract. This matches the status stated in
@@ -140,6 +142,29 @@
   Xray's own UI state, while the panel-internal frame-selection sub
   (`:rf.xray/observed-frame`) drives the data axis.
 
+  ## `:instance-id` opt — `mount-app-db-diff!` ONLY (rf2-2n8q)
+
+  Two mounts under two DIFFERENT `:frame`s are already told apart:
+  rf2-d2aj keys the edn-inspector's per-mount store by `[frame-id
+  mount-id]`. Two mounts sharing ONE `:frame` are not, and nothing
+  inside the panel can separate them — its view is a Fresco boundary,
+  a React function component with no per-instance storage its body may
+  use. So the caller names them, and `:instance-id` is how a STANDALONE
+  mount does it:
+
+      (mount-app-db-diff! left-el  {:instance-id \"left\"})
+      (mount-app-db-diff! right-el {:instance-id \"right\"})
+
+  rf2-t3fz gave `app-db-diff/Panel` the prop; this opt is the door for
+  a caller that mounts rather than renders, which passes opts and never
+  props. Omit it and every id is byte-for-byte what it was.
+
+  It is ONE panel's opt rather than the surface's, and deliberately so:
+  it is only meaningful where a panel's view accepts it, and handing a
+  props map to a panel whose view takes none is an arity error rather
+  than an ignored key. `render-panel!`'s `props` argument is the seam —
+  see its docstring.
+
   See `tools/xray/spec/007-UX-IA.md` §Mountable panel contract and
   `tools/xray/spec/008-Embedding-Contract.md` for the full
   embedding contract."
@@ -212,13 +237,29 @@
     panel to observe a specific app frame pass that frame id; the
     panel's own Xray state still lives on `:rf/xray` (the panel
     facade always opens with its own `frame-provider :rf/xray`
-    when its body subscribes to `:rf.xray/*` data)."
-  [panel-view mount-point opts]
-  (ensure-xray-handlers-installed!)
-  (let [frame (get opts :frame :rf/xray)
-        tree  [rf/frame-provider {:frame frame}
-               [panel-view]]]
-    (rf.substrate.adapter/render tree mount-point nil)))
+    when its body subscribes to `:rf.xray/*` data).
+  - `props` — OPTIONAL (rf2-2n8q), and it is the PANEL's props map, not
+    the mount opts. nil — every caller but `mount-app-db-diff!` — mounts
+    `[panel-view]`, the element this fn has always built. A map mounts
+    `[panel-view props]`. The caller decides, because only the caller
+    knows whether its panel's view takes props at all: `[trace/Panel
+    {…}]` is an arity error, not an ignored map, so this must NOT be
+    filled in from `opts` here on every panel's behalf.
+
+  rf2-2n8q — the 4-arity is an ADDITION and the couplings `mount-resources!`
+  reserves this fn for are untouched: the frame-provider wrap and the
+  `adapter/render` delegation are still written once, here, and are still
+  one edit when the shell becomes a Fresco tree."
+  ([panel-view mount-point opts]
+   (render-panel! panel-view mount-point opts nil))
+  ([panel-view mount-point opts props]
+   (ensure-xray-handlers-installed!)
+   (let [frame (get opts :frame :rf/xray)
+         tree  [rf/frame-provider {:frame frame}
+                (if props
+                  [panel-view props]
+                  [panel-view])]]
+     (rf.substrate.adapter/render tree mount-point nil))))
 
 ;; ---- per-panel mount fns ------------------------------------------------
 ;;
@@ -243,11 +284,36 @@
 
 (defn mount-app-db-diff!
   "Mount Xray's App-DB tab in isolation at `mount-point`. Renders the
-  sections-per-cluster structural diff for the focused event-bundle."
+  sections-per-cluster structural diff for the focused event-bundle.
+
+  `opts :instance-id` — OPTIONAL (rf2-2n8q). A non-blank string or a
+  keyword naming THIS mount, for the case where two standalone mounts
+  share one `:frame`. It qualifies every id the sections compose — the
+  edn-inspector's `:mount-id` AND the expansion/zoom `:site-id` — and
+  both halves are the fix: the store's lifecycle key is `[frame-id
+  mount-id]` while the measured-width slot is keyed by the bare
+  `mount-id` inside the frame, so qualifying one and not the other
+  leaves two panels writing one width slot. Left unnamed, two mounts in
+  one frame share one store entry, one ResizeObserver and one width
+  slot, and detaching either releases the survivor's state.
+
+  OMIT IT when only one app-db panel is on screen in this frame, which
+  is every call site in this tree today: the ids are then byte-for-byte
+  what they were. `app-db-diff-state/instance-token` refuses, loudly,
+  the shapes that could not be stable across renders.
+
+  See `app-db-diff/Panel`'s own `:instance-id` note for what the prop
+  means once it arrives, and the ns docstring §`:instance-id` opt for
+  why this is one panel's key rather than the surface's."
   ([mount-point]      (mount-app-db-diff! mount-point nil))
   ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`; see `mount-resources!` below
-  ;; for the reasoning. `render-panel!` itself is untouched.
-  ([mount-point opts] (render-panel! app-db-diff/Panel-bridge mount-point opts)))
+  ;; for the reasoning. rf2-2n8q — and the props map is what carries
+  ;; `:instance-id` across that bridge; `Panel-bridge`'s 1-arity is the
+  ;; door, its 0-arity is what an unnamed mount still takes.
+  ([mount-point opts]
+   (render-panel! app-db-diff/Panel-bridge mount-point opts
+                  (when-let [id (:instance-id opts)]
+                    {:instance-id id}))))
 
 (defn mount-reactive-panel!
   "Mount Xray's Reactive tab in isolation at `mount-point`.

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_mount_instance_id_dom_cljs_test.cljs
@@ -1,0 +1,299 @@
+(ns day8.re-frame2-xray.panels.app-db-diff-mount-instance-id-dom-cljs-test
+  "TWO STANDALONE `mount-app-db-diff!` MOUNTS IN ONE FRAME, read off a real
+  React commit (rf2-2n8q).
+
+  ## The claim, and why it needs a DOM
+
+  rf2-t3fz gave `app-db-diff/Panel` an optional `:instance-id` PROP, so a
+  caller that RENDERS two panels under one `frame-provider` can name them.
+  `panels/mount-app-db-diff!` is the caller that cannot: it takes OPTS, and
+  `render-panel!` mounted `[panel-view]` with no props at all — so two
+  standalone mounts sharing the default `:frame` had no way to be told
+  apart. rf2-2n8q is the opts key that opens that door.
+
+  A row asserting the opts key was THREADED would pass while both mounts
+  still collided, which is the failure one level up. So nothing here reads
+  the opts map, the captured tree, or the props. Two mounts are made
+  through the public facade into two real containers, and every assertion
+  below reads `container.querySelector` — the DOM React committed on its
+  own — or the widget's own per-mount store.
+
+  ## The two observables, and both are the bug rather than a proxy
+
+  The edn-inspector publishes both ids it composes as DOM attributes on
+  each widget's container (`edn_inspector.cljs`, both the chromed and the
+  flat branch): `data-rf-mount-id` and `data-rf-site-id`. They are not
+  decoration — they are the two keys the defect collides on, and they are
+  keyed differently, which is why BOTH are asserted:
+
+    * `mount-id` keys the widget's per-mount store (qualified by frame, as
+      `[frame-id mount-id]` — rf2-d2aj) AND, unqualified, the measured
+      width slot inside the frame's app-db. Two mounts in ONE frame
+      therefore share one store entry, one ResizeObserver and one width
+      slot: qualifying the store key alone would be half a repair.
+    * `site-id` keys expansion and zoom, so two colliding mounts expand and
+      zoom in lockstep.
+
+  ## The negative control IS the defect, and it is a row rather than a note
+
+  [[two-unnamed-standalone-mounts-still-collide]] mounts the same two
+  panels with NO `:instance-id` and asserts the id sets are IDENTICAL. It
+  carries two claims at once: the instrument can see a collision (so the
+  disjointness above is separation and not silence), and omitting the opt
+  leaves every id byte-for-byte what it always was — which is every call
+  site in this tree today.
+
+  ## Substrate: the Reagent adapter, and the mount is the PUBLIC one
+
+  `mount-app-db-diff!` delegates to `rf.substrate.adapter/render`, so the
+  installed adapter is what renders. Nothing here reaches past the facade
+  to build a tree of its own — the thing under test is the mount fn.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`. The `:node-test` build's `cljs-test$`
+  regex also matches, so it LOADS under Node — where every row
+  short-circuits through [[browser?]] and reports the skip rather than
+  passing silently."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.panels :as panels]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; READ-ONLY, and only for the per-mount store's public test
+            ;; surface (`lifecycle-key`, `mount-state-held`). The widget's own
+            ;; lifecycle rows live in `views/edn_inspector_mount_state_cljs_test`;
+            ;; what W2 below asserts is that two STANDALONE MOUNTS hand that
+            ;; store two distinct keys.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(def ^:private host-frame
+  "The ordinary application frame the panel OBSERVES. EP-0002 (rf2-bd4div)
+  removed the default, so without selecting one the panel renders its TOP
+  section with the empty-state body and no widget mounts at all — which
+  would leave every disjointness assertion below comparing two empty sets.
+  The `(seq …)` control in each row is what separates that silence from
+  real separation, and it is why this frame is seeded with real data."
+  :rf/default)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about, and
+                      ;; `app-db-diff/Panel` is a Fresco boundary — a
+                      ;; neighbour's entry left in the cache would make these
+                      ;; rows read a residue that is not this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- setup ---------------------------------------------------------------
+
+(defn- setup!
+  "Seed the host frame with real app-db content and point Xray at it.
+
+  `ensure-xray-frame!` is called HERE, before the target selection, and the
+  ordering is load-bearing rather than tidy: the first call for a frame-id
+  runs the first-mount seed hooks — `::seed-trace-and-target-frame` among
+  them — and its run-once guard then makes every later call (each `mount!`
+  below) skip the fan-out. Selecting the target BEFORE those hooks had run
+  would leave the selection at the mercy of a seed pass firing inside the
+  first mount."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id host-frame})
+  (rf/replace-frame-state! host-frame
+                           {:rf.db/app {:counter 5 :user {:name "ada"}}})
+  (mount/ensure-xray-frame! :rf/xray)
+  (rf/dispatch-sync [:rf.xray/set-target-frame host-frame] {:frame :rf/xray})
+  nil)
+
+;; ---- mounting, and reading the DOM back ----------------------------------
+
+(defn- mount!
+  "Mount the app-db panel through the PUBLIC facade with `opts`, committed
+  synchronously.
+
+  `react-dom/flushSync` rather than a Reagent queue drain: the panel's view
+  is a Fresco boundary, which is not in Reagent's render queue at all, so
+  draining that queue commits nothing of this panel's and a row written
+  that way reads a container that never moved."
+  [opts]
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    (let [unmount (react-dom/flushSync
+                    (fn [] (panels/mount-app-db-diff! container opts)))]
+      {:container container :unmount unmount})))
+
+(defn- unmount!
+  "Tear one mount down inside `flushSync` so React's ref-detach has RUN by
+  the time the next line reads the per-mount store. A bare unmount
+  schedules it."
+  [{:keys [container unmount]}]
+  (react-dom/flushSync (fn [] (unmount)))
+  (.remove container))
+
+(defn- attr-values
+  "Every value of `attr` in `container`'s committed DOM, in document order.
+  Reads the DOM React wrote — nothing here reproduces the panel."
+  [container attr]
+  (->> (.querySelectorAll container (str "[" attr "]"))
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % attr))))
+
+(defn- mount-ids  [container] (attr-values container "data-rf-mount-id"))
+(defn- site-ids   [container] (attr-values container "data-rf-site-id"))
+
+;; ===========================================================================
+;; W1 — two NAMED standalone mounts compose two disjoint sets of ids
+;; ===========================================================================
+
+(deftest two-named-standalone-mounts-compose-disjoint-ids
+  (testing "rf2-2n8q — `mount-app-db-diff!` given two different
+            `:instance-id`s mounts two panels whose committed DOM carries
+            two disjoint sets of `data-rf-mount-id` AND `data-rf-site-id`,
+            in the ONE `:rf/xray` frame they both default to."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})]
+        (try
+          (let [ids-l  (mount-ids (:container left))
+                ids-r  (mount-ids (:container right))
+                sites-l (site-ids (:container left))
+                sites-r (site-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (seq ids-l)
+                "control: the left mount committed at least one edn-inspector
+                 widget, so an empty intersection below means separation and
+                 not an empty-state panel that rendered no widget at all")
+            (is (= (count ids-l) (count ids-r))
+                "naming an instance changes the ids, never the sections —
+                 two mounts of the same panel over the same app-db")
+            (is (seq sites-l)
+                "control: and the widgets carry a site-id, so the second
+                 disjointness assertion is about a populated set too")
+
+            ;; ---- the claim ---------------------------------------------
+            (is (nil? (some (set ids-l) ids-r))
+                (str "no mount-id survives from one standalone mount to the "
+                     "other — the store's lifecycle key and the measured "
+                     "width slot are both derived from this string. left="
+                     (pr-str ids-l) " right=" (pr-str ids-r)))
+            (is (nil? (some (set sites-l) sites-r))
+                (str "and no site-id either, so the two expand and zoom "
+                     "independently rather than in lockstep. left="
+                     (pr-str sites-l) " right=" (pr-str sites-r)))
+            (is (every? #(re-find #"/left/" %) ids-l)
+                (str "each id carries the name THIS mount was given, rather "
+                     "than a per-render nonce or a shared string: "
+                     (pr-str ids-l))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W2 — the lifecycle half: detaching one leaves the other whole
+;; ===========================================================================
+
+(deftest detaching-one-named-mount-leaves-the-other-whole
+  (testing "rf2-2n8q — two named standalone mounts hold two entries in the
+            widget's per-mount store, and unmounting one releases ONLY its
+            own. Under the shared identity both mounts share one entry, so
+            the survivor's read is nil and it is left with a disconnected
+            observer on a node still in the document."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})
+            id-l  (first (mount-ids (:container left)))
+            id-r  (first (mount-ids (:container right)))]
+        (try
+          (is (some? id-l)
+              "control: the left mount committed a widget, so the store keys
+               below name something that really mounted")
+          (is (not= id-l id-r)
+              "the two mounts composed two mount-ids")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :ref)
+              "the left mount holds its own store entry")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r))
+                         :ref)
+              "and so does the right — two live mounts, two entries, not one")
+
+          (unmount! right)
+
+          (is (nil? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r)))
+              "the detached mount is gone")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :ref)
+              "and the mount still on screen is untouched — releasing the
+               survivor is what the shared key did, and it disconnected an
+               observer of a node still in the document")
+          (finally
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W3 — the negative control: unnamed mounts collide, and are unchanged
+;; ===========================================================================
+
+(deftest two-unnamed-standalone-mounts-still-collide
+  (testing "rf2-2n8q — the defect verbatim, kept as a row. Two standalone
+            mounts with NO `:instance-id` present the SAME ids, which is
+            what makes W1's disjointness a measurement rather than a
+            coincidence; and the ids they present carry no instance segment
+            at all, so every existing single-mount call site composes
+            exactly what it always did."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            a     (mount! nil)
+            b     (mount! {})
+            named (mount! {:instance-id "left"})]
+        (try
+          (let [ids-a (mount-ids (:container a))
+                ids-b (mount-ids (:container b))
+                ids-n (mount-ids (:container named))]
+            (is (seq ids-a)
+                "control: both unnamed mounts committed widgets")
+            (is (= ids-a ids-b)
+                (str "two unnamed mounts present the SAME ids — so the "
+                     "instrument W1 uses CAN see a collision, and its "
+                     "disjointness is a measurement rather than silence. a="
+                     (pr-str ids-a)))
+            (is (= ids-n
+                   (mapv #(str "app-db-state/left/"
+                               (subs % (count "app-db-state/")))
+                         ids-a))
+                (str "and a named mount's ids are the UNNAMED ids with the "
+                     "caller's name spliced in after the surface prefix — "
+                     "which says both halves at once: naming qualifies the id "
+                     "without disturbing the surface name inside it, and an "
+                     "unnamed mount composes byte-for-byte what it always did. "
+                     "unnamed=" (pr-str ids-a) " named=" (pr-str ids-n)))
+            (is (= ids-a (mount-ids (:container a)))
+                "re-reading the same container is stable — these are
+                 identities, not per-render nonces"))
+          (finally
+            (unmount! named)
+            (unmount! b)
+            (unmount! a)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -358,6 +358,96 @@
           (is (= {:frame :my-app/cart} (second tree))
               "explicit :frame opt overrides the default :rf/xray"))))))
 
+;; ---- contract — instance-id opt (rf2-2n8q) ----------------------------
+;;
+;; THE EVIDENCE THAT TWO NAMED MOUNTS ARE ACTUALLY SEPARATED IS NOT HERE. It
+;; is `panels/app_db_diff_mount_instance_id_dom_cljs_test`, which mounts two
+;; of them for real and reads `data-rf-mount-id` / `data-rf-site-id` off the
+;; committed DOM, plus the widget's per-mount store across an unmount. These
+;; rows pin the MOUNT-API half in the file that owns the mount API, and they
+;; are deliberately not written as "the opts key was threaded": nothing below
+;; reads the opts map or the captured props. Each row takes the ELEMENT the
+;; mount delivered and APPLIES it — which is what the substrate does to a
+;; Reagent form-1 element — so the real `Panel-bridge` runs and what is
+;; asserted is the props the boundary is mounted with.
+
+(defn- delivered-element
+  "The element `render-panel!` put inside the frame-provider — the hiccup the
+  substrate is asked to render, taken off the captured tree rather than
+  rebuilt here."
+  [capture]
+  (nth (captured-tree capture) 2))
+
+(defn- delivered-by
+  "Mount the app-db panel through the public facade with `opts`; return the
+  element it delivered to the substrate."
+  [opts]
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [rf.substrate.adapter/render render-stub]
+      (panels/mount-app-db-diff! :mount-point opts))
+    (delivered-element capture)))
+
+(defn- crossed
+  "Apply `el`'s head to its arguments — what a substrate does with a Reagent
+  form-1 element — and return the props map the resulting `[:> Component
+  props]` mounts the boundary with. The real bridge runs, so this is what the
+  panel RECEIVES rather than what the caller passed."
+  [el]
+  (nth (apply (first el) (rest el)) 2))
+
+(deftest mount-app-db-diff-instance-id-reaches-the-boundary
+  (testing "rf2-2n8q — `mount-app-db-diff!`'s `:instance-id` opt reaches the
+            Fresco boundary's props, across the real `Panel-bridge`. This is
+            the mount door onto the prop rf2-t3fz gave `Panel`: a caller that
+            MOUNTS passes opts and never props, so before this the standalone
+            embed could not name an instance at all."
+    (is (= {:instance-id "left"}
+           (crossed (delivered-by {:instance-id "left"})))
+        "the name the mount was given is the name the boundary is mounted with")
+    (is (= {:instance-id :left}
+           (crossed (delivered-by {:instance-id :left})))
+        "a keyword crosses too — Reagent converts a prop value to its name on
+         the way to React, and `instance-token` accepts both spellings for
+         exactly that reason")
+    (is (= {:instance-id "right"}
+           (crossed (delivered-by {:frame :my-app/cart :instance-id "right"})))
+        "and it composes with `:frame` rather than replacing it"))
+
+  (testing "rf2-2n8q — the `:frame` opt is untouched by the addition."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-app-db-diff! :mount-point
+                                   {:frame :my-app/cart :instance-id "right"})
+        (is (= {:frame :my-app/cart} (second (captured-tree capture)))
+            "the frame-provider still wraps the frame the host named")))))
+
+(deftest mount-fns-without-an-instance-name-deliver-exactly-what-they-did
+  (testing "rf2-2n8q — an UNNAMED app-db mount delivers the bare
+            `[Panel-bridge]` element it always delivered, not `[Panel-bridge
+            {}]`. The 0-arity is the shape the shell's `[(:panel tab)]` and
+            every standalone call site in this tree take today, and it is what
+            keeps their composed ids byte-for-byte unchanged."
+    (is (= [app-db-diff/Panel-bridge] (delivered-by nil))
+        "no opts at all")
+    (is (= [app-db-diff/Panel-bridge] (delivered-by {:frame :my-app/cart}))
+        "opts carrying no instance name")
+    (is (= {} (crossed (delivered-by nil)))
+        "and the bridge's 0-arity mounts the boundary with no props"))
+
+  (testing "rf2-2n8q — `:instance-id` is ONE PANEL's opt, not the surface's.
+            Only `app-db-diff/Panel` takes the prop; handing a props map to a
+            panel view that takes none is an arity error, not an ignored key,
+            so every other mount fn must keep delivering a bare element even
+            when its caller sets the opt."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-trace! :mount-point {:instance-id "left"})
+        (panels/mount-epoch-panel! :mount-point {:instance-id "left"})
+        (is (= [trace/Panel] (delivered-element capture))
+            "the trace mount delivers its view with no props")
+        (is (= [epoch-panel/Panel] (nth (:tree (second @capture)) 2))
+            "and so does the epoch mount")))))
+
 ;; ---- contract — idempotency under repeat mount ------------------------
 
 (deftest repeat-mount-is-idempotent-for-handler-registration


### PR DESCRIPTION
Closes rf2-2n8q (mayor closes after merge).

## What this closes

rf2-t3fz (#9605, `7886452fd0`) gave `app-db-diff/Panel` an optional `:instance-id` **prop**, so a caller that RENDERS two panels under one `frame-provider` can name them. `panels/mount-app-db-diff!` is the caller that **cannot**: it takes OPTS, and `render-panel!` mounted `[panel-view]` with no props at all — so two standalone mounts sharing the default `:frame` had no way to be told apart. The affordance existed and one door did not open onto it.

## The change

`render-panel!` gains an optional fourth `props` argument; `mount-app-db-diff!` threads `:instance-id` into it. Naming an instance qualifies **both** ids the sections compose — the edn-inspector's `:mount-id` and the expansion/zoom `:site-id`. That pair is the point rather than a detail: the store's lifecycle key is `[frame-id mount-id]` while the measured-width slot is keyed by the **bare** `mount-id` inside the frame, so qualifying the store key alone would leave both instances writing one width slot.

Two design calls worth a reviewer's attention:

**The nil case is byte-identical.** `props` nil builds `[panel-view]`, the element this fn has always built, so every other mount fn and every existing single-mount call site is untouched and composes exactly the ids it always did.

**The props map is the CALLER's to fill, not `render-panel!`'s to derive from `opts` on every panel's behalf.** Only `app-db-diff/Panel` takes the prop. `[trace/Panel {…}]` is an **arity error**, not an ignored map — so a `render-panel!` that helpfully forwarded `(select-keys opts [:instance-id])` for everyone would break six mount fns the moment a caller set the opt. A row pins that directly: `mount-trace!` and `mount-epoch-panel!` given `{:instance-id "left"}` still deliver a bare element.

`render-panel!`'s reserved role is intact. `mount-resources!`'s comment reserves it as the single chokepoint where the frame-provider wrap and the `adapter/render` delegation are severed when the shell becomes a Fresco tree; the 4-arity is an ADDITION and both couplings are still written once, here, still one edit later.

### HD-016 — where each symbol-headed hiccup vector lands

`render-panel!`'s tree contains exactly two symbol-headed vectors, both pre-existing heads; this change adds none, it only adds a second element to an existing vector.

1. `[rf/frame-provider {:frame frame} …]` — `re-frame.core/frame-provider`, re-exported from `rf.views` and documented as a "SCOPE-only Reagent component".
2. `[panel-view]` / `[panel-view props]` — the bound argument; here `app-db-diff/Panel-bridge`, a plain `defn` returning `[:> Panel-component props]`.

A plain fn in head position is a loud error under Fresco, but this is a **Reagent** tree, where it is an ordinary form-1 component — and the bridge exists precisely so the raw Fresco boundary is never what `render-panel!` heads with. The change does not move this head under Fresco.

### `^{:key ...}`-on-a-call-form census

**Zero**, across all four panels read (`panels.cljs`, `panels/app_db_diff.cljs`, `panels/app_db_diff_state.cljs`, `views/edn_inspector.cljs`). Live control with the same instrument over `tools/xray/src`: **59 hits across 26 files**, which independently reproduces a control taken by another worker on this tree today — so the zero is absence rather than a broken instrument.

## Evidence — and the failure here is invisible, so the standard is not optional

A row asserting the opts key was *threaded* is a hollow gate: it passes while both mounts still collide. Nothing in the evidence reads the opts map or the captured props.

**`tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_mount_instance_id_dom_cljs_test.cljs`** (new, browser lane) mounts two panels **for real** through the public facade into two containers and reads only what React committed:

- **W1** — two named mounts produce disjoint sets of `data-rf-mount-id` **and** `data-rf-site-id`, read off the committed DOM. Both are asserted because they key different things: `mount-id` keys the per-mount store and the width slot, `site-id` keys expansion and zoom.
- **W2** — the lifecycle half, and it is the bug rather than a proxy: two named mounts hold two store entries, and unmounting one leaves the survivor's `:ref` intact. Under the shared identity the survivor's entry is released and `mount-state-held` returns nil, i.e. `(contains? nil :ref)` — rf2-t3fz's own signature, now at the standalone-mount level.
- **W3** — the negative control **is** the defect, kept as a row: two UNNAMED mounts present *identical* ids, which is what makes W1's disjointness a measurement rather than silence; and a named mount's ids are the unnamed ids with the caller's name spliced in after the `app-db-state/` prefix, which says at once that naming qualifies the id and that an unnamed mount is byte-for-byte what it always was.

Every row carries a `(seq …)` control taken from the target, because EP-0002 means an unselected observed frame renders the TOP section with an empty-state body and no widget mounts at all — two empty sets would otherwise intersect emptily and read as separation.

**`panels_mount_cljs_test.cljs`** carries the mount-API half in the file that owns the mount API. It does not inspect a props map either: each row takes the element the mount **delivered** and APPLIES it — which is what a substrate does to a Reagent form-1 element — so the real `Panel-bridge` runs and what is asserted is the props the boundary is mounted with.

## Quality gates

| Gate | Captured exit | Result |
|---|---|---|
| `sh scripts/assert-worker-worktree.sh` | 0 | `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/mountid-a` |
| clj-kondo (`--fail-level error`, 3 touched files) | 0 | errors 0; 2 pre-existing unused-require warnings, not introduced here |
| Splint (`--fail-on-errors`, 3 touched files) | 0 | 3 files, 0 style warnings |
| Xray JVM (`clojure -M:test` in `tools/xray`) | 0 | 1276 tests, 6118 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (node) | 0 | 11569 tests, 58057 assertions, 0 failures, 0 errors |
| `npm run test:browser` | pending | compile gated on its own captured exit; re-running on rebased trunk |

Exit codes are captured unpiped to files and quoted from those files, not from a harness summary. The browser lane runs `shadow-cljs compile browser-test` and the Playwright runner as two separately-captured steps, with the runner refused outright if the compile's captured exit is non-zero — a browser lane chained behind a failed compile serves the previous bundle and returns a plausible green.

### Sabotage — delete the signal, keep the fault

Real work was committed first, then the threading alone was removed. `render-panel!`'s 4-arity survived and the opts key stayed accepted and documented — nothing threaded it, so both mounts collide. Run on rebased trunk `2b7e026254`, browser lane, compile captured exit 0 so the runner served the PLANTED bundle rather than a stale one.

| | tests | assertions | failures | errors | captured run exit |
|---|---|---|---|---|---|
| plant in | 900 | 4973 | 6 | 0 | 1 |
| restored | 900 | 4973 | 0 | 0 | 0 |

**Unchanged totals with 0 errors** is the load-bearing half: the plant changed behaviour rather than crashing a namespace, so the six failures are meaningful rather than a load error. All six are the new rows; nothing else moved.

The signature is rf2-t3fz's verbatim, which is what makes it the bug rather than a proxy:

- shared mount-id — `left=["app-db-state/top"] right=["app-db-state/top"]`
- one shared site-id — `left=["[:rf.xray/app-db \"top\"]"]`, right identical
- `actual: (not (contains? nil :ref))` — the survivor's store entry released when the OTHER mount detached
- W3, the negative control, failed in the direction that proves it is one: `(not (= ["app-db-state/top"] ["app-db-state/left/top"]))`

Restore verified by blob hash, form taken from the index side of `git ls-files --eol` (`i/lf`, so the default `git hash-object` form, not `--no-filters`): restored `7ef6460eddec9cf45494917a8061a997caa59231` equals the committed blob, `git cat-file -t` answers `blob` at exit 0, tree clean. The `--no-filters` form hashes the CRLF worktree bytes to `aecb91d019...`, an oid nothing stores, which would read a byte-perfect restore as a failure.

## Out of slice — reported, not reached for

Three spec restatements are falsified by this change and are **not** touched here. `panels.cljs`'s own ns docstring is in slice and is corrected; these three are rf2-jw2ny's deliberate "one honest status across `panels.cljs`, `008`, and `API.md`", which is exactly the kind of coordinated surface another panel slice is likely to be holding:

- `tools/xray/spec/007-UX-IA.md:1799` — "(the only opt is `:frame`)"
- `tools/xray/spec/008-Embedding-Contract.md:548` — "it carries one `opts` key — `:frame` — and is not a host-facing embed contract."
- `tools/xray/spec/API.md:409` — "it accepts one `opts` key — `:frame` — defaulting to `:rf/xray`."

**No gate grades any of them**, so this PR is not red on their account: the single-source guard (`panel_enum_guard_cljs_test`) reconciles mount-fn NAMES against the enum and the spec, never opts vocabularies. Measured rather than assumed.

## Tracker boundary and attribution

No `.beads/` path is touched; every path was staged explicitly. **The `Co-Authored-By` and generated-with trailers were declined** — the session harness asks for them and CLAUDE.md's Git Conventions outrank it, which is the tie this note records being broken by convention rather than at random.
