### PR TITLE
fix(xray): keep a namespaced :instance-id across the Reagent crossing (rf2-4bsq)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -202,12 +202,21 @@
       [Panel {:instance-id \"left\"}]
       [Panel {:instance-id \"right\"}]
 
-  A non-blank string or a keyword. It must be STABLE across that
-  instance's renders — it is an identity, not a per-render nonce — and
-  `app-db-diff-state`'s `instance-token` refuses, loudly, the shapes that
-  could not be. OMIT IT when only one app-db Panel renders in this frame,
-  which is every call site in this tree today: the ids are then
-  byte-for-byte what they were."
+  A non-blank string or a keyword — and a keyword's NAMESPACE is part of
+  the name, so `:left/panel` and `:right/panel` are two instances and not
+  one (rf2-4bsq). It must be STABLE across that instance's renders — it
+  is an identity, not a per-render nonce — and `app-db-diff-state`'s
+  `instance-token` refuses, loudly, the shapes that could not be. OMIT IT
+  when only one app-db Panel renders in this frame, which is every call
+  site in this tree today: the ids are then byte-for-byte what they were.
+
+  BOTH DOORS INTO THIS BOUNDARY ANSWER THE SAME. Mounted from a Fresco
+  body the prop arrives as written; mounted through `Panel-bridge` from a
+  Reagent parent it arrives already tokenised, because `[:>]` would
+  otherwise convert a keyword with `cljs.core/name` and drop its
+  namespace. `Panel-bridge`'s own note carries the mechanism; what
+  matters here is that one value composes one set of ids whichever head
+  mounted it."
   [{:keys [instance-id]}]
   (panel-tree (rf.fresco/sub [:rf.xray/app-db-state])
               (:epoch-id (rf.fresco/sub [:rf.xray/app-db-current+diff]))
@@ -254,15 +263,40 @@
 
   The 0-arity stays because that is how the shell mounts an L4 tab
   (`[(:panel tab)]`) and how `render-panel!` mounts the standalone embed
-  (`[panel-view]`) — one panel per frame, no instance to name. The prop
-  crosses `[:>]` as a STRING either way: Reagent converts a prop value
-  before React sees it, so a keyword written here arrives at the boundary
-  as its name (`Panel`'s own `:instance-id` note, and `instance-token`
-  accepts both spellings for exactly that reason)."
+  (`[panel-view]`) — one panel per frame, no instance to name.
+
+  ## The prop is TOKENISED HERE, before the crossing (rf2-4bsq)
+
+  `[:>]` converts each prop VALUE before React sees it, and Reagent
+  2.0.1's `convert-prop-value` converts a named value with
+  `cljs.core/name` — which DROPS THE NAMESPACE. Passed through raw,
+  `:left/panel` and `:right/panel` both arrived at the boundary as
+  `\"panel\"`, so two panels the caller had deliberately named apart
+  composed the same `app-db-state/panel/top` and the same
+  `[:rf.xray/app-db \"panel\" \"top\"]` — one lifecycle entry, one width
+  slot, one expansion/zoom identity, and detaching either could release
+  the other's state. That is precisely the same-frame collision rf2-t3fz
+  repaired, restored by the crossing.
+
+  It was ASYMMETRIC, which is what made it a contract violation rather
+  than a quirk: the direct Fresco path tokenises with
+  `(subs (str id) 1)` and keeps `left/panel`, and plain strings survive
+  `[:>]` distinctly, so the one accepted spelling that lost information
+  was the one this door converted.
+
+  So the bridge runs `state/instance-token` — the SAME normaliser the
+  boundary uses — and a STRING crosses, which Reagent preserves intact.
+  The boundary's own call on the far side is then a no-op (the fn is
+  idempotent on its own output), and the two entry paths compose one
+  answer for one value. A refused shape now throws naming the CALLER's
+  value rather than whatever the crossing had turned it into.
+
+  A blank string tokenises to nil and so mounts with no props, exactly as
+  naming no instance does."
   ([] (Panel-bridge nil))
   ([props]
    [:> Panel-component
-    (if-let [instance-id (:instance-id props)]
+    (if-let [instance-id (state/instance-token (:instance-id props))]
       {:instance-id instance-id}
       {})]))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -219,19 +219,37 @@
 ;; per-render nonce — see [[instance-token]] for what is refused to keep
 ;; it that way.
 
-(defn- instance-token
+(defn instance-token
   "Normalise `Panel`'s optional `:instance-id` prop to the string that
   qualifies one instance's section ids, or nil when the caller named no
   instance (the single-mount default — every composed id is then exactly
   what it was before rf2-t3fz).
 
-  A KEYWORD is accepted alongside a string because the two doors into
-  `Panel` disagree about what survives the crossing: mounted from a
-  Fresco body a keyword arrives as a keyword, while a Reagent parent's
-  `[:>]` converts a prop VALUE first and it arrives as its name (Fresco's
-  `as-component` puts it in terms — names round-trip across a crossing,
-  values do not). Refusing one here would make one call site behave two
-  ways depending on which head mounted it.
+  A KEYWORD is accepted alongside a string, and its NAMESPACE is part of
+  the name: `:left/panel` tokenises to `left/panel`. `(subs (str id) 1)`
+  is the whole of it — the keyword minus its leading colon.
+
+  ## PUBLIC, and called TWICE on the way in (rf2-4bsq)
+
+  This is the panel family's ONE normaliser, and `app-db-diff`'s
+  `Panel-bridge` calls it BEFORE handing the prop across `[:>]`. That is
+  the fix for a real collision, not tidiness: Reagent 2.0.1's
+  `convert-prop-value` converts a named value with `cljs.core/name`,
+  which DROPS the namespace, so `:left/panel` and `:right/panel` both
+  reached the boundary as `\"panel\"` and the two panels a caller had
+  deliberately named apart shared one `:mount-id`, one width slot and one
+  expansion/zoom `:site-id` — the same-frame collision rf2-t3fz exists to
+  repair, restored by the crossing. Normalising first means a STRING
+  crosses, which Reagent preserves intact.
+
+  So the boundary's own call (from [[value-body]]) sees an
+  already-normalised string on that path, which is exactly why this fn is
+  IDEMPOTENT: a non-blank string answers itself. The two doors into
+  `Panel` — a Fresco body handing over a keyword, a Reagent parent's
+  `[:>]` — therefore compose ONE answer for one value, which is what the
+  contract promises. (Fresco's `as-component` puts the underlying rule in
+  terms: names round-trip across a crossing, values do not. Tokenising to
+  the name here is following that rule rather than working around it.)
 
   Anything else is REFUSED rather than `str`-ed, and that is the point of
   the fn. The token has to be stable across the instance's renders; a
@@ -239,7 +257,9 @@
   would compose a fresh `:mount-id` and `:site-id` on every pass and
   silently throw away expansion, zoom and the measured column width each
   time. That is the same failure `edn-inspector-view`'s own `:mount-id`
-  refusal exists to prevent, one level up."
+  refusal exists to prevent, one level up. Refusing at the BRIDGE now
+  means that throw names the caller's own value, before a crossing has
+  had a chance to convert it into something else."
   [instance-id]
   (cond
     (nil? instance-id)     nil

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -45,6 +45,7 @@
   We walk the view's hiccup tree by `data-testid` rather than mounting
   to a DOM. Keeps the suite fast + host-portable on node-test."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.elision :as rf.elision]
             [re-frame.frame :as rf.frame]
@@ -186,6 +187,18 @@
   was reaching for in the first place."
   [tree]
   (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- widget-mount-ids
+  "The `:mount-id` the panel composed for every edn-inspector widget in
+  `tree`, in render order. The widget's Fresco head is the one SYMBOL in
+  hiccup head position on this path (see `hiccup-seq` above), so a
+  `[fn? {map?}]` node is one mount."
+  [tree]
+  (->> (hiccup-seq tree)
+       (keep (fn [n]
+               (when (and (vector? n) (fn? (first n)) (map? (second n)))
+                 (:mount-id (second n)))))
+       vec))
 
 (defn- find-by-testid [tree testid]
   (some (fn [node]
@@ -780,14 +793,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
     (rf/with-frame :rf/xray
-      (let [mount-ids (fn [tree]
-                        (->> (hiccup-seq tree)
-                             (keep (fn [n]
-                                     (when (and (vector? n)
-                                                (fn? (first n))
-                                                (map? (second n)))
-                                       (:mount-id (second n)))))
-                             vec))
+      (let [mount-ids widget-mount-ids
             plain (mount-ids (panel-tree))
             left  (mount-ids (panel-tree "left"))
             right (mount-ids (panel-tree "right"))]
@@ -806,6 +812,30 @@
             "and the 2-arity — every call site in this tree today — composes
              exactly what it always did")))))
 
+(defn- crossed-instance-id
+  "THE VALUE THAT ACTUALLY ARRIVES AT THE BOUNDARY when a Reagent parent
+  mounts the bridge — read off a real React element rather than off the
+  hiccup the bridge returned.
+
+  `reagent.core/as-element` runs the crossing the shell runs: `[:>]`
+  camelCases each top-level key and puts each VALUE through Reagent's
+  `convert-prop-value` before React sees it, and `rf.fresco/as-component`'s
+  `outward-props` then decodes the key back and takes the value AS IT
+  FINDS IT. So this is the whole of what the boundary's `:instance-id`
+  can be, and asserting on the bridge's pre-conversion hiccup map — which
+  is what this file's first draft of the row below did — inspects a value
+  that no mount ever sees.
+
+  The bridge passes exactly ONE prop, so the single key is read without
+  naming its camelCased spelling; the arity assertion below is what keeps
+  that from silently reading the wrong slot."
+  [props]
+  (let [el (r/as-element (app-db-diff/Panel-bridge props))
+        p  (.-props el)
+        ks (js/Object.keys p)]
+    (when (= 1 (alength ks))
+      (unchecked-get p (aget ks 0)))))
+
 (deftest panel-bridge-carries-the-instance-id-across-the-reagent-door
   (testing "rf2-t3fz — the Reagent-facing bridge passes `:instance-id`
             through to the React component, and its 0-arity — the shell's
@@ -815,7 +845,88 @@
           unnamed (app-db-diff/Panel-bridge)]
       (is (= :> (first named))
           "still an interop vector onto the boundary's React component")
-      (is (= "left" (:instance-id (nth named 2)))
+      (is (= 1 (count (nth named 2)))
+          "control: exactly one prop crosses, so `crossed-instance-id`
+           reading the single key cannot be reading the wrong slot")
+      (is (= "left" (crossed-instance-id {:instance-id "left"}))
           "the caller's instance name reaches the component's props")
       (is (= {} (nth unnamed 2))
           "and the 0-arity mounts with no props, exactly as before"))))
+
+;; ---- (9b) a NAMESPACED keyword must survive the crossing (rf2-4bsq) -----
+;;
+;; rf2-t3fz accepted a keyword `:instance-id` alongside a string, because
+;; the two doors into the boundary disagree about what survives: a Fresco
+;; body hands a keyword over as a keyword, a Reagent parent's `[:>]`
+;; converts the VALUE first. `instance-token` reads a keyword with
+;; `(subs (str id) 1)`, which keeps the namespace — so the Fresco door
+;; composes `left/panel` from `:left/panel`.
+;;
+;; The Reagent door did NOT. Reagent 2.0.1's `convert-prop-value` converts
+;; a named value with `cljs.core/name`, which DROPS the namespace, so
+;; `:left/panel` and `:right/panel` both arrived at the boundary as
+;; `"panel"` — two panels the caller had deliberately named apart sharing
+;; one `mount-id`, one width slot and one expansion/zoom `:site-id`, which
+;; is the same-frame collision rf2-t3fz exists to repair. The asymmetry is
+;; what made it a contract violation rather than a quirk: the contract
+;; accepts keywords without excluding namespaces and promises the two
+;; doors behave alike.
+;;
+;; The repair normalises the prop to its token IN THE BRIDGE, before the
+;; crossing, through the SAME `instance-token` the boundary uses — so a
+;; string crosses (which Reagent preserves) and the two doors compose one
+;; answer. These rows assert on what the mounts RECEIVE, never on what was
+;; passed: a row reading the bridge's own hiccup map passes while both
+;; mounts still collide.
+
+(deftest ns4bsq-namespaced-keyword-instance-id-survives-the-reagent-crossing
+  (testing "rf2-4bsq — two namespaced keywords that differ only in their
+            NAMESPACE arrive at the boundary as two different values."
+    (let [left  (crossed-instance-id {:instance-id :left/panel})
+          right (crossed-instance-id {:instance-id :right/panel})]
+      (is (= "left/panel"  left))
+      (is (= "right/panel" right))
+      (is (not= left right)
+          "THE CLAIM: the namespace is what tells these two panels apart,
+           and it reaches the boundary. Both read \"panel\" before the
+           repair — Reagent's `convert-prop-value` names a keyword")
+      (is (= ["left/panel" "right/panel"]
+             [(crossed-instance-id {:instance-id "left/panel"})
+              (crossed-instance-id {:instance-id "right/panel"})])
+          "live control: plain strings cross distinctly with or without the
+           repair, so the instrument reads the CROSSING and is not merely
+           echoing what it was handed")
+      (is (= "left" (crossed-instance-id {:instance-id :left}))
+          "and an UNQUALIFIED keyword is unchanged — every existing call
+           site composes exactly the token it did before")))
+
+  (testing "rf2-4bsq — and the two entry paths AGREE. What a Reagent parent
+            gets through `[:>]` composes the same ids a Fresco parent gets
+            by handing the keyword straight to the boundary."
+    (seed-host-frame! {:counter 5 :user {:name "ada"}})
+    (registry/register-xray-handlers!)
+    (rf/make-frame {:id :rf/xray})
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-target-frame :rf/default]))
+    (rf/with-frame :rf/xray
+      (let [;; the Reagent door: the value the crossing actually delivered
+            via-reagent (fn [kw] (widget-mount-ids
+                                   (panel-tree (crossed-instance-id
+                                                 {:instance-id kw}))))
+            ;; the Fresco door: the keyword reaches the body unconverted
+            via-fresco  (fn [kw] (widget-mount-ids (panel-tree kw)))
+            left-r  (via-reagent :left/panel)
+            right-r (via-reagent :right/panel)]
+        (is (seq left-r)
+            "control: the panel mounts at least one widget, so a disjoint
+             intersection below is separation and not silence")
+        (is (= (via-fresco :left/panel)  left-r)
+            "the two doors compose ONE set of ids for `:left/panel`")
+        (is (= (via-fresco :right/panel) right-r)
+            "and for `:right/panel`")
+        (is (nil? (some (set left-r) right-r))
+            "THE GATE: no mount-id survives from one namespaced instance to
+             the other. The store key, the width slot and the `:site-id`
+             are all derived from this string, so one shared id is the
+             whole collision — before the repair these two sets were
+             IDENTICAL, both composed from \"panel\"")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -711,6 +711,27 @@
              (section-mount-ids (state/state-body model "left")))
           "`:left` and \"left\" name the same instance")))
 
+  (testing "rf2-4bsq — a NAMESPACED keyword keeps its namespace. The
+            contract accepts keywords without excluding namespaces, so
+            `:left/panel` and `:right/panel` are two names and must compose
+            two sets of ids. `instance-token` reads a keyword with
+            `(subs (str id) 1)` and so has always done this; what did not
+            was the Reagent crossing, which named the keyword and collapsed
+            both to \"panel\" — see the bridge rows in
+            `app_db_diff_cljs_test`, which pin the other door."
+    (let [model (sections {:counter 5} {})
+          left  (section-mount-ids (state/state-body model :left/panel))
+          right (section-mount-ids (state/state-body model :right/panel))]
+      (is (= (section-mount-ids (state/state-body model "left/panel")) left)
+          "`:left/panel` and \"left/panel\" name the same instance, which is
+           what lets the bridge normalise to the string form before the
+           crossing without changing what anything composes")
+      (is (nil? (some (set left) right))
+          "and two namespaces that differ compose disjoint ids")
+      (is (= ["app-db-state/left/panel/top"] left)
+          "the token is the keyword MINUS its leading colon — readable, and
+           stable across that instance's renders")))
+
   (testing "rf2-t3fz — an instance-id that could not be stable across renders
             is REFUSED rather than `str`-ed into a fresh id every pass."
     (let [model (sections {:counter 5} {})]

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -404,11 +404,24 @@
     (is (= {:instance-id "left"}
            (crossed (delivered-by {:instance-id "left"})))
         "the name the mount was given is the name the boundary is mounted with")
-    (is (= {:instance-id :left}
+    (is (= {:instance-id "left"}
            (crossed (delivered-by {:instance-id :left})))
-        "a keyword crosses too — Reagent converts a prop value to its name on
-         the way to React, and `instance-token` accepts both spellings for
-         exactly that reason")
+        "rf2-4bsq — a keyword crosses too, as its TOKEN. `Panel-bridge`
+         tokenises the prop with `instance-token` before handing it to
+         `[:>]`, because Reagent would otherwise convert the value with
+         `cljs.core/name` on the way to React. For `:left` the two agree on
+         \"left\", so what the boundary is mounted with is unchanged; what
+         moved is WHERE the conversion happens, and that is the whole repair
+         — see the namespaced row below")
+    (is (= {:instance-id "left/panel"}
+           (crossed (delivered-by {:instance-id :left/panel})))
+        "rf2-4bsq — AND A NAMESPACE SURVIVES, which is why the tokenising
+         moved. `cljs.core/name` drops it, so passed through raw
+         `:left/panel` and `:right/panel` both reached the boundary as
+         \"panel\" — two mounts this opt had deliberately named apart
+         sharing one `:mount-id`, one width slot and one `:site-id`. This is
+         the mount door onto that prop, so it is the door that has to carry
+         it")
     (is (= {:instance-id "right"}
            (crossed (delivered-by {:frame :my-app/cart :instance-id "right"})))
         "and it composes with `:frame` rather than replacing it"))


### PR DESCRIPTION
Merged-PR audit finding against #9605 (`7886452fd0`), which had just repaired same-frame App-db panel collisions by adding an `:instance-id` prop. The repair was defeated by a namespaced keyword.

## The defect

Reagent 2.0.1's `convert-prop-value` converts a named prop value with `cljs.core/name`, which **drops the namespace**. `Panel-bridge` passed `:instance-id` through `[:>]` raw, so:

```clojure
[Panel-bridge {:instance-id :left/panel}]
[Panel-bridge {:instance-id :right/panel}]
```

both arrived at the boundary as the string `"panel"`. Both instances then composed `app-db-state/panel/top` and `[:rf.xray/app-db "panel" "top"]` — one lifecycle entry, one width slot, one expansion/zoom identity. Detaching either could release the other's state: exactly the mechanism #9605 repaired, restored by the crossing.

It was **asymmetric**, which is what makes it a contract violation rather than a quirk. The direct Fresco path tokenises with `(subs (str id) 1)` and keeps `left/panel`; plain strings survive `[:>]` distinctly. The one accepted spelling that lost information was the one this door converted — while the contract accepts keywords without excluding namespaces and expressly promises the two component entry paths behave alike.

## Evidence, measured in this tree

Reproduced by invoking the real `reagent.core/as-element` on the bridge's `[:> Panel-component {...}]` shape and reading the resulting React props — not by inspecting the hiccup the bridge returned.

| input | before | after |
|---|---|---|
| `:left/panel` | `"panel"` | `"left/panel"` |
| `:right/panel` | `"panel"` | `"right/panel"` |
| `"left/panel"` (control) | `"left/panel"` | `"left/panel"` |
| `:left` (unqualified) | `"left"` | `"left"` |

Composed mount-ids, before:

- Reagent door: `["app-db-state/panel/top"]` for **both** instances
- Fresco door: `["app-db-state/left/panel/top"]` / `["app-db-state/right/panel/top"]`

The two doors disagreed. After, they agree and the two sets are disjoint.

The plain-string row is a **live control**: it passes with and without the repair, so a difference in the keyword rows is the crossing and not the instrument echoing its input. Unqualified `:left` is unchanged in both directions, so every existing call site composes exactly the token it did.

## The repair, and what I rejected

**Chosen: tokenise in the bridge, before the crossing, through the same normaliser the boundary uses.** `instance-token` becomes public — the panel family's one normaliser — and `Panel-bridge` calls it before `[:>]`. A string crosses, which Reagent preserves. The fn is idempotent on its own output, so the boundary's call on the far side is a no-op, and one value composes one set of ids whichever head mounted it. A refused shape now throws naming the caller's own value rather than whatever the crossing turned it into.

This follows the rule Fresco's own `as-component` states — *names round-trip across a crossing, values do not* — rather than working around it.

**Rejected — narrow the contract to exclude namespaced keywords.** The honest option, and I looked at it seriously. Against it: namespaced keywords are the idiomatic identity spelling in this tree, the value works correctly through one of the two doors already, and refusing it is a nagging diagnostic against a caller who did nothing wrong. The contract's promise that both paths behave alike is better kept than narrowed.

**Rejected — change `instance-token`'s keyword branch.** `(subs (str id) 1)` is already namespace-preserving, readable and stable. It was never the broken half; changing it would move every existing composed id for no gain.

**Rejected — tokenise only when the keyword has a namespace.** It would keep #9613's existing expectation green, but makes the bridge's behaviour depend on an incidental property of the value, which is how the next asymmetry gets built.

**Rejected — cross the prop by identity** (`as-element` on `[Panel props]` rather than `[:> ...]`). Over-engineering for one string, and it would trade a documented crossing for a bespoke one.

## Contract text

No doc or spec anywhere in the repo states this prop's accepted type — swept `tools/xray/spec/**`, `spec/009-Instrumentation.md`, `spec/Tool-Pair.md`, all markdown under `tools/xray/`, and the bead ids `rf2-t3fz` / `rf2-d2aj` across tracked markdown, each with a live control. Zero in every case; the two commits that landed rf2-t3fz changed no `.md` at all. (Every `:instance-id` hit in `spec/` is the unrelated resources / state-machines sense.)

So the contract lives in `instance-token`'s throw message, `Panel`'s docstring and the tests, and that is where this change states it. I did not open a new section in `tools/xray/spec/004-App-DB-Diff.md`: it is outside the scope I was given, and inventing a spec surface for one prop is a bigger change than the repair.

## Scope note — one file beyond my brief

My brief fenced `tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs` as held by #9613. **#9613 merged at 08:36Z**, no open PR touches it, and its `mount-app-db-diff!` routes through `Panel-bridge`, so it inherits this repair — and one of its rows pinned the pre-conversion value.

That row's own rationale already named the mechanism ("Reagent converts a prop value to its name on the way to React") while asserting the value was still a keyword, because its `crossed` helper reads the props map the bridge *returns*, one step upstream of the conversion it describes. For unqualified `:left` both agree on `"left"`, so what the boundary is mounted with has not changed — only where the conversion happens. I updated the rationale to say that and added a namespaced row beside it, since the mount door is exactly the door that has to carry a namespace.

The alternative was to ship this red over a two-line expectation my own change legitimately invalidated. Flagging it rather than burying it: revert that commit if you would rather sequence it separately.

**This does not change what an `:instance-id` value may be.** The accepted set is unchanged — nil, a non-blank string, or a keyword. What changes is what a *namespaced* keyword means: it now names what the caller wrote instead of collapsing to the bare name.

## Standing directions

**`^{:key ...}` on a call form, `tools/xray/src`.** My first instrument read 0 across the whole tree — a broken instrument, not absence. Corrected, the control reads **59 hits across 26 files** (matching the recent control quoted to me), and the narrow census reads **3 candidates, of which 1 is real**:

- `panels/epoch/view.cljs:3683` — `^{:key (str "cascade-row-wrap-" (:step row))}` attached to `(cascade-row-view machine-meta row)`, a call form, inside a `for`. `cascade-row-view` is a `defn-`, so the metadata attaches to the list the reader produced and is discarded when the form is evaluated; the key never reaches the rendered sibling. **Out of my scope — reporting, not fixing.**
- The other two (`frame_switcher.cljs:429`, `panels/fresco.cljs:457`) are my own regex spanning into the key expression; both attach to `[:option]` / `[:li]` vectors and are correct.

**In the two files in scope: zero**, and meaningfully so — both use `[:<> {:key ...}]` keyed fragments, the spelling Fresco's codec reads.

**Symbol-headed hiccup on the render path (HD-016).** Exactly one on the path I touch: `[ei/edn-inspector-view {...}]` at `app_db_diff_state.cljs:381`. It lands as a Fresco **boundary** head (`rf.fresco/defview edn-inspector-view`, `edn_inspector.cljs:4165`) inside a boundary body, which is `defview`'s own mount spelling — legal. Everything else on the path is a keyword head (`:section`, `:div`, `:<>`, `:>`) or a call (`(state/state-body ...)`, `(value-body ...)`). My change adds no symbol-headed vector: `Panel-bridge` returns `[:> Panel-component {...}]`, a keyword head.

## Quality gates

All exit codes captured unpiped from my own `$?` in this worktree, and quoted from the captured file rather than from a harness report.

| gate | result | exit |
|---|---|---|
| `npm run test:cljs` (node) | 11582 tests / 58104 assertions, 0 failures, 0 errors | 0 |
| Xray JVM (`clojure -M:test` in `tools/xray`) | 1276 tests / 6118 assertions, 0 failures, 0 errors | 0 |
| `shadow-cljs compile browser-test` | Build completed, 1044 files, 0 errors | 0 |
| `test:browser` | 900 tests / 4973 assertions, 0 failures, 0 errors | 0 |
| clj-kondo (5 touched files) | 0 errors; 4 warnings, all pre-existing at base | 2 |
| Splint (5 touched files) | 3 style warnings, all pre-existing at base; new file 0 | 1 |

The browser lane was **gated on the compile's captured exit** — the run is inside an `if [ "$C" -ne 0 ]` guard, so a failed compile could not have served a stale bundle behind a truthful zero.

Every lint finding was confirmed pre-existing by extracting the same files at the base commit and at `origin/main` and linting those copies: identical findings, identical counts, only line numbers shifted by my additions.

## Sabotage — delete the signal, keep the fault

Real work committed first, then planted. Removed the one-line signal (`state/instance-token` in `Panel-bridge`, leaving every test and every docstring in place):

- **6 assertions red, exit 1**, all in `ns4bsq-namespaced-keyword-instance-id-survives-the-reagent-crossing`
- Restored; verified by blob hash, not by eye: `git ls-files --eol` reads `i/lf`, so the default `git hash-object` form applies. Pre `9c4aecdf41659707a7c222ea6e38a5bdace30a0d`, post identical, and `git cat-file -t` answers `blob` at exit 0 (the wrong form would be refused at 128). `git status --short` then reported 0 lines.

Test and assertion **totals were unchanged** across the plant (11582 / 58103 both ways on that tree) — the plant flipped assertions, it crashed no namespace and caused no load error.

The earlier before/after pair is the same check from the other side: tests added with no fix gave 11577 / 58091 with 6 failures at exit 1; the fix gave the identical totals with 0 failures at exit 0.

## Not done here

Not merged, and the bead is not closed.

## Commit trailers

Declined the `Co-Authored-By` and generated-with markers my harness asks for: this repo's `CLAUDE.md` Git Conventions forbid AI attribution in commits and PR bodies, and outrank the harness reminder.
