### PR TITLE
docs(test): the walk steps are guarded now, so the crash no longer skips (rf2-s6nh)

### DIFF
--- a/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
+++ b/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
@@ -104,7 +104,9 @@
 ;; none. It is DETERMINISTIC in span length; what varies between runs is the
 ;; stack, which is why re-running "fixed" it and why re-running is not a remedy.
 ;; This lint's step also runs FIRST in test.yml's `jvm-repo-source-walks` job,
-;; whose steps carry no `if:`, so the crash SKIPS the six walks behind it.
+;; whose seven walks are each guarded to run even after an earlier one fails
+;; (rf2-gf3y), so the crash reds THIS step alone while the six behind it still
+;; run — which makes it easier to read, not harder.
 ;;
 ;; THE REPAIR IS THE SAME LANGUAGE, not merely a faster one. The two branches
 ;; are DISJOINT — `[^\"\\]` excludes both the backslash and the quote, `\\.`


### PR DESCRIPTION
## What

One comment sentence in `implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj`.

The `StackOverflowError` paragraph (the one explaining why `string-literal-re` is possessive on purpose) ended with:

> This lint's step also runs FIRST in test.yml's `jvm-repo-source-walks` job, whose steps carry no `if:`, so the crash SKIPS the six walks behind it.

That was true when written. PR #9610 (rf2-gf3y) gave all seven walk steps a step-level `if:` precisely so a failing walk cannot skip the six behind it, so the sentence now states the OPPOSITE of the workflow's behaviour.

## The repair

The paragraph is an argument about how this crash *presents* — it reads like a genuine floor finding on a PR that introduced none. The old sentence was the final aggravation in that argument; the truth is now a mitigation, so the repair stays inside the argument rather than bolting on a note:

> whose seven walks are each guarded to run even after an earlier one fails (rf2-gf3y), so the crash reds THIS step alone while the six behind it still run — which makes it easier to read, not harder.

**It deliberately does not quote the `if:` expression.** PR #9618 is in flight refining that spelling, and a comment that quotes a condition verbatim is a comment that goes stale the next time anyone touches it — which is precisely the defect being repaired. This describes what is guaranteed and lets the workflow own how it spells it.

## Scope

**One file.** `.github/workflows/test.yml` and `implementation/scripts/_changed-surfaces.test.cjs` are a hot-zone pair currently held by PR #9618 and are deliberately untouched — that is why this is its own bead rather than part of rf2-7lj2.

## Verification

**No gate covers this prose, so it was verified by READING** — I am not nominating a gate that inspected nothing I changed. The claim was checked against `.github/workflows/test.yml` at this branch's base: all seven walk steps carry a step-level `if:`, and this lint's step is the first of the seven.

The file still compiles and its own test passes. Run from `implementation/core`, reading the runner's own exit status rather than a pipeline's:

```
clojure -M:test -n re-frame.no-rf-default-floor-lint-test
Ran 3 tests containing 9 assertions.
0 failures, 0 errors.
RUNNER_EXIT=0
```

Diff is 3 insertions / 1 deletion in one file — no line-ending churn.

## Other stale claims in the file

None found. The only other CI references are generic ("runs in CI", "shift detection left into a CI lint") and still accurate, and the docstring's cited test-helper example is still live (`tools/xray/test/day8/re_frame2_xray/test_helpers/sub_reactivity.cljs:232` carries the `:or {frame :rf/default}` it describes).

Closes rf2-s6nh.
