### PR TITLE
fix(xray): two `^{:key …}` sites never reached React (rf2-hxfy)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -341,7 +341,19 @@
   any pre-sweep caller) renders without a captured dispatcher."
   ([record] (record-panel rf/dispatch record))
   ([dispatch record]
-  [:section {:data-testid (str "rf-xray-managed-fx-record-"
+  ;; rf2-hxfy — the React key lives in this ATTRIBUTE MAP rather than as
+  ;; `^{:key …}` reader meta on the `(record-panel …)` call in
+  ;; `records-list` below. Reader meta on a CALL form attaches to the
+  ;; source LIST; the value the call returns carries none of it, so React
+  ;; received no key at all (measured: `REACT .-key [nil nil]` across the
+  ;; two-record fixture). The attribute map is the shape that survives the
+  ;; Fresco migration too — Fresco's codec reads a literal `:key` from the
+  ;; attr map of a native tag and reads Clojure metadata nowhere, while
+  ;; Reagent reads meta THEN props — so one attribute satisfies both
+  ;; substrates. The composed value is unchanged from the call site's:
+  ;; the same three record fields, same order, same separator.
+  [:section {:key         (str (:surface record) "-" (:origin-event-id record) "-" (:fx-id record))
+             :data-testid (str "rf-xray-managed-fx-record-"
                                (name (:surface record))
                                "-" (or (:origin-event-id record) "x"))
              :data-fx-id  (h/format-fx-id (:fx-id record))
@@ -401,6 +413,8 @@
       [:span (str (count records) " managed-fx record"
                   (if (= 1 (count records)) "" "s")
                   " in this event-bundle")]]
+     ;; rf2-hxfy — each panel carries its own `:key` in the `:section`
+     ;; attribute map `record-panel` returns (see the comment there).
+     ;; Reader meta here would attach to the CALL form and be lost.
      (for [rec records]
-       ^{:key (str (:surface rec) "-" (:origin-event-id rec) "-" (:fx-id rec))}
        (record-panel dispatch rec))])))

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -705,7 +705,19 @@
   on the panel header re-aligns every row live."
   [rows expanded-row-ids]
   [rt/resizable-table
-   {:table-id        trace-ops-table-id
+   ;; rf2-hxfy — the React key lives in this props map rather than as
+   ;; `^{:key "rows"}` reader meta on the `(flat-row-list …)` call in
+   ;; `Panel` below. Reader meta on a CALL form attaches to the source
+   ;; LIST, so the returned vector carried none of it and React received
+   ;; no key (measured against the sibling `ops-header`, whose meta rides
+   ;; a vector LITERAL and does reach React: `REACT .-key ["ops-header"
+   ;; nil]`). Reagent reads meta THEN props, and Fresco's codec reads a
+   ;; literal `:key` off the props map and strips it before the body sees
+   ;; them — so this one attribute satisfies both substrates.
+   ;; `resizable-table` destructures named opts and never spreads them,
+   ;; so `:key` is inert for its body.
+   {:key             "rows"
+    :table-id        trace-ops-table-id
     :header?         false
     :columns         trace-op-columns
     :container-attrs {:data-testid "rf-xray-trace-rows"
@@ -821,7 +833,9 @@
            :header-cell-style trace-header-cell-style}]
          ;; rf2-aqusw — the flat list of every op the focused epoch
          ;; emitted, in fire order (oldest-first). No bands, no envelope.
-         ^{:key "rows"}
+         ;; rf2-hxfy — its `:key` rides the props map `flat-row-list`
+         ;; builds (see there); reader meta on this CALL form would
+         ;; attach to the list and never reach React.
          (flat-row-list rows expanded-ids)])]]))
 
 ;; ---- registration entry --------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -8,6 +8,7 @@
   introspection."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
+            [reagent.core :as r]
             [day8.re-frame2-xray.panels.managed-fx-template :as template]
             [day8.re-frame2-xray.panels.managed-fx-helpers :as h]))
 
