### PR TITLE
docs(api): move the escaped continuation blocks back into their list items (rf2-6ml6)

### DIFF
--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -96,11 +96,11 @@ Three things hold for that head, and they are the point of using the registry ra
   ```
 - **Description**: Subscribe inside a UIx component. This is the hook-shaped equivalent of `subscribe`, and it carries the same name `re-frame.fresco.native` publishes for a React island under Fresco: one value-hook name for every React function component. The verb `subscribe` returns a subscription; this noun returns its value.
 
-  Returns the current sub value and re-renders the calling component when the value changes.
+    Returns the current sub value and re-renders the calling component when the value changes.
 
-  - The 1-arg form resolves the frame from **React context only**: the surrounding `frame-provider` (SCOPE) / `frame-root` (ENSURE), and nothing else. It raises `:rf.error/no-frame-context` when there is no boundary above it (there is no `:rf/default` floor).
-  - A `with-frame` / `bind-fn` dynamic scope around a synchronous render does **not** reach a hook — not under `act()`, not under `flushSync`, not under a server render. That is the one rule the whole React hook family follows, `re-frame.fresco.native`'s hooks included, and the reason is that a hook runs when React renders, by which time the block's extent has unwound: the same component tree must resolve the same frame however the flush was driven. To pin a hook to a frame explicitly, wrap it in a `frame-provider` — or pass `{:frame …}` on this read.
-  - The opts form pins ONE read to an explicit frame, bypassing the chain — the same `{:frame target}` opts map `subscribe` takes, where `target` is a frame-id keyword or a live frame value. `:frame` is **required** there: the opts form is the explicit read and the 1-arity is the ambient one. Where a whole subtree shares a frame, scope it with `frame-provider {:frame target}` and read with the 1-arity instead.
+    - The 1-arg form resolves the frame from **React context only**: the surrounding `frame-provider` (SCOPE) / `frame-root` (ENSURE), and nothing else. It raises `:rf.error/no-frame-context` when there is no boundary above it (there is no `:rf/default` floor).
+    - A `with-frame` / `bind-fn` dynamic scope around a synchronous render does **not** reach a hook — not under `act()`, not under `flushSync`, not under a server render. That is the one rule the whole React hook family follows, `re-frame.fresco.native`'s hooks included, and the reason is that a hook runs when React renders, by which time the block's extent has unwound: the same component tree must resolve the same frame however the flush was driven. To pin a hook to a frame explicitly, wrap it in a `frame-provider` — or pass `{:frame …}` on this read.
+    - The opts form pins ONE read to an explicit frame, bypassing the chain — the same `{:frame target}` opts map `subscribe` takes, where `target` is a frame-id keyword or a live frame value. `:frame` is **required** there: the opts form is the explicit read and the 1-arity is the ambient one. Where a whole subtree shares a frame, scope it with `frame-provider {:frame target}` and read with the 1-arity instead.
 - **Example**:
   ```clojure
   (defui cart-total []
@@ -117,11 +117,11 @@ Three things hold for that head, and they are the point of using the registry ra
   ```
 - **Description**: Returns the frame ops map for the ambient frame — exactly what `(rf/capture-frame)` returns (the frame-locked ops map), captured in hook position. This is how a UIx component gets hold of `dispatch` (and the other frame-locked ops) without auto-injection: destructure `dispatch` off it and close over that.
 
-  `capture-frame` is *the* hold primitive; `reg-view` injection (Reagent) and `use-frame` (UIx) are its two ergonomic spellings — one primitive, three faces.
+    `capture-frame` is *the* hold primitive; `reg-view` injection (Reagent) and `use-frame` (UIx) are its two ergonomic spellings — one primitive, three faces.
 
-  - Frame resolution matches `use-sub`: the surrounding `frame-provider` / `frame-root` via React context, and nothing else — a `with-frame` dynamic scope around a synchronous render does not reach it. It raises `:rf.error/no-frame-context` when there is no boundary above it. For an explicit frame there is no hook tax: call `(rf/capture-frame frame-id)` directly.
-  - The returned map is reference-stable across re-renders for the same resolved frame *incarnation* (safe in effect deps and child props). A provider swap re-renders the caller and yields a map locked to the new frame — and so does destroying the resolved frame and creating another under the same id, because a frame keyword is an address and the ops bundle is pinned to the incarnation it was captured against.
-  - No options map, no variants — for an explicit frame, call `(rf/capture-frame frame-id)` directly.
+    - Frame resolution matches `use-sub`: the surrounding `frame-provider` / `frame-root` via React context, and nothing else — a `with-frame` dynamic scope around a synchronous render does not reach it. It raises `:rf.error/no-frame-context` when there is no boundary above it. For an explicit frame there is no hook tax: call `(rf/capture-frame frame-id)` directly.
+    - The returned map is reference-stable across re-renders for the same resolved frame *incarnation* (safe in effect deps and child props). A provider swap re-renders the caller and yields a map locked to the new frame — and so does destroying the resolved frame and creating another under the same id, because a frame keyword is an address and the ops bundle is pinned to the incarnation it was captured against.
+    - No options map, no variants — for an explicit frame, call `(rf/capture-frame frame-id)` directly.
 - **Example**:
   ```clojure
   (defui counter-buttons []
@@ -155,7 +155,7 @@ Three things hold for that head, and they are the point of using the registry ra
     - `:rf.error/bad-frame-provider-arg` on a `:frame` that is neither a keyword nor a live frame value
     - `:rf.error/frame-provider-given-id` when given an `:id` (the ENSURE key — use `frame-root`)
 
-  Children ride the idiomatic `$` trailing-args channel. Pass them after the prop map, as for any other UIx component (there is no `:children` prop-map key).
+    Children ride the idiomatic `$` trailing-args channel. Pass them after the prop map, as for any other UIx component (there is no `:children` prop-map key).
 - **Example**:
   ```clojure
   ($ uix-adapter/frame-provider {:frame :session}
@@ -173,7 +173,7 @@ Three things hold for that head, and they are the point of using the registry ra
     - **Commit-owned two-pass**: the create/seed runs in a client `useLayoutEffect` (at commit), not during render — the first render emits no descendant subtree, and children render only after the frame is live. A render React discards before commit creates + seeds nothing (no ghost frame).
     - Re-mounting under the same `:id` (hot reload, React StrictMode dev double-invoke) neither destroys durable state nor re-runs `:initial-events`. A mounted `:id`/opts change raises `:rf.error/frame-root-reconfigured`; a stray `:frame` raises `:rf.error/frame-root-given-frame`.
 
-  Children ride the idiomatic `$` trailing-args channel.
+    Children ride the idiomatic `$` trailing-args channel.
 - **Example**:
   ```clojure
   ;; create the frame on first mount, seed it once via :initial-events,

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -73,11 +73,11 @@ Every entry here registers a named handler into the frame's registrar.
   ```
 - **Description**: A computed view over `app-db` and other subs. A subscription declares its dependencies under **`:inputs`** in the metadata map — the same slot `reg-flow` uses — and there are three input-production modes (see the table below). Omitting `:inputs` is a layer-1 `app-db` reader with no producer; a literal `:inputs` vector is a static producer; an `:inputs` fn computes the inputs from the outer `query-v`.
 
-  **Declared inputs always arrive as a vector** — at zero, one or many, in declaration order. Moving a dependency between the literal and the fn form never changes the body, and adding a second input never turns a scalar argument into a vector. `{:inputs []}` declares no dependencies and delivers `[]`; omitting `:inputs` delivers `app-db` itself.
+    **Declared inputs always arrive as a vector** — at zero, one or many, in declaration order. Moving a dependency between the literal and the fn form never changes the body, and adding a second input never turns a scalar argument into a vector. `{:inputs []}` declares no dependencies and delivers `[]`; omitting `:inputs` delivers `app-db` itself.
 
-  An `:inputs` **producer fn** is a *pure* function from the outer `query-v` to a **vector of query vectors**. It must not call `subscribe`, deref `app-db`, dispatch, or perform IO. It must not return live reactions either — it is not a v1 reaction-returning signal fn. It never runs at registration; the runtime resolves each returned query vector in the *same frame* as the outer subscription, at materialization.
+    An `:inputs` **producer fn** is a *pure* function from the outer `query-v` to a **vector of query vectors**. It must not call `subscribe`, deref `app-db`, dispatch, or perform IO. It must not return live reactions either — it is not a v1 reaction-returning signal fn. It never runs at registration; the runtime resolves each returned query vector in the *same frame* as the outer subscription, at materialization.
 
-  This is the only sub-registration form in v2; `reg-sub-raw` is gone (see the [migration reference](../../migration/from-re-frame-v1/README.md)). Full input grammar and error ids: [Subscriptions concept guide](../core/subscriptions.md).
+    This is the only sub-registration form in v2; `reg-sub-raw` is gone (see the [migration reference](../../migration/from-re-frame-v1/README.md)). Full input grammar and error ids: [Subscriptions concept guide](../core/subscriptions.md).
 
 | Mode | Form | Where the inputs come from |
 |---|---|---|
@@ -367,7 +367,7 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
     - you are writing a **Form-3 component** (`(rf/reg-view* :id (r/create-class {...}))` — the one app-facing reason to touch the starred form);
     - you are writing **consumer-side library code** that registers without imposing a `def`.
 
-  A `reg-view*` body has no auto-injected `dispatch` / `subscribe`. If the view needs frame-bound dispatch, capture a `(rf/capture-frame)` at render and use its ops.
+    A `reg-view*` body has no auto-injected `dispatch` / `subscribe`. If the view needs frame-bound dispatch, capture a `(rf/capture-frame)` at render and use its ops.
 - **Example**:
   ```clojure
   ;; Computed id — the id isn't a literal symbol at the call site.
@@ -513,7 +513,7 @@ The effect map is **closed**, at seven top-level keys: everyday app handlers ret
     - `{:before f}` / `{:after f}` / `{:before f :after g}`;
     - `{:factory f}` for a parameterized family (`f` receives one arg and returns a descriptor; referenced as `[id arg]` — the standard `[:rf.interceptor/path …]` is the canonical factory consumer).
 
-  An optional middle slot carries the standard registration-metadata map (`:doc`, `:schema`, `:tags`, …). Use this for any work not covered by the standard interceptors — analytics, logging, validation, ad-hoc context manipulation. (`->interceptor*` is the framework-internal lowering constructor that turns a descriptor into an executable chain entry; it must not appear directly in a public chain.)
+    An optional middle slot carries the standard registration-metadata map (`:doc`, `:schema`, `:tags`, …). Use this for any work not covered by the standard interceptors — analytics, logging, validation, ad-hoc context manipulation. (`->interceptor*` is the framework-internal lowering constructor that turns a descriptor into an executable chain entry; it must not appear directly in a public chain.)
 - **Example**:
   ```clojure
   (rf/reg-interceptor :log-on-error
@@ -754,26 +754,26 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```
 - **Description**: The installed adapter spec map — the exact value passed to `rf/init!` — or `nil` when no adapter is installed. It carries the adapter contract fns (`:make-state-container`, `:replace-container!`, `:make-derived-value`, …) plus a `:kind` discriminator.
 
-  ONE read, map-shaped. Branch code asks for the discriminator as a KEY: `(:kind (rf/current-adapter))` answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/fresco` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr`, or `nil` for a custom adapter map that picked no canonical kind — nothing is synthesised for it. (`:rf.adapter/ui` and `:rf.adapter/freehand` stay reserved and are never recycled, but the two donor view substrates were removed on 2026-08-16 and nothing produces either value now.)
+    ONE read, map-shaped. Branch code asks for the discriminator as a KEY: `(:kind (rf/current-adapter))` answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/fresco` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr`, or `nil` for a custom adapter map that picked no canonical kind — nothing is synthesised for it. (`:rf.adapter/ui` and `:rf.adapter/freehand` stay reserved and are never recycled, but the two donor view substrates were removed on 2026-08-16 and nothing produces either value now.)
 
-  A PRESENCE check inspects the MAP, never `:kind`: a kind-less adapter is installed and present while `(:kind (rf/current-adapter))` reads `nil`.
+    A PRESENCE check inspects the MAP, never `:kind`: a kind-less adapter is installed and present while `(:kind (rf/current-adapter))` reads `nil`.
 - **Example**:
   ```clojure
   (rf/current-adapter)          ;; => the adapter spec map passed to (rf/init! …), or nil
   (:kind (rf/current-adapter))  ;; => :rf.adapter/reagent
   ```
 - **On Fresco**: `(:kind (rf/current-adapter))` asks *which substrate*, and Fresco is a
-  view layer rather than one — it owns Hiccup interpretation and the render boundary,
-  while the reactive container comes from an adapter the application installs. What
-  Fresco now ships is one of the answers: `re-frame.fresco.substrate` is an optional
-  module of `day8/re-frame2-fresco` declaring `:kind :rf.adapter/fresco`, and the
-  install chapter teaches `(rf/init! substrate/adapter)` as the default, so
-  `(:kind (rf/current-adapter))` normally reads `:rf.adapter/fresco` in a Fresco
-  application. Installing Reagent or UIx under a Fresco tree instead stays supported,
-  and then the kind is that adapter's — either way `current-adapter` itself answers the
-  installed adapter map, and the `:kind` on it names the substrate the app booted on,
-  never the layer its views are authored in. See
-  [Fresco needs a substrate adapter](../core/fresco/00-installation.md#fresco-needs-a-substrate-adapter).
+    view layer rather than one — it owns Hiccup interpretation and the render boundary,
+    while the reactive container comes from an adapter the application installs. What
+    Fresco now ships is one of the answers: `re-frame.fresco.substrate` is an optional
+    module of `day8/re-frame2-fresco` declaring `:kind :rf.adapter/fresco`, and the
+    install chapter teaches `(rf/init! substrate/adapter)` as the default, so
+    `(:kind (rf/current-adapter))` normally reads `:rf.adapter/fresco` in a Fresco
+    application. Installing Reagent or UIx under a Fresco tree instead stays supported,
+    and then the kind is that adapter's — either way `current-adapter` itself answers the
+    installed adapter map, and the `:kind` on it names the substrate the app booted on,
+    never the layer its views are authored in. See
+    [Fresco needs a substrate adapter](../core/fresco/00-installation.md#fresco-needs-a-substrate-adapter).
 
 ### `configure!`
 
@@ -787,18 +787,18 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
     - the `set-!` / `install-!` setters — adapter-pluggable hooks;
     - per-frame metadata — frame-scoped overrides.
 
-  The key vocabulary is closed-and-additive: existing keys cannot be renamed, and new keys are added by extending the table. Four keys ship:
+    The key vocabulary is closed-and-additive: existing keys cannot be renamed, and new keys are added by extending the table. Four keys ship:
 
-  | Key | Opts | Default | Status | What it tunes |
-  |---|---|---|---|---|
-  | `:epoch-history` | `{:depth N :trace-events-keep N}` | `{:depth 50, :trace-events-keep 50}` | v1 (dev-only) | Per-frame epoch ring depth and trace-event retention cap per record. |
-  | `:trace-buffer` | `{:events-retained N}` | `{:events-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's event-slot count: one slot per event, regardless of how many trace events its run emitted. 0 disables retention (the surface stays live). |
-  | `:elision` | `{:rf.egress/threshold-bytes N}` | `{:rf.egress/threshold-bytes 16384}` | v1 | The size threshold above which the internal `re-frame.elision/elide-wire-value` walker emits the `:rf.warning/large-value-unschema'd` advisory for an *undeclared* large string. It is a warning signal, not a cap: the value is forwarded raw. Substituting the `:rf.size/large-elided` marker requires declaring the path `:large`. 0 disables runtime auto-detect. |
-  | `:observability` | `{:handled-events [<entry>…] :errors [<entry>…]}` | none declared | v1 | The **process default** for production observation sinks, in the same closed grammar a frame's `:observability` takes. Precedence is per stream: a frame declaring a stream uses its own entries for it, a frame omitting it inherits this default's, and `{:errors []}` on a frame is that frame's opt-out — exactly one source per record per stream. Inheritance moves the sink list, not the redaction authority. Records with no frame authority (frameless producers; a `:frame` that no longer resolves) reach this default alone, projected with the governing frame explicitly nil. Two departures from its neighbours, both deliberate: an explicit **`nil` clears** it, and it is validated **at the call** (`:rf.error/bad-frame-classification`, `:where 'rf/configure!`). |
+    | Key | Opts | Default | Status | What it tunes |
+    |---|---|---|---|---|
+    | `:epoch-history` | `{:depth N :trace-events-keep N}` | `{:depth 50, :trace-events-keep 50}` | v1 (dev-only) | Per-frame epoch ring depth and trace-event retention cap per record. |
+    | `:trace-buffer` | `{:events-retained N}` | `{:events-retained 50}` | v1 (dev-only) | The dev-only per-frame trace ring's event-slot count: one slot per event, regardless of how many trace events its run emitted. 0 disables retention (the surface stays live). |
+    | `:elision` | `{:rf.egress/threshold-bytes N}` | `{:rf.egress/threshold-bytes 16384}` | v1 | The size threshold above which the internal `re-frame.elision/elide-wire-value` walker emits the `:rf.warning/large-value-unschema'd` advisory for an *undeclared* large string. It is a warning signal, not a cap: the value is forwarded raw. Substituting the `:rf.size/large-elided` marker requires declaring the path `:large`. 0 disables runtime auto-detect. |
+    | `:observability` | `{:handled-events [<entry>…] :errors [<entry>…]}` | none declared | v1 | The **process default** for production observation sinks, in the same closed grammar a frame's `:observability` takes. Precedence is per stream: a frame declaring a stream uses its own entries for it, a frame omitting it inherits this default's, and `{:errors []}` on a frame is that frame's opt-out — exactly one source per record per stream. Inheritance moves the sink list, not the redaction authority. Records with no frame authority (frameless producers; a `:frame` that no longer resolves) reach this default alone, projected with the governing frame explicitly nil. Two departures from its neighbours, both deliberate: an explicit **`nil` clears** it, and it is validated **at the call** (`:rf.error/bad-frame-classification`, `:where 'rf/configure!`). |
 
-  **An unrecognised top-level key applies nothing — and, if it is bare, says so.** The vocabulary above is closed and its keys are *bare*, so `{:epoch-histroy {:depth 100}}` is a typo of a real key rather than an extension point. A bare (or `rf`-namespaced) unknown key therefore emits `:rf.warning/unknown-configure-key` in dev builds, naming every offending key and the known set; the call still returns `nil` and still applies nothing (`:recovery :ignored` — observational, never a refusal), and the whole diagnostic is DCE'd out of production. A **user-namespaced** key (`:myapp/thing`) passes in silence, which is what lets a wrapper hand `configure!` a composed config value without filtering it first.
+    **An unrecognised top-level key applies nothing — and, if it is bare, says so.** The vocabulary above is closed and its keys are *bare*, so `{:epoch-histroy {:depth 100}}` is a typo of a real key rather than an extension point. A bare (or `rf`-namespaced) unknown key therefore emits `:rf.warning/unknown-configure-key` in dev builds, naming every offending key and the known set; the call still returns `nil` and still applies nothing (`:recovery :ignored` — observational, never a refusal), and the whole diagnostic is DCE'd out of production. A **user-namespaced** key (`:myapp/thing`) passes in silence, which is what lets a wrapper hand `configure!` a composed config value without filtering it first.
 
-  There is **no `:sub-cache` knob**: sub-cache disposal happens synchronously when the derefer count hits 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key; it is per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.egress/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`).
+    There is **no `:sub-cache` knob**: sub-cache disposal happens synchronously when the derefer count hits 0. SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure!` key; it is per-frame metadata on the frame's `:ssr` map. Framework-owned semantic sub-keys use a namespaced keyword (`:rf.egress/threshold-bytes`); ergonomic per-knob sub-keys are unqualified (`:depth`, `:trace-events-keep`).
 - **Example**:
   ```clojure
   (rf/configure! {:epoch-history {:depth 100}
@@ -816,13 +816,13 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```
 - **Description**: The read twin of `configure!` — the process-level config values currently in effect, in `configure!`'s own nested shape. Use it to answer "what is this process actually running with?" from a tool, a health check, or a diagnostic panel.
 
-  **Process values only.** There are no per-frame effective values here: a frame carrying its own `:rf.trace/events-retained` metadata is not reflected, because this reads back exactly the slots `configure!` writes.
+    **Process values only.** There are no per-frame effective values here: a frame carrying its own `:rf.trace/events-retained` metadata is not reflected, because this reads back exactly the slots `configure!` writes.
 
-  **A subsystem's key is ABSENT when its OWN producer is unavailable** — not `nil`, and never a fabricated default. The two optional keys are **independent**, each read through its own late-bind hook: `:epoch-history` comes from the optional `day8/re-frame2-epoch` artefact, `:trace-buffer` from the dev-only trace-tooling sibling. A production bundle that DCEs the tooling ns therefore omits `:trace-buffer` *alone* — a loaded epoch artefact still reports `:epoch-history` beside it, and vice versa. `(get-in (rf/current-config) [:epoch-history :depth])` reads `nil` when the **epoch** artefact is absent, never merely because trace tooling is; that is the answer a health query wants — and the facade owns that branch, so callers do not resolve optional-artefact vars by symbol.
+    **A subsystem's key is ABSENT when its OWN producer is unavailable** — not `nil`, and never a fabricated default. The two optional keys are **independent**, each read through its own late-bind hook: `:epoch-history` comes from the optional `day8/re-frame2-epoch` artefact, `:trace-buffer` from the dev-only trace-tooling sibling. A production bundle that DCEs the tooling ns therefore omits `:trace-buffer` *alone* — a loaded epoch artefact still reports `:epoch-history` beside it, and vice versa. `(get-in (rf/current-config) [:epoch-history :depth])` reads `nil` when the **epoch** artefact is absent, never merely because trace tooling is; that is the answer a health query wants — and the facade owns that branch, so callers do not resolve optional-artefact vars by symbol.
 
-  **`:observability` is absent-not-nil for a different reason, and the distinction is normative.** `re-frame.observability` is always loaded, so its key is absent when no process default has been *declared* — a statement about configuration, never about the build. It reports the declared policy **verbatim**: never any frame's effective policy, which is per-stream and resolved per record.
+    **`:observability` is absent-not-nil for a different reason, and the distinction is normative.** `re-frame.observability` is always loaded, so its key is absent when no process default has been *declared* — a statement about configuration, never about the build. It reports the declared policy **verbatim**: never any frame's effective policy, which is per-stream and resolved per record.
 
-  The result is a key-by-key snapshot rather than a transactional one, and it is not promised to be wire-serialisable. A **user-namespaced** pass-through key `configure!` accepted in silence (`:myapp/thing`) is *not* reflected back: the vocabulary is closed, so only keys the runtime reads have live values to report.
+    The result is a key-by-key snapshot rather than a transactional one, and it is not promised to be wire-serialisable. A **user-namespaced** pass-through key `configure!` accepted in silence (`:myapp/thing`) is *not* reflected back: the vocabulary is closed, so only keys the runtime reads have live values to report.
 - **Example**:
   ```clojure
   (rf/configure! {:epoch-history {:depth 100}})
@@ -844,7 +844,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```
 - **Description**: Return a map of every optional feature keyword to its inspection entry: the feature's static coordinate data (`:maven` / `:require` / `:spec`) merged with its live `:loaded?` status. Detection is a pure keyword lookup in the always-loaded feature registry (no exception, no classpath probe). The known features are `:schemas`, `:machines`, `:routing`, `:flows`, `:http`, `:ssr`, `:epoch`, `:resources`.
 
-  This is the ONE feature-inspection door. Read the per-feature boolean out of the map; an **unknown** feature keyword has no entry, so the lookup reads `nil`. For boot-time rather than first-call failure, write the guard yourself — one line, and not an elidable `assert`.
+    This is the ONE feature-inspection door. Read the per-feature boolean out of the map; an **unknown** feature keyword has no entry, so the lookup reads `nil`. For boot-time rather than first-call failure, write the guard yourself — one line, and not an elidable `assert`.
 - **Example**:
   ```clojure
   (rf/features)

--- a/docs/api/re-frame.epoch.md
+++ b/docs/api/re-frame.epoch.md
@@ -228,7 +228,7 @@ Read the live configuration back through the facade's own read twin, `rf/current
     - emits `:rf.epoch/snapshotted` with an `:outcome` tag plus its consumer-facing companion `:rf.epoch/outcome` (`:ok` / `:blocked` / `:error`);
     - fans out to every registered listener.
 
-  A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records, one per event. A machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router rather than read from an ambient assembly-time clock; this keeps the record replayable. The 4-arity is the clean `:ok` settle, skipped when the captured buffer is empty. The 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
+    A drain that processes a parent event and an `:fx [[:dispatch …]]` child it queued commits two records, one per event. A machine macrostep stays one epoch. `committed-at` is the committing causal token's `:rf.cofx` `:rf/time-ms`, threaded down by the router rather than read from an ambient assembly-time clock; this keeps the record replayable. The 4-arity is the clean `:ok` settle, skipped when the captured buffer is empty. The 6-arity is the drain-boundary commit with an explicit outcome (`:ok` / `:halted-depth` / `:halted-destroy`).
 
 ```clojure
 ;; Framework-internal — the router invokes this through the :epoch/settle! late-bind hook.

--- a/docs/api/re-frame.flows.md
+++ b/docs/api/re-frame.flows.md
@@ -28,21 +28,21 @@ See [Flows: derived values your handlers can read](../core/flows.md) for the con
   ```
 - **Description**: Register a flow. Returns `flow-id` (per the `reg-*` return-value convention). A rejected registration mutates nothing; the prior definition, if any, survives.
 
-  The 3-slot grammar is `flow-id` first, the pure `derive-fn` last, and `metadata` (the reflection-config map) in the middle. `metadata` carries:
+    The 3-slot grammar is `flow-id` first, the pure `derive-fn` last, and `metadata` (the reflection-config map) in the middle. `metadata` carries:
 
-  - `:inputs` and `:output-path` — both **required**.
-  - `:doc` / `:schema` — optional.
-  - `:sensitive` / `:large` / `:large?` — optional output-classification keys.
-  - `:frame` — optional; selects the owning frame.
+    - `:inputs` and `:output-path` — both **required**.
+    - `:doc` / `:schema` — optional.
+    - `:sensitive` / `:large` / `:large?` — optional output-classification keys.
+    - `:frame` — optional; selects the owning frame.
 
-  Raises:
+    Raises:
 
-  - `:rf.error/invalid-flow-metadata` — non-map metadata, or a `:derive` left inside the metadata map.
-  - `:rf.error/flow-missing-id` / `:rf.error/flow-bad-id` / `:rf.error/flow-bad-inputs` / `:rf.error/flow-bad-output` / `:rf.error/flow-bad-path` / `:rf.error/flow-bad-marks` — shape validation of the id, `:inputs`, `derive-fn`, `:output-path`, and classification keys.
-  - `:rf.error/no-frame-context` — no surrounding scope and no `:frame` key.
-  - `:rf.error/flow-frame-not-live` — the target frame is absent or destroyed.
-  - `:rf.error/flow-path-overlap` — the `:output-path` stands in a prefix relationship with a same-frame sibling's.
-  - `:rf.error/flow-cycle` — the registration would make the frame's dependency graph cyclic.
+    - `:rf.error/invalid-flow-metadata` — non-map metadata, or a `:derive` left inside the metadata map.
+    - `:rf.error/flow-missing-id` / `:rf.error/flow-bad-id` / `:rf.error/flow-bad-inputs` / `:rf.error/flow-bad-output` / `:rf.error/flow-bad-path` / `:rf.error/flow-bad-marks` — shape validation of the id, `:inputs`, `derive-fn`, `:output-path`, and classification keys.
+    - `:rf.error/no-frame-context` — no surrounding scope and no `:frame` key.
+    - `:rf.error/flow-frame-not-live` — the target frame is absent or destroyed.
+    - `:rf.error/flow-path-overlap` — the `:output-path` stands in a prefix relationship with a same-frame sibling's.
+    - `:rf.error/flow-cycle` — the registration would make the frame's dependency graph cyclic.
 - **Example**:
   ```clojure
   (rf/reg-flow :cart/subtotal

--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -136,7 +136,7 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
     - Query keys are emitted percent-encoded, in a deterministic canonical order.
     - **Address-only.** `:url`, `:query-merge`, policy keys (`:replace?` / `:scroll` / `:bypass-leave?`), and any unknown key reject **loud** (`:rf.error/route-url-validation`, `:reason :bad-address-keys`) rather than being silently ignored. There is no in-place form — a pure helper cannot read the current route.
 
-  Throws:
+    Throws:
     - `:rf.error/no-such-route` — `:to` route not registered.
     - `:rf.error/missing-route-param` — a required path segment's param is nil or absent.
     - `:rf.error/route-url-validation` — `:params` / `:query` fail the route's `:params` / `:query` schemas, or the map carries non-address keys.
@@ -159,7 +159,7 @@ The URL ↔ route mapping is a prism. `match-url` reads a URL into route data. `
   ```
 - **Description**: `true` when any percent-encoded portion of `url` is malformed — a non-empty path segment, a query key or value, or the `#fragment`. The check is purely lexical; no route table is consulted.
 
-  The `:rf.route/handle-url-change` handler uses it to tell two cases apart: a plain route miss (`{:url url}`) and a malformed URL that failed closed (`{:url url :reason :malformed-url}`). Both cases end at `:rf.route/not-found`. The structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
+    The `:rf.route/handle-url-change` handler uses it to tell two cases apart: a plain route miss (`{:url url}`) and a malformed URL that failed closed (`{:url url :reason :malformed-url}`). Both cases end at `:rf.route/not-found`. The structured `:reason` lets per-route error UIs and SSR projections branch on the cause.
 
 ## Introspection and slice access
 

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -112,13 +112,13 @@ Streaming emits the shell HTML first, then continues rendering boundary subtrees
     - `:id` — the boundary's identity, unique per page. It is how an arriving chunk is paired with its placeholder. A keyword or a string.
     - `:fallback` — hiccup rendered inline in the shell while the body is still resolving, and re-rendered by this component when the boundary is reported failed.
 
-  Per host:
+    Per host:
     - **Server**: expands to the internal `:rf/suspense-boundary` marker the shell walker consumes. That marker is wire syntax, never authored directly; outside a stream the non-streaming emitter still rejects it with `:rf.error/ssr-suspense-boundary-outside-stream`.
     - **Client**: renders `body`, or `:fallback` when `:id` is in the page's failed-boundary record written at stream finalization. No recorded outcome — a plain client mount, a non-streamed page — renders `body`, so it fails soft by construction.
 
-  Malformed `attrs` raise `:rf.error/suspense-boundary-invalid-attrs`.
+    Malformed `attrs` raise `:rf.error/suspense-boundary-invalid-attrs`.
 
-  This is not React Suspense: no promises, no thrown thenables, no selective hydration. The server decides what defers; the client paints the fallback and swaps content as chunks land.
+    This is not React Suspense: no promises, no thrown thenables, no selective hydration. The server decides what defers; the client paints the fallback and swaps content as chunks land.
 - **Example**:
   ```clojure
   (require '[re-frame.ssr :as ssr])

--- a/docs/api/re-frame.ssr.ring.md
+++ b/docs/api/re-frame.ssr.ring.md
@@ -19,54 +19,54 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: Returns a synchronous Ring handler that renders one re-frame2 SSR request per call.
 
-  The returned handler owns the whole per-request lifecycle:
+    The returned handler owns the whole per-request lifecycle:
 
-  1. Populate the per-frame request slot.
-  2. Register the per-request frame, draining `:initial-events` synchronously so the `:rf.server/request` cofx can resolve.
-  3. Read the resolved response accumulator, and branch on `:redirect`.
-  4. Otherwise, render `:root-view`, build the hydration payload, wrap it in the HTML shell, and materialise structured cookies to `Set-Cookie` headers.
-  5. Destroy the frame in a `finally`.
+    1. Populate the per-frame request slot.
+    2. Register the per-request frame, draining `:initial-events` synchronously so the `:rf.server/request` cofx can resolve.
+    3. Read the resolved response accumulator, and branch on `:redirect`.
+    4. Otherwise, render `:root-view`, build the hydration payload, wrap it in the HTML shell, and materialise structured cookies to `Set-Cookie` headers.
+    5. Destroy the frame in a `finally`.
 
-  Required opts:
+    Required opts:
 
-  - `:initial-events` — an ordered vector of events, dispatched synchronously and in order into the per-request frame at creation. Alternatively, a `(fn [request] → initial-events-vector)` that derives the vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's payload, e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`. For non-durable request reads inside a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead.
-    - Omission throws `:rf.error/ssr-ring-missing-initial-events` at construction.
-    - A value that is neither a vector nor a fn, or a fn returning a non-vector, throws `:rf.error/invalid-initial-events` per request.
-  - `:root-view` — **required exactly when the renderer is the default** (i.e. when `:renderer` is absent), because only the default JVM-local renderer resolves one. A hiccup vector (e.g. `[(rf/view :app/root)]`) or a 0-arity fn returning hiccup, rendered against the per-request frame after the drain settles. The head must be a **callable** — the Var `rf/reg-view` defs, or `(rf/view :id)`. A keyword head is an HTML element on every host, never a view, so `[:app/root]` renders an empty `<root>` element.
-    - Omission *without* a `:renderer` throws `:rf.error/ssr-ring-missing-root-view` at construction.
-    - Any other shape throws `:rf.error/invalid-root-view` at render time.
-  - `:payload` — **REQUIRED, fail-closed.** The hydration-payload policy, one opt with two shapes:
-    - A non-empty vector of top-level app-db keys (keywords) is an allowlist (recommended). Only the listed keys ship in `:rf/app-db`. Every other key is dropped, including keys added later.
-    - The keyword `:rf.ssr.payload/whole-app-db` ships the whole `app-db`. Use it only when the app-db is structurally safe to expose.
-    - Absence or an empty allowlist throws `:rf.error/ssr-missing-payload-policy`. An unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`. An allowlist with non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`. All three throw at construction.
+    - `:initial-events` — an ordered vector of events, dispatched synchronously and in order into the per-request frame at creation. Alternatively, a `(fn [request] → initial-events-vector)` that derives the vector from the Ring request. The fn form is the replay-safe seam for folding a request-derived fact into a boot event's payload, e.g. `(fn [req] [[:auth/server-init {:user (extract-user req)}]])`. For non-durable request reads inside a handler, declare `:rf.cofx/requires [:rf.server/request]` on the registration instead.
+        - Omission throws `:rf.error/ssr-ring-missing-initial-events` at construction.
+        - A value that is neither a vector nor a fn, or a fn returning a non-vector, throws `:rf.error/invalid-initial-events` per request.
+    - `:root-view` — **required exactly when the renderer is the default** (i.e. when `:renderer` is absent), because only the default JVM-local renderer resolves one. A hiccup vector (e.g. `[(rf/view :app/root)]`) or a 0-arity fn returning hiccup, rendered against the per-request frame after the drain settles. The head must be a **callable** — the Var `rf/reg-view` defs, or `(rf/view :id)`. A keyword head is an HTML element on every host, never a view, so `[:app/root]` renders an empty `<root>` element.
+        - Omission *without* a `:renderer` throws `:rf.error/ssr-ring-missing-root-view` at construction.
+        - Any other shape throws `:rf.error/invalid-root-view` at render time.
+    - `:payload` — **REQUIRED, fail-closed.** The hydration-payload policy, one opt with two shapes:
+        - A non-empty vector of top-level app-db keys (keywords) is an allowlist (recommended). Only the listed keys ship in `:rf/app-db`. Every other key is dropped, including keys added later.
+        - The keyword `:rf.ssr.payload/whole-app-db` ships the whole `app-db`. Use it only when the app-db is structurally safe to expose.
+        - Absence or an empty allowlist throws `:rf.error/ssr-missing-payload-policy`. An unrecognised keyword throws `:rf.error/ssr-unknown-payload-policy`. An allowlist with non-keyword entries throws `:rf.error/ssr-malformed-payload-allowlist`. All three throw at construction.
 
-  Optional opts:
+    Optional opts:
 
-  - `:renderer` — the **render-body seam**. A plain fn `(fn [{:keys [frame-id request opts]}] → {:body-html <string> :render-hash <string-or-nil>})`, called once per request inside the request frame's scope, after the boot-event drain and the blocking-resource settle and before head resolution and the payload build consume its result. It receives the live post-drain frame by id, the Ring request and the handler opts — never a hiccup value — and owns body markup plus an optional locally-derived render hash, and nothing else. A `nil` `:render-hash` omits both the `data-rf-render-hash` marker and the payload's `:rf/render-hash`. Omitted, the renderer is the local one (resolve `:root-view` → hash → render), whose bytes and errors are unchanged. A throw is projected like any render-time throw. The one non-local renderer the reference ships is [`re-frame.ssr.ring.node/renderer`](../ssr/concepts.md#render-on-node), the JVM→Node sidecar adapter; `stream-handler` refuses the opt at construction.
-  - `:render-state` — the render-visible state policy a **non-local** renderer projects under, distinct in policy from `:payload` though it shares its two-partition envelope `{:rf/app-db {…} :rf/runtime-db {…}}`. A fail-closed per-partition allowlist of top-level keys, or a `(fn [frame-id] → partitions)` projector. Unused by the default local renderer, which reads the frame directly. See [Render on Node](../ssr/concepts.md#render-on-node) for why the two policies differ.
-  - `:fx-overrides` — per-frame `:fx-overrides` map, passed through verbatim (e.g. to stub `:rf.http/managed` in tests).
-  - `:ssr` — per-frame `:ssr` config map, e.g. `{:dev-error-detail? true :public-error-id :myapp/projector}`.
-  - `:emit-hash?` — embed `data-rf-render-hash` on the root element; default `true`.
-  - `:version` — hydration payload's `:rf/version`; default `1`.
-  - `:schema-digest` — hydration payload's `:rf/schema-digest`.
-  - `:html-shell` — `(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell).
-  - `:content-type` — **no default**, and supplying one *force-replaces* the response Content-Type. Omit it (the normal case) and the wire value stays `text/html; charset=utf-8` — either the runtime's seeded default or the app's own `:rf.server/set-header "content-type"`, whichever the request established. See [`handler-defaults`](#handler-defaults).
+    - `:renderer` — the **render-body seam**. A plain fn `(fn [{:keys [frame-id request opts]}] → {:body-html <string> :render-hash <string-or-nil>})`, called once per request inside the request frame's scope, after the boot-event drain and the blocking-resource settle and before head resolution and the payload build consume its result. It receives the live post-drain frame by id, the Ring request and the handler opts — never a hiccup value — and owns body markup plus an optional locally-derived render hash, and nothing else. A `nil` `:render-hash` omits both the `data-rf-render-hash` marker and the payload's `:rf/render-hash`. Omitted, the renderer is the local one (resolve `:root-view` → hash → render), whose bytes and errors are unchanged. A throw is projected like any render-time throw. The one non-local renderer the reference ships is [`re-frame.ssr.ring.node/renderer`](../ssr/concepts.md#render-on-node), the JVM→Node sidecar adapter; `stream-handler` refuses the opt at construction.
+    - `:render-state` — the render-visible state policy a **non-local** renderer projects under, distinct in policy from `:payload` though it shares its two-partition envelope `{:rf/app-db {…} :rf/runtime-db {…}}`. A fail-closed per-partition allowlist of top-level keys, or a `(fn [frame-id] → partitions)` projector. Unused by the default local renderer, which reads the frame directly. See [Render on Node](../ssr/concepts.md#render-on-node) for why the two policies differ.
+    - `:fx-overrides` — per-frame `:fx-overrides` map, passed through verbatim (e.g. to stub `:rf.http/managed` in tests).
+    - `:ssr` — per-frame `:ssr` config map, e.g. `{:dev-error-detail? true :public-error-id :myapp/projector}`.
+    - `:emit-hash?` — embed `data-rf-render-hash` on the root element; default `true`.
+    - `:version` — hydration payload's `:rf/version`; default `1`.
+    - `:schema-digest` — hydration payload's `:rf/schema-digest`.
+    - `:html-shell` — `(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell).
+    - `:content-type` — **no default**, and supplying one *force-replaces* the response Content-Type. Omit it (the normal case) and the wire value stays `text/html; charset=utf-8` — either the runtime's seeded default or the app's own `:rf.server/set-header "content-type"`, whichever the request established. See [`handler-defaults`](#handler-defaults).
 
-  Error handling — `:error-view` vs `:on-error`. These two opts handle two different failures, and a robust deployment wires both. Classification is by the **projected status**: a projected **4xx** (routing miss / bad client input) keeps the app's own not-found / bad-request body + hydration payload and does **not** call `:error-view`; a projected **5xx** (server fault) ships the error page. A buggy `:error-view` — whether it throws OR depends on a reactive sub that recovers to `nil` — falls back once to the default template; a buggy `:on-error` falls back to `default-on-error`. Neither bug bypasses the error boundary.
+    Error handling — `:error-view` vs `:on-error`. These two opts handle two different failures, and a robust deployment wires both. Classification is by the **projected status**: a projected **4xx** (routing miss / bad client input) keeps the app's own not-found / bad-request body + hydration payload and does **not** call `:error-view`; a projected **5xx** (server fault) ships the error page. A buggy `:error-view` — whether it throws OR depends on a reactive sub that recovers to `nil` — falls back once to the default template; a buggy `:on-error` falls back to `default-on-error`. Neither bug bypasses the error boundary.
 
-  | Aspect | `:error-view` | `:on-error` |
-  |---|---|---|
-  | Which failure? | A projected **5xx** the error projector catches: a drain-time handler/fx/sub exception, a render-time view throw, or an unrenderable root/shell throw. A projected **4xx** does NOT reach it — the app keeps its own body. | A transport / Ring-layer failure the projector cannot see: a per-request frame setup throw, a render-time CLJ exception, a header/cookie materialise throw, or a thrown initial-event. |
-  | What does it produce? | The projected error-page body (hiccup): a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn. It renders through the standard SSR emitter, with no app body / hydration payload alongside it. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
-  | What is its input? | ONLY the public-error map, sanitised by the projector and safe to render (never the request, throwable, or frame). | The raw `(request throwable)`, carrying the unsanitised throwable. The locked default never reads it. |
-  | Default when omitted? | Minimal default error template (absence does NOT keep the root body). | Minimal locked 500 ([`default-on-error`](#default-on-error), topology-leak-safe). |
+    | Aspect | `:error-view` | `:on-error` |
+    |---|---|---|
+    | Which failure? | A projected **5xx** the error projector catches: a drain-time handler/fx/sub exception, a render-time view throw, or an unrenderable root/shell throw. A projected **4xx** does NOT reach it — the app keeps its own body. | A transport / Ring-layer failure the projector cannot see: a per-request frame setup throw, a render-time CLJ exception, a header/cookie materialise throw, or a thrown initial-event. |
+    | What does it produce? | The projected error-page body (hiccup): a registered-view keyword (resolved as `[error-view public-error]`) or a `(public-error) → hiccup` fn. It renders through the standard SSR emitter, with no app body / hydration payload alongside it. | A raw Ring response map `{:status … :headers … :body …}` returned verbatim to the server. |
+    | What is its input? | ONLY the public-error map, sanitised by the projector and safe to render (never the request, throwable, or frame). | The raw `(request throwable)`, carrying the unsanitised throwable. The locked default never reads it. |
+    | Default when omitted? | Minimal default error template (absence does NOT keep the root body). | Minimal locked 500 ([`default-on-error`](#default-on-error), topology-leak-safe). |
 
-  Trusted shell-hook string opts. Four optional strings cross the trust boundary into the rendered HTML envelope, split by injection position:
+    Trusted shell-hook string opts. Four optional strings cross the trust boundary into the rendered HTML envelope, split by injection position:
 
-  - `:head` and `:body-end` — raw content hooks, injected verbatim with no escaping.
-  - `:script-src` (default `"/main.js"`) and `:app-element-id` (default `"app"`) — escaped attribute hooks, escape-attr'd into a quoted attribute value.
+    - `:head` and `:body-end` — raw content hooks, injected verbatim with no escaping.
+    - `:script-src` (default `"/main.js"`) and `:app-element-id` (default `"app"`) — escaped attribute hooks, escape-attr'd into a quoted attribute value.
 
-  Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (a CMS field, a tenant-admin form, a query-string parameter) is an arbitrary-script-injection XSS vector. When content originates upstream of the trust boundary, use the structured alternatives: [`reg-head`](re-frame.ssr.md) for head fragments, and registered views plus the [`:rf.server/*` fx](re-frame.ssr.md) for body content.
+    Non-string non-nil values throw `:rf.error/ssr-trusted-shell-opt-invalid` at construction. Wiring the raw content hooks from untrusted input (a CMS field, a tenant-admin form, a query-string parameter) is an arbitrary-script-injection XSS vector. When content originates upstream of the trust boundary, use the structured alternatives: [`reg-head`](re-frame.ssr.md) for head fragments, and registered views plus the [`:rf.server/*` fx](re-frame.ssr.md) for body content.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -98,22 +98,22 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The streaming counterpart of `ssr-handler`. Returns a synchronous Ring handler that streams SSR responses via `Transfer-Encoding: chunked`.
 
-  Streaming behaviour:
+    Streaming behaviour:
 
-  - Flushes a shell on the first byte, then streams `:rf/suspense-boundary` subtrees as their data resolves.
-  - A boundary whose drain changed app-db also carries a speculative per-subtree hydration delta, projected through the same `:payload` policy as the final payload. An off-allowlist or empty delta emits no delta script.
-  - The final chunk carries the canonical full hydration payload. If a speculative delta and the canonical payload ever disagree, the payload wins.
-  - Failure isolation is per-boundary: a boundary whose render throws keeps its fallback (with a `:rf.ssr/suspense-boundary-failed` trace) while the rest of the page streams on.
-  - Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path, with zero continuations. The wire shape collapses to shell-prefix + shell-html + final-payload + shell-suffix.
-  - A `:redirect` set during the drain short-circuits to a bodiless Location response before any chunk is written.
-  - The shell renders on the request thread, before the chunked head commits. A root-view or shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector), with no writer thread spawned.
-  - Any `Content-Length` header accumulated during the drain is stripped (case-insensitively) so the host server owns chunked transfer framing.
+    - Flushes a shell on the first byte, then streams `:rf/suspense-boundary` subtrees as their data resolves.
+    - A boundary whose drain changed app-db also carries a speculative per-subtree hydration delta, projected through the same `:payload` policy as the final payload. An off-allowlist or empty delta emits no delta script.
+    - The final chunk carries the canonical full hydration payload. If a speculative delta and the canonical payload ever disagree, the payload wins.
+    - Failure isolation is per-boundary: a boundary whose render throws keeps its fallback (with a `:rf.ssr/suspense-boundary-failed` trace) while the rest of the page streams on.
+    - Non-streaming responses (no `:rf/suspense-boundary` in the tree) still ride the chunked path, with zero continuations. The wire shape collapses to shell-prefix + shell-html + final-payload + shell-suffix.
+    - A `:redirect` set during the drain short-circuits to a bodiless Location response before any chunk is written.
+    - The shell renders on the request thread, before the chunked head commits. A root-view or shell-walk throw fails closed to a non-200 projected error page (`:rf.error/ssr-render-failed` via the projector), with no writer thread spawned.
+    - Any `Content-Length` header accumulated during the drain is stripped (case-insensitively) so the host server owns chunked transfer framing.
 
-  Opts mirror `ssr-handler`: `:initial-events` (both vector and `(fn [request] → …)` forms), `:root-view`, `:payload`, `:fx-overrides`, `:ssr`, `:on-error`, `:error-view`, `:emit-hash?`, `:version`, `:schema-digest`, `:content-type`, plus the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by [`default-streaming-prefix`](#default-streaming-prefix) / [`default-streaming-suffix`](#default-streaming-suffix)).
+    Opts mirror `ssr-handler`: `:initial-events` (both vector and `(fn [request] → …)` forms), `:root-view`, `:payload`, `:fx-overrides`, `:ssr`, `:on-error`, `:error-view`, `:emit-hash?`, `:version`, `:schema-digest`, `:content-type`, plus the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by [`default-streaming-prefix`](#default-streaming-prefix) / [`default-streaming-suffix`](#default-streaming-suffix)).
 
-  One exception: `:html-shell` is not supported and is rejected at construction (`:rf.error/ssr-streaming-unsupported-opt`). The streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run. Customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
+    One exception: `:html-shell` is not supported and is rejected at construction (`:rf.error/ssr-streaming-unsupported-opt`). The streaming path flushes a split prefix/suffix straddling the continuation chunks, so a one-piece shell callback can never run. Customise the streaming envelope through the trusted shell-hook opts, or use `ssr-handler` when a bespoke one-piece shell is required.
 
-  Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request. There is no framework pool and no framework in-flight cap. Every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path (no-leak). The in-flight ceiling is the host server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph). Operators size that limit as the one knob for high streaming concurrency or slow-client hardening.
+    Concurrency model: one raw daemon `java.lang.Thread` per in-flight streamed request. There is no framework pool and no framework in-flight cap. Every writer's `catch`/`finally` closes the pipe and tears the frame down on every exit path (no-leak). The in-flight ceiling is the host server's accept-queue / worker-thread limit (Jetty / http-kit / Aleph). Operators size that limit as the one knob for high streaming concurrency or slow-client hardening.
 - **Example**:
   ```clojure
   (require '[ring.adapter.jetty :as jetty]
@@ -140,7 +140,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: Returns Ring middleware that delegates to `ssr-handler` for requests its `:match?` predicate accepts, and to the wrapped handler otherwise. Curried: `(ssr-middleware opts)` returns a `(handler) → wrapped-handler` middleware.
 
-  Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?`, a `(request) → boolean` predicate. When it returns truthy, SSR renders. When it returns falsy, the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
+    Opts are `ssr-handler`'s opts (including the required, fail-closed `:payload`) plus `:match?`, a `(request) → boolean` predicate. When it returns truthy, SSR renders. When it returns falsy, the call falls through to the wrapped handler. `:match?` defaults to matching every GET request.
 - **Example**:
   ```clojure
   ;; ssr-middleware is CURRIED: (ssr-middleware opts) returns a Ring
@@ -186,17 +186,17 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The default HTML envelope: wraps the rendered body in a minimal, runnable document. Override via the `:html-shell` opt on `ssr-handler` for a custom `<head>` / scripts / styles.
 
-  Arguments:
+    Arguments:
 
-  - `body-html` — the string returned by `re-frame.ssr/render-to-string`.
-  - `payload-edn` — the hydration payload pre-serialised with `pr-str`.
-  - `opts` — the adapter opts; the keys `:head` / `:html-attrs` / `:body-attrs` / `:body-end` / `:script-src` / `:app-element-id` / `:lang` influence the envelope.
+    - `body-html` — the string returned by `re-frame.ssr/render-to-string`.
+    - `payload-edn` — the hydration payload pre-serialised with `pr-str`.
+    - `opts` — the adapter opts; the keys `:head` / `:html-attrs` / `:body-attrs` / `:body-end` / `:script-src` / `:app-element-id` / `:lang` influence the envelope.
 
-  Behaviour:
+    Behaviour:
 
-  - The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload`; the client bootstrap reads it via `document.getElementById("__rf_payload")`. Its EDN body is escaped EDN-aware, so a payload containing `</script>` cannot close the envelope. A custom shell must emit the payload `<script>` under this id, with equivalent escaping, or substitute its own bootstrap that reads a custom id.
-  - The shell does not emit `<title>`. The head fragment threaded in as `:head` is the canonical source.
-  - The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd. The two content hooks (`:head`, `:body-end`) are injected raw.
+    - The hydration-payload `<script>` is stamped with the framework-pinned id `__rf_payload`; the client bootstrap reads it via `document.getElementById("__rf_payload")`. Its EDN body is escaped EDN-aware, so a payload containing `</script>` cannot close the envelope. A custom shell must emit the payload `<script>` under this id, with equivalent escaping, or substitute its own bootstrap that reads a custom id.
+    - The shell does not emit `<title>`. The head fragment threaded in as `:head` is the canonical source.
+    - The two attribute-value hooks (`:script-src`, `:app-element-id`) are escape-attr'd. The two content hooks (`:head`, `:body-end`) are injected raw.
 - **Example**:
   ```clojure
   ;; The default envelope, invoked directly (the handler does this for you).
@@ -217,7 +217,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The minimal 500 response used when a handler caller omits `:on-error`. Shared by `ssr-handler` and `stream-handler`, so the topology-leak contract lives in one place. It covers exceptions the SSR error projector can't see: Ring-layer throws, render-time CLJ exceptions, and writer-thread-pre-spawn throws. Trace-emitted drain errors are handled by the projector instead.
 
-  The body must not leak the throwable's message: `.getMessage` carries internal topology, such as JDBC URLs, deploy-root file paths, partial SQL, and server-internal class names. So the fn ignores the throwable and emits a fixed generic plaintext body. Apps wanting a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. Exposed as a value: a 2-arity fn, not a `defn`, so it carries no `:arglists`.
+    The body must not leak the throwable's message: `.getMessage` carries internal topology, such as JDBC URLs, deploy-root file paths, partial SQL, and server-internal class names. So the fn ignores the throwable and emits a fixed generic plaintext body. Apps wanting a branded transport-failure body supply an explicit leak-safe `:on-error` fn that returns a fixed response and ignores the throwable. Exposed as a value: a 2-arity fn, not a `defn`, so it carries no `:arglists`.
 - **Example**:
   ```clojure
   ;; The host-locked transport-failure net (used when :on-error is omitted).
@@ -241,7 +241,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
     - `head-html` — the resolved head fragment.
     - `opts` — honours `:html-attrs` / `:body-attrs` / `:lang` (default `"en"`) / `:app-element-id` (default `"app"`) / `:render-hash`.
 
-  When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div, the first DOM root of the streamed document. This mirrors the non-streaming handler's root-element marker.
+    When `:render-hash` is supplied (the handler passes it iff `:emit-hash?` is true), `data-rf-render-hash` is stamped on the `#app` div, the first DOM root of the streamed document. This mirrors the non-streaming handler's root-element marker.
 - **Example**:
   ```clojure
   ;; The first streamed chunk — open + <head> + <body> + app-div-open.
@@ -260,7 +260,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: The shell suffix flushed after the final-payload chunk. It emits the bootstrap `<script>` (if `:script-src` is set; default `"/main.js"`, escape-attr'd), the raw `:body-end` HTML, and the document close (`</body></html>`).
 
-  The app root (`</div>`) is not closed here. It is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely bootstrap script + raw `:body-end` + document close. All of it is already outside `#app`, mirroring the non-streaming `default-html-shell`.
+    The app root (`</div>`) is not closed here. It is closed at the end of the shell chunk, so the resolved templates, hydration-delta scripts, and the final `__rf_payload` script all stream outside `#app`. The suffix is therefore purely bootstrap script + raw `:body-end` + document close. All of it is already outside `#app`, mirroring the non-streaming `default-html-shell`.
 - **Example**:
   ```clojure
   ;; The trailing chunk — bootstrap <script>, raw :body-end, document close.
@@ -279,18 +279,18 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   ```
 - **Description**: Serialises one structured `re-frame.ssr` cookie map to a `Set-Cookie` header value, per RFC 6265 §4.1. It is re-exposed from the façade so that tests, alternate host adapters (Pedestal, http-kit), and user code needing a one-off serialisation can reach it without an internal namespace.
 
-  Fields:
+    Fields:
 
-  - `:name` — required.
-  - `:value` — URL-encoded; serialises as the empty string when absent.
-  - Everything else (`:max-age`, `:domain`, `:path`, `:expires` (epoch-millis long), `:secure`, `:http-only`, `:same-site`) is an attribute appended after semicolons.
+    - `:name` — required.
+    - `:value` — URL-encoded; serialises as the empty string when absent.
+    - Everything else (`:max-age`, `:domain`, `:path`, `:expires` (epoch-millis long), `:secure`, `:http-only`, `:same-site`) is an attribute appended after semicolons.
 
-  Validation is fail-loud:
+    Validation is fail-loud:
 
-  - `:name` must be a string or a keyword/symbol, and it must match the RFC 6265 §4.1.1 token grammar. Either violation throws `:rf.error/cookie-invalid-name`.
-  - A missing `:name` throws `:rf.error/cookie-missing-name`.
-  - `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation; a violation throws `:rf.error/cookie-invalid-attribute`. This closes header-splitting injection.
-  - A non-integer `:expires` throws `:rf.error/cookie-invalid-expires`.
+    - `:name` must be a string or a keyword/symbol, and it must match the RFC 6265 §4.1.1 token grammar. Either violation throws `:rf.error/cookie-invalid-name`.
+    - A missing `:name` throws `:rf.error/cookie-missing-name`.
+    - `:domain` / `:path` / `:max-age` / `:same-site` are checked for CR / LF / NUL before concatenation; a violation throws `:rf.error/cookie-invalid-attribute`. This closes header-splitting injection.
+    - A non-integer `:expires` throws `:rf.error/cookie-invalid-expires`.
 - **Example**:
   ```clojure
   (ssr.ring/cookie->set-cookie-header

--- a/docs/api/re-frame.test-helpers.md
+++ b/docs/api/re-frame.test-helpers.md
@@ -203,14 +203,14 @@ This namespace pairs with `render-to-string` in [re-frame.ssr.md](re-frame.ssr.m
   ```
 - **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into that map, and `:data-testid` always wins on collision. Use it at the view call site. Pair it with `find-by-testid` at the assertion site.
 - **Example**:
-  ```clojure
-  (rf/reg-view counter-inc-button []
-    [:button (th/testid "counter-inc" {:on-click #(dispatch [:counter/inc])})
-     "+"])
-  ;; the button node => [:button {:data-testid "counter-inc" :on-click ...} "+"]
-  ```
+    ```clojure
+    (rf/reg-view counter-inc-button []
+      [:button (th/testid "counter-inc" {:on-click #(dispatch [:counter/inc])})
+       "+"])
+    ;; the button node => [:button {:data-testid "counter-inc" :on-click ...} "+"]
+    ```
 
-  `dispatch` here is the local `rf/reg-view` injects, and that lexical binding is what the deferred `:on-click` closes over. A bare `rf/dispatch` in the callback fires after the render scope has unwound and raises `:rf.error/no-frame-context` (EP-0002 — there is no `:rf/default` floor).
+    `dispatch` here is the local `rf/reg-view` injects, and that lexical binding is what the deferred `:on-click` closes over. A bare `rf/dispatch` in the callback fires after the render scope has unwound and raises `:rf.error/no-frame-context` (EP-0002 — there is no `:rf/default` floor).
 
 ## Single-frame view test — composition recipe
 

--- a/docs/api/re-frame.test-support.md
+++ b/docs/api/re-frame.test-support.md
@@ -54,19 +54,19 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   ```
 - **Description**: Build a `clojure.test` / `cljs.test` `:each` fixture that resets the per-process runtime around each test. Pair with `use-fixtures :each`.
 
-  Around each test the fixture:
+    Around each test the fixture:
 
-  - reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time, which makes tests independent of run order inside a shared test bundle;
-  - snapshots the registrar;
-  - resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch). This runs via late-bind hooks that no-op when an artefact is absent from the classpath;
-  - disposes then reinstalls the adapter;
-  - restores everything in a `finally`.
+    - reinstates the stable ns-load registrar and source-store baseline captured at fixture-build time, which makes tests independent of run order inside a shared test bundle;
+    - snapshots the registrar;
+    - resets the frames registry, trace listeners, and per-artefact state (flows, schemas, machines, routing, resources, http, epoch). This runs via late-bind hooks that no-op when an artefact is absent from the classpath;
+    - disposes then reinstalls the adapter;
+    - restores everything in a `finally`.
 
-  `opts` (all optional):
+    `opts` (all optional):
 
-  | Key | Meaning |
-  |-----|---------|
-  | `:adapter` | Substrate adapter to install; also ensures the `:rf/default` frame. When omitted, no adapter is installed. |
+    | Key | Meaning |
+    |-----|---------|
+    | `:adapter` | Substrate adapter to install; also ensures the `:rf/default` frame. When omitted, no adapter is installed. |
 | `:app-ns` | **Bundle co-load hygiene.** A provenance-namespace PREFIX string naming **this suite's own app** (`"realworld-http."` — the whole tree, not one ns; never a sibling's). Rows whose `:rf.provenance/ns` starts with it are captured and removed from the live registrar and the source store when the fixture is **built** — before it takes its baselines, so no suite's baseline holds them — and reinstated through `registrar/register!` before each test, after the reset and before `:init-fn`. The ordinary source-store restore takes them out again, on the exceptional path too. Omit it unless your bundle co-loads rival apps. |
   | `:init-fn` | Zero-arg fn run after adapter install, before the test body, under the same ambient frame scope as the body. |
   | `:clear-kinds` | Collection of registrar kinds cleared after the snapshot capture and before the body (the snapshot restores them on the way out). |
@@ -74,41 +74,41 @@ The fixture primitives follow one pattern: snapshot the registrar before the tes
   | `:ambient-frame` | Frame id bound as the body's ambient scope when an adapter is installed. Default `:rf/default`; pass `nil` to opt out (for tests that create their own top-level frames). |
   | `:async?` | Boolean, default `false`. Declares the suite **async-capable**; the return shape that delivers it is chosen per host. On CLJS you get a `cljs.test` map-form fixture `{:before … :after …}`, **required** for suites with `(async done …)` tests. On the JVM the option is inert and you always get the fn-form — `clojure.test` has no async tests, and no map-fixture support at all (it *invokes* a fixture, and a Clojure map is `IFn`, so a map fixture would silently skip every test body). |
 - **Example**:
-  ```clojure
-  (use-fixtures :each
-    (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+    ```clojure
+    (use-fixtures :each
+      (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-  ;; CLJS suite with (async done …) tests — map-form fixture:
-  (use-fixtures :each
-    (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter :async? true}))
-  ```
+    ;; CLJS suite with (async done …) tests — map-form fixture:
+    (use-fixtures :each
+      (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter :async? true}))
+    ```
 
-  A `.cljc` suite whose CLJS rows are async writes the same plain `:async? true`
-  — no reader conditional at the call site, because the factory already picks
-  the map on CLJS and the fn-form on the JVM.
+    A `.cljc` suite whose CLJS rows are async writes the same plain `:async? true`
+    — no reader conditional at the call site, because the factory already picks
+    the map on CLJS and the fn-form on the JVM.
 
-  **`:app-ns` — when your bundle co-loads more than one app.** A CLJS node
-  runner loads *every* test namespace into one bundle before any test runs. Two
-  co-loaded apps that register the same per-app id — `:rf.route/not-found`, or
-  shared event vocabulary — leave duplicate provenance rows in the source store,
-  and default-image assembly then fails loud with
-  `:rf.error/image-duplicate-id` for any suite whose baseline was captured after
-  the second app loaded. `:app-ns` folds the whole capture/reinstate cycle into
-  the fixture that already owns the baseline:
+    **`:app-ns` — when your bundle co-loads more than one app.** A CLJS node
+    runner loads *every* test namespace into one bundle before any test runs. Two
+    co-loaded apps that register the same per-app id — `:rf.route/not-found`, or
+    shared event vocabulary — leave duplicate provenance rows in the source store,
+    and default-image assembly then fails loud with
+    `:rf.error/image-duplicate-id` for any suite whose baseline was captured after
+    the second app loaded. `:app-ns` folds the whole capture/reinstate cycle into
+    the fixture that already owns the baseline:
 
-  ```clojure
-  (use-fixtures :each
-    (ts/make-reset-runtime-fixture
-      {:adapter reagent-adapter/adapter
-       :app-ns  "my-app."          ; rows under this provenance prefix are MINE
-       :init-fn init!}))
-  ```
+    ```clojure
+    (use-fixtures :each
+      (ts/make-reset-runtime-fixture
+        {:adapter reagent-adapter/adapter
+         :app-ns  "my-app."          ; rows under this provenance prefix are MINE
+         :init-fn init!}))
+    ```
 
-  Name **your own** app's root namespace and cover its whole tree — never a
-  sibling's. When every app suite hides itself, no suite needs to know its
-  sibling's name, and the suites are independent of each other's load order. A
-  workspace with one app in its bundle never meets the collision and never needs
-  this key.
+    Name **your own** app's root namespace and cover its whole tree — never a
+    sibling's. When every app suite hides itself, no suite needs to know its
+    sibling's name, and the suites are independent of each other's load order. A
+    workspace with one app in its bundle never meets the collision and never needs
+    this key.
 
 ## Test-flavoured helpers
 
@@ -129,9 +129,9 @@ To fire several events in order, call `rf/dispatch-sync` per event — each drai
   ```
 - **Description**: Assert `(get-in db path) == expected-val` against the resolved frame's `app-db`. A mismatch fires a `clojure.test/is`-style failure via `do-report`. Returns `true` on pass and `false` otherwise; the failure has already been reported either way.
 
-  `opts`: `:frame` targets a non-default frame; frame resolution is `:frame` opt → `(current-frame)` → `:rf/default`.
+    `opts`: `:frame` targets a non-default frame; frame resolution is `:frame` opt → `(current-frame)` → `:rf/default`.
 
-  This is the fn-side counterpart to the `:rf.assert/path-equals` story event-family: same name root, different runner channel.
+    This is the fn-side counterpart to the `:rf.assert/path-equals` story event-family: same name root, different runner channel.
 - **Example**:
   ```clojure
   (rf/dispatch-sync [:counter/inc])
@@ -157,9 +157,9 @@ For a full-db assertion, compare directly: `(is (= expected-db (rf/app-db-value 
     - **JVM**: synchronous. Returns the truthy value, or throws `ex-info` on timeout.
     - **CLJS**: returns a `js/Promise` that resolves with the truthy value, or rejects on timeout. A `pred` that returns a `js/Promise` is awaited; its resolved value drives the truthy check.
 
-  The timeout error carries `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator), plus `:elapsed-ms` and `:label` in its data.
+    The timeout error carries `:rf.error/id` `:rf.error/poll-until-timeout` (the canonical discriminator), plus `:elapsed-ms` and `:label` in its data.
 
-  `opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+    `opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
 - **Example**:
   ```clojure
   ;; JVM — synchronous; returns the truthy value (throws on timeout).
@@ -183,16 +183,16 @@ For a full-db assertion, compare directly: `(is (= expected-db (rf/app-db-value 
   ```
 - **Description**: Bracket `body` with a fresh trace-tooling listener that accumulates matching trace events into an atom bound to `recs-sym`. The listener is registered before `body` runs and unregistered in a `finally` on the way out, even if `body` throws. Returns the value of `body`'s final form.
 
-  `opts` (optional map literal; keys evaluated at macroexpansion):
+    `opts` (optional map literal; keys evaluated at macroexpansion):
 
-  - `:pred` — a 1-arg `(fn [ev] truthy?)` filter. Default: accept every event.
-  - `:shape` — `:flat` (default; the atom holds a vector of events) or `:by-op` (the atom holds a map keyed by `(:operation ev)`).
-  - `:key` — listener key. Default: a freshly-gensym'd keyword unique to the expansion site, so two brackets in one test do not collide.
+    - `:pred` — a 1-arg `(fn [ev] truthy?)` filter. Default: accept every event.
+    - `:shape` — `:flat` (default; the atom holds a vector of events) or `:by-op` (the atom holds a map keyed by `(:operation ev)`).
+    - `:key` — listener key. Default: a freshly-gensym'd keyword unique to the expansion site, so two brackets in one test do not collide.
 
-  Macro requires:
+    Macro requires:
 
-  - **JVM**: resolves alias-qualified through the normal `(:require [re-frame.test-support :as ts])`.
-  - **CLJS**: the namespace carries no self-`:require-macros` (unlike `re-frame.core`). CLJS test files must therefore require the macro explicitly: `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
+    - **JVM**: resolves alias-qualified through the normal `(:require [re-frame.test-support :as ts])`.
+    - **CLJS**: the namespace carries no self-`:require-macros` (unlike `re-frame.core`). CLJS test files must therefore require the macro explicitly: `(:require-macros [re-frame.test-support :refer [with-trace-recorder!]])`, or `:as ts` in `:require-macros` for alias-qualified use.
 - **Example**:
   ```clojure
   ;; Flat shape (default), default filter, simple read.
@@ -224,15 +224,15 @@ For a full-db assertion, compare directly: `(is (= expected-db (rf/app-db-value 
   ```
 - **Description**: The always-on sibling of [`with-trace-recorder!`](#with-trace-recorder). Brackets `body` with a fresh listener on one of the two always-on substrates, accumulating records into an atom bound to `recs-sym`. Registered before `body` runs, unregistered in a `finally` on the way out, even if `body` throws. Returns the value of `body`'s final form.
 
-  `opts` (optional map literal; keys evaluated at macroexpansion):
+    `opts` (optional map literal; keys evaluated at macroexpansion):
 
-  - `:stream` — `:errors` (default; brackets `re-frame.error-emit`, one record per promoted `:rf.error/*`) or `:events` (brackets `re-frame.event-emit`, one record per processed event).
-  - `:pred` — a 1-arg `(fn [record] truthy?)` filter. Default: accept every record.
-  - `:key` — listener key. Default: a freshly-gensym'd keyword unique to the expansion site, so two brackets in one test do not collide.
+    - `:stream` — `:errors` (default; brackets `re-frame.error-emit`, one record per promoted `:rf.error/*`) or `:events` (brackets `re-frame.event-emit`, one record per processed event).
+    - `:pred` — a 1-arg `(fn [record] truthy?)` filter. Default: accept every record.
+    - `:key` — listener key. Default: a freshly-gensym'd keyword unique to the expansion site, so two brackets in one test do not collide.
 
-  **These are the framework's own registries, not an application surface.** `re-frame.event-emit` and `re-frame.error-emit` carry no public registration verb: rf2-kuky.69 retired the `register-listener!` `:events` / `:errors` streams, because an unprojected fan-out no frame's policy governs was a second, fail-open production door beside the projected one. They survive as implementation-tier seams for two consumers — the framework's own synchronous-window capture sites, and tests. An application observes production records through a frame's `:observability` sink, or the `(rf/configure! {:observability …})` process default, both of which deliver a projected record. A test brackets the raw substrate on purpose: it wants the unprojected shape, inside a window it owns.
+    **These are the framework's own registries, not an application surface.** `re-frame.event-emit` and `re-frame.error-emit` carry no public registration verb: rf2-kuky.69 retired the `register-listener!` `:events` / `:errors` streams, because an unprojected fan-out no frame's policy governs was a second, fail-open production door beside the projected one. They survive as implementation-tier seams for two consumers — the framework's own synchronous-window capture sites, and tests. An application observes production records through a frame's `:observability` sink, or the `(rf/configure! {:observability …})` process default, both of which deliver a projected record. A test brackets the raw substrate on purpose: it wants the unprojected shape, inside a window it owns.
 
-  Macro requires: the same shape as `with-trace-recorder!` above — JVM refers it through the ordinary `:require`; CLJS test files reach it with `(:require-macros [re-frame.test-support :refer [with-emit-recorder!]])`.
+    Macro requires: the same shape as `with-trace-recorder!` above — JVM refers it through the ordinary `:require`; CLJS test files reach it with `(:require-macros [re-frame.test-support :refer [with-emit-recorder!]])`.
 - **Example**:
   ```clojure
   ;; Default stream (:errors) — capture what one dispatch fails with.


### PR DESCRIPTION
Continues rf2-luch's sweep (#9615) across the rest of `docs/api`.

## The defect

Python-Markdown's four-column rule governs CONTINUATION content as well as child
items. A paragraph indented two or three columns under a `- parent` has not lost a
nesting level — it has left the list item altogether. The list CLOSES, the prose
renders at document level, and a new list opens after it, so one bullet list is
shown to the reader as two halves with body text stranded between them.

Rendered, at `docs/api/re-frame.adapter.uix.md`:

    BEFORE   …subscription; this noun returns its value.</li>
             </ul>
             <p>Returns the current sub value and re-renders the calling component…</p>
             <ul>
             <li>The 1-arg form resolves the frame from <strong>React context only</strong>…

    AFTER    …subscription; this noun returns its value.</p>
             <p>Returns the current sub value and re-renders the calling component…</p>
             <ul>
             <li>The 1-arg form resolves the frame from <strong>React context only</strong>…

## Measured by rendering, never by counting spaces

With the instrument rf2-gyq4 shipped: python-markdown under the exact ELEVEN-extension
list `mkdocs.yml` produces, loaded through mkdocs' own config loader, with a sentinel
injected into each candidate CONTINUATION line and the rendered tree asked whether that
sentinel landed inside an `<li>`.

Escaped continuation lines, per file, before → after:

    re-frame.test-support.md   27 → 0
    re-frame.core.md           26 → 0
    re-frame.ssr.ring.md       18 → 0
    re-frame.adapter.uix.md     4 → 0
    re-frame.ssr.md             3 → 0
    re-frame.flows.md           2 → 0
    re-frame.routing.md         2 → 0
    re-frame.epoch.md           1 → 0
    re-frame.test-helpers.md    1 → 0
                               ---
                               84 → 0

Three indented TABLES had escaped too, and the probe cannot see them (a sentinel in a
table row breaks the table, so those lines are excluded from injection). Counted
separately by asking whether each rendered `<table>` sits inside an `<li>`: `docs/api`
has exactly **3** source table blocks indented under a list item, and tables rendering
inside an `<li>` go **0 → 3** while the 28 legitimately at document level are untouched.

## Safety property

#9615's, not rf2-qsjr's, and it has to be: moving prose INTO a list item changes the
per-item text sequence by construction.

- **I1'** the ordered sequence of non-empty BLOCK-LEVEL text units is unchanged, a unit
  being the direct text of a block element. Units are ordered by each block's OPENING
  position — emitting at close would order a promoted `<li>text<ul>…</ul></li>`
  differently from its repaired `<li><p>text</p><ul>…</ul></li>` and report a reorder
  where reading order is in fact unchanged.
- **I2** whole-document text content unchanged.
- **I3** non-list HTML, with `ul`/`ol`/`li`/`p` stripped, unchanged.
- **I4** the `<pre>` count is unchanged — not merely "no new `<pre>`". The half-fix
  degenerates into an indented code block, and the opposite error (dedenting a real one
  out of existence) needs catching too.

All four hold on all nine files. **`git diff -w` is EMPTY**: leading whitespace and
nothing else, 211 insertions against 211 deletions with no line added or removed. 195
lines are actually reindented; the remaining 16 are byte-identical blank lines riding
inside merged hunks.

## Scope

Restricted to the item bodies that carry a MEASURED escape. Applying the same transform
to every file under `docs/api` is also invariant-clean but touches 2453 lines across 24
files, nearly all of it material that already renders inside its list item (a fence or a
lazy continuation two columns under its own marker). Those render correctly today and
are left alone.

Element counts do NOT move one-per-site, and that is a result rather than a miss: the
repair BOTH adds a nesting level and rejoins the list the escaped block had split. Root
list elements fall (`re-frame.ssr.ring.md` 19 → 10, `re-frame.test-support.md` 12 → 8)
while `<li>` counts hold exactly (85 → 85, 43 → 43). Grade by the escape count per file
going to zero.

## Gates

| Gate | Result |
|---|---|
| `python scripts/check_flattened_lists.py` | 0 both before and after — see below |
| `python scripts/check_doc_slugs.py` | exit 0 |
| `python scripts/check_readme_links.py --ci` | exit 0 |
| `python -m mkdocs build --strict` | exit 0 |

**`check_flattened_lists.py` reads 0 before AND after, and that is expected rather than a
gap.** Its pair rule requires two document-consecutive items to share a ROOT list, and an
escaped continuation splits that root in two — so this class MASKS flattened nesting from
the gate instead of being reported by it. The gate is therefore a regression guard here,
not the detector: it must stay 0, and it does. Nothing else in the repository sees this
class either — `check_doc_slugs.py` and `mkdocs build --strict` grade link targets and
heading anchors only.

**Ungraded, so checked by hand and stated here as the brief requires**: prose, tables,
rendering and nav are graded by nothing. The repair was verified by RENDERING — the
before/after fragment above, at three sites across three files — and the three moved
tables were verified to land inside their list items by walking the rendered tree, not
by reading the source. Column counts of the three moved tables are unchanged (I3 holds:
the non-list HTML is byte-identical).

## Out of scope, reported not fixed

Corpus-wide escaped continuation lines fall 542 → 458. What remains is entirely outside
`docs/api`, and the two largest carriers are method docs whose fences are pasteable
deliverables:

    166  docs/the-mayor-method/loops.md
     81  docs/EP/EP-0012-path-optics-and-canonical-forms.md
     75  docs/the-mayor-method/dispatch-prompt-template.md
     …    31 lines across 8 files under spec/

19 further indented table blocks sit under list items outside `docs/api`.

Closes rf2-6ml6.
