### PR TITLE
docs(xray): the panel mount surface carries two opts keys, not one (rf2-s2g7)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1797,8 +1797,10 @@ a master `mount-shell!` for the full 4-layer chrome. This per-panel
 surface is **internal-but-stable**, NOT a v1.0 host-facing embed
 contract: the 4-layer shell + the test suite depend on it and hosts
 MAY use it, but it carries no host-facing-contract guarantee (the
-only opt is `:frame`) — the v1.0 host-facing embed contract is the
-**full-shell** embed per
+opts vocabulary is two keys wide and one of them is a single
+panel's: `:frame` on every mount fn, defaulting to `:rf/xray`, and
+`:instance-id` on `mount-app-db-diff!` alone, per rf2-2n8q) — the
+v1.0 host-facing embed contract is the **full-shell** embed per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
 §Full-shell embed contract. (rf2-jw2ny — one honest status across
 `panels.cljs`, `008`, and `API.md`.)

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -546,7 +546,8 @@ that needs it, not in a central shim layer.
   `mount-<panel>!` aggregator surface is documented at
   [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract for
   internal use (shell composition, tests, future tools); it carries
-  one `opts` key — `:frame` — and is not a host-facing embed contract.
+  `:frame` universally and `:instance-id` on `mount-app-db-diff!`
+  alone (rf2-2n8q), and is not a host-facing embed contract.
 - **No two-way binding.** Beyond the `configure!` slots and the
   one-way **focus command** (§Host-facing focus API — the host pushes
   a focus *intent*, not arbitrary state, and Xray owns what it means),

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -406,7 +406,9 @@ mount Xray embed the **full shell** per
 embed contract. The `mount-<panel>!` aggregator surface enumerated in
 [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract is
 internal-but-stable (used by shell composition and tests); it accepts
-one `opts` key — `:frame` — defaulting to `:rf/xray`.
+`:frame` — defaulting to `:rf/xray` — on every mount fn, plus
+`:instance-id` on `mount-app-db-diff!` alone (rf2-2n8q), which names
+one of two standalone app-db mounts sharing a frame.
 
 ### Static-mode Panel reg-views
 


### PR DESCRIPTION
## What

rf2-2n8q (#9613, merged at `8e8f39bdd5`) gave `mount-app-db-diff!` a second
`opts` key, `:instance-id`, so two standalone app-db mounts sharing one
`:frame` can be told apart. Three normative statements in `tools/xray/spec/`
say the aggregator surface carries exactly **one** `opts` key. They became
false the moment #9613 landed. This corrects them.

| File | Line (pre-edit) | Was |
|---|---|---|
| `tools/xray/spec/007-UX-IA.md` | 1800 | "…no host-facing-contract guarantee (the only opt is `:frame`)" |
| `tools/xray/spec/008-Embedding-Contract.md` | 549 | "…it carries one `opts` key — `:frame` — and is not a host-facing embed contract." |
| `tools/xray/spec/API.md` | 409 | "…it accepts one `opts` key — `:frame` — defaulting to `:rf/xray`." |

All three now say the same true thing, each in its own document's register:
**`:frame` on every mount fn, defaulting to `:rf/xray`, plus `:instance-id`
on `mount-app-db-diff!` alone.**

These are rf2-jw2ny's deliberately coordinated four-way "one honest status"
set. The fourth member — `panels.cljs`'s own ns docstring — was inside
#9613's slice and is **already correct on trunk**; it was checked and left
untouched. Its claim that the status "matches … `008-Embedding-Contract.md`,
`tools/xray/spec/API.md`, and `007-UX-IA.md`" is true again with this PR.

The correction deliberately **keeps the count** rather than deleting it. The
narrowness is the point: `render-panel!` does not derive the prop from `opts`
on every panel's behalf, because `[trace/Panel {…}]` is an arity error rather
than an ignored map. "The surface takes any opts" would be false in the other
direction.

## Verified against the source, not by phrase-matching

The statements are phrased three different ways; a phrase grep for the shape
returns zero. They were located by line number and re-derived at this base.
The claim itself was checked against `tools/xray/src/day8/re_frame2_xray/panels.cljs`:

- `render-panel!` reads `(get opts :frame :rf/xray)` and no other opt — every
  one of the 13 `mount-<panel>!` fns goes through it.
- Line 315 is the sole read of `:instance-id`, in `mount-app-db-diff!`.
- `mount-shell!` reads `:frame` + `:mode`, but it is the full-shell master
  entry, outside the per-panel surface all three sentences scope themselves
  to ("This **per-panel** surface", "The `mount-<panel>!` aggregator surface").

## Gate coverage — and what it does NOT cover

`scripts/check_doc_slugs.py` runs green (exit 0, unpiped). **Report that green
as coverage of LINK TARGETS AND HEADING ANCHORS only** — it exits 0 on prose
that contradicts the code, which is exactly why this needed a bead rather than
a CI failure. Its liveness on these files was confirmed in both directions: a
planted broken anchor in `tools/xray/spec/API.md` took it to exit 1 naming file,
line and target; restored, exit 0.

`mkdocs build --strict` is **not** nominated and was not run: `docs_dir` is
`docs`, `tools/` sits outside it and was never a candidate for `exclude_docs`,
so the strict build does not reach this tree at all.

### Checked by hand, since nothing validates prose, tables, rendering or nav

- **Anchors and links**: no added or removed line contains link markup
  (`](`), a heading, or a `|`. Zero headings touched, so no anchor moved.
- **Tables**: no table row touched — column counts cannot have changed.
- **Fences**: all three edits are in prose, outside every fenced block
  (even fence-marker count before each edit point; all files balanced). This
  matters because both doc gates strip fences before reading a link, so a
  green inside one would have inspected nothing.
- **Wrap**: every edited line sits within each file's existing ~70-column
  wrap (widths 60–68); the 007 paragraph was reflowed by one line so the
  edit leaves no short orphan.
- **Encoding**: em-dash and `§` intact, zero U+FFFD, and CR == CRLF with
  zero bare CR in all three files (counted with Python over the bytes).

## Reported, not swept — a related site left alone

`tools/xray/spec/007-UX-IA.md:1939` (§The mount-fn contract, "Every
`mount-<panel>!` fn:") step 3 says the fn "Wraps the panel's view in
`[rf/frame-provider {:frame :rf/xray} [Panel]]`". After #9613 a *named*
`mount-app-db-diff!` mounts `[Panel {:instance-id …}]`, so that universal is
now narrower than the code. It is **not** an opts-count statement and so not a
member of this coordinated set, and it is not contradicted — `[Panel]` is what
`render-panel!` builds in the nil-props case, which is every call site in the
tree today. Flagging for a mayor call rather than widening this PR's scope.

Two nearby statements were checked and are **still true**, needing no change:
`008-Embedding-Contract.md:60` ("the spine carries no host-facing props beyond
the shared `:frame` opt") is scoped to `mount-event-spine!`, which reads only
`:frame`; and its cross-reference to §Frame-provider opt still resolves in
`panels.cljs` (line 136).

## Scope

Prose only, three files, all under `tools/xray/spec/`. No code touched.
`tools/xray/spec/API.md` is **not** the top-level `spec/API.md` and carries
none of its manifest-sidecar coupling, so no hot-zone file is involved.

Per `CLAUDE.md` §Git Conventions, no AI attribution trailers are present in
the commit or in this body; the harness reminder asking for them is outranked.