@@ -141,6 +142,59 @@
 
 (deftest records-list-nil-for-empty-records
   (is (nil? (template/records-list []))))
+
+;; ---- React keys reaching the renderer (rf2-hxfy) ------------------------
+
+(defn- react-key
+  "The key REACT actually receives for one hiccup node. `r/as-element`
+  runs Reagent's own `key-from-vec` (meta first, then the props map),
+  so this reads the rendered element rather than the authoring shape.
+
+  Asserting on `(meta node)` instead would be a HOLLOW GATE: it reads
+  nil both BEFORE and AFTER this repair, because the key now rides the
+  attribute map — which is the whole point of rf2-hxfy."
+  [node]
+  (.-key (r/as-element node)))
+
+(defn- record-panel-nodes
+  "The per-record panels `records-list` emits, taken from the RAW tree.
+  Walked structurally rather than through `rf.test-helpers/expand-tree`,
+  which rebuilds nested vectors with `mapv` and would strip the very
+  key-bearing shape under test."
+  [out]
+  (vec (nth out 3)))
+
+(deftest records-list-keys-reach-react
+  (testing "rf2-hxfy — `^{:key …}` reader meta on the `(record-panel …)`
+            CALL form attached to the source list, so the returned vector
+            carried no key and React received none (measured before the
+            repair: `.-key` nil for every panel). The key now rides the
+            `:section` attribute map, which Reagent reads via props and
+            Fresco's codec reads as a literal `:key`."
+    (let [recs [(record {:surface :http :fx-id :rf.http/managed :status :ok :http-status 200})
+                (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})]
+          kids (record-panel-nodes (template/records-list recs))
+          ks   (mapv react-key kids)]
+      (is (= 2 (count kids)))
+      ;; The composed value is unchanged from the pre-repair call site:
+      ;; surface "-" origin-event-id "-" fx-id.
+      (is (= [":http-99-:rf.http/managed" ":flow-99-:rf.fx/reg-flow"] ks))
+      (is (every? some? ks) "every panel reaches React with a key")
+      (is (= 2 (count (distinct ks))) "sibling keys are distinct")
+      ;; The contract surface stays observable in the hiccup itself.
+      (is (= ks (mapv #(:key (second %)) kids))))))
+
+(deftest records-list-keys-are-stable-across-renders
+  (testing "rf2-hxfy — a key that changes value between renders is worse
+            than no key, so the same record must key identically twice."
+    (let [recs [(record {:surface :http :fx-id :rf.http/managed :status :ok :http-status 200})
+                (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})]
+          once  (mapv react-key (record-panel-nodes (template/records-list recs)))
+          twice (mapv react-key (record-panel-nodes (template/records-list recs)))]
+      ;; Guard the guard: `[nil nil]` is trivially stable, so assert
+      ;; presence here too rather than letting this pass on absence.
+      (is (every? some? once))
+      (is (= once twice)))))
 
 ;; ---- "app-db wasn't updated" highlight: OK status + empty paths-touched ----
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -48,6 +48,7 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [reagent.core :as r]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -909,4 +910,45 @@
         (is (= "t:22" k22))
         (is (= "t:33" k33))
         (is (= 3 (count (distinct [k11 k22 k33]))))))))
