### PR TITLE
fix(ci): gate the repo-source walks on essential setup, not cancellation alone (rf2-7lj2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3203,6 +3203,26 @@ jobs:
       - name: Set up Clojure CLI
         run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
 
+      # The ESSENTIAL-SETUP MARKER the seven walks below gate on. It carries
+      # GitHub's default step condition (`success()`) and nothing else, so it
+      # reaches `success` only when the checkout, the JDK install and the
+      # Clojure CLI install ALL succeeded — a step skipped by a failure ahead of
+      # it reports `skipped`, not `success`, so one id covers all three. The
+      # walks name `steps.setup.outcome` rather than `.conclusion` so that a
+      # `continue-on-error:` could not launder a failure into a success.
+      # `_changed-surfaces.test.cjs` pins this step: delete it and
+      # `steps.setup.outcome` reads null, which SKIPS all seven walks on a
+      # GREEN job. A separate step rather than an `id:` on the installer step
+      # above, whose exact two-line shape is pinned across ~50 call sites by
+      # rf2-e7ja9.
+      #
+      # It sits ABOVE the Maven cache deliberately: a cache miss or a
+      # cache-service error is not a reason to skip the walks, only to run them
+      # slower.
+      - name: Essential setup complete
+        id: setup
+        run: echo "checkout, JDK 21 and the Clojure CLI all installed"
+
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -3218,48 +3238,63 @@ jobs:
             ${{ runner.os }}-clj-
 
       # The seven walks below are INDEPENDENT — they share only the JDK and the
-      # Maven cache — so each carries `if: ${{ !cancelled() }}` and runs even
-      # when an earlier walk has failed. Without it, GitHub's default step
-      # condition (`success()`) makes the first failing walk SKIP the six behind
-      # it. That does not admit a bad merge — the job reds either way — but it
-      # is badly misread: "the lane is red because of step 1" hides that the six
-      # behind it were never EVALUATED, so the green after the fix is the first
-      # time they have run at all and looks identical to one that was passing
-      # all along. That is the incident behind rf2-ep7u. It bites hardest on a
-      # prose-only PR, where `implementation_jvm` is false, `jvm-core` never
-      # runs, and this lane is the only place those walks execute anywhere.
+      # Maven cache — so each carries
+      #     if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+      # and runs even when an earlier WALK has failed. Without a condition,
+      # GitHub's default step condition (`success()`) makes the first failing
+      # walk SKIP the six behind it. That does not admit a bad merge — the job
+      # reds either way — but it is badly misread: "the lane is red because of
+      # step 1" hides that the six behind it were never EVALUATED, so the green
+      # after the fix is the first time they have run at all and looks identical
+      # to one that was passing all along. That is the incident behind rf2-ep7u.
+      # It bites hardest on a prose-only PR, where `implementation_jvm` is false,
+      # `jvm-core` never runs, and this lane is the only place those walks
+      # execute anywhere.
+      #
+      # BOTH CONJUNCTS ARE LOAD-BEARING, and the condition guarantees exactly
+      # this much: a walk runs when essential setup succeeded and the run has
+      # not been cancelled, whatever the six walks beside it did.
       #
       # `!cancelled()` rather than `always()`, so a cancelled run stops burning
-      # the lane instead of grinding through seven more walks. The three SETUP
-      # steps above are deliberately NOT guarded: a walk whose JDK never
-      # installed fails for a reason that has nothing to do with the walk, and
-      # seven of those is a worse log than one honest one. (rf2-gf3y)
+      # the lane instead of grinding through seven more walks.
+      #
+      # `steps.setup.outcome == 'success'` is what keeps a failed PREREQUISITE
+      # from selecting all seven. A status-check function REPLACES the implicit
+      # `success()` rather than adding to it
+      # (https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions),
+      # and `cancelled()` reports cancellation, never a preceding failure — so
+      # `!cancelled()` ALONE runs the walks after a failed checkout or a failed
+      # Clojure CLI install, turning one honest setup failure into seven
+      # missing-tool ones. Leaving the setup steps at their own default
+      # `success()` does not restore that prerequisite on the steps behind them;
+      # only naming it does. That was the defect in rf2-gf3y's repair, caught by
+      # the merged-PR audit and fixed here (rf2-7lj2).
       - name: Absence-repair floor lint for :rf/default (implementation/** + tools/**)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.no-rf-default-floor-lint-test
 
       - name: Egress-chokepoint conformance (every implementation/ src root)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.egress-chokepoint-conformance-test
 
       - name: Error-catalogue channel conformance (every implementation/ src root)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.error-catalogue-channel-conformance-test
 
       - name: Warn-once-clear governance (file-seq over implementation/)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.warn-once-clear-governance-test
 
       - name: Production-gate naming drift (every artefact's test/ tree)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.prod-gate-naming-drift-test
 
       - name: Late-bind directory drift (every implementation/ src root)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.late-bind-drift-test
 
       - name: Observation render-law drift (every tracked prose file, git ls-files)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: clojure -M:test -n re-frame.observation-render-law-drift-test
 
   cljs:

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -507,15 +507,29 @@ test('the unconditional walk lane runs every namespace whose false arm it excuse
       'exists to avoid rather than relocate',
   );
 
-  // Step conditions are allowed for exactly ONE purpose (rf2-gf3y). The seven
-  // walks are independent of one another, so each carries `if: ${{ !cancelled() }}`
-  // and runs even when an earlier walk has failed. Without it GitHub's default
-  // step condition (`success()`) makes the first failing walk SKIP the six behind
-  // it. That never admitted a bad merge — the job reds either way — but it hid
-  // that the six were never EVALUATED, so the green after the fix was the first
-  // time they had run at all and looked identical to one that had always passed.
-  // Anything OTHER than that exact guard at step level is the same read-set model
-  // wearing a different indentation, so it is refused here.
+  // Step conditions are allowed for exactly ONE spelling (rf2-gf3y, rf2-7lj2):
+  //
+  //     if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+  //
+  // The seven walks are independent OF ONE ANOTHER, so each runs even when an
+  // earlier WALK has failed. Without a condition, GitHub's default step
+  // condition (`success()`) makes the first failing walk SKIP the six behind it.
+  // That never admitted a bad merge — the job reds either way — but it hid that
+  // the six were never EVALUATED, so the green after the fix was the first time
+  // they had run at all and looked identical to one that had always passed.
+  //
+  // The `steps.setup` conjunct is NOT decoration, and this pin is what stops it
+  // being trimmed back to a bare `!cancelled()`: a status-check function
+  // REPLACES the implicit `success()` rather than adding to it, and
+  // `cancelled()` reports cancellation and never a preceding failure — so
+  // `!cancelled()` ALONE selects all seven walks after a failed checkout or a
+  // failed Clojure CLI install, turning one honest setup failure into seven
+  // missing-tool ones. That was the defect in rf2-gf3y's own repair, and
+  // leaving the setup steps at their default `success()` does not restore the
+  // prerequisite on the steps behind them.
+  //
+  // Anything OTHER than that exact guard at step level is the read-set model of
+  // the job-level `if:` above wearing a different indentation, so it is refused.
   //
   // `\r` is stripped before the comparison: `jobBlock` preserves CRLF, and this
   // file is checked out CRLF on Windows, so a trailing carriage return would sit
@@ -526,18 +540,38 @@ test('the unconditional walk lane runs every namespace whose false arm it excuse
   for (const cond of stepConditions) {
     assert.match(
       cond,
-      /^ {8}if: \$\{\{ !cancelled\(\) \}\}$/,
+      /^ {8}if: \$\{\{ !cancelled\(\) && steps\.setup\.outcome == 'success' \}\}$/,
       `"${cond.trim()}" is a step condition other than the permitted ` +
-        '`!cancelled()` failure-independence guard',
+        'setup-gated failure-independence guard',
     );
   }
   assert.equal(
     stepConditions.length,
     REPO_SOURCE_WALK_NAMESPACES.length,
-    'every walk step must carry `if: ${{ !cancelled() }}`, so a failing walk cannot ' +
-      'skip the walks behind it. The setup steps (checkout, JDK, Clojure CLI, ' +
-      'Maven cache) deliberately carry no guard: a walk whose JDK never installed ' +
-      'fails for a reason that is not about the walk',
+    "every walk step must carry `if: ${{ !cancelled() && steps.setup.outcome == " +
+      "'success' }}`, so a failing walk cannot skip the walks behind it while a " +
+      'failed prerequisite still can. The setup steps deliberately carry no ' +
+      'guard of their own: that is what makes the `setup` marker transitive',
+  );
+
+  // The guard above names a step id, and a MISSING id fails OPEN — GitHub
+  // evaluates `steps.setup.outcome` to null, `null == 'success'` is false, so
+  // all seven walks SKIP and the job still reports green. Pin the marker.
+  assert.match(
+    block,
+    /^ {6}- name: Essential setup complete\r?\n {8}id: setup\r?\n {8}run:[^\n]*\r?\n/m,
+    'the `setup` marker step must sit after the Clojure CLI install and carry ' +
+      'NO condition of its own. Its default `success()` is what makes it ' +
+      'transitive: it reaches `success` only when the checkout, the JDK and the ' +
+      'Clojure CLI install all succeeded, since a step skipped by a failure ' +
+      'ahead of it reports `skipped`. Delete it and every walk condition reads ' +
+      'null, so all seven SKIP on a green job',
+  );
+  assert.ok(
+    block.indexOf('id: setup') < block.indexOf('        if: ${{ !cancelled()'),
+    'the `setup` marker must be declared BEFORE the walks that gate on it — a ' +
+      'step id reads null until its step has run, so a marker below them skips ' +
+      'all seven on a green job',
   );
   assert.match(
     workflow,


### PR DESCRIPTION
Closes rf2-7lj2 — the merged-PR audit of #9610.

## The defect

`#9610` gave the seven `jvm-repo-source-walks` steps `if: ${{ !cancelled() }}` so
that a failing walk could not skip the six behind it. That part works, and is
kept. But a status-check function **replaces** a step's implicit `success()`
rather than adding to it, and `cancelled()` reports cancellation and never a
preceding failure
([expressions#status-check-functions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions)).

So a failed checkout, JDK install or Clojure CLI install still **selected all
seven walks**, producing seven missing-tool / missing-directory errors where the
comment beside them promised the one honest setup failure. Leaving the setup
steps at their own default `success()` does not restore that prerequisite on the
steps behind them; only naming it does.

## The repair

A single essential-setup marker, gated on by all seven walks:

```yaml
- name: Essential setup complete
  id: setup
  run: echo "checkout, JDK 21 and the Clojure CLI all installed"
```

It carries nothing but GitHub's default step condition, so it reaches `success`
only when the checkout, the JDK install and the Clojure CLI install all
succeeded — a step skipped by a failure ahead of it reports `skipped`, not
`success`, so one id covers all three. Each walk then reads:

```yaml
if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
```

Both requirements hold: a failed prerequisite skips the walks, and a failing
walk still does not skip the six behind it.

Three smaller calls, each recorded in the workflow comment:

- `outcome` rather than `conclusion`, so a `continue-on-error:` could not
  launder a failure into a success.
- The marker sits **above** the Maven cache step. A cache miss or cache-service
  error is not a reason to skip the walks, only to run them slower.
- A separate step rather than an `id:` on the installer step, whose exact
  two-line shape is pinned across ~50 call sites by rf2-e7ja9.

The comment that overstated what the old condition guaranteed is rewritten to
say what the new one actually guarantees. An overstated comment is what let this
survive review the first time.

## The paired test moves in the same commit

`implementation/scripts/_changed-surfaces.test.cjs` permitted **only** the exact
`!cancelled()` spelling, so it would have rejected any prerequisite conjunct.
The two files are a one-toucher pair by construction — the test pins what the
workflow says — so both halves are in one commit. The assertion now pins the new
spelling, plus two things that fail **open** if lost: with the marker step
deleted or moved below the walks, `steps.setup.outcome` evaluates to null,
`null == 'success'` is false, and all seven walks SKIP while the job reports
green.

## Verification — what was run and what it returned

- `node --test implementation/scripts/_changed-surfaces.test.cjs` — **369
  passed**. This is the gate that grades both halves of the diff; it runs in
  CI's `js-harness-self-tests` job (`npm run test:scripts`), which carries no
  surface guard and so runs on every PR.
- Controls both ways. Three deliberate regressions applied to the workflow, each
  red with the intended message, each then reverted:
  - conditions trimmed back to bare `!cancelled()` → *"is a step condition other
    than the permitted setup-gated failure-independence guard"*
  - marker step deleted → *"the `setup` marker step must sit after the Clojure
    CLI install…"*
  - marker moved below the walks → *"the `setup` marker must be declared BEFORE
    the walks that gate on it…"*
- The eight other JS harness tests that read `.github/workflows/` pass.
- `python scripts/check_workflow_yaml.py` — `PASS workflow YAML well-formed
  (11 files under .github/workflows)`.
- The parsed job structure was dumped and checked: no job-level `if:`, marker
  after the Clojure CLI step and before the cache step, all seven walks carrying
  the new condition and nothing else carrying one.

**Not run, and not claimed:** a real setup failure was not injected into CI. The
setup-failure behaviour is reasoned from GitHub's documented status-check
function semantics, cited above, exactly as the bead's own counterexample was.
