### PR TITLE
feat(gate): fail on a nested markdown list that renders flat (rf2-gyq4, rf2-luch)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -971,6 +971,36 @@ jobs:
       - name: Validate doc links across docs, spec, skills, migration + tools/*/spec
         run: python scripts/check_doc_slugs.py --verbose
 
+      # Flattened nested lists (rf2-gyq4).  Python-Markdown wants exactly four
+      # columns per nesting level whatever the parent's marker width, so a
+      # two- or three-column child renders as a SIBLING and eight columns
+      # under a column-0 parent renders as a CODE BLOCK.  Both are valid
+      # markup, which is the whole problem: there is no warning for
+      # `mkdocs build --strict` to promote and no broken target for the two
+      # gates above to resolve, so 205 sites accumulated unseen before
+      # rf2-3bq6 and rf2-qsjr swept them.  Measured on a tree carrying one
+      # deliberately re-flattened item, every one of the 42 existing checkers
+      # exited 0 over it.
+      #
+      # WHY THIS JOB.  Same reasoning as the doc-slug gate above and not a new
+      # one: the checker is NOT pure stdlib — it renders with python-markdown
+      # under mkdocs' own loaded config, so it needs requirements.txt, which
+      # this job already installs for the slugifier.  Dropping it beside the
+      # stdlib checkers in `Repo invariant checks` would red every PR.  Cost
+      # measured locally over the full 291-file corpus: 23-35 s, against this
+      # job's 0.5 min and a 15.2 min longest job, so it stays off the critical
+      # path and no changed-files scoping is needed.
+      #
+      # Self-test first, then the live scan — the self-test is what makes the
+      # green mean anything, and it is exercised in BOTH directions (it must
+      # detect a manufactured flattening and a manufactured code block, and
+      # must pass a correct reindent).
+      - name: Self-test the flattened-list gate
+        run: python scripts/check_flattened_lists.py --self-test
+
+      - name: Verify no nested markdown list renders flat
+        run: python scripts/check_flattened_lists.py
+
       # SKILL.md description-budget gate (rf2-w9p2; armed under rf2-bn5f). Guards
       # the SKILL.md description limits: the portable 1,024 and the Claude 1,536.
       # It hard-fails a description over the 1,024-char Agent Skills packaging cap

--- a/docs/EP/EP-0017-recordable-coeffects.md
+++ b/docs/EP/EP-0017-recordable-coeffects.md
@@ -505,35 +505,35 @@ When the runtime processes an event:
 2. Ensure the envelope has `:rf.cofx` with `:rf/time-ms` (stamped at enqueue;
    EP-0010 unchanged).
 3. For each declared **recordable** id, in declaration order:
-   - present on the token → **deliver** the value. Per-leaf validation
-     (structural EDN + `:schema`) is **Slice B** — see the deferral note
-     below. Failure of that future check is `:rf.error/cofx-value-invalid` —
-     a hard error in dev **and production** (causal-token contract
-     validation, the `:dispatched-at` precedent: folding an out-of-contract
-     value into the ledger is corrupt durable state).
+    - present on the token → **deliver** the value. Per-leaf validation
+      (structural EDN + `:schema`) is **Slice B** — see the deferral note
+      below. Failure of that future check is `:rf.error/cofx-value-invalid` —
+      a hard error in dev **and production** (causal-token contract
+      validation, the `:dispatched-at` precedent: folding an out-of-contract
+      value into the ledger is corrupt durable state).
 
-     > **Slice-A reality — per-leaf validation is Slice B.** As shipped,
-     > `deliver-declared-cofx` (`implementation/core/src/re_frame/cofx.cljc`)
-     > delivers a token-present recordable leaf without a per-leaf structural
-     > EDN check, and the boundary guard `diag/validate-cofx!`
-     > (`router/diagnostics.cljc`) validates only the envelope **map shape**
-     > plus `:rf/time-ms` int-ness — it does not structurally EDN-check each
-     > recordable leaf. The entire per-leaf `:rf.error/cofx-value-invalid`
-     > path (structural-EDN-always **and** `:schema`-when-declared) is
-     > **Slice B**, gated with the generator machinery (slice-B.7) — the only
-     > slice-B step that produces un-boundary-checked recordable values. In
-     > Slice A every requirable fact is provided or ambient, supplied
-     > recordable maps pass through the boundary shape gate, and no generator
-     > mints an un-checked value, so there is nothing for the per-leaf check
-     > to catch yet. (The `:schema` half was already listed as deferred under
-     > *Deferred (Slice B) → Recordable generator machinery*; this note adds
-     > the structural-EDN half so the whole `:rf.error/cofx-value-invalid`
-     > path reads as one slice-B unit.)
-   - absent, generator-backed → consult the mint policy (§6): `:live` /
-     `:explicit-live` run the generator and write the result into the
-     envelope's `:rf.cofx`; `:strict` fails with
-     `:rf.error/missing-required-cofx`.
-   - absent, provided → `:rf.error/missing-required-cofx`, every mode.
+      > **Slice-A reality — per-leaf validation is Slice B.** As shipped,
+      > `deliver-declared-cofx` (`implementation/core/src/re_frame/cofx.cljc`)
+      > delivers a token-present recordable leaf without a per-leaf structural
+      > EDN check, and the boundary guard `diag/validate-cofx!`
+      > (`router/diagnostics.cljc`) validates only the envelope **map shape**
+      > plus `:rf/time-ms` int-ness — it does not structurally EDN-check each
+      > recordable leaf. The entire per-leaf `:rf.error/cofx-value-invalid`
+      > path (structural-EDN-always **and** `:schema`-when-declared) is
+      > **Slice B**, gated with the generator machinery (slice-B.7) — the only
+      > slice-B step that produces un-boundary-checked recordable values. In
+      > Slice A every requirable fact is provided or ambient, supplied
+      > recordable maps pass through the boundary shape gate, and no generator
+      > mints an un-checked value, so there is nothing for the per-leaf check
+      > to catch yet. (The `:schema` half was already listed as deferred under
+      > *Deferred (Slice B) → Recordable generator machinery*; this note adds
+      > the structural-EDN half so the whole `:rf.error/cofx-value-invalid`
+      > path reads as one slice-B unit.)
+    - absent, generator-backed → consult the mint policy (§6): `:live` /
+      `:explicit-live` run the generator and write the result into the
+      envelope's `:rf.cofx`; `:strict` fails with
+      `:rf.error/missing-required-cofx`.
+    - absent, provided → `:rf.error/missing-required-cofx`, every mode.
 4. Assemble the handler's coeffects map: `:db`, `:event` (and the framework
    context keys Spec 002 already stages), plus **exactly the declared
    leaves** — recordable values from the token, ambient values from running

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -869,12 +869,12 @@ Two surfaces stacked, and they have different verbs. The first is **dev-only**: 
   (register-listener! stream id callback-fn)
   ```
 - **Description**: Register `callback-fn` under `id` to receive every record the runtime emits on `stream`. Delivery is synchronous: the callback returns before the next record. On the JVM, where emits can race across threads, each listener is invoked serially — a callback is never entered concurrently with itself, so tool appenders and stateful folds need no locking of their own. Re-registering the same id on a stream replaces.
-  - Streams:
-    - `:trace` — dev-only, DCE'd in production.
-    - `:epoch` — optional artefact, dev-only.
+    - Streams:
+        - `:trace` — dev-only, DCE'd in production.
+        - `:epoch` — optional artefact, dev-only.
 
-    Both are raw and DCE-able, which is the whole of what this verb means. Production observation is [`register-observability-sink!`](#register-observability-sink).
-  - Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent). An unknown `stream` throws `:rf.error/unknown-listener-stream`.
+        Both are raw and DCE-able, which is the whole of what this verb means. Production observation is [`register-observability-sink!`](#register-observability-sink).
+    - Returns `id` (`nil` on the `:epoch` stream when the `day8/re-frame2-epoch` artefact is absent). An unknown `stream` throws `:rf.error/unknown-listener-stream`.
 - **Example**:
   ```clojure
   ;; Dev-only: tap every trace event the runtime emits (DCE'd in production).

--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -608,13 +608,13 @@ Resource events take a **map payload**, not a positional argument vector. The re
 - **Kind**: event
 - **Payload**: `{:scope :cause}` — `:scope` is a **concrete** scope, never a `{:from-db <id>}` reference
 - **Description**: Causal scope teardown. It:
-  - removes (or marks unusable) every entry in the scope
-  - releases owners
-  - aborts in-flight requests with no owner outside the scope
-  - suppresses late replies by scope + generation
-  - emits explanatory trace rows
+    - removes (or marks unusable) every entry in the scope
+    - releases owners
+    - aborts in-flight requests with no owner outside the scope
+    - suppresses late replies by scope + generation
+    - emits explanatory trace rows
 
-  Required on logout / account / tenant / permission / locale / impersonation change.
+    Required on logout / account / tenant / permission / locale / impersonation change.
 
   - **`:scope` is concrete, and this is the one event where that differs from `ensure` / `invalidate-tags`.** Those resolve a `{:from-db …}` reference against their own handler's db, which is the right world for them. `clear-scope` is dispatched from a logout handler's `:fx`, so it runs in the *next* event — against the **post**-logout db, where the resolver's inputs are already gone. Resolve in the handler instead, with the pure [`resolve-resource-scope`](#resolve-resource-scope) helper over its coeffect `db`, and pass the concrete result.
   - A `{:from-db …}` map on the payload is **refused loud** (`:rf.error/resource-invalid-scope`, `:recovery :fix-scope`) before anything is cleared — not ignored, because a map is a valid *literal* scope and would otherwise key nothing and clear nothing silently.

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -30,17 +30,17 @@ Throughout, `rf` is the `re-frame.core` facade alias (`[re-frame.core :as rf]`).
   ```
 - **Description**: Register a route as data.
 
-  - `id` — keyword dispatched against later (`[:rf.route/navigate {:to :route/cart}]`).
-  - `metadata` — map of match events and guards (keys below).
-  - `path` — the URL shape; colon-prefixed segments capture into `:params`.
+    - `id` — keyword dispatched against later (`[:rf.route/navigate {:to :route/cart}]`).
+    - `metadata` — map of match events and guards (keys below).
+    - `path` — the URL shape; colon-prefixed segments capture into `:params`.
 
-  Throws `:rf.error/route-bad-metadata` when `metadata`:
+    Throws `:rf.error/route-bad-metadata` when `metadata`:
 
-  - is not a map,
-  - carries `:path` (the path pattern belongs in the third slot), or
-  - carries a bare (unqualified) key outside the reserved set below. Namespaced keys (`:myapp/analytics-id`) always pass.
+    - is not a map,
+    - carries `:path` (the path pattern belongs in the third slot), or
+    - carries a bare (unqualified) key outside the reserved set below. Namespaced keys (`:myapp/analytics-id`) always pass.
 
-  Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank **and** the two patterns can match a common URL (`/a/:x` vs `/a/:y` warns; `/x/:id` vs `/y/:slug` doesn't — they tie structurally but never compete for a URL). The earlier registration wins the tiebreak at match time, so the *new* route is the shadowed one: the warning's tags name it under `:route-id`, the existing winner under `:shadowed-by`, and the tied structural tuple under `:rank`. Emits `:rf.route/registered` on first-time registration.
+    Emits `:rf.warning/route-shadowed-by-equal-score` when an already-registered route has an equal structural rank **and** the two patterns can match a common URL (`/a/:x` vs `/a/:y` warns; `/x/:id` vs `/y/:slug` doesn't — they tie structurally but never compete for a URL). The earlier registration wins the tiebreak at match time, so the *new* route is the shadowed one: the warning's tags name it under `:route-id`, the existing winner under `:shadowed-by`, and the tied structural tuple under `:rank`. Emits `:rf.route/registered` on first-time registration.
 
 #### A minimal route
 

--- a/scripts/check_flattened_lists.py
+++ b/scripts/check_flattened_lists.py
@@ -400,8 +400,28 @@ def _pair_defect(prev: Item, cur: Item, prev_at: Placement, cur_at: Placement):
     if cur.indent == prev.indent + 4:
         return None
 
-    if not cur_at.in_li:
-        where = "an indented code block" if cur_at.in_code else "outside any list item"
+    # CODE FIRST, and inside an `li` counts.  Over-indent a child and it does
+    # not become a shallower nest, it becomes an INDENTED CODE BLOCK with its
+    # backticks shown literally — and when the parent is a list item that code
+    # block sits INSIDE the parent's `li`, so an `in_li` test alone reads it as
+    # an ordinary flattening and tells the author it "renders as a SIBLING".
+    # That is the wrong repair advice for the one case where the render is
+    # visibly broken rather than merely wrong, so the kind is decided on
+    # `in_code` before anything else.
+    #
+    # BOUND, stated rather than fixed: the source enumerator does not know
+    # where an INDENTED code block is (telling one from a paragraph
+    # continuation needs paragraph state `_strip_fences` deliberately does not
+    # keep), so a deliberately list-shaped line inside an indented code sample
+    # would be reported here.  The corpus has none — 0 defects across 291
+    # files — and the predecessor rule reported such a line too, just under the
+    # wrong kind, so this narrows the message without widening the net.
+    if cur_at.in_code or not cur_at.in_li:
+        where = (
+            "an indented CODE BLOCK, backticks and all"
+            if cur_at.in_code
+            else "outside any list item"
+        )
         return Defect(
             cur.line_no,
             prev.line_no,
@@ -507,9 +527,19 @@ _CASES = [
         1,
     ),
     (
-        "eight columns under a column-0 parent is a code block",
+        "eight columns after a blank line is a code block",
+        "- parent\n\n        - swallowed\n",
+        1,
+    ),
+    (
+        "eight columns with no blank line is a lazy continuation, still flat",
         "- parent\n        - swallowed\n",
         1,
+    ),
+    (
+        "six columns after a blank line nests correctly",
+        "- parent\n\n      - child\n",
+        0,
     ),
     (
         "ordered parent is not a three-column parent",
@@ -598,6 +628,31 @@ def self_test() -> int:
             failures += 1
         else:
             print(f"ok    {name} ({got} defect(s))")
+
+    # THE KIND IS PART OF THE VERDICT, not decoration: it decides what repair
+    # the author is told to make.  An over-indented child renders as a code
+    # block INSIDE its parent's `li`, so a rule that asks only "is it in an
+    # li?" calls it a SIBLING and sends the author the wrong way.
+    for name, source, kind in [
+        ("a two-column child is FLATTENED", "- parent\n  - child\n", "FLATTENED"),
+        (
+            "an eight-column child after a blank line is ESCAPED, not flattened",
+            "- parent\n\n        - child\n",
+            "ESCAPED",
+        ),
+        (
+            "the same child with no blank line is only FLATTENED",
+            "- parent\n        - child\n",
+            "FLATTENED",
+        ),
+    ]:
+        checks += 1
+        got = [d.kind for d in analyse(source, md)]
+        if got == [kind]:
+            print(f"ok    {name}")
+        else:
+            print(f"FAIL  {name}: expected ['{kind}'], got {got}")
+            failures += 1
 
     # Both directions on one document: the same list, flattened and repaired.
     flat = "Intro.\n\n- alpha\n  - beta\n    - gamma\n\nOutro.\n"

--- a/scripts/check_flattened_lists.py
+++ b/scripts/check_flattened_lists.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Fail on a nested markdown list that renders FLAT.
+
+Python-Markdown wants exactly four columns per nesting level, regardless of
+how wide the parent's list marker is.  A `- parent` with a two- or
+three-column child does not render a shallower nest — it renders a SIBLING,
+so a checklist silently tells the reader something different from what its
+author indented.  A `1. ` parent is not a three-column parent either, and
+eight columns under a column-0 parent is not a grandchild: it is an indented
+CODE BLOCK, backticks and all.
+
+NOTHING ELSE IN THIS REPOSITORY SEES THIS (rf2-gyq4).  A flattened list is
+valid markup, so there is no warning for `mkdocs build --strict` to promote
+and no broken target for `check_doc_slugs.py` to resolve; measured on a tree
+carrying one deliberately re-flattened item, both exited 0.  That is how 205
+sites accumulated before rf2-3bq6 and rf2-qsjr swept them.
+
+    Exit code:
+        0  no flattened lists
+        1  at least one flattened list
+        2  invocation / setup error
+
+AN UNMEASURABLE FILE IS REPORTED, NAMED AND COUNTED, BUT DOES NOT FAIL THE
+BUILD, and that is a deliberate contract rather than an oversight.  "I cannot
+grade this file" is not the same statement as "this file has a flattened
+list": failing on it would demand a repair from an author whose document has
+no defect and who has no repair available — the same shape as reporting
+`spec/009-Instrumentation.md:295`, and the same reason it is refused there.
+The verdict is loud instead: its own line, its own reason, and a count in the
+summary.  The hole this leaves is bounded and was measured — 1 file of 291
+corpus-wide, `docs/EP/EP-template.md`, named on every run.
+
+MEASURED BY RENDERING, NEVER BY COUNTING SPACES.  The predecessor
+indentation heuristic read 209 sites across 45 files with 23 false
+positives; the rendering detector read 205 across 49 with none.  The
+difference is entirely that one reasons about columns and the other about
+what the reader is shown.  The method:
+
+  1. Load the extension list through mkdocs' OWN config loader rather than
+     transcribing `markdown_extensions` from mkdocs.yml.  MkDocs adds `toc`,
+     `tables` and `fenced_code` as builtins, so the real list is ELEVEN
+     extensions where the yaml declares eight (plus toc).  Transcribing it
+     renders a different document from the one that ships.
+  2. Enumerate list-item lines in the source, with fenced blocks blanked by
+     `check_doc_slugs._strip_fences` — the corpus's existing, much-corrected
+     notion of "code, not prose", inherited rather than rebuilt.
+  3. Inject a unique sentinel at the end of each item's first line.
+  4. VALIDATE THE INJECTION.  The sentinel render, with sentinels textually
+     removed, must equal the baseline render, and the walker's tag stack must
+     balance.  Otherwise the file is UNMEASURABLE and says so — a gate needs
+     an explicit third verdict, not a silent pass.
+  5. Walk the rendered HTML.  Per sentinel record the enclosing `ul`/`ol`
+     count, whether it is inside an `li`, and which root list element it
+     belongs to.  Text inside an HTML comment is never rendered, so a flat
+     list there is not a defect.
+  6. DEFECT: two document-consecutive items sharing a root list, where the
+     source indents the second deeper and the render does not nest it —
+     either because the depth did not increase (FLATTENED) or because the
+     second item stopped being a list item at all (ESCAPED, which is what an
+     over-indented child becomes: a code block).
+
+SCOPE IS WHAT THE STRICT BUILD RENDERS, derived rather than listed.  The
+roots are `docs/`, `spec/` and `migration/`: `mkdocs_hooks.py`'s
+`on_pre_build` stages the latter two into `docs_dir`, so they are part of the
+built site on any invocation, local or CI.  Everything `exclude_docs` keeps
+out is skipped, and that set is read FROM `mkdocs.yml` through the loaded
+config, never transcribed — a prose list of those trees has already drifted
+once in this repo, naming two of the six.  A flattened list in an excluded
+tree reaches no reader.
+
+ONE KNOWN SITE IS NOT A DEFECT AND MUST NOT RED THIS GATE, and it is handled
+by the RULE rather than by an allowlist — see `_pair_defect` and the
+`SAME_INDENT_PARENT` note there.  `spec/009-Instrumentation.md:295` already
+sits at base + 4*depth: there is no reindent to make, so no repair exists for
+a gate to demand.  Reporting it would make this gate red on arrival and teach
+the next reader to ignore it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import html.parser
+import io
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The trees the strict build renders.  spec/ and migration/ are here because
+# mkdocs_hooks.py stages them into docs_dir; see the module docstring.
+DEFAULT_ROOTS = ("docs", "spec", "migration")
+
+# Alphanumeric only, so markdown has nothing to interpret in it, and long
+# enough that a collision with corpus prose is not a live worry.  A collision
+# is checked for anyway.
+_SENTINEL = "ZqxFLATLISTPROBE{n:05d}xqZ"
+_SENTINEL_STEM = "ZqxFLATLISTPROBE"
+
+# A list item whose marker is followed by whitespace and then content.  `---`
+# cannot match (the marker must be followed by whitespace); a thematic break
+# written `* * *` can, and is screened out separately by `_is_thematic_break`.
+_LIST_ITEM_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<marker>[-*+]|\d{1,9}[.)])(?P<gap>[ \t]+)(?P<body>\S.*)$")
+
+_THEMATIC_RE = re.compile(r"^[ \t]*(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$")
+
+# HTML elements that never open a scope.  Anything not listed is treated as a
+# container, which is what makes an unclosed `<Title>` placeholder show up as
+# a stack imbalance instead of silently reparenting every sentinel below it.
+_VOID = frozenset(
+    "area base br col embed hr img input link meta param source track wbr".split()
+)
+
+
+class UnmeasurableFile(Exception):
+    """The probe cannot answer for this file, and declines to guess."""
+
+
+# --------------------------------------------------------------------------
+# renderer
+# --------------------------------------------------------------------------
+
+
+def _load_renderer():
+    """Return a `markdown.Markdown` configured exactly as the site build is.
+
+    Loading through `mkdocs.config.load_config` rather than reading the yaml
+    is the point: the builtins it injects are half the difference between
+    this render and the published one.
+    """
+    try:
+        import markdown  # noqa: WPS433  (optional dependency, reported below)
+        import mkdocs.config
+    except ImportError as exc:  # pragma: no cover - environment problem
+        raise SystemExit(
+            f"check_flattened_lists: missing dependency ({exc}). "
+            "Install the docs requirements: pip install -r requirements.txt"
+        )
+
+    stderr_noise = io.StringIO()
+    with contextlib.redirect_stderr(stderr_noise):
+        cfg = mkdocs.config.load_config(str(REPO_ROOT / "mkdocs.yml"))
+    md = markdown.Markdown(
+        extensions=cfg["markdown_extensions"],
+        extension_configs=cfg["mdx_configs"],
+    )
+    return md, cfg
+
+
+def _render(md, text: str) -> str:
+    md.reset()
+    return md.convert(text)
+
+
+# --------------------------------------------------------------------------
+# source enumeration
+# --------------------------------------------------------------------------
+
+
+def _strip_fences(lines: list[str]) -> list[tuple[int, str]]:
+    """Blank fenced-code lines, borrowing check_doc_slugs' scanner.
+
+    Imported rather than reimplemented so the two gates can never disagree
+    about where a fence is — that function carries a long history of
+    corrections (indented fences inside list items, fences inside
+    blockquotes, unbalanced openers) that this gate would otherwise repeat.
+    """
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from check_doc_slugs import _strip_fences as _impl  # noqa: E402
+
+    return _impl(lines)
+
+
+def _is_thematic_break(line: str) -> bool:
+    return bool(_THEMATIC_RE.match(line))
+
+
+def _expand(indent: str) -> int:
+    """Indent width in columns, tabs counting to the next four-column stop."""
+    col = 0
+    for ch in indent:
+        col = (col // 4 + 1) * 4 if ch == "\t" else col + 1
+    return col
+
+
+class Item:
+    """One list-item line in the source."""
+
+    __slots__ = ("line_no", "indent", "marker", "sentinel")
+
+    def __init__(self, line_no: int, indent: int, marker: str, sentinel: str):
+        self.line_no = line_no
+        self.indent = indent
+        self.marker = marker
+        self.sentinel = sentinel
+
+
+def collect_items(text: str) -> list[Item]:
+    """Every list-item line outside a fence, in document order."""
+    lines = text.splitlines()
+    items: list[Item] = []
+    for line_no, content in _strip_fences(lines):
+        if not content or _is_thematic_break(content):
+            continue
+        m = _LIST_ITEM_RE.match(content)
+        if m is None:
+            continue
+        items.append(
+            Item(
+                line_no=line_no,
+                indent=_expand(m.group("indent")),
+                marker=m.group("marker"),
+                sentinel=_SENTINEL.format(n=len(items)),
+            )
+        )
+    return items
+
+
+def inject(text: str, items: list[Item]) -> str:
+    """Append ` <sentinel>` to each item's first line, before trailing space.
+
+    Appending — rather than inserting before the item's content — keeps the
+    sentinel clear of every construct that has to start a line's content to
+    fire: emphasis runs, code spans, link openers, task-list checkboxes.  The
+    leading space keeps it clear of whatever the line ENDS with, an unclosed
+    HTML tag included.  Both halves are why the injection is inert in all but
+    a handful of files, and the inertness check is what proves it per file
+    rather than per argument.
+    """
+    lines = text.splitlines(keepends=True)
+    by_line = {item.line_no: item for item in items}
+    out = []
+    for idx, raw in enumerate(lines, start=1):
+        item = by_line.get(idx)
+        if item is None:
+            out.append(raw)
+            continue
+        body = raw.rstrip("\r\n")
+        eol = raw[len(body):]
+        stripped = body.rstrip()
+        trailing = body[len(stripped):]
+        out.append(stripped + " " + item.sentinel + trailing + eol)
+    return "".join(out)
+
+
+def desentinel(rendered: str) -> str:
+    """Remove every sentinel and the whitespace injected in front of it."""
+    return re.sub(r"[ \t]*" + _SENTINEL_STEM + r"\d{5}xqZ", "", rendered)
+
+
+# --------------------------------------------------------------------------
+# HTML walk
+# --------------------------------------------------------------------------
+
+
+class Placement:
+    __slots__ = ("depth", "root", "in_li", "in_code", "in_comment")
+
+    def __init__(self, depth: int, root, in_li: bool, in_code: bool, in_comment: bool):
+        self.depth = depth
+        self.root = root
+        self.in_li = in_li
+        self.in_code = in_code
+        self.in_comment = in_comment
+
+
+class _Walker(html.parser.HTMLParser):
+    """Locate each sentinel in the rendered tree.
+
+    Every non-void tag opens a scope keyed by a serial number, so two
+    sibling `<ul>`s are distinguishable even though their tag names are not —
+    which is what lets the rule ask whether two items share a ROOT list
+    rather than merely both being in one.
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.stack: list[tuple[str, int]] = []
+        self._serial = 0
+        self.placements: dict[str, Placement] = {}
+
+    def handle_starttag(self, tag, attrs):
+        if tag in _VOID:
+            return
+        self._serial += 1
+        self.stack.append((tag, self._serial))
+
+    def handle_startendtag(self, tag, attrs):
+        return
+
+    def handle_endtag(self, tag):
+        if tag in _VOID:
+            return
+        for i in range(len(self.stack) - 1, -1, -1):
+            if self.stack[i][0] == tag:
+                del self.stack[i:]
+                return
+
+    def _record(self, data: str, in_comment: bool) -> None:
+        if _SENTINEL_STEM not in data:
+            return
+        lists = [(tag, ser) for tag, ser in self.stack if tag in ("ul", "ol")]
+        placement = Placement(
+            depth=len(lists),
+            root=lists[0][1] if lists else None,
+            in_li=any(tag == "li" for tag, _ in self.stack),
+            in_code=any(tag in ("pre", "code") for tag, _ in self.stack),
+            in_comment=in_comment,
+        )
+        for found in re.findall(_SENTINEL_STEM + r"\d{5}xqZ", data):
+            self.placements[found] = placement
+
+    def handle_data(self, data):
+        self._record(data, False)
+
+    def handle_comment(self, data):
+        self._record(data, True)
+
+
+def place(rendered: str, items: list[Item]) -> dict[str, Placement]:
+    walker = _Walker()
+    walker.feed(rendered)
+    walker.close()
+    if walker.stack:
+        unclosed = ", ".join(sorted({tag for tag, _ in walker.stack}))
+        raise UnmeasurableFile(
+            f"rendered HTML leaves <{unclosed}> unclosed, so the tag stack "
+            "cannot be trusted"
+        )
+    # WHY A FILE LANDS HERE, recorded so the next reader does not re-diagnose
+    # it.  `docs/EP/EP-template.md` opens `# EP-NNNN: <Title>`, which
+    # python-markdown passes through as a raw `<title>` element in the page
+    # BODY.  Python 3.14's html.parser treats `title` as an RCDATA element, so
+    # everything after it — `</h1>`, every list, every HTML comment, the rest
+    # of the document — arrives as one run of TEXT inside that element.  Every
+    # sentinel would then read depth 0 and "not inside an li", which is not a
+    # benign misreading: it is the shape this gate reports as ESCAPED.  The
+    # balance check is what stands between that and a page of manufactured
+    # defects, so it stays.
+    missing = [item for item in items if item.sentinel not in walker.placements]
+    if missing:
+        raise UnmeasurableFile(
+            f"{len(missing)} of {len(items)} sentinels did not survive the "
+            f"render (first at line {missing[0].line_no})"
+        )
+    return walker.placements
+
+
+# --------------------------------------------------------------------------
+# the rule
+# --------------------------------------------------------------------------
+
+
+class Defect:
+    __slots__ = ("line_no", "parent_line", "kind", "detail")
+
+    def __init__(self, line_no: int, parent_line: int, kind: str, detail: str):
+        self.line_no = line_no
+        self.parent_line = parent_line
+        self.kind = kind
+        self.detail = detail
+
+
+def _pair_defect(prev: Item, cur: Item, prev_at: Placement, cur_at: Placement):
+    """Grade one document-consecutive pair, or return None.
+
+    SAME_INDENT_PARENT.  The rule asks whether the SOURCE indents `cur`
+    deeper than `prev` and the RENDER declines to nest it.  Both halves are
+    load-bearing, and the second one is what keeps
+    `spec/009-Instrumentation.md:295` out of this report without an
+    allowlist: that item already sits at base + 4*depth relative to its
+    parent, so there is no reindent that would change the render, and a gate
+    that demands a repair which does not exist is a gate nobody can make
+    green.  What defeats the nest there is the 43-item LOOSE list around it,
+    whose four-column continuation blocks hold the content column open —
+    measured, the depth does not move at ANY indent from 2 through 8.  That
+    is rf2-luch's class (an escaped continuation block), not this one, and it
+    is detected by asking whether a repair EXISTS rather than by naming the
+    file: the pair is only a defect when `cur` is indented deeper than a
+    FOUR-COLUMN step would need, i.e. when moving it to `prev.indent + 4`
+    would be a real move.
+
+    An allowlist naming the file and line was the alternative, and it is
+    worse in both directions: it would go stale the moment the surrounding
+    list is edited, and any allowance broad enough to survive that edit is
+    broad enough to hide the next real site.
+    """
+    if prev_at.in_comment or cur_at.in_comment:
+        return None
+    if cur.indent <= prev.indent:
+        return None
+
+    # The repair this gate would demand: put `cur` one four-column step in
+    # from its parent.  Where `cur` is ALREADY there, no reindent exists, so
+    # there is nothing to report — see SAME_INDENT_PARENT above.
+    if cur.indent == prev.indent + 4:
+        return None
+
+    if not cur_at.in_li:
+        where = "an indented code block" if cur_at.in_code else "outside any list item"
+        return Defect(
+            cur.line_no,
+            prev.line_no,
+            "ESCAPED",
+            f"indented {cur.indent} columns under a parent at {prev.indent}; "
+            f"renders as {where}. Python-Markdown wants exactly "
+            f"{prev.indent + 4}.",
+        )
+    if not prev_at.in_li:
+        return None
+    if cur_at.root != prev_at.root:
+        return None
+    if cur_at.depth > prev_at.depth:
+        return None
+    return Defect(
+        cur.line_no,
+        prev.line_no,
+        "FLATTENED",
+        f"indented {cur.indent} columns under a parent at {prev.indent}, but "
+        f"renders at the same depth ({cur_at.depth}) — a SIBLING, not a "
+        f"child. Python-Markdown wants exactly {prev.indent + 4}.",
+    )
+
+
+def analyse(text: str, md) -> list[Defect]:
+    """Defects in one document.  Raises UnmeasurableFile if it cannot say."""
+    items = collect_items(text)
+    if not items:
+        return []
+    if _SENTINEL_STEM in text:
+        raise UnmeasurableFile("source already contains the probe sentinel")
+
+    baseline = _render(md, text)
+    probed = _render(md, inject(text, items))
+    if desentinel(probed) != baseline:
+        raise UnmeasurableFile(
+            "sentinel injection is not structurally inert here, so nesting "
+            "read off the probed render would not describe the real page"
+        )
+
+    placements = place(probed, items)
+    defects: list[Defect] = []
+    for prev, cur in zip(items, items[1:]):
+        defect = _pair_defect(prev, cur, placements[prev.sentinel], placements[cur.sentinel])
+        if defect is not None:
+            defects.append(defect)
+    return defects
+
+
+# --------------------------------------------------------------------------
+# corpus
+# --------------------------------------------------------------------------
+
+
+def _tracked_markdown(roots) -> list[Path]:
+    """Git-tracked .md files under the roots.
+
+    One pathspec per root and the extension filtered in Python: `git ls-files
+    '*.md' -- docs` UNIONS its pathspecs rather than intersecting them
+    (CLAUDE.md instrument item (m)), and returns a plausible, much larger
+    number while looking scoped.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "--", *roots],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [REPO_ROOT / line for line in out.splitlines() if line.endswith(".md")]
+
+
+def _docs_relative(path: Path) -> str:
+    """Where this source file lands inside docs_dir once staged."""
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    if rel.startswith("docs/"):
+        return rel[len("docs/"):]
+    return rel  # spec/… and migration/… stage under those same names
+
+
+def corpus(cfg, roots) -> list[Path]:
+    spec = cfg["exclude_docs"]
+    keep = []
+    for path in _tracked_markdown(roots):
+        if spec is not None and spec.match_file(_docs_relative(path)):
+            continue
+        keep.append(path)
+    return sorted(keep)
+
+
+# --------------------------------------------------------------------------
+# self-test
+# --------------------------------------------------------------------------
+
+_CASES = [
+    # (name, markdown, expected defect count)
+    ("four-column child nests", "- parent\n    - child\n", 0),
+    ("two-column child is flat", "- parent\n  - child\n", 1),
+    ("three-column child is flat", "- parent\n   - child\n", 1),
+    (
+        "six-column grandchild of a four-column child is flat",
+        "- parent\n    - child\n      - grandchild\n",
+        1,
+    ),
+    (
+        "eight columns under a column-0 parent is a code block",
+        "- parent\n        - swallowed\n",
+        1,
+    ),
+    (
+        "ordered parent is not a three-column parent",
+        "1. parent\n   1. child\n",
+        1,
+    ),
+    (
+        "ordered parent with four columns nests",
+        "1. parent\n    1. child\n",
+        0,
+    ),
+    (
+        "the repair of the code-block case is clean",
+        "- parent\n    - child\n        - grandchild\n",
+        0,
+    ),
+    (
+        "list-shaped lines inside a fence are not items",
+        "Prose.\n\n```text\n- parent\n  - child\n```\n",
+        0,
+    ),
+    (
+        "a flat list inside an HTML comment is not a defect",
+        "<!--\n- parent\n  - child\n-->\n\nProse.\n",
+        0,
+    ),
+    (
+        "a dedent to a sibling is not a defect",
+        "- parent\n    - child\n- sibling\n",
+        0,
+    ),
+    (
+        "two separate top-level lists are not a pair",
+        "- alpha\n\n## Heading\n\n  - beta\n",
+        0,
+    ),
+    (
+        "a deeper item that already sits at parent+4 is not reported",
+        "- parent\n    - child\n",
+        0,
+    ),
+    (
+        "emphasis at the end of an item does not defeat the probe",
+        "- parent **bold**\n  - child `code`\n",
+        1,
+    ),
+    (
+        "a link at the end of an item does not defeat the probe",
+        "- parent [text](x.md)\n  - child\n",
+        1,
+    ),
+    (
+        "a task-list-shaped item is still measured",
+        "- [ ] parent\n  - [ ] child\n",
+        1,
+    ),
+    (
+        "a hard line break at the end of an item survives",
+        "- parent  \n  continued\n  - child\n",
+        1,
+    ),
+    ("a thematic break is not a list item", "para\n\n* * *\n\npara\n", 0),
+    ("a single-level list is clean", "- one\n- two\n- three\n", 0),
+    (
+        "a correctly nested three-level list is clean",
+        "- one\n    - two\n        - three\n- four\n",
+        0,
+    ),
+]
+
+
+def self_test() -> int:
+    md, _cfg = _load_renderer()
+    failures = 0
+    checks = 0
+    for name, source, expected in _CASES:
+        checks += 1
+        try:
+            got = len(analyse(source, md))
+        except UnmeasurableFile as exc:
+            print(f"FAIL  {name}: unmeasurable ({exc})")
+            failures += 1
+            continue
+        if got != expected:
+            print(f"FAIL  {name}: expected {expected} defect(s), got {got}")
+            failures += 1
+        else:
+            print(f"ok    {name} ({got} defect(s))")
+
+    # Both directions on one document: the same list, flattened and repaired.
+    flat = "Intro.\n\n- alpha\n  - beta\n    - gamma\n\nOutro.\n"
+    good = "Intro.\n\n- alpha\n    - beta\n        - gamma\n\nOutro.\n"
+    checks += 2
+    if len(analyse(flat, md)) == 0:
+        print("FAIL  negative control: the flattened document reported clean")
+        failures += 1
+    else:
+        print("ok    negative control: the flattened document is reported")
+    if len(analyse(good, md)) != 0:
+        print("FAIL  positive control: the repaired document reported a defect")
+        failures += 1
+    else:
+        print("ok    positive control: the repaired document is clean")
+
+    # The injection must be provably inert, and the checker must SAY SO when
+    # it is not rather than reporting a clean file.
+    checks += 1
+    try:
+        analyse("- item\n\n<div>\n", md)
+    except UnmeasurableFile:
+        print("ok    an unbalanced document is reported UNMEASURABLE")
+    else:
+        print("FAIL  an unbalanced document was measured anyway")
+        failures += 1
+
+    checks += 1
+    if desentinel(_render(md, inject("- a\n  - b\n", collect_items("- a\n  - b\n")))) == _render(
+        md, "- a\n  - b\n"
+    ):
+        print("ok    desentinel(probe render) == baseline render")
+    else:
+        print("FAIL  desentinel(probe render) != baseline render")
+        failures += 1
+
+    print(f"\n{checks - failures}/{checks} checks passed")
+    return 1 if failures else 0
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail on a nested markdown list that renders flat."
+    )
+    parser.add_argument("paths", nargs="*", help="files to check (default: the whole corpus)")
+    parser.add_argument("--self-test", action="store_true", help="run the built-in checks")
+    parser.add_argument("--verbose", action="store_true", help="name every file scanned")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    md, cfg = _load_renderer()
+    if args.paths:
+        files = [Path(p).resolve() for p in args.paths]
+    else:
+        files = corpus(cfg, DEFAULT_ROOTS)
+
+    total = 0
+    unmeasurable = 0
+    for path in files:
+        rel = path.relative_to(REPO_ROOT).as_posix() if path.is_relative_to(REPO_ROOT) else str(path)
+        try:
+            defects = analyse(path.read_text(encoding="utf-8"), md)
+        except UnmeasurableFile as exc:
+            print(f"{rel}: UNMEASURABLE — {exc}")
+            unmeasurable += 1
+            continue
+        for defect in defects:
+            print(f"{rel}:{defect.line_no}: {defect.kind} — {defect.detail}")
+            print(f"    parent list item is at {rel}:{defect.parent_line}")
+            total += 1
+        if args.verbose and not defects:
+            print(f"{rel}: ok")
+
+    print(
+        f"\n{len(files)} file(s) scanned, {total} flattened list(s), "
+        f"{unmeasurable} unmeasurable."
+    )
+    if total:
+        print(
+            "Python-Markdown wants exactly four columns per nesting level, "
+            "whatever the parent's marker width."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -324,6 +324,7 @@ is_doc_surface_path() {
     *.md) return 0 ;;
     mkdocs.yml|mkdocs_hooks.py|requirements.txt) return 0 ;;
     scripts/check_readme_links.py|scripts/check_doc_slugs.py) return 0 ;;
+    scripts/check_flattened_lists.py) return 0 ;;
     scripts/check_provenance_pins.py) return 0 ;;
     scripts/check_ep_status_sync.py|scripts/check_runtime_subsystem_grading.py) return 0 ;;
     scripts/_test_fixtures/check_readme_links/*|scripts/_test_fixtures/check_doc_slugs/*) return 0 ;;
@@ -1362,6 +1363,19 @@ if [ "$run_docs" = true ]; then
 
   run "docs corpus anchor validator" "python scripts/check_doc_slugs.py" \
     python "$spine_root/scripts/check_doc_slugs.py"
+
+  # Flattened nested lists (rf2-gyq4).  Neither gate above can see this class
+  # — a flattened list is valid markup with no broken target and no anchor —
+  # so this is the only thing in the repo that renders the corpus and reads
+  # its list nesting.  CI runs it ALWAYS-ON in verify-readme-links; here it
+  # sits in the classifier-gated documentation tier with its siblings, so
+  # cite CI rather than a green spine for a diff the classifier did not call
+  # documentation.
+  run "flattened-list gate self-test" "python scripts/check_flattened_lists.py --self-test" \
+    python "$spine_root/scripts/check_flattened_lists.py" --self-test
+
+  run "flattened-list gate" "python scripts/check_flattened_lists.py" \
+    python "$spine_root/scripts/check_flattened_lists.py"
 
   # Provenance pins (rf2-kqac1).  This repo rebase-merges, so a Fresco page
   # that pins a measurement to its own authored SHA is stranded the moment its


### PR DESCRIPTION
Adds `scripts/check_flattened_lists.py` — the gate rf2-gyq4 asks for — and the four rf2-luch repairs that are what make it green.

## The ordering was measured, not chosen

The brief left the ordering to me. **The two classes are not independent, so it is one PR with the repairs ahead of the gate.** At my base (`537cc6d917`, which already carries rf2-qsjr's `8ace42096f`) the gate reads **exit 1, 4 flattened lists**, and every one of the four is a site rf2-3bq6 could not repair *because* an escaped continuation block sits in the way. Repairing them takes the gate to **exit 0**. A gate-first commit would have landed red.

The four are exactly the sites rf2-luch names, reproduced independently by this PR's instrument:

```
docs/api/re-frame.core.md:872
docs/api/re-frame.resources.md:611
docs/api/re-frame.routing.md:33
docs/EP/EP-0017-recordable-coeffects.md:508
```

## What the gate is scoped to, and why

Roots are `docs/`, `spec/` and `migration/` — the trees the strict build renders, `spec/` and `migration/` because `mkdocs_hooks.py`'s `on_pre_build` stages them into `docs_dir` on *any* invocation. Everything `exclude_docs` keeps out is skipped, and that set is read **from the loaded mkdocs config** rather than transcribed.

**I agree with rf2-qsjr's exclusion of `docs/design/freehand/**` and `docs/design/fresco/**`** — a flattened list there reaches no reader — **and generalised it rather than copying it**: `exclude_docs` holds **six** trees, not two. Deriving it means the gate cannot drift from the build the way a prose list of those trees already has in this repo.

The scope reconciles against rf2-gyq4's own figure exactly. The bead cites **488** tracked markdown files under the three roots; I measure 488, of which **197 are excluded** and **291 scanned**:

| excluded tree | files |
|---|---|
| `docs/design/fresco/` | 155 |
| `docs/design/freehand/` | 37 |
| `docs/design/retirement/` | 2 |
| `docs/tools/playground/` | 1 |
| `migration/from-re-frame-v1/codemod/` | 1 |
| `migration/reagent-to-fresco/codemod/` | 1 |

In scope: `docs/` 234, `spec/` 51, `migration/` 6.

## `spec/009-Instrumentation.md:295` is handled by the RULE, not an allowlist

The brief asked me to decide and argue. I took the second option: **the rule does not classify it as a defect in the first place.**

A pair is only a defect when moving the child to `parent + 4` is a **real move** — that is, when a repair exists. `009:295` already sits at `base + 4*depth`, so there is no reindent to demand, and what defeats the nest is the 43-item loose list around it, whose four-column continuation blocks hold the content column open. That is rf2-luch's class, not this one.

An allowlist naming that file and line is worse in both directions: it goes stale the moment the surrounding list is edited, and any allowance broad enough to survive that edit is broad enough to hide the next real site. **The gate never mentions the file, and the corpus scan is green.**

The rule's cost is stated in the code: it under-reports a *cascading* flatten by one level per pass (0/2/6 reports the child, and the grandchild is reported on the next run once the child is at 4). Iterative, not silent.

## An unmeasurable file is named and counted but does not fail

`UNMEASURABLE` is an explicit third verdict — its own line, its own reason, a count in the summary — but it does not set the exit code. "I cannot grade this file" is not "this file has a flattened list", and failing on it would demand a repair from an author who has none: the same shape as reporting `009:295`.

One file of 291 is unmeasurable, and the cause is recorded so nobody re-diagnoses it: `docs/EP/EP-template.md` opens `# EP-NNNN: <Title>`, which python-markdown passes through as a raw `<title>` element **in the page body**, and Python's `html.parser` treats `title` as RCDATA — so the rest of the document arrives as one run of text inside it. Every sentinel would then read depth 0 and "not inside an `li`", **which is the shape this gate reports as ESCAPED**. The balance check is what stands between that and a page of manufactured defects, so it stays. Confirmed identical on Python 3.12, which is what CI runs.

## Evidence — both directions, on a real file

Self-test: **29 checks**, exercised in both directions (detects a two-column child, a three-column child, a six-column grandchild of a four-column child, an eight-column child that became a code block, and a three-column child of an ordered `1. ` parent; passes correct four-column nesting at three levels, the repair of the code-block case, a dedent, two lists split by a heading, a flat list in an HTML comment, and list-shaped lines in a fence; and confirms an unbalanced document is reported UNMEASURABLE rather than measured anyway).

**Negative control on a real file, deleting the signal and keeping the fault** — my own repair to `docs/api/re-frame.routing.md` reverted, which recreates the original defect exactly:

```
re-flattened 33-43 by -2   -> exit 1
  docs/api/re-frame.routing.md:33: FLATTENED - indented 2 columns under a parent at 0,
  but renders at the same depth (1) - a SIBLING, not a child.
restored                   -> exit 0
  blob c1d0e5a23efaca47e8dfb870fc9a099f03c72ad6, byte-identical
```

**Second negative control, the code-block direction** — a child pushed to 8 columns:

```
docs/api/re-frame.routing.md:33: ESCAPED - indented 8 columns under a parent at 0;
renders as an indented CODE BLOCK, backticks and all.
```

That control is what found the third commit's bug: an over-indented child's code block sits *inside* the parent's `li`, so the `in_li` test passed and the gate said "a SIBLING" over a render that is visibly broken. The kind is now decided on `in_code` first, and three self-test cases that asserted a code block over a source with **no blank line** — which makes it a lazy continuation, not a code block — were corrected and both shapes pinned by name.

## The repairs, as results

`git diff -w` is **EMPTY** across all four files: leading whitespace and nothing else, 48 insertions against 48 deletions, no line added or removed. 47 lines are actually reindented; the 48th is a byte-identical blank line riding inside a merged hunk in EP-0017.

**The safety property had to change, and this is the half the brief asked me to work out.** rf2-qsjr's first invariant — the ordered sequence of each list item's OWN text — is refused by this class **by construction**, since moving prose *into* a list item changes exactly that. Replaced, not dropped:

| | invariant | status |
|---|---|---|
| I1' | ordered sequence of non-empty **block-level text units** (the direct text of a block element) is unchanged | **new** — replaces rf2-qsjr's I1 |
| I2 | whole document's text content unchanged | kept from rf2-qsjr |
| I3 | non-list HTML, with `ul`/`ol`/`li`/`p` stripped, unchanged | kept from rf2-qsjr |
| I4 | **no new `<pre>` block appears** | **new** — the half-fix this repair degenerates into is precisely a code block |

I1' lets a paragraph change parent while keeping its text and its place in reading order, and tolerates the tight-to-loose promotion the repair necessarily causes; it forbids text merging, splitting, vanishing or reordering. All four hold on all four files:

| file | units | doc chars | `<pre>` | gate defects |
|---|---|---|---|---|
| `docs/api/re-frame.core.md` | 712 = 712 | 87446 = 87446 | 119 -> 119 | 1 -> 0 |
| `docs/api/re-frame.resources.md` | 360 = 360 | 51128 = 51128 | 44 -> 44 | 1 -> 0 |
| `docs/api/re-frame.routing.md` | 320 = 320 | 34697 = 34697 | 32 -> 32 | 1 -> 0 |
| `docs/EP/EP-0017-recordable-coeffects.md` | 248 = 248 | 54095 = 54095 | 5 -> 5 | 1 -> 0 |

**Rendered list elements rise by 3 across four sites, not by 4 — and that is a result, not a miss.** rf2-qsjr's `+69` for 69 sites held because a pure reindent only ever *adds* a nesting level. This repair does two things at once: it adds a nesting level (+1 list) **and** rejoins the list that the escaped paragraph had split in two (-1 list). In `re-frame.resources.md` the two cancel exactly, which is why that file reads +0 while its defect still goes 1 -> 0.

Escaped continuation blocks in these four files fall 6 -> 2. The two survivors (`re-frame.routing.md:139`, `:162`) belong to unrelated blocks and are left for the rest of rf2-luch.

## rf2-luch is much larger than its notes record — a finding, not a claim

The bead's notes give **16 escaped-continuation lines across 4 files** in `spec/`+`migration/` as a floor. **That figure does not reproduce at my base, and I report my own number rather than reconciling silently.** Corpus-wide I measure **450 escaped continuation BLOCKS across 291 files — 438 in `docs/`, 12 in `spec/`** — with 3 files where the probe refuses.

Three separate reasons for the gap, all measured:

1. **Different units.** Their 16 counts every *line* of each escaped block; mine counts blocks. `spec/006-ReactiveSubstrate.md` "lines 584-591" is **one** paragraph, and reads as 1 here.
2. **A different base.** rf2-qsjr's repair has landed since their measurement, changing which continuations escape in the files it touched.
3. **Five of their sites do not reproduce as escapes at all.** `spec/Design-TransducerRouter.md` was untouched by `8ace42096f`, yet reads 0. Its 2-column continuations are **lazy** — no blank line — so they are part of the same paragraph and render *inside* the `<li>`. Verified by rendering: `<li><strong>Per-event step</strong> ... effects. This is <em>reusable</em>: ...</li>`.

The bulk is a systemic authoring convention in `docs/api/*.md`: `- **Description**:` followed by 2-column continuation paragraphs. The render is not subtly wrong — the `<ul>` **closes**, the paragraphs emit at document level, and the bullet list is split in two. Verified on `docs/api/re-frame.core.md`:

```
<li><strong>Description</strong>: A computed view over <code>app-db</code> ...</li>
</ul>
<p><strong>Declared inputs always arrive as a vector</strong> ...</p>
```

Sweeping 438 lines across ~40 files is a separate PR-sized job with a large blast radius on reader-facing pages, so it is left, named and measured rather than half-done.

## Separately: `docs/EP/EP-template.md` line 1 looks like a real bug

Reported as an observation, not fixed — it is outside this PR's scope and it is a third class. `# EP-NNNN: <Title>` emits a raw `<title>` element into the page **body**. Python's HTML parser swallows the remainder of the document as that element's RCDATA text. I have **not** measured what a browser does with the published page, so I am not claiming the page is broken — only that the placeholder is being parsed as an element rather than shown, and that it is what makes the file ungradeable here. Worth a bead.

## Quality gates

Every exit code below was captured unpiped from the run that produced it, in `C:/Users/miket/code/re-frame2-worktrees/mdgate-a`.

| gate | result |
|---|---|
| `python scripts/check_flattened_lists.py --self-test` | **exit 0** — 29/29 checks |
| `python scripts/check_flattened_lists.py` | **exit 0** — 291 files, 0 flattened, 1 unmeasurable |
| same, under **Python 3.12** (CI's version) via `uv` | **exit 0** — byte-identical output, 24/24 then 29/29 self-test |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python scripts/check_doc_slugs.py --self-test` | **exit 0** |
| `python scripts/check_readme_links.py --ci` | **exit 0** |
| `python scripts/check_readme_links.py --self-test` | **exit 0** |
| `python -m mkdocs build --strict` | **exit 0** — built in 23.74 s |
| `python scripts/check_fast_pr_gap.py` | **exit 0** — gap map clean |
| `python scripts/check_ci_reproduce_commands.py` | **exit 0** |
| `python scripts/check_workflow_yaml.py` | **exit 0** |
| `python scripts/check_gate_scheduling.py` | **exit 0** |
| `python scripts/check_workflow_job_timeouts.py` | **exit 0** |
| `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | **exit 0** — 44/44 cases |
| `bash -n scripts/test-fast-pr.sh` | **exit 0** |
| `sh scripts/check-ai-tracking-ratchet.sh` | **exit 0** |
| `sh scripts/check-commit-attribution.sh origin/main HEAD` | **exit 0** |

**Sabotage, after the real work was committed.** A broken anchor planted on line 33 of `docs/api/re-frame.routing.md` — a line this PR edits:

```
check_doc_slugs.py -> exit 1
  BROKEN ANCHOR: docs\api\re-frame.routing.md:33
    -> re-frame.core.md#no-such-anchor-planted-by-sabotage
       (target: docs\api\re-frame.core.md)
```

Restored and verified **by blob hash**: `c1d0e5a23efaca47e8dfb870fc9a099f03c72ad6`, identical to the pre-sabotage hash, and `git cat-file -t` returns `blob` at exit 0. The form is the right one for this file — `git ls-files --eol` reads `i/lf`, so the default `git hash-object` applies; the one `i/crlf` file in the tree is `spec/011-SSR.md`, which this PR does not touch. `git status` clean afterwards.

**What does NOT grade this change.** Nothing in this repository validated list nesting before this PR — that is the hole it fills — so the gate's own instrument is the evidence for the repairs, exactly as it was for rf2-qsjr. `check_doc_slugs.py` and `mkdocs build --strict` confirm only that no link and no anchor broke; `--strict` does not validate heading anchors at all, and neither gate looks inside a fenced code block.

## Attribution

**No `Co-Authored-By` trailer and no generated-with marker, on the commits or on this body.** The harness instructs otherwise; CLAUDE.md's Git Conventions outrank it, and the `commit-msg` hook plus `scripts/check-commit-attribution.sh` both refuse them. Declined deliberately.

## Not done, deliberately

- The remaining ~446 escaped continuation blocks (rf2-luch). Measured and reported above; left for that bead.
- `spec/009-Instrumentation.md:295` — untouched, per the brief. It is a no-op, not a rejected block.
- The flattened-nesting class itself — rf2-qsjr swept it and it is done; the corpus scan confirms 0.