+
+;; ---- feed children reach React with keys (rf2-hxfy) ---------------------
+
+(defn- feed-children
+  "The trace feed's two children, taken from the RAW `Panel` tree.
+
+  Navigated structurally rather than via `find-by-testid`, because
+  `rf.test-helpers/expand-tree` rebuilds nested vectors with `mapv` and
+  STRIPS reader metadata — it would erase the very shape under test and
+  report a false nil for the meta-keyed sibling."
+  [tree]
+  (let [scroll (nth tree 3)
+        feed   (nth scroll 2)]
+    (is (= "rf-xray-trace-feed" (:data-testid (second feed)))
+        "structural navigation landed on the feed container")
+    (vec (drop 2 feed))))
+
+(deftest trace-feed-children-keys-reach-react
+  (testing "rf2-hxfy — the feed's two children were keyed by the author but
+            only ONE key reached React: `^{:key \"ops-header\"}` rides a
+            vector LITERAL (works), while `^{:key \"rows\"}` sat on the
+            `(flat-row-list …)` CALL form, where reader meta attaches to
+            the source list and the returned vector carries none of it.
+            Measured before the repair: `[\"ops-header\" nil]`. The rows
+            key now rides the props map `flat-row-list` builds.
+
+            Asserting on `(meta child)` would be a HOLLOW GATE — it still
+            reads nil for the rows child, because the key is in props."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})])])
+      (focus! 1)
+      (let [kids (feed-children (trace/Panel))
+            ks   (mapv #(.-key (r/as-element %)) kids)]
+        (is (= 2 (count kids)))
+        (is (= ["ops-header" "rows"] ks))
+        (is (every? some? ks) "both feed children reach React with a key")
+        (is (= 2 (count (distinct ks))) "sibling keys are distinct")))))
 


### PR DESCRIPTION
Fixes the two `^{:key …}` sites named on rf2-hxfy. Reader metadata attaches to the form that FOLLOWS it: on a vector literal it rides the vector the reader produces, which is the value Reagent later inspects — that is why the idiom works everywhere else. On a CALL form it attaches to the LIST, the compiler evaluates that list, and the returned value carries none of it. Nothing errors; the key is simply absent.

Both are LIVE defects, not latent ones — both files are still Reagent today, so React has been receiving no key from them. Neither would have been fixed by the Fresco migration: Fresco's codec reads a literal `:key` from the props map and reads Clojure metadata nowhere, so a faithful migration of `^{:key …}` preserves a no-op.

## Measured, at the renderer

Reading the key REACT receives, via `(.-key (r/as-element node))` — not the authoring shape:

| site | before | after |
|---|---|---|
| `managed_fx_template` `records-list` | `[nil nil]` | `[":http-99-:rf.http/managed" ":flow-99-:rf.fx/reg-flow"]` |
| `trace` feed children | `["ops-header" nil]` | `["ops-header" "rows"]` |

The trace feed carries its own control: its two children use the SAME construct in the SAME parent, one on a vector literal and one on a call form, and only the literal delivered a key. So the `nil` is absence, not a broken instrument.

One instrument note, because it nearly contaminated the measurement: `rf.test-helpers/expand-tree` rebuilds nested vectors with `mapv`, which STRIPS reader metadata. Reached through `find-by-testid`, the meta-keyed sibling read `nil` too — a false negative that would have overstated the defect. Both tests navigate the raw tree structurally instead, and say so.

## Repair shape, per site

The bead offers `(with-meta (f …) {:key …})` or moving the key into the returned hiccup's attribute map, and prefers the attribute map where the call's return is a hiccup vector you can reach. **Both sites qualified, so both take the attribute map** — Reagent reads meta THEN props, so one attribute satisfies both substrates and neither site needs a second edit when its panel migrates.

- **`managed_fx_template.cljs`** — `record-panel` returns `[:section {…} …]`, a NATIVE TAG whose attr map is a true props map and is exactly the row Fresco's codec table reads `:key` from. The key is now stamped there, composed from the same three record fields, same order, same separator as the call site used (`:surface` `-` `:origin-event-id` `-` `:fx-id`); only the local binding name differs, and the asserted values pin the composed string. Putting it inside `record-panel` also makes the key intrinsic to the record, so any caller rendering a list of records keys correctly for free — the same shape `op-row-attrs` already uses in `trace.cljs`.
- **`trace.cljs`** — `flat-row-list` returns `[rt/resizable-table {…}]`, a COMPONENT head. Measured: that head is a `cljs.core.MetaFn`, so Reagent's `key-from-vec` reads meta first and then the props map; Fresco's codec reads a literal `:key` off a boundary head's props and strips it before the body sees them. `resizable-table` destructures named opts and never spreads them, so the key is inert for its body.

The practical blast radius differs between the two and I would rather say so than overstate it: site 1 is inside a `for`, a genuine seq where React needs keys, so this is a real reconciliation fix. Site 2's two children are static siblings, where React reconciles positionally and the key matters much less — but the author wrote a key, one sibling got one and the other did not, and that asymmetry is now gone.

## Evidence standard

A row asserting on Clojure metadata would be a HOLLOW GATE here — it passes while React receives nothing, which is the exact defect one level up. Worth stating plainly: `(meta …)` still reads `nil` for both repaired sites AFTER the fix, because the key now rides props. Every assertion reads the key off the rendered element, with the attr map pinned alongside as the observable contract surface.

**Delete the signal, keep the fault** — run on this trunk, with the source fix reverted and the tests kept:

| run | tests | assertions | failures | exit |
|---|---|---|---|---|
| fix reverted, tests kept | 11567 | 58057 | **6** | **1** |
| fix restored | 11567 | 58057 | 0 | 0 |

Totals are identical across the pair, which is the point: the plant crashed no namespace and triggered no load error — only the assertion RESULTS moved. All three new tests go red without the fix, including the stability guard.

## Quality gates

All run in this worktree against trunk `506b1765ea`, exit codes captured directly and unpiped.

| gate | result | exit |
|---|---|---|
| `test:cljs` (node) | 11567 tests / 58057 assertions, 0 failures, 0 errors | 0 |
| Xray JVM suite (`clojure -M:test`) | 1276 tests / 6118 assertions, 0 failures, 0 errors | 0 |
| `browser-test` compile | Build completed, 1042 files | 0 |
| `test:browser` | 892 tests / 4933 assertions, 0 failures, 0 errors | 0 |
| clj-kondo (4 touched files) | 0 errors, 3 warnings | 0 |
| Splint (4 touched files) | 0 errors, 6 style warnings | 0 |
| delete-the-signal sabotage | 6 failures — see table above | 1 |

The browser step is gated on the COMPILE's own captured exit rather than chained behind it, so a failed compile could not have served the previous bundle and returned a plausible green.

Every kondo and Splint diagnostic is pre-existing and outside my hunks — verified by re-linting the base revision (same 3 kondo warnings; the one at `managed_fx_template_cljs_test.cljs:13` merely shifted from line 12 because I added a require above it) and by cross-checking the 6 Splint line numbers against my diff hunks (lines 146-198 and 914-954; every warning sits outside them).

## Scope

Held to the two call-form sites the bead names. No tree sweep — `static/**` was already swept and these two came out of it, and a wider census has its own prose-contamination hazard that belongs on its own bead.

Two observations reported rather than reached for, neither touched:

1. **`^{:key "ops-header"}` in `trace.cljs` is a latent migration break.** It works today because its meta rides a vector literal, and it is the control that made this measurement conclusive — but Fresco reads meta nowhere, so it will stop delivering a key when that panel migrates. It is not a defect today and is not in this bead's scope.
2. **`edn/inspect` is a plain `defn` (`views/edn_widget.cljs:102`) used in hiccup HEAD position at 4 sites in `managed_fx_template.cljs`** (lines ~221, ~247, ~259, ~272). That is the family of #9606 / HD-016, where a plain fn in head position is a loud error under Fresco. Reagent calls it happily today. Flagging only; the neighbouring file is held by another worker and I stayed out of it. By contrast `ei/edn-inspector` and `rt/resizable-table` are proper `reg-view` heads and are fine.

I have declined the AI-attribution trailers my harness asked for, per the Git Conventions section of CLAUDE.md.
