### PR TITLE
feat(xray): Static Flows + Schemas panels become Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -211,13 +211,7 @@
        [:span {:style {:color (:text-tertiary tokens)
                        :flex  "0 0 auto"}}
         "inputs:"]
-       ;; The testid makes the inputs SEQ addressable as a container. A
-       ;; keyed fragment adds no DOM node, so this span's direct children
-       ;; are exactly the per-input widget roots — which is what lets the
-       ;; browser lane assert row identity across a reorder without
-       ;; reaching into `edn-inspector`'s own testid derivation.
-       (into [:span {:data-testid (str "rf-xray-static-flows-inputs-" flow-key)
-                     :style {:display     "inline-flex"
+       (into [:span {:style {:display     "inline-flex"
                              :flex-wrap   "wrap"
                              :gap         "6px"}}]
              ;; THE KEY RIDES ON A KEYED FRAGMENT'S ATTRIBUTE MAP, and this

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -47,10 +47,22 @@
 
   Same contract as every Xray view — pure hiccup, no Reagent / UIx
   references. Frame isolation comes from the enclosing
-  `[rf/frame-provider {:frame :rf/xray}]` in `static/shell.cljs`."
+  `[rf/frame-provider {:frame :rf/xray}]` in `static/shell.cljs`.
+
+  ## Public surface
+
+  - `Panel`        — the tab's root. Since rf2-k97c.3 an
+                     `rf.fresco/defview` BOUNDARY — a real React function
+                     component, not an `rf/reg-view`.
+  - `panel-tree`   — the whole body, as a pure fn of the read's VALUE and
+                     a frame-bound dispatcher. `Panel` is the read plus a
+                     call to this.
+  - `install!`     — idempotent install for the subs, events and the L4
+                     tab registration."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.flows :as rf.flows]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.shared.catalogue :as catalogue]
             [day8.re-frame2-xray.static.shared.search-box :as search-box]
@@ -134,21 +146,26 @@
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
-  [query total filtered?]
-  ;; Render-time frame capture so the deferred search input dispatches
-  ;; into the surrounding instance frame (rendered inside the flows Panel
-  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
-  ;; the shared `search-box` component.
-  (let [frame (rf/current-frame-id)]
-    [search-box/search-box
-     {:testid-prefix   "rf-xray-static-flows"
-      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
-      :set-query-event :rf.xray.static.flows/set-query
-      :placeholder     "flow-id, path, or doc…"
-      :value           query
-      :count-noun      "flow"
-      :total           total
-      :filtered?       filtered?}]))
+  ;; CALLED, never used as a hiccup head (rf2-k97c.3). `search-box/search-box`
+  ;; is a plain fn, and a plain function in head position is a loud error
+  ;; inside a Fresco body by design; applying it renders the identical
+  ;; markup. The flex-row chrome still lives in the shared component.
+  ;;
+  ;; `dispatch` arrives from the boundary rather than being captured here.
+  ;; The keystroke dispatch is an OUT-OF-RENDER affordance — it fires after
+  ;; render unwinds, when the ambient frame is gone — so it must be bound to
+  ;; a frame at render time; `Panel` binds it once with `rf/capture-frame`
+  ;; and threads it down. nil is legal for a mount that never types.
+  [dispatch query total filtered?]
+  (search-box/search-box
+    {:testid-prefix   "rf-xray-static-flows"
+     :dispatch        dispatch
+     :set-query-event :rf.xray.static.flows/set-query
+     :placeholder     "flow-id, path, or doc…"
+     :value           query
+     :count-noun      "flow"
+     :total           total
+     :filtered?       filtered?}))
 
 ;; ---- row -----------------------------------------------------------------
 
@@ -175,11 +192,16 @@
    ;; Input + output path values render through the shared cljs-devtools
    ;; EDN widget (spec 007:119 — "all values rendered via the
    ;; cljs-devtools-shaped renderer") rather than raw `pr-str` +
-   ;; `[:code]`. `edn/inspect` is the canonical L4 renderer (same call
-   ;; the App-DB segment-inspector uses); each value gets a stable
-   ;; per-flow `node-key` so the widget's per-node expand state + copy
-   ;; affordance ride the same way they do in the App-DB / Trace / Event
-   ;; surfaces.
+   ;; `[:code]`. `edn/inspect-view` is the widget's FRESCO head — same
+   ;; value, same opts, same renderer as `edn/inspect`, differing ONLY in
+   ;; that it emits `[ei/edn-inspector-view …]` (a boundary) rather than
+   ;; `[ei/edn-inspector …]` (a Reagent component). rf2-k97c.3 made the
+   ;; swap mandatory rather than stylistic: `ei/edn-inspector` is a plain
+   ;; fn, and a plain fn in hiccup head position is a loud error inside a
+   ;; Fresco body. Each value keeps its stable per-flow `node-key`, which
+   ;; is now load-bearing twice over — it is the panel-id keying expand
+   ;; state AND the boundary's required `:mount-id`, so two mounts sharing
+   ;; one node-key would share a width slot and a projection cache.
    (let [flow-key (subs (pr-str flow-id) 1)]
      [:div {:style {:margin-left  "12px"
                     :color        (:text-secondary tokens)
@@ -189,29 +211,44 @@
        [:span {:style {:color (:text-tertiary tokens)
                        :flex  "0 0 auto"}}
         "inputs:"]
-       (into [:span {:style {:display     "inline-flex"
+       ;; The testid makes the inputs SEQ addressable as a container. A
+       ;; keyed fragment adds no DOM node, so this span's direct children
+       ;; are exactly the per-input widget roots — which is what lets the
+       ;; browser lane assert row identity across a reorder without
+       ;; reaching into `edn-inspector`'s own testid derivation.
+       (into [:span {:data-testid (str "rf-xray-static-flows-inputs-" flow-key)
+                     :style {:display     "inline-flex"
                              :flex-wrap   "wrap"
                              :gap         "6px"}}]
-             ;; `^{:key …}` reader meta on the `(edn/inspect …)` call below
-             ;; would be attached to the SOURCE LIST and lost when the call
-             ;; returns its fresh vector — Reagent's `get-react-key` only
-             ;; reads `:key` meta from vectors. `edn/inspect` always returns
-             ;; an `[ei/edn-inspector …]` vector, so apply the key directly
-             ;; via `with-meta` (rf2-k97c.3, the same repair
-             ;; `static/machines/sim.cljs` already carries for this defect).
-             ;; Measured before the repair: all three input values in the
-             ;; unit fixture carried nil metadata, so NO key reached React
-             ;; and the inputs seq reconciled by index.
+             ;; THE KEY RIDES ON A KEYED FRAGMENT'S ATTRIBUTE MAP, and this
+             ;; site has now been wrong in TWO different ways for two
+             ;; different reasons (rf2-k97c.3, RULING 2's key sweep).
+             ;;
+             ;; It was first `^{:key …}` reader meta on the `(edn/inspect …)`
+             ;; CALL FORM — metadata on a source list, discarded when the
+             ;; call returns its fresh vector, so NO key ever reached React
+             ;; and the inputs seq reconciled by index. That was repaired to
+             ;; `with-meta` on the RETURNED VECTOR, which Reagent's
+             ;; `get-react-key` really does read.
+             ;;
+             ;; Fresco's codec reads `:key` from an ATTRIBUTE MAP and reads
+             ;; Clojure metadata NOWHERE, so that repair goes inert the
+             ;; moment this panel renders through a boundary — and a lost key
+             ;; does not fail, it degrades silently into index-based
+             ;; reconciliation, which paints identically and corrupts
+             ;; identity only once the seq changes shape. The fragment
+             ;; carries the key without adding a DOM node, and the key
+             ;; EXPRESSION is unchanged.
              (for [[i input-path] (map-indexed vector inputs)]
-               (with-meta
-                 (edn/inspect input-path
-                              (str "static-flows/" flow-key "/input/" i))
-                 {:key (str "in-" i)})))]
+               [:<> {:key (str "in-" i)}
+                (edn/inspect-view input-path
+                                  (str "static-flows/" flow-key "/input/" i))]))]
       [:div {:style {:display "flex" :align-items "baseline" :gap "6px"}}
        [:span {:style {:color (:text-tertiary tokens)
                        :flex  "0 0 auto"}}
         "output →"]
-       (edn/inspect output-path (str "static-flows/" flow-key "/output"))]
+       ;; The single output value is not in a seq, so it needs no key.
+       (edn/inspect-view output-path (str "static-flows/" flow-key "/output"))]
       (when doc
         [:div {:style {:margin-top  "4px"
                        :color       (:text-secondary tokens)
@@ -219,27 +256,137 @@
                        :font-style  "italic"}}
          doc])])))
 
+;; ---- the body, as a pure fn of the read's value ---------------------------
+
+(defn panel-tree
+  "The Static Flows tab's WHOLE body, as a pure function of the one value
+  [[Panel]] reads — the `:rf.xray.static.flows/tab-data` composite — and
+  the frame-bound `dispatch` the search box needs.
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup — while the catalogue's
+  projection is ordinary data → data and is worth testing in the fast node
+  lane. `panel_cljs_test` drives THIS fn with the value it takes from the
+  sub directly; the boundary's own behaviour — first paint, liveness,
+  frame targeting, evidence isolation, teardown and row identity — is
+  `panel_fresco_boundary_dom_cljs_test`'s subject.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [silent? flows total filtered? query]} dispatch]
+  (catalogue/catalogue-panel
+   {:testid     "rf-xray-static-flows"
+    :noun       "flow"
+    :query      query
+    :silent?    silent?
+    :rows       flows
+    :search     (search-box dispatch query total filtered?)
+    ;; THE KEY RIDES ON A KEYED FRAGMENT, not on reader metadata
+    ;; (rf2-k97c.3) — the same move the input seq above makes, for the
+    ;; same reason. `^{:key …}` on this vector literal is read by Reagent
+    ;; and by Fresco's codec NOWHERE, so it would reach React as nothing
+    ;; once the panel renders through a boundary. The fragment carries the
+    ;; key without adding a DOM node, which is what keeps `catalogue-row`'s
+    ;; `li` chrome the shared presentational helper it is; the key
+    ;; expression is unchanged and identity stays domain-shaped and local,
+    ;; exactly as `catalogue-panel`'s `:row-render` contract asks.
+    :row-render (fn [row]
+                  [:<> {:key (str (:frame row) "/" (:flow-id row))}
+                   (flow-row row)])}))
+
 ;; ---- root view -----------------------------------------------------------
 
-(rf/reg-view Panel
-  "Static Flows panel root view. Subscribes to the registered-flows
-  composite + the search-query slot and composes the header + search +
-  flat list.
+(rf.fresco/defview Panel
+  "The Static Flows tab's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads the flows composite and hands its value plus a
+  frame-bound dispatcher to [[panel-tree]].
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
+  The READ is `rf.fresco/sub`, a plain call the shipped collector records
+  an edge for — no deref, no reaction owned by the installed adapter, and
+  a re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and the
+  one a first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which the
+  enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context — so this resolves
+  `:rf/xray` identically under today's Reagent-rendered Static shell and
+  under the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
+  same guarantee, one call, and it is the spelling every migrated panel
+  now uses. The search box's keystroke dispatch therefore still lands on
+  THIS Xray instance's frame after render scope unwinds rather than
+  leaking to `:rf/default`.
+
+  ONE read and ONE boundary. Boundary count tracks reads and
+  head-position use, not file size: `catalogue-panel`, `catalogue-row`,
+  `search-box` and `flow-row` are all CALLED, never used as a hiccup head,
+  so Fresco's \"a plain function in head position is a loud error\" rule
+  never meets one. The one fn-headed vector that REMAINS in the tree is
+  `edn/inspect-view`'s `[ei/edn-inspector-view …]`, which is itself a
+  boundary and so is a legal head; nothing else in the interior wants a
+  boundary of its own.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray.static.flows/tab-data])
+              (:dispatch (rf/capture-frame))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's Static shell is still a `reg-view` tree rendered by the installed
+;; adapter. `static/shell.cljs`'s `detail-panel` mounts the active tab as
+;; the hiccup head `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s
+;; `:pre` requires `:panel` to be CALLABLE — neither of which a React
+;; component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; BOTH DEFS ARE PRIVATE, and that is a measured property of this panel
+;; rather than a default: `Panel` is named outside this file only in
+;; `static/shell.cljs`'s PROSE (a docstring listing the L4 tabs) and in
+;; `spec/api-manifest*.edn`'s rows — never mounted or called by name. The
+;; L4 registry is the only consumer, and `install!` below is the only
+;; thing that passes the bridge. A panel carrying a standalone `mount-*!`
+;; facade needs a PUBLIC bridge instead, because `panels/render-panel!`
+;; takes the view to mount as an argument and needs a name to pass; this
+;; panel has none — `panels.cljs` names no Static sub-tab.
+;;
+;; `Panel` KEEPS THE NATURAL NAME, which is the spelling ruled to survive
+;; (the #9581 assignment) and is also what keeps the two hot-zone
+;; api-manifest rows for `static.flows.panel/Panel` valid without touching
+;; either file.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the Static shell is itself
+;; a Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the Static shell's enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
   []
-  (let [data @(rf/subscribe [:rf.xray.static.flows/tab-data])
-        {:keys [silent? flows total filtered? query]} data]
-    (catalogue/catalogue-panel
-     {:testid     "rf-xray-static-flows"
-      :noun       "flow"
-      :query      query
-      :silent?    silent?
-      :rows       flows
-      :search     (search-box query total filtered?)
-      :row-render (fn [row]
-                    ^{:key (str (:frame row) "/" (:flow-id row))}
-                    [flow-row row])})))
+  [:> Panel-component {}])
 
 ;; ---- production value source ---------------------------------------------
 ;;
@@ -354,7 +501,11 @@
      :mnem  "f"
      :modes #{:static}
      :order 3
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the Static shell mounts `:panel`
+     ;; as a Reagent hiccup head; the bridge is the one line between them
+     ;; and goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)
 

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -51,9 +51,21 @@
 
   Same contract as every Xray view — pure hiccup. Frame isolation
   comes from the enclosing `[rf/frame-provider {:frame :rf/xray}]`
-  in `static/shell.cljs`."
+  in `static/shell.cljs`.
+
+  ## Public surface
+
+  - `Panel`        — the tab's root. Since rf2-k97c.3 an
+                     `rf.fresco/defview` BOUNDARY — a real React function
+                     component, not an `rf/reg-view`.
+  - `panel-tree`   — the whole body, as a pure fn of the read's VALUE and
+                     a frame-bound dispatcher. `Panel` is the read plus a
+                     call to this.
+  - `install!`     — idempotent install for the subs, events and the L4
+                     tab registration."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.schemas :as rf.schemas]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
@@ -161,20 +173,26 @@
 ;; ---- search box ----------------------------------------------------------
 
 (defn- search-box
-  [query total filtered?]
-  ;; Render-time frame capture (rendered inside the schemas Panel
-  ;; reg-view), not a `:rf/xray` literal. The flex-row markup lives in
-  ;; the shared `search-box` component.
-  (let [frame (rf/current-frame-id)]
-    [search-box/search-box
-     {:testid-prefix   "rf-xray-static-schemas"
-      :dispatch        (fn [ev] (rf/dispatch ev {:frame frame}))
-      :set-query-event :rf.xray.static.schemas/set-query
-      :placeholder     "kind, id, frame, or doc…"
-      :value           query
-      :count-noun      "schema"
-      :total           total
-      :filtered?       filtered?}]))
+  ;; CALLED, never used as a hiccup head (rf2-k97c.3). `search-box/search-box`
+  ;; is a plain fn, and a plain function in head position is a loud error
+  ;; inside a Fresco body by design; applying it renders the identical
+  ;; markup. The flex-row chrome still lives in the shared component.
+  ;;
+  ;; `dispatch` arrives from the boundary rather than being captured here.
+  ;; The keystroke dispatch is an OUT-OF-RENDER affordance — it fires after
+  ;; render unwinds, when the ambient frame is gone — so it must be bound to
+  ;; a frame at render time; `Panel` binds it once with `rf/capture-frame`
+  ;; and threads it down. nil is legal for a mount that never types.
+  [dispatch query total filtered?]
+  (search-box/search-box
+    {:testid-prefix   "rf-xray-static-schemas"
+     :dispatch        dispatch
+     :set-query-event :rf.xray.static.schemas/set-query
+     :placeholder     "kind, id, frame, or doc…"
+     :value           query
+     :count-noun      "schema"
+     :total           total
+     :filtered?       filtered?}))
 
 ;; ---- row -----------------------------------------------------------------
 
@@ -226,15 +244,31 @@
                 :style       {:color     (:text-tertiary tokens)
                               :font-size "10px"}}
          (pr-str frame)])
+      ;; CALLED, never used as a hiccup head (rf2-k97c.3).
+      ;; `open-in-editor/open-chip` is a plain fn answering hiccup (or nil
+      ;; when the coord carries no usable `:file`), and a plain fn in head
+      ;; position is a loud error inside a Fresco body; applying it renders
+      ;; the identical `<a>` chrome, and a nil is a legal child either way.
+      ;; Its click handler is untouched — `defview`'s contract passes a
+      ;; plain fn at an `on-*` prop through, and `chip-click!` already
+      ;; carries its own explicit `{:frame …}`.
       (when (and source-coord (:file source-coord))
-        [open-in-editor/open-chip source-coord])]
+        (open-in-editor/open-chip source-coord))]
      ;; The Malli schema EDN renders through the shared cljs-devtools EDN
      ;; widget (spec 007:119 — "all values rendered via the
      ;; cljs-devtools-shaped renderer") rather than raw `pr-str` +
      ;; `[:code]`, so it gains expand/collapse, syntax-colouring parity,
-     ;; and the per-node copy host. The `node-key` is stable per
-     ;; (kind,id) so expand state survives reloads and doesn't collide
-     ;; across rows.
+     ;; and the per-node copy host. `edn/inspect-view` is the widget's
+     ;; FRESCO head — same value, same opts, same renderer as
+     ;; `edn/inspect`, differing ONLY in that it emits
+     ;; `[ei/edn-inspector-view …]` (a boundary) rather than
+     ;; `[ei/edn-inspector …]` (a Reagent component). rf2-k97c.3 made the
+     ;; swap mandatory rather than stylistic: `ei/edn-inspector` is a
+     ;; plain fn, and a plain fn in hiccup head position is a loud error
+     ;; inside a Fresco body. The `node-key` is stable per (kind,id) so
+     ;; expand state survives reloads and doesn't collide across rows —
+     ;; now load-bearing twice over, since it is also the boundary's
+     ;; required `:mount-id`.
      [:div {:data-testid (str "rf-xray-static-schemas-schema-" row-id)
             :style {:margin-left "20px"
                     :margin-top  "2px"
@@ -242,7 +276,7 @@
                     :font-size   "11px"
                     :white-space "pre-wrap"
                     :word-break  "break-word"}}
-      (edn/inspect schema (str "static-schemas/" row-id))]
+      (edn/inspect-view schema (str "static-schemas/" row-id))]
      (when doc
        [:div {:style {:margin-left "20px"
                       :margin-top  "2px"
@@ -252,29 +286,140 @@
                       :font-size   "11px"}}
         doc]))))
 
+;; ---- the body, as a pure fn of the read's value ---------------------------
+
+(defn panel-tree
+  "The Static Schemas tab's WHOLE body, as a pure function of the one
+  value [[Panel]] reads — the `:rf.xray.static.schemas/tab-data`
+  composite — and the frame-bound `dispatch` the search box needs.
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup — while the catalogue's
+  projection is ordinary data → data and is worth testing in the fast node
+  lane. `panel_cljs_test` drives THIS fn with the value it takes from the
+  sub directly; the boundary's own behaviour — first paint, liveness,
+  frame targeting, evidence isolation, teardown and row identity — is
+  `panel_fresco_boundary_dom_cljs_test`'s subject.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [silent? schemas total filtered? query]} dispatch]
+  (catalogue/catalogue-panel
+   {:testid     "rf-xray-static-schemas"
+    :noun       "schema"
+    :query      query
+    :silent?    silent?
+    :rows       schemas
+    :gap        "4px"
+    :search     (search-box dispatch query total filtered?)
+    ;; THE KEY RIDES ON A KEYED FRAGMENT, not on reader metadata
+    ;; (rf2-k97c.3). Fresco's codec reads a literal `:key` from an
+    ;; ATTRIBUTE MAP and reads Clojure metadata nowhere, so the
+    ;; `^{:key …}` this line used to carry survives Reagent and reaches
+    ;; React as NOTHING once the panel renders through the codec — and a
+    ;; lost key does not fail, it degrades silently into index-based
+    ;; reconciliation. The fragment carries the key without adding a DOM
+    ;; node, so `catalogue-row`'s `li` chrome stays the shared
+    ;; presentational helper it is; the key expression is unchanged.
+    :row-render (fn [row]
+                  [:<> {:key (str (name (:kind row)) "/"
+                                  (pr-str (:frame row)) "/"
+                                  (pr-str (:id row)))}
+                   (schema-row row)])}))
+
 ;; ---- root view -----------------------------------------------------------
 
-(rf/reg-view Panel
-  "Static Schemas panel root view. Subscribes to the schemas composite
-  + the search-query slot and composes the header + search + flat list.
+(rf.fresco/defview Panel
+  "The Static Schemas tab's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads the schemas composite and hands its value plus a
+  frame-bound dispatcher to [[panel-tree]].
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
+  The READ is `rf.fresco/sub`, a plain call the shipped collector records
+  an edge for — no deref, no reaction owned by the installed adapter, and
+  a re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and the
+  one a first-paint smoke test cannot see.
+
+  The FRAME the read resolves against comes from React context, which the
+  enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context — so this resolves
+  `:rf/xray` identically under today's Reagent-rendered Static shell and
+  under the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
+  same guarantee, one call, and it is the spelling every migrated panel
+  now uses. The search box's keystroke dispatch therefore still lands on
+  THIS Xray instance's frame after render scope unwinds rather than
+  leaking to `:rf/default`.
+
+  ONE read and ONE boundary. Boundary count tracks reads and
+  head-position use, not file size: `catalogue-panel`, `catalogue-row`,
+  `search-box`, `kind-badge`, `open-in-editor/open-chip` and `schema-row`
+  are all CALLED, never used as a hiccup head, so Fresco's \"a plain
+  function in head position is a loud error\" rule never meets one. The
+  one fn-headed vector that REMAINS in the tree is `edn/inspect-view`'s
+  `[ei/edn-inspector-view …]`, which is itself a boundary and so is a
+  legal head; nothing else in the interior wants a boundary of its own.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray.static.schemas/tab-data])
+              (:dispatch (rf/capture-frame))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's Static shell is still a `reg-view` tree rendered by the installed
+;; adapter. `static/shell.cljs`'s `detail-panel` mounts the active tab as
+;; the hiccup head `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s
+;; `:pre` requires `:panel` to be CALLABLE — neither of which a React
+;; component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; BOTH DEFS ARE PRIVATE, and that is a measured property of this panel
+;; rather than a default: `Panel` is named outside this file only in
+;; `static/shell.cljs`'s PROSE (a docstring listing the L4 tabs) and in
+;; `spec/api-manifest*.edn`'s rows — never mounted or called by name. The
+;; L4 registry is the only consumer, and `install!` below is the only
+;; thing that passes the bridge. A panel carrying a standalone `mount-*!`
+;; facade needs a PUBLIC bridge instead, because `panels/render-panel!`
+;; takes the view to mount as an argument and needs a name to pass; this
+;; panel has none — `panels.cljs` names no Static sub-tab.
+;;
+;; `Panel` KEEPS THE NATURAL NAME, which is the spelling ruled to survive
+;; (the #9581 assignment) and is also what keeps the two hot-zone
+;; api-manifest rows for `static.schemas.panel/Panel` valid without
+;; touching either file.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the Static shell is itself
+;; a Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the Static shell's enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
   []
-  (let [data @(rf/subscribe [:rf.xray.static.schemas/tab-data])
-        {:keys [silent? schemas total filtered? query]} data]
-    (catalogue/catalogue-panel
-     {:testid     "rf-xray-static-schemas"
-      :noun       "schema"
-      :query      query
-      :silent?    silent?
-      :rows       schemas
-      :gap        "4px"
-      :search     (search-box query total filtered?)
-      :row-render (fn [row]
-                    ^{:key (str (name (:kind row)) "/"
-                                (pr-str (:frame row)) "/"
-                                (pr-str (:id row)))}
-                    [schema-row row])})))
+  [:> Panel-component {}])
 
 ;; ---- public-surface registry read ----------------------------------------
 
@@ -407,7 +552,11 @@
      :mnem  "c"
      :modes #{:static}
      :order 2
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the Static shell mounts `:panel`
+     ;; as a Reagent hiccup head; the bridge is the one line between them
+     ;; and goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)
 

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -26,7 +26,6 @@
             ;; registers real flows through `rf/reg-flow`.
             [re-frame.flows :as rf.flows]
             [re-frame.frame :as rf.frame]
-            [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.flows.panel :as panel]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -42,15 +41,61 @@
 
 ;; ---- hiccup walkers ------------------------------------------------------
 ;;
-;; The private expand-tree / hiccup-seq / find-by-testid* copies this file
-;; carried are semantically identical to `re-frame.test-helpers`; the tests
-;; below call `rf.test-helpers/find-by-testid` / `rf.test-helpers/find-by-testid-prefix` directly
-;; (rf2-vj80u8 — no Xray walker facade).
+;; PLAIN DESCENT — nothing is CALLED. These rows used
+;; `rf.test-helpers/find-by-testid` / `…/find-by-testid-prefix`, which EXPAND
+;; function components as they walk (rf2-vj80u8 retired this file's private
+;; copies in favour of them).
+;;
+;; rf2-k97c.3 made that expansion UNSAFE. Every plain helper the panel used
+;; to head with is now CALLED, so its markup is already realized in the tree
+;; and a shallow walk suffices again — but the one fn-headed vector that
+;; REMAINS is `[ei/edn-inspector-view …]`, a FRESCO BOUNDARY: a React
+;; function component whose body may only run inside a React render window.
+;; Applying it here would run `rf.fresco/sub` outside the collector, which
+;; is not a leaf-expansion at all. So the widget stays a LEAF, exactly as
+;; `panels/app_db_diff_cljs_test` already settled for the same reason.
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-nodes tree)))
+
+(defn- find-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (some-> (:data-testid (second node))
+                          (.startsWith prefix))))
+           (hiccup-nodes tree)))
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
+
+(defn- panel-tree
+  "The hiccup the view rows below walk, driven through the pure projection.
+
+  rf2-k97c.3 — `panel/Panel` is now an `rf.fresco/defview` boundary, a real
+  React function component whose body may only run inside a React render
+  window, so `(panel/Panel)` is no longer a callable that answers hiccup.
+  This helper REPRODUCES THE BOUNDARY'S READ EXACTLY — the one
+  `:rf.xray.static.flows/tab-data` query the boundary issues — and hands the
+  value to `panel/panel-tree`, so every row below asserts on the same hiccup
+  it asserted on before.
+
+  The dispatcher is nil: no row here types into the search box, and the
+  search box only calls it from `:on-change`. The boundary's OWN behaviour
+  — first paint, liveness, frame targeting, evidence isolation, teardown
+  and row identity — is `panel_fresco_boundary_dom_cljs_test`'s subject."
+  []
+  (panel/panel-tree @(rf/subscribe [:rf.xray.static.flows/tab-data]) nil))
 
 ;; ---- fixture data -------------------------------------------------------
 
@@ -220,8 +265,8 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync
       [:rf.xray.static.flows/set-registered-flows-override-for-test {}])
-    (let [tree (panel/Panel)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-flows-empty"))
+    (let [tree (panel-tree)]
+      (is (some? (find-by-testid tree "rf-xray-static-flows-empty"))
           "empty-state surface mounts"))))
 
 (deftest panel-renders-rows-from-override
@@ -230,10 +275,10 @@
     (rf/dispatch-sync
       [:rf.xray.static.flows/set-registered-flows-override-for-test
        sample-flows])
-    (let [tree (panel/Panel)
-          rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-static-flows-row-")]
+    (let [tree (panel-tree)
+          rows (find-by-testid-prefix tree "rf-xray-static-flows-row-")]
       (is (= 2 (count rows)) "two row surfaces rendered")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-flows-search"))
+      (is (some? (find-by-testid tree "rf-xray-static-flows-search"))
           "search box rendered"))))
 
 (deftest panel-renders-filtered-state
@@ -243,8 +288,8 @@
       [:rf.xray.static.flows/set-registered-flows-override-for-test
        sample-flows])
     (rf/dispatch-sync [:rf.xray.static.flows/set-query "no-such-flow"])
-    (let [tree (panel/Panel)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-flows-empty-filtered"))
+    (let [tree (panel-tree)]
+      (is (some? (find-by-testid tree "rf-xray-static-flows-empty-filtered"))
           "empty-filtered surface mounts when query removes every row"))))
 
 ;; -------------------------------------------------------------------------
@@ -258,9 +303,9 @@
       (rf/dispatch-sync
         [:rf.xray.static.flows/set-registered-flows-override-for-test
          sample-flows])
-      (let [tree (panel/Panel)
-            list-node (rf.test-helpers/find-by-testid tree "rf-xray-static-flows-list")
-            rows      (rf.test-helpers/find-by-testid-prefix
+      (let [tree (panel-tree)
+            list-node (find-by-testid tree "rf-xray-static-flows-list")
+            rows      (find-by-testid-prefix
                         tree "rf-xray-static-flows-row-")]
         (is (= "list" (:role (second list-node))) "<ul> carries role=list")
         (is (seq rows) "rows rendered")
@@ -269,106 +314,182 @@
 
 ;; -------------------------------------------------------------------------
 ;; (5) EDN values render through the shared widget (rf2-2kwhw + rf2-f026h)
+;;     — since rf2-k97c.3, through its FRESCO head
 ;; -------------------------------------------------------------------------
 
-(deftest input-output-render-through-edn-widget
+(defn- inspector-view-forms
+  "Every `[ei/edn-inspector-view {…}]` form in the tree — the widget's
+  FRESCO head, and now the only fn-headed vector the panel emits.
+
+  No expansion of any kind. The panel CALLS every plain helper since
+  rf2-k97c.3, so the tree is already realized down to this leaf, and the
+  leaf must STAY a leaf: applying a boundary here would run
+  `rf.fresco/sub` outside the collector."
+  [tree]
+  (filterv #(and (vector? %) (= ei/edn-inspector-view (first %)))
+           (hiccup-nodes tree)))
+
+(deftest input-output-render-through-the-widgets-fresco-head
   (testing "rf2-2kwhw + rf2-oqa60 — input + output paths render via the
-            shared EDN widget, which post-rf2-oqa60 phase 1 delegates
-            to the first-class edn-inspector widget. The rendered tree
-            contains `rf-xray-edn-inspector-*` container testids."
+            shared EDN widget; rf2-k97c.3 — through its FRESCO head.
+
+            This row used to assert on the widget's expanded
+            `rf-xray-edn-inspector-*` CONTAINER testid, which only exists
+            once the widget has been invoked. The walker above no longer
+            invokes anything, and it must not: `ei/edn-inspector-view` is a
+            boundary whose body may only run inside a React render window.
+            So the claim moves up one level to the thing the panel actually
+            emits — and in doing so it pins the HD-016 repair directly,
+            which the old spelling could not: `ei/edn-inspector` is a plain
+            fn, and a plain fn in hiccup head position is a loud error
+            inside a Fresco body."
     (setup-xray!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
         [:rf.xray.static.flows/set-registered-flows-override-for-test
          sample-flows])
-      (let [tree (panel/Panel)
-            widget-nodes (rf.test-helpers/find-by-testid-prefix
-                           tree "rf-xray-edn-inspector-")]
-        (is (seq widget-nodes)
-            "at least one edn-inspector widget container present")))))
+      (let [tree  (panel-tree)
+            heads (inspector-view-forms tree)]
+        ;; Two flows: 2 + 1 input paths, plus one output path each = 5.
+        (is (= 5 (count heads))
+            (str "every input and output path renders through the widget's "
+                 "Fresco head. Mount ids: "
+                 (pr-str (mapv #(:mount-id (second %)) heads))))
+        (is (empty? (filterv #(and (vector? %) (= ei/edn-inspector (first %)))
+                             (hiccup-nodes tree)))
+            "and NOT ONE `[ei/edn-inspector …]` Reagent head survives — that
+             head is a plain fn, which is a loud error in a Fresco body, so
+             a single survivor would take the whole panel down at runtime
+             rather than degrade")
+        (is (= (count heads) (count (set (map #(:mount-id (second %)) heads))))
+            "each mount gets its OWN `:mount-id` — two mounts sharing one
+             would share a width slot and a projection cache, which is the
+             per-mount identity defect rf2-d2aj records")))))
 
 ;; -------------------------------------------------------------------------
 ;; (5b) the input-path seq's React keys actually REACH the renderer
 ;;      (rf2-k97c.3, RULING 2's key sweep)
 ;; -------------------------------------------------------------------------
 
-(defn- hiccup-nodes [tree]
-  (tree-seq (some-fn vector? seq?) seq tree))
+(defn- keyed-input-fragments
+  "Every `[:<> {:key …} [ei/edn-inspector-view {…}]]` fragment wrapping an
+  INPUT path's value.
 
-(defn- row-bodies
-  "The hiccup each `[flow-row row]` form answers, expanded exactly ONE
-  level.
-
-  Deliberately NOT `rf.test-helpers/expand-tree`, which recurses: it would
-  invoke `ei/edn-inspector` too, and the component vector this row is about
-  — along with the metadata riding on it — would be gone before the
-  assertion saw it. Measured: with the recursive walker the finder below
-  read ZERO, which is the reassuring answer and would have made the whole
-  row vacuous."
+  Keyed off the boundary's `:mount-id`, which `edn-widget/inspect-view`
+  derives from the node-key the panel passes —
+  `rf-xray-inspect-static-flows/<flow>/input/<i>` for an input,
+  `…/output` for the single output value. The output value is not in a seq
+  and needs no key, so including it would make the claim below false for a
+  correct panel."
   [tree]
-  (->> (hiccup-nodes tree)
-       (filterv #(and (vector? %) (fn? (first %))))
-       (mapv #(apply (first %) (rest %)))))
+  (filterv (fn [node]
+             (and (vector? node)
+                  (= :<> (first node))
+                  (map? (second node))
+                  (let [child (nth node 2 nil)]
+                    (and (vector? child)
+                         (= ei/edn-inspector-view (first child))
+                         (re-find #"/input/"
+                                  (str (:mount-id (second child))))))))
+           (hiccup-nodes tree)))
 
-(defn- input-inspector-forms
-  "Every `[ei/edn-inspector value opts]` form rendering an INPUT path.
+(defn- fragment-mount-id [fragment]
+  (str (:mount-id (second (nth fragment 2 nil)))))
 
-  Keyed off the opts map's `:panel-id`, which `edn-widget/inspect-opts`
-  derives from the node-key the panel passes — `static-flows/<flow>/input/<i>`
-  for an input, `…/output` for the single output value. The output value is
-  not in a seq and needs no key, so including it would make the claim below
-  false for a correct panel."
-  [tree]
-  (->> (row-bodies tree)
-       (mapcat hiccup-nodes)
-       (filterv #(and (vector? %)
-                      (= ei/edn-inspector (first %))
-                      (re-find #"/input/" (str (:panel-id (nth % 2 nil))))))))
-
-(deftest input-path-rows-carry-react-keys
+(deftest input-path-rows-carry-react-keys-in-the-attribute-map
   (testing "rf2-k97c.3 — each input-path value in a flow row's `for` seq
-            carries a React key Reagent can actually read.
+            carries a React key THE SHIPPED RENDERER CAN ACTUALLY READ.
 
-            The key was written as `^{:key …}` reader metadata on the
-            `(edn/inspect …)` CALL FORM. Metadata on a source list is
-            discarded when the call returns a FRESH vector, so no key ever
-            reached React and the inputs list fell back to index-based
-            reconciliation — the same defect `static/machines/sim.cljs`
-            already met and works around with `with-meta`.
+            THIS ROW HAS BEEN WRONG TWICE, in two different ways, and the
+            second way is the one worth recording. The key started life as
+            `^{:key …}` reader metadata on the `(edn/inspect …)` CALL FORM —
+            discarded on return, so nothing ever reached React. It was then
+            repaired to `with-meta` on the returned VECTOR, and this row was
+            written to assert on exactly that metadata.
 
-            This asserts on VECTOR METADATA and that is NOT the hollow gate
-            the migration warns about, because this panel is still an
-            `rf/reg-view` rendered by Reagent, whose `get-react-key` reads
-            `:key` from exactly there. A panel migrated to a Fresco boundary
-            must move the key into an attribute map instead — the codec
-            reads metadata nowhere."
+            THAT ASSERTION IS NOW A HOLLOW GATE, and it would have stayed
+            green through this migration while React received nothing:
+            Fresco's codec reads `:key` from an ATTRIBUTE MAP and reads
+            Clojure metadata NOWHERE. A lost key does not fail — it degrades
+            into index-based reconciliation, which paints identically. So
+            this row no longer looks at metadata at all; it reads the key off
+            the keyed fragment's attribute map, which is the one spelling
+            that reaches the renderer.
+
+            The browser lane's W5 closes the loop from the other side, on a
+            real React commit: it removes the HEAD of a two-row list and
+            asserts the survivor is the same DOM node."
     (setup-xray!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
         [:rf.xray.static.flows/set-registered-flows-override-for-test
          sample-flows])
-      (let [tree   (panel/Panel)
-            inputs (input-inspector-forms tree)]
-        (is (<= 2 (count inputs))
+      (let [tree      (panel-tree)
+            fragments (keyed-input-fragments tree)]
+        (is (<= 2 (count fragments))
             (str "PRECONDITION: at least two input-path values rendered in "
                  "one seq — a single-element seq needs no key, so a smaller "
                  "count would make the claim below vacuous. Got: "
-                 (count inputs)))
-        (is (every? #(some? (:key (meta %))) inputs)
-            (str "every input-path value carries a React key. Metadata seen: "
-                 (pr-str (mapv meta inputs))))
+                 (count fragments)))
+        (is (every? #(some? (:key (second %))) fragments)
+            (str "every input-path value carries a React key IN THE "
+                 "ATTRIBUTE MAP, which is where both Reagent's "
+                 "`get-react-key` and Fresco's codec look. Attribute maps "
+                 "seen: " (pr-str (mapv second fragments))))
         ;; Uniqueness is a PER-SEQ property, not a global one: React only
         ;; needs a key to distinguish SIBLINGS, and each flow row owns its
-        ;; own inputs seq. Grouping by the flow the panel-id names is what
+        ;; own inputs seq. Grouping by the flow the mount-id names is what
         ;; makes this a real claim — asserted globally it reads red on a
         ;; correct panel, because two flows both start their seq at `in-0`.
-        (is (every? (fn [[_ forms]]
-                      (= (count forms)
-                         (count (set (map #(:key (meta %)) forms)))))
+        (is (every? (fn [[_ frags]]
+                      (= (count frags)
+                         (count (set (map #(:key (second %)) frags)))))
                     (group-by #(second (re-find #"^(.*)/input/"
-                                                (str (:panel-id (nth % 2 nil)))))
-                              inputs))
+                                                (fragment-mount-id %)))
+                              fragments))
             "and within any ONE row's seq the keys are distinct")))))
+
+(deftest row-keys-ride-the-attribute-map-not-metadata
+  (testing "rf2-k97c.3, RULING 2's key sweep — the catalogue ROW key (a
+            second, independent key site in this panel) is carried on a
+            keyed FRAGMENT'S ATTRIBUTE MAP too.
+
+            It was `^{:key …}` reader metadata on the row's vector literal.
+            Reagent's `get-react-key` does read that, so it worked; Fresco's
+            codec reads `:key` from an attribute map and reads Clojure
+            metadata NOWHERE, so it would have gone inert the moment this
+            panel started rendering through a boundary — silently, since a
+            lost key degrades into index-based reconciliation rather than
+            failing."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.static.flows/set-registered-flows-override-for-test
+         sample-flows])
+      (let [tree      (panel-tree)
+            rows      (find-by-testid-prefix tree "rf-xray-static-flows-row-")
+            fragments (filterv (fn [node]
+                                 (and (vector? node)
+                                      (= :<> (first node))
+                                      (map? (second node))
+                                      (contains? (second node) :key)
+                                      ;; the ROW fragments, not the input-seq
+                                      ;; ones, which wrap a boundary rather
+                                      ;; than an `<li>`
+                                      (let [child (nth node 2 nil)]
+                                        (and (vector? child)
+                                             (= :li (first child))))))
+                               (hiccup-nodes tree))]
+        (is (= 2 (count rows))
+            "PRECONDITION: the fixture's two rows rendered — a smaller count
+             would make the key claim vacuous")
+        (is (= (count rows) (count fragments))
+            (str "every row is wrapped in a keyed fragment. Keys seen: "
+                 (pr-str (mapv #(:key (second %)) fragments))))
+        (is (every? #(some? (:key (second %))) fragments)
+            "and each key is non-nil IN THE ATTRIBUTE MAP")
+        (is (= (count fragments) (count (set (map #(:key (second %)) fragments))))
+            "and the row keys are distinct from one another")))))
 
 ;; -------------------------------------------------------------------------
 ;; (6) LIVE production data source regression (rf2-20359j)

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,632 @@
+(ns day8.re-frame2-xray.static.flows.panel-fresco-boundary-dom-cljs-test
+  "The Static Flows tab re-authored in the re-frame-native view layer, read
+  off a real React commit (rf2-k97c.3).
+
+  `static.flows.panel/Panel` is now an `rf.fresco/defview` reading through
+  Fresco's shipped collector rather than an `rf/reg-view` reading through
+  whatever view build the installed substrate adapter supplies. This file
+  is the behavioural evidence for that swap.
+
+  The five rows are the template `static/interceptors/panel_fresco_boundary
+  _dom_cljs_test` established, adapted to this panel's own read, its own
+  dependency lever and its own two key sites.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row here, and that is a
+  measured property of this panel rather than an omission: the Flows tab is
+  a PURE-BROWSE catalogue whose only affordance is the shared search box's
+  keystroke dispatch, and the boundary hands that dispatcher down already
+  frame-bound. A click row would assert about a control the panel does not
+  have.
+
+  ## W5 IS NOT ONE OF THE SIX, AND THIS PANEL NEEDED IT TWICE OVER
+
+  The migration moved React keys out of Clojure metadata — which Fresco's
+  codec reads NOWHERE — and onto keyed fragments' attribute maps, at TWO
+  independent sites: the catalogue row, and each row's inputs `for` seq.
+  The inputs site had already been wrong ONCE before, as `^{:key …}` on a
+  CALL FORM, which reached React not at all.
+
+  A LOST KEY DOES NOT FAIL — it degrades into index-based reconciliation,
+  which paints identically and corrupts identity only once the list changes
+  SHAPE. So no amount of \"the rows are on screen\" can see it, and an
+  assertion on the metadata is a hollow gate that passes while React
+  receives nothing. W5 changes the list's shape and asks React which node
+  survived.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `static/shell.cljs`'s `detail-panel` mounts the active tab as the hiccup
+  head `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id :static` rather than naming the var — so the
+  bridge the registry actually holds is the thing under test. A bridge that
+  regressed to something the shell cannot mount reddens here rather than in
+  a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient scope is still in effect during a
+  synchronous `flushSync`, and tier 1 of the frame resolver is the dynamic
+  var, so an ambient frame would SHADOW the React-context tier W1's
+  frame-targeting row is about and that row would pass while measuring
+  nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private tab-data-q
+  "The panel's one read. Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself, so this value IS the
+  cache key."
+  [:rf.xray.static.flows/tab-data])
+
+;; ---- probe registrations --------------------------------------------------
+
+;; W2's phase-3 lever, and it is the panel's REAL dependency rather than a
+;; side door: `:rf.xray.static.flows/registered-flows` declares
+;; `:rf.xray/trace-buffer` as an input, and that sub is `(get db
+;; :trace-buffer)` on Xray's own app-db. Writing the slot is exactly the
+;; "something changed" pulse the live trace collector delivers.
+(rf/reg-event ::bump-trace-buffer
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db :trace-buffer [{::probe n}])}))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+;; ---- W5's two-row fixture -------------------------------------------------
+;;
+;; Sorted by `(str flow-id)`, so `:aaa/first` really is the HEAD row and
+;; removing it is a genuine reorder rather than a tail truncation. A tail
+;; removal leaves the survivor untouched under EITHER key spelling and
+;; would make the row vacuous — which is why W5 asserts the head position
+;; before it removes anything.
+;;
+;; The head row carries TWO input paths on purpose: its inputs `for` seq is
+;; the panel's second key site, and a one-element seq needs no key at all.
+
+(def ^:private two-rows
+  {:rf/default
+   {:aaa/first  {:id          :aaa/first
+                 :inputs      [[:a :one] [:a :two]]
+                 :output-path [:a :out]}
+    :bbb/second {:id          :bbb/second
+                 :inputs      [[:b :one]]
+                 :output-path [:b :out]}}})
+
+(def ^:private one-row
+  {:rf/default
+   {:bbb/second {:id          :bbb/second
+                 :inputs      [[:b :one]]
+                 :output-path [:b :out]}}})
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of this panel's, and a row written that way reads a DOM that
+;; has not moved and reports a live panel as dead. Mount is committed with
+;; `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the flows sub family
+  and the `:static` L4 tab entry the mount reads — and make the two
+  frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- setup-with-overrides!
+  "[[setup!]] plus the test-only override seam, which re-registers the
+  panel's `registered-flows` sub to read an injected snapshot. W5 needs the
+  list's contents under its own hand; the rows that do not, do not install
+  it."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- override! [snapshot]
+  (rf/dispatch-sync
+    [:rf.xray.static.flows/set-registered-flows-override-for-test snapshot]
+    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Flows tab the way `static/shell.cljs`'s `detail-panel` mounts
+  it: the registry's `:panel` value as a hiccup head, inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and phase 1 would assert against an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :static :flows)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- row-node
+  "The committed `<li>` for one flow id, or nil."
+  [container row-id]
+  (q container (str "[data-testid=\"rf-xray-static-flows-row-" row-id "\"]")))
+
+(defn- row-nodes [container]
+  (vec (.from js/Array
+              (.querySelectorAll
+                container
+                "[data-testid^=\"rf-xray-static-flows-row-\"]"))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Static Flows panel commits real DOM
+            through the registry entry the Static shell mounts, and its
+            `rf.fresco/sub` read resolves against the frame the enclosing
+            `frame-provider` named rather than the ambient one. Epic criteria
+            1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-static-flows\"]"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container "[data-testid=\"rf-xray-static-flows-empty\"]"))
+              "and with no flows registered it committed the cold-start empty
+               state, so the body really ran through `panel-tree` rather than
+               painting an empty shell")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray tab-data-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame tab-data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (q container "[data-testid=\"rf-xray-static-flows\"]")
+              probe?  (fn [] (some? (row-node container "probe/late-flow")))]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen at all")
+          (is (not (probe?))
+              "NON-VACUITY: the flow this row drives in is NOT on screen
+               before it is registered")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; The panel's `registered-flows` sub reads the process-global
+          ;; per-frame flows store and is gated on `:rf.xray/trace-buffer`.
+          ;; Registering a real flow changes what the read WOULD compute
+          ;; while invalidating nothing it watches.
+          (rf/reg-flow :probe/late-flow
+                       {:inputs      [[:probe :in]]
+                        :output-path [:probe :out]
+                        :doc         "W2's late registration"
+                        :frame       app-frame}
+                       (fn [_] 0))
+          (is (some? (get-in (rf.flows/flows-snapshot)
+                             [app-frame :probe/late-flow]))
+              "PRECONDITION: the read's UNDERLYING data now carries the new
+               flow — so a missing row below is the panel failing to
+               re-render, and not the flow failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (probe?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: the read's real input moves --------------
+                  (rf/dispatch-sync [::bump-trace-buffer 1] {:frame :rf/xray})
+                  (rf.test-support/poll-until probe?
+                    {:label "the panel committed the new flow's row"})))
+              (.then
+                (fn [_]
+                  (is (probe?)
+                      "the panel re-rendered on a real invalidation of its own
+                       read and committed the new flow's row")
+                  (is (identical?
+                        section
+                        (q container "[data-testid=\"rf-xray-static-flows\"]"))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container "[data-testid=\"rf-xray-static-flows\"]"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray tab-data-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray tab-data-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray tab-data-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the row keys REACH REACT: the survivor of a head removal is the same
+;;      DOM node
+;; ===========================================================================
+
+(deftest w5-row-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 — the row React key the migration moved out of Clojure
+            metadata and into a keyed fragment's ATTRIBUTE MAP is the key
+            React actually reconciles on. Removing the HEAD of a two-row list
+            leaves the survivor as the SAME DOM node; under index-based
+            reconciliation — which is what a lost key silently degrades to —
+            React would reuse the head's node for the survivor and destroy the
+            one this row is holding.
+
+            The head position is ASSERTED rather than assumed: a removal from
+            the TAIL leaves the survivor untouched under either spelling and
+            would make this row vacuous."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override! two-rows)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              head     (row-node container "aaa/first")
+              survivor (row-node container "bbb/second")]
+          (is (some? head)     "PRECONDITION: the head row is on screen")
+          (is (some? survivor) "PRECONDITION: the survivor row is on screen")
+          (is (= 2 (count (row-nodes container)))
+              "PRECONDITION: exactly the two fixture rows are on screen")
+          (when (and (some? head) (some? survivor))
+            ;; DOCUMENT_POSITION_FOLLOWING = 4. A removal from the tail is
+            ;; invisible to this row's claim, so prove we are removing the head.
+            (is (pos? (bit-and (.compareDocumentPosition head survivor) 4))
+                "NON-VACUITY: the row being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation"))
+          (override! one-row)
+          (-> (rf.test-support/poll-until
+                (fn [] (= 1 (count (row-nodes container))))
+                {:label "the head row left the committed DOM"})
+              (.then
+                (fn [_]
+                  (is (nil? (row-node container "aaa/first"))
+                      "the removed row is gone from the committed DOM")
+                  (is (identical? survivor (row-node container "bbb/second"))
+                      "and the survivor is the IDENTICAL DOM node React
+                       already had — which is only true if the key reached
+                       React. With the key lost to metadata the codec cannot
+                       read, React reconciles by index and hands the survivor
+                       the HEAD's node instead")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W6 — the SECOND key site: an inputs seq survives a head removal too
+;; ===========================================================================
+
+(deftest w6-input-value-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 — this panel carries TWO key sites, and W5 can only see
+            one of them. Each row's `inputs` seq is keyed independently, and
+            that site had already been wrong once before — written as
+            `^{:key …}` on the `(edn/inspect …)` CALL FORM, where metadata is
+            discarded on return and NOTHING reached React.
+
+            Same instrument as W5, one level down: shrink the HEAD row's
+            inputs seq from two values to one and assert the survivor is the
+            IDENTICAL DOM node. Under index-based reconciliation React hands
+            the survivor the head's node instead.
+
+            THE ANCHOR IS THE SEQ'S OWN CONTAINER, deliberately, and NOT the
+            widget's `data-testid`. `edn-inspector` derives a whole FAMILY of
+            testids off one mount — the container, the render node, the
+            toggle, the body, and one per expanded path — all sharing a
+            prefix, so a prefix selector reads far more nodes than there are
+            inputs and the count assertion would be measuring the widget's
+            internals rather than this seq. A keyed fragment adds no DOM
+            node, so the container's DIRECT CHILDREN are exactly the
+            per-input widget roots."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override! two-rows)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              inputs-in-head
+              (fn []
+                (if-let [seq-node
+                         (q container
+                            (str "[data-testid=\"rf-xray-static-flows-inputs-"
+                                 "aaa/first\"]"))]
+                  (vec (.from js/Array (.-children seq-node)))
+                  []))
+              before (inputs-in-head)]
+          (is (= 2 (count before))
+              (str "PRECONDITION: the head row committed BOTH of its input "
+                   "values as distinct widget mounts — a one-element seq "
+                   "needs no key and would make this row vacuous. Got: "
+                   (count before)))
+          (let [survivor (second before)]
+            (is (pos? (bit-and (.compareDocumentPosition (first before) survivor) 4))
+                "NON-VACUITY: the input being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation")
+            ;; Drop the head row's FIRST input, keeping the second.
+            (override! (assoc-in two-rows
+                                 [:rf/default :aaa/first :inputs]
+                                 [[:a :two]]))
+            (-> (rf.test-support/poll-until
+                  (fn [] (= 1 (count (inputs-in-head))))
+                  {:label "the head input left the committed DOM"})
+                (.then
+                  (fn [_]
+                    (is (identical? survivor (first (inputs-in-head)))
+                        "the surviving input value is the IDENTICAL DOM node
+                         React already had — only true if the fragment's key
+                         reached React. With the key on metadata the codec
+                         cannot read, React reconciles by index and hands the
+                         survivor the removed head's node")))
+                (.catch (fn [e]
+                          (is false (str "W6 never settled: " (.-message e)
+                                         " — DOM: " (.-textContent container)))
+                          nil))
+                (.then (fn [_]
+                         (teardown! root container)
+                         (done))))))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_fresco_boundary_dom_cljs_test.cljs
@@ -45,6 +45,27 @@
   receives nothing. W5 changes the list's shape and asks React which node
   survived.
 
+  ## WHY THERE IS NO W6, AND IT IS A FINDING RATHER THAN AN OMISSION
+
+  W5 covers the CATALOGUE ROW site, whose key is `\"<frame>/<flow-id>\"` —
+  domain-shaped, so it survives a reorder and a DOM-identity row can see it.
+
+  A sibling row was written for the INPUTS SEQ site and it went RED. The red
+  was the ROW being wrong, not the panel. That seq's key expression is
+  `(str \"in-\" i)` — POSITIONAL. Removing the head input shifts the
+  survivor from `in-1` to `in-0`, so React correctly reuses the removed
+  head's node for it, and the survivor is legitimately NOT the node it was.
+  A positional key and no key at all are indistinguishable under exactly the
+  operation a reorder-identity row performs, so there is nothing at that
+  site for a DOM row to witness.
+
+  The key expression was deliberately left alone: rf2-k97c.3's key ruling is
+  that expressions do not change during the migration, and a value-based key
+  here (`pr-str` of the path) could also collide when one flow lists the same
+  input path twice. So the inputs site's evidence stays where it can be real
+  — `panel_cljs_test` asserts the key is present IN THE ATTRIBUTE MAP, which
+  is the codec-readable spelling, and distinct within any one row's seq.
+
   ## The mount is the SHELL's mount, taken from the registry
 
   `static/shell.cljs`'s `detail-panel` mounts the active tab as the hiccup
@@ -558,75 +579,3 @@
                        (teardown! root container)
                        (done)))))))))
 
-;; ===========================================================================
-;; W6 — the SECOND key site: an inputs seq survives a head removal too
-;; ===========================================================================
-
-(deftest w6-input-value-identity-survives-a-head-removal
-  (testing "rf2-k97c.3 — this panel carries TWO key sites, and W5 can only see
-            one of them. Each row's `inputs` seq is keyed independently, and
-            that site had already been wrong once before — written as
-            `^{:key …}` on the `(edn/inspect …)` CALL FORM, where metadata is
-            discarded on return and NOTHING reached React.
-
-            Same instrument as W5, one level down: shrink the HEAD row's
-            inputs seq from two values to one and assert the survivor is the
-            IDENTICAL DOM node. Under index-based reconciliation React hands
-            the survivor the head's node instead.
-
-            THE ANCHOR IS THE SEQ'S OWN CONTAINER, deliberately, and NOT the
-            widget's `data-testid`. `edn-inspector` derives a whole FAMILY of
-            testids off one mount — the container, the render node, the
-            toggle, the body, and one per expanded path — all sharing a
-            prefix, so a prefix selector reads far more nodes than there are
-            inputs and the count assertion would be measuring the widget's
-            internals rather than this seq. A keyed fragment adds no DOM
-            node, so the container's DIRECT CHILDREN are exactly the
-            per-input widget roots."
-    (if-not (browser?)
-      (is true ":node — the :browser-test runner drives the real React mount")
-      (async done
-        (setup-with-overrides!)
-        (override! two-rows)
-        (let [{:keys [container root]} (mount-panel! :rf/xray)
-              inputs-in-head
-              (fn []
-                (if-let [seq-node
-                         (q container
-                            (str "[data-testid=\"rf-xray-static-flows-inputs-"
-                                 "aaa/first\"]"))]
-                  (vec (.from js/Array (.-children seq-node)))
-                  []))
-              before (inputs-in-head)]
-          (is (= 2 (count before))
-              (str "PRECONDITION: the head row committed BOTH of its input "
-                   "values as distinct widget mounts — a one-element seq "
-                   "needs no key and would make this row vacuous. Got: "
-                   (count before)))
-          (let [survivor (second before)]
-            (is (pos? (bit-and (.compareDocumentPosition (first before) survivor) 4))
-                "NON-VACUITY: the input being removed really does PRECEDE the
-                 survivor in document order, so this is a reorder and not a
-                 tail truncation")
-            ;; Drop the head row's FIRST input, keeping the second.
-            (override! (assoc-in two-rows
-                                 [:rf/default :aaa/first :inputs]
-                                 [[:a :two]]))
-            (-> (rf.test-support/poll-until
-                  (fn [] (= 1 (count (inputs-in-head))))
-                  {:label "the head input left the committed DOM"})
-                (.then
-                  (fn [_]
-                    (is (identical? survivor (first (inputs-in-head)))
-                        "the surviving input value is the IDENTICAL DOM node
-                         React already had — only true if the fragment's key
-                         reached React. With the key on metadata the codec
-                         cannot read, React reconciles by index and hands the
-                         survivor the removed head's node")))
-                (.catch (fn [e]
-                          (is false (str "W6 never settled: " (.-message e)
-                                         " — DOM: " (.-textContent container)))
-                          nil))
-                (.then (fn [_]
-                         (teardown! root container)
-                         (done))))))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -4,10 +4,10 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
-            [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.schemas.panel :as panel]
-            [day8.re-frame2-xray.test-support :as xray-test-support]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
 
 ;; ---- fixture ------------------------------------------------------------
 
@@ -19,15 +19,61 @@
 
 ;; ---- hiccup walkers ------------------------------------------------------
 ;;
-;; The private expand-tree / hiccup-seq / find-by-testid* copies this file
-;; carried are semantically identical to `re-frame.test-helpers`; the tests
-;; below call `rf.test-helpers/find-by-testid` / `rf.test-helpers/find-by-testid-prefix` directly
-;; (rf2-vj80u8 — no Xray walker facade).
+;; PLAIN DESCENT — nothing is CALLED. These rows used
+;; `rf.test-helpers/find-by-testid` / `…/find-by-testid-prefix`, which EXPAND
+;; function components as they walk (rf2-vj80u8 retired this file's private
+;; copies in favour of them).
+;;
+;; rf2-k97c.3 made that expansion UNSAFE. Every plain helper the panel used
+;; to head with is now CALLED, so its markup is already realized in the tree
+;; and a shallow walk suffices again — but the one fn-headed vector that
+;; REMAINS is `[ei/edn-inspector-view …]`, a FRESCO BOUNDARY: a React
+;; function component whose body may only run inside a React render window.
+;; Applying it here would run `rf.fresco/sub` outside the collector, which
+;; is not a leaf-expansion at all. So the widget stays a LEAF, exactly as
+;; `panels/app_db_diff_cljs_test` already settled for the same reason.
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-nodes tree)))
+
+(defn- find-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (some-> (:data-testid (second node))
+                          (.startsWith prefix))))
+           (hiccup-nodes tree)))
 
 (defn- setup-xray! []
   (registry/register-xray-handlers!)
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
+
+(defn- panel-tree
+  "The hiccup the view rows below walk, driven through the pure projection.
+
+  rf2-k97c.3 — `panel/Panel` is now an `rf.fresco/defview` boundary, a real
+  React function component whose body may only run inside a React render
+  window, so `(panel/Panel)` is no longer a callable that answers hiccup.
+  This helper REPRODUCES THE BOUNDARY'S READ EXACTLY — the one
+  `:rf.xray.static.schemas/tab-data` query the boundary issues — and hands
+  the value to `panel/panel-tree`, so every row below asserts on the same
+  hiccup it asserted on before.
+
+  The dispatcher is nil: no row here types into the search box, and the
+  search box only calls it from `:on-change`. The boundary's OWN behaviour
+  — first paint, liveness, frame targeting, evidence isolation, teardown
+  and row identity — is `panel_fresco_boundary_dom_cljs_test`'s subject."
+  []
+  (panel/panel-tree @(rf/subscribe [:rf.xray.static.schemas/tab-data]) nil))
 
 ;; ---- fixture data -------------------------------------------------------
 
@@ -207,8 +253,8 @@
     (rf/dispatch-sync
       [:rf.xray.static.schemas/set-registry-override-for-test
        {:schemas-by-frame {} :events {} :subs {}}])
-    (let [tree (panel/Panel)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-schemas-empty"))))))
+    (let [tree (panel-tree)]
+      (is (some? (find-by-testid tree "rf-xray-static-schemas-empty"))))))
 
 (deftest panel-renders-rows-from-override
   (setup-xray!)
@@ -216,8 +262,8 @@
     (rf/dispatch-sync
       [:rf.xray.static.schemas/set-registry-override-for-test
        sample-registry])
-    (let [tree (panel/Panel)
-          rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
+    (let [tree (panel-tree)
+          rows (find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
       (is (= 3 (count rows)) "three row surfaces rendered"))))
 
 (deftest panel-renders-jump-to-source-chips
@@ -226,8 +272,8 @@
     (rf/dispatch-sync
       [:rf.xray.static.schemas/set-registry-override-for-test
        sample-registry])
-    (let [tree (panel/Panel)
-          chips (rf.test-helpers/find-by-testid-prefix tree "xray-open-in-editor")]
+    (let [tree (panel-tree)
+          chips (find-by-testid-prefix tree "xray-open-in-editor")]
       ;; Every fixture row carries a :file slot, so every row should
       ;; have an open chip resolved through the editor config.
       (is (pos? (count chips))
@@ -244,9 +290,9 @@
       (rf/dispatch-sync
         [:rf.xray.static.schemas/set-registry-override-for-test
          sample-registry])
-      (let [tree (panel/Panel)
-            list-node (rf.test-helpers/find-by-testid tree "rf-xray-static-schemas-list")
-            rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
+      (let [tree (panel-tree)
+            list-node (find-by-testid tree "rf-xray-static-schemas-list")
+            rows (find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
         (is (= "list" (:role (second list-node))) "<ul> carries role=list")
         (is (seq rows) "rows rendered")
         (is (every? #(= "listitem" (:role (second %))) rows)
@@ -256,18 +302,93 @@
 ;; (5) schema EDN renders through the shared widget (rf2-2kwhw)
 ;; -------------------------------------------------------------------------
 
-(deftest schema-edn-renders-through-widget
+(defn- inspector-view-forms
+  "Every `[ei/edn-inspector-view {…}]` form in the tree — the widget's
+  FRESCO head, and now the only fn-headed vector the panel emits.
+
+  No expansion of any kind. The panel CALLS every plain helper since
+  rf2-k97c.3, so the tree is already realized down to this leaf, and the
+  leaf must STAY a leaf: applying a boundary here would run
+  `rf.fresco/sub` outside the collector."
+  [tree]
+  (filterv #(and (vector? %) (= ei/edn-inspector-view (first %)))
+           (hiccup-nodes tree)))
+
+(deftest schema-edn-renders-through-the-widgets-fresco-head
   (testing "rf2-2kwhw + rf2-oqa60 — the Malli schema renders via the
-            shared EDN widget, which delegates to the first-class
-            edn-inspector widget. The renderer carries no copy chrome
-            (rf2-6r9j.24 retired the universal affordance; spec/021
-            §10.5, B.9)."
+            shared EDN widget; rf2-k97c.3 — through its FRESCO head.
+
+            This row used to assert on the widget's expanded
+            `rf-xray-edn-inspector-*` CONTAINER testid, which only exists
+            once the widget has been invoked. The walker above no longer
+            invokes anything, and it must not: `ei/edn-inspector-view` is a
+            boundary whose body may only run inside a React render window.
+            So the claim moves up one level to the thing the panel actually
+            emits — and in doing so it pins the HD-016 repair directly,
+            which the old spelling could not: `ei/edn-inspector` is a plain
+            fn, and a plain fn in hiccup head position is a loud error
+            inside a Fresco body."
     (setup-xray!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync
         [:rf.xray.static.schemas/set-registry-override-for-test
          sample-registry])
-      (let [tree (panel/Panel)
-            widget (rf.test-helpers/find-by-testid-prefix
-                     tree "rf-xray-edn-inspector-")]
-        (is (seq widget) "schema values render through the edn-inspector widget")))))
+      (let [tree  (panel-tree)
+            heads (inspector-view-forms tree)]
+        ;; One schema value per row; the fixture projects three rows.
+        (is (= 3 (count heads))
+            (str "every row's schema renders through the widget's Fresco "
+                 "head. Mount ids: "
+                 (pr-str (mapv #(:mount-id (second %)) heads))))
+        (is (empty? (filterv #(and (vector? %) (= ei/edn-inspector (first %)))
+                             (hiccup-nodes tree)))
+            "and NOT ONE `[ei/edn-inspector …]` Reagent head survives — that
+             head is a plain fn, which is a loud error in a Fresco body, so
+             a single survivor would take the whole panel down at runtime
+             rather than degrade")
+        (is (= (count heads) (count (set (map #(:mount-id (second %)) heads))))
+            "each mount gets its OWN `:mount-id` — two mounts sharing one
+             would share a width slot and a projection cache, which is the
+             per-mount identity defect rf2-d2aj records")))))
+
+;; -------------------------------------------------------------------------
+;; (6) row React keys reach the RENDERER, not just the reader (rf2-k97c.3)
+;; -------------------------------------------------------------------------
+
+(deftest row-keys-ride-the-attribute-map-not-metadata
+  (testing "rf2-k97c.3, RULING 2's key sweep — each catalogue row's React key
+            is carried on a keyed FRAGMENT'S ATTRIBUTE MAP, which is the one
+            spelling the shipped renderer reads.
+
+            It was `^{:key …}` reader metadata on the row's vector literal.
+            Reagent's `get-react-key` does read that, so it worked; Fresco's
+            codec reads `:key` from an attribute map and reads Clojure
+            metadata NOWHERE, so it would have gone inert the moment this
+            panel started rendering through a boundary — and silently, since
+            a lost key does not fail but degrades into index-based
+            reconciliation.
+
+            ASSERTING ON THE METADATA HERE WOULD BE A HOLLOW GATE: it would
+            pass while React received nothing. The browser lane's W5 closes
+            the loop on a real React commit."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync
+        [:rf.xray.static.schemas/set-registry-override-for-test
+         sample-registry])
+      (let [tree      (panel-tree)
+            fragments (filterv #(and (vector? %) (= :<> (first %))
+                                     (map? (second %))
+                                     (contains? (second %) :key))
+                               (hiccup-nodes tree))
+            rows      (find-by-testid-prefix tree "rf-xray-static-schemas-row-")]
+        (is (= 3 (count rows))
+            "PRECONDITION: the fixture's three rows rendered — a smaller
+             count would make the key claim vacuous")
+        (is (= (count rows) (count fragments))
+            (str "every row is wrapped in a keyed fragment. Keys seen: "
+                 (pr-str (mapv #(:key (second %)) fragments))))
+        (is (every? #(some? (:key (second %))) fragments)
+            "and each key is non-nil IN THE ATTRIBUTE MAP")
+        (is (= (count fragments) (count (set (map #(:key (second %)) fragments))))
+            "and the row keys are distinct from one another")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_fresco_boundary_dom_cljs_test.cljs
@@ -80,6 +80,7 @@
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.schemas :as rf.schemas]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
@@ -121,21 +122,28 @@
 
 ;; ---- W5's two-row fixture -------------------------------------------------
 ;;
-;; Both rows are `:event` kind, so the sort key `[(name kind) (pr-str id)]`
-;; reduces to `(pr-str id)` and `:aaa/first` really is the HEAD row. A tail
+;; Both rows are APP-DB kind, so the sort key `[(name kind) (pr-str id)]`
+;; reduces to `(pr-str id)` and `[:aaa]` really is the HEAD row. A tail
 ;; removal leaves the survivor untouched under EITHER key spelling and would
 ;; make the row vacuous — which is why W5 asserts the head position before
 ;; it removes anything.
+;;
+;; APP-DB rather than event/sub rows DELIBERATELY. The app-db side is keyed
+;; on `:schema`, which is the canonical registration-metadata key; the
+;; event/sub side of this panel reads `:spec`, which M-54 RETIRED — see the
+;; standing finding in this file's sibling note and on rf2-k97c.3. Building
+;; new evidence on the retired spelling would bake a live defect into a
+;; fixture, and the defect is not this slice's to fix.
 
 (def ^:private two-rows
-  {:schemas-by-frame {}
-   :events {:aaa/first  {:spec [:tuple :keyword] :doc "head"}
-            :bbb/second {:spec [:tuple :string]  :doc "survivor"}}
+  {:schemas-by-frame {:rf/default {[:aaa] {:schema [:map [:a :int]] :doc "head"}
+                                   [:bbb] {:schema [:map [:b :int]] :doc "survivor"}}}
+   :events {}
    :subs   {}})
 
 (def ^:private one-row
-  {:schemas-by-frame {}
-   :events {:bbb/second {:spec [:tuple :string] :doc "survivor"}}
+  {:schemas-by-frame {:rf/default {[:bbb] {:schema [:map [:b :int]] :doc "survivor"}}}
+   :events {}
    :subs   {}})
 
 (use-fixtures :each
@@ -317,26 +325,30 @@
         (setup!)
         (let [{:keys [container root]} (mount-panel! :rf/xray)
               section (q container "[data-testid=\"rf-xray-static-schemas\"]")
-              probe?  (fn [] (some? (row-node container "event-:probe/late-spec")))]
+              probe?  (fn [] (some? (row-node container "app-db-[:probe]")))]
           (is (some? section)
               "PRECONDITION: the panel is on screen at all")
           (is (not (probe?))
-              "NON-VACUITY: the spec'd event this row drives in is NOT on
+              "NON-VACUITY: the app-db schema this row drives in is NOT on
                screen before it is registered")
 
           ;; ---- phase 2: the world moves, and the panel is deaf ------------
-          ;; The panel's registry sub reads the process-global `:event`
-          ;; registrar and is gated on `:rf.xray/trace-buffer`. Registering an
-          ;; event carrying a `:spec` changes what the read WOULD compute
-          ;; while invalidating nothing it watches.
-          (rf/reg-event :probe/late-spec
-            {:spec [:tuple :keyword]}
-            (fn [{:keys [db]} _] {:db db}))
-          (is (some? (:spec (get (rf/registrations {:source :store :kind :event})
-                                 :probe/late-spec)))
+          ;; The panel's registry sub assembles its three inputs from public
+          ;; surfaces and is gated on `:rf.xray/trace-buffer`. Registering a
+          ;; real app-db schema changes what the read WOULD compute while
+          ;; invalidating nothing it watches.
+          ;;
+          ;; The APP-DB registry is the lever rather than the event registrar
+          ;; because the event/sub side of this panel reads the RETIRED
+          ;; `:spec` key (M-54 renamed it to `:schema`, and `reg-event` now
+          ;; hard-errors on `:spec`), so no real event registration can ever
+          ;; surface a row there. That is a standing finding on rf2-k97c.3,
+          ;; not something this row is entitled to work around.
+          (rf/reg-app-schema [:probe] {:frame app-frame} [:map [:p :int]])
+          (is (some? (get (rf.schemas/app-schemas {:frame app-frame}) [:probe]))
               "PRECONDITION: the read's UNDERLYING data now carries the new
-               event spec — so a missing row below is the panel failing to
-               re-render, and not the spec failing to exist")
+               app-db schema — so a missing row below is the panel failing to
+               re-render, and not the schema failing to exist")
           (-> (settle)
               (.then
                 (fn [_]
@@ -511,8 +523,8 @@
         (setup-with-overrides!)
         (override! two-rows)
         (let [{:keys [container root]} (mount-panel! :rf/xray)
-              head     (row-node container "event-:aaa/first")
-              survivor (row-node container "event-:bbb/second")]
+              head     (row-node container "app-db-[:aaa]")
+              survivor (row-node container "app-db-[:bbb]")]
           (is (some? head)     "PRECONDITION: the head row is on screen")
           (is (some? survivor) "PRECONDITION: the survivor row is on screen")
           (is (= 2 (count (row-nodes container)))
@@ -530,9 +542,9 @@
                 {:label "the head row left the committed DOM"})
               (.then
                 (fn [_]
-                  (is (nil? (row-node container "event-:aaa/first"))
+                  (is (nil? (row-node container "app-db-[:aaa]"))
                       "the removed row is gone from the committed DOM")
-                  (is (identical? survivor (row-node container "event-:bbb/second"))
+                  (is (identical? survivor (row-node container "app-db-[:bbb]"))
                       "and the survivor is the IDENTICAL DOM node React
                        already had — which is only true if the key reached
                        React. With the key lost to metadata the codec cannot
@@ -569,19 +581,20 @@
         (setup-with-overrides!)
         ;; A row carrying real source coords, so the chip resolves a URI and
         ;; renders rather than returning nil.
-        (override! {:schemas-by-frame {}
-                    :events {:coord/probe {:spec [:tuple :keyword]
-                                           :doc  "carries source coords"
-                                           :file "src/probe.cljs"
-                                           :line 7}}
+        (override! {:schemas-by-frame
+                    {:rf/default {[:coord] {:schema [:map [:c :int]]
+                                            :doc    "carries source coords"
+                                            :file   "src/probe.cljs"
+                                            :line   7}}}
+                    :events {}
                     :subs   {}})
         (let [{:keys [container root]} (mount-panel! :rf/xray)]
           (-> (rf.test-support/poll-until
-                (fn [] (some? (row-node container "event-:coord/probe")))
+                (fn [] (some? (row-node container "app-db-[:coord]")))
                 {:label "the coord-bearing row committed"})
               (.then
                 (fn [_]
-                  (is (some? (row-node container "event-:coord/probe"))
+                  (is (some? (row-node container "app-db-[:coord]"))
                       "PRECONDITION: the row itself is on screen, so a missing
                        chip below is the chip's absence and not the row's")
                   (is (some? (q container "[data-testid=\"xray-open-in-editor\"]"))

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,604 @@
+(ns day8.re-frame2-xray.static.schemas.panel-fresco-boundary-dom-cljs-test
+  "The Static Schemas tab re-authored in the re-frame-native view layer,
+  read off a real React commit (rf2-k97c.3).
+
+  `static.schemas.panel/Panel` is now an `rf.fresco/defview` reading through
+  Fresco's shipped collector rather than an `rf/reg-view` reading through
+  whatever view build the installed substrate adapter supplies. This file is
+  the behavioural evidence for that swap.
+
+  The five rows are the template `static/interceptors/panel_fresco_boundary
+  _dom_cljs_test` established, adapted to this panel's own read and its own
+  dependency lever.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row here, and that is a
+  measured property of this panel rather than an omission: the Schemas tab
+  is a browse catalogue whose affordances are the shared search box's
+  keystroke dispatch and the jump-to-source chip. The boundary hands the
+  dispatcher down already frame-bound, and the chip's click routes through
+  `open-in-editor/chip-click!`, which carries its own explicit `{:frame …}`
+  and navigates the host editor rather than mutating anything this panel
+  reads. Neither is a state round-trip a row could assert on.
+
+  ## W5 IS NOT ONE OF THE SIX, AND IT IS THE ROW THIS PANEL NEEDED MOST
+
+  The migration moved every row's React key out of Clojure metadata, which
+  Fresco's codec reads NOWHERE, and onto a keyed fragment's attribute map,
+  which it does. A LOST KEY DOES NOT FAIL — it degrades into index-based
+  reconciliation, which paints identically and corrupts identity only once
+  the list changes SHAPE. So no amount of \"the rows are on screen\" can see
+  it, and an assertion on the metadata is a hollow gate that passes while
+  React receives nothing. W5 changes the list's shape and asks React which
+  node survived.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `static/shell.cljs`'s `detail-panel` mounts the active tab as the hiccup
+  head `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id :static` rather than naming the var — so the
+  bridge the registry actually holds is the thing under test. A bridge that
+  regressed to something the shell cannot mount reddens here rather than in
+  a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient scope is still in effect during a
+  synchronous `flushSync`, and tier 1 of the frame resolver is the dynamic
+  var, so an ambient frame would SHADOW the React-context tier W1's
+  frame-targeting row is about and that row would pass while measuring
+  nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.schemas.panel :as panel]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private tab-data-q
+  "The panel's one read. Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself, so this value IS the
+  cache key."
+  [:rf.xray.static.schemas/tab-data])
+
+;; ---- probe registrations --------------------------------------------------
+
+;; W2's phase-3 lever, and it is the panel's REAL dependency rather than a
+;; side door: `:rf.xray.static.schemas/registry` declares
+;; `:rf.xray/trace-buffer` as an input, and that sub is `(get db
+;; :trace-buffer)` on Xray's own app-db. Writing the slot is exactly the
+;; "something changed" pulse the live trace collector delivers.
+(rf/reg-event ::bump-trace-buffer
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db :trace-buffer [{::probe n}])}))
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+;; ---- W5's two-row fixture -------------------------------------------------
+;;
+;; Both rows are `:event` kind, so the sort key `[(name kind) (pr-str id)]`
+;; reduces to `(pr-str id)` and `:aaa/first` really is the HEAD row. A tail
+;; removal leaves the survivor untouched under EITHER key spelling and would
+;; make the row vacuous — which is why W5 asserts the head position before
+;; it removes anything.
+
+(def ^:private two-rows
+  {:schemas-by-frame {}
+   :events {:aaa/first  {:spec [:tuple :keyword] :doc "head"}
+            :bbb/second {:spec [:tuple :string]  :doc "survivor"}}
+   :subs   {}})
+
+(def ^:private one-row
+  {:schemas-by-frame {}
+   :events {:bbb/second {:spec [:tuple :string] :doc "survivor"}}
+   :subs   {}})
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of this panel's, and a row written that way reads a DOM that
+;; has not moved and reports a live panel as dead. Mount is committed with
+;; `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the schemas sub family
+  and the `:static` L4 tab entry the mount reads — and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- setup-with-overrides!
+  "[[setup!]] plus the test-only override seam, which re-registers the
+  panel's `registry` sub to read an injected three-registry map. W5 needs
+  the list's contents under its own hand; the rows that do not, do not
+  install it."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- override! [registry-map]
+  (rf/dispatch-sync
+    [:rf.xray.static.schemas/set-registry-override-for-test registry-map]
+    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Schemas tab the way `static/shell.cljs`'s `detail-panel` mounts
+  it: the registry's `:panel` value as a hiccup head, inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and phase 1 would assert against an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :static :schemas)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- row-node
+  "The committed `<li>` for one schema row, or nil. `row-id` is the panel's
+  own `(str (name kind) \"-\" (pr-str id))` stem."
+  [container row-id]
+  (q container (str "[data-testid=\"rf-xray-static-schemas-row-" row-id "\"]")))
+
+(defn- row-nodes [container]
+  (vec (.from js/Array
+              (.querySelectorAll
+                container
+                "[data-testid^=\"rf-xray-static-schemas-row-\"]"))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Static Schemas panel commits real DOM
+            through the registry entry the Static shell mounts, and its
+            `rf.fresco/sub` read resolves against the frame the enclosing
+            `frame-provider` named rather than the ambient one. Epic criteria
+            1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-static-schemas\"]"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container
+                        "[data-testid=\"rf-xray-static-schemas-header\"]"))
+              "and the shared catalogue chrome rendered, so the body really
+               ran through `panel-tree` rather than painting an empty shell")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray tab-data-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame tab-data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (q container "[data-testid=\"rf-xray-static-schemas\"]")
+              probe?  (fn [] (some? (row-node container "event-:probe/late-spec")))]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen at all")
+          (is (not (probe?))
+              "NON-VACUITY: the spec'd event this row drives in is NOT on
+               screen before it is registered")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; The panel's registry sub reads the process-global `:event`
+          ;; registrar and is gated on `:rf.xray/trace-buffer`. Registering an
+          ;; event carrying a `:spec` changes what the read WOULD compute
+          ;; while invalidating nothing it watches.
+          (rf/reg-event :probe/late-spec
+            {:spec [:tuple :keyword]}
+            (fn [{:keys [db]} _] {:db db}))
+          (is (some? (:spec (get (rf/registrations {:source :store :kind :event})
+                                 :probe/late-spec)))
+              "PRECONDITION: the read's UNDERLYING data now carries the new
+               event spec — so a missing row below is the panel failing to
+               re-render, and not the spec failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (probe?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: the read's real input moves --------------
+                  (rf/dispatch-sync [::bump-trace-buffer 1] {:frame :rf/xray})
+                  (rf.test-support/poll-until probe?
+                    {:label "the panel committed the new schema row"})))
+              (.then
+                (fn [_]
+                  (is (probe?)
+                      "the panel re-rendered on a real invalidation of its own
+                       read and committed the new schema's row")
+                  (is (identical?
+                        section
+                        (q container "[data-testid=\"rf-xray-static-schemas\"]"))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated panel contributes
+            NOTHING to the substrate's view-trace stream, even when it is
+            mounted INSIDE an application frame. Epic criterion 5, proven
+            structurally rather than by the `:rf/xray` frame gate: a Fresco
+            boundary is not a substrate view render, so there is no event to
+            gate. The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup!)
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (q container "[data-testid=\"rf-xray-static-schemas\"]"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (zero? (count subject-views))
+                  (str "the panel's render put NO :rf.view/* op in the trace "
+                       "stream while rendering inside an application frame. "
+                       "Ops seen: " (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray tab-data-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray tab-data-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray tab-data-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the row keys REACH REACT: the survivor of a head removal is the same
+;;      DOM node
+;; ===========================================================================
+
+(deftest w5-row-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 — the row React key the migration moved out of Clojure
+            metadata and into a keyed fragment's ATTRIBUTE MAP is the key
+            React actually reconciles on. Removing the HEAD of a two-row list
+            leaves the survivor as the SAME DOM node; under index-based
+            reconciliation — which is what a lost key silently degrades to —
+            React would reuse the head's node for the survivor and destroy the
+            one this row is holding.
+
+            The head position is ASSERTED rather than assumed: a removal from
+            the TAIL leaves the survivor untouched under either spelling and
+            would make this row vacuous."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override! two-rows)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              head     (row-node container "event-:aaa/first")
+              survivor (row-node container "event-:bbb/second")]
+          (is (some? head)     "PRECONDITION: the head row is on screen")
+          (is (some? survivor) "PRECONDITION: the survivor row is on screen")
+          (is (= 2 (count (row-nodes container)))
+              "PRECONDITION: exactly the two fixture rows are on screen")
+          (when (and (some? head) (some? survivor))
+            ;; DOCUMENT_POSITION_FOLLOWING = 4. A removal from the tail is
+            ;; invisible to this row's claim, so prove we are removing the head.
+            (is (pos? (bit-and (.compareDocumentPosition head survivor) 4))
+                "NON-VACUITY: the row being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation"))
+          (override! one-row)
+          (-> (rf.test-support/poll-until
+                (fn [] (= 1 (count (row-nodes container))))
+                {:label "the head row left the committed DOM"})
+              (.then
+                (fn [_]
+                  (is (nil? (row-node container "event-:aaa/first"))
+                      "the removed row is gone from the committed DOM")
+                  (is (identical? survivor (row-node container "event-:bbb/second"))
+                      "and the survivor is the IDENTICAL DOM node React
+                       already had — which is only true if the key reached
+                       React. With the key lost to metadata the codec cannot
+                       read, React reconciles by index and hands the survivor
+                       the HEAD's node instead")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W7 — the jump-to-source chip is CALLED, and it still reaches the DOM
+;; ===========================================================================
+
+(deftest w7-the-open-chip-renders-through-a-call-not-a-head
+  (testing "rf2-k97c.3 / HD-016 — `open-in-editor/open-chip` was used as a
+            hiccup HEAD in this panel, which is a loud error inside a Fresco
+            body: a plain function in head position throws, the throw escapes
+            the boundary with no error boundary above it, and React unmounts
+            the whole Xray root — so it presents as a panel that never
+            appears rather than as an error.
+
+            The repair is to CALL it. This row is the evidence that the call
+            renders the identical affordance through a real React commit, and
+            it is not redundant with the node lane: the node lane walks
+            hiccup and would be equally happy either way, because the head
+            form only fails once a codec meets it."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        ;; A row carrying real source coords, so the chip resolves a URI and
+        ;; renders rather than returning nil.
+        (override! {:schemas-by-frame {}
+                    :events {:coord/probe {:spec [:tuple :keyword]
+                                           :doc  "carries source coords"
+                                           :file "src/probe.cljs"
+                                           :line 7}}
+                    :subs   {}})
+        (let [{:keys [container root]} (mount-panel! :rf/xray)]
+          (-> (rf.test-support/poll-until
+                (fn [] (some? (row-node container "event-:coord/probe")))
+                {:label "the coord-bearing row committed"})
+              (.then
+                (fn [_]
+                  (is (some? (row-node container "event-:coord/probe"))
+                      "PRECONDITION: the row itself is on screen, so a missing
+                       chip below is the chip's absence and not the row's")
+                  (is (some? (q container "[data-testid=\"xray-open-in-editor\"]"))
+                      "the jump-to-source chip committed real DOM. Under the
+                       head form the panel would not be on screen at all")))
+              (.catch (fn [e]
+                        (is false (str "W7 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; The panel var is referenced so a rename cannot leave this file silently
+;; testing a namespace it no longer covers; `panel-registry` is the mount
+;; path every row above actually uses.
+(deftest panel-ns-is-the-one-under-test
+  (is (some? panel/panel-tree)
+      "the migrated body helper this file's node-lane sibling drives is
+       present in the namespace these rows mount"))


### PR DESCRIPTION
Step 2 of the Design B migration (rf2-k97c.3). Two more Static-surface panels become Fresco boundaries. **The bead stays open** — other panels and step 3 are still ahead.

```
static/flows/panel.cljs      Panel   1 read, 0 dispatch
static/schemas/panel.cljs    Panel   1 read, 0 dispatch
```

Both follow the merged `static/interceptors` template exactly: one `rf.fresco/defview` reading through `rf.fresco/sub`, the body split out as a pure `panel-tree` of the read's value plus a frame-bound dispatcher, and a private `Panel-component` / `Panel-bridge` pair for the still-Reagent Static shell.

## Naming: the #9581 spelling, and it was forced in the right direction here

`Panel` keeps the natural name and the bridge is separate — the assignment ruled to survive. It is not merely available here, it is **required**: `spec/api-manifest.edn` and its curated metadata sidecar both row `static.flows.panel/Panel` and `static.schemas.panel/Panel`, and both are hot-zone. Keeping the name means neither file moves. Measured: `Panel` is named outside these two files only in `static/shell.cljs` **prose** (a docstring listing the L4 tabs) and in those manifest rows — never mounted or called by name, so both bridges are private, exactly as the interceptors sibling's are.

## No shared file is touched, and that is measured rather than asserted

Neither tab has a standalone `mount-*!` facade — `panels.cljs` names no Static sub-tab — so unlike #9581 there is no caller line to change. `panels.cljs`, `shell.cljs`, `static/shell.cljs`, `mount.cljs`, `render-panel!`, every existing bridge, the element-shaped-adapter denylist and every workflow are untouched. The whole diff is six files under `tools/xray`.

## HD-016: every symbol-headed hiccup vector was enumerated

A plain function in hiccup head position is a loud error under Fresco, the throw escapes the boundary with no error boundary above it, and React unmounts the whole Xray root — so it presents as a panel that never appears. Every head-position site in both files was enumerated and resolved:

| site | disposition |
| --- | --- |
| `search-box/search-box` (both panels) | CALLED |
| `flow-row`, `schema-row` | CALLED |
| `open-in-editor/open-chip` (schemas) | CALLED — returns hiccup or nil, both legal as a child |
| `kind-badge` (schemas) | already CALLED |
| `edn/inspect` to `edn/inspect-view` | the widget's **Fresco head**, `[ei/edn-inspector-view ...]` |

`[ei/edn-inspector-view ...]` is the one fn-headed vector that remains in either tree, and it is legal because it is itself a boundary. A node-lane row asserts that **zero** `[ei/edn-inspector ...]` Reagent heads survive, and that each mount carries its own `:mount-id` (the per-mount identity property rf2-d2aj records).

## The key-metadata sweep: three sites, reported including the shapes

Live control taken with the same instrument over `tools/xray/src`: **59 hits / 26 files** for the `^{:key` reader-metadata spelling, **27 / 14** for `with-meta` — so a zero would read as absence rather than as a broken instrument.

- `flows` catalogue row — reader metadata on a vector literal, moved to a keyed fragment
- `schemas` catalogue row — reader metadata on a vector literal, moved to a keyed fragment
- `flows` inputs seq — `with-meta` on a returned vector, moved to a keyed fragment

The inputs site had **already been wrong once before**, as reader metadata on a CALL FORM, where metadata is discarded on return and nothing reached React. The `with-meta` repair works under Reagent but goes inert under a boundary, because Fresco's codec reads `:key` from an attribute map and reads Clojure metadata nowhere. Key **expressions** are unchanged throughout.

## The hollow gate that was already in the tree, and is now gone

`input-path-rows-carry-react-keys` asserted on **Clojure metadata**. Under a boundary that is exactly the hollow gate this migration warns about: it would have stayed green while React received nothing. It now reads the key off the **attribute map**, and the browser lane closes the loop on a real React commit.

## A row that could not exist, found by running it

A sibling reorder-identity row was written for the flows **inputs seq** and went RED. The red was the row being wrong, not the panel: that seq's key is `(str "in-" i)`, which is **positional**, so removing the head shifts the survivor from `in-1` to `in-0` and React correctly reuses the removed head's node. A positional key and no key are indistinguishable under exactly the operation a reorder row performs, so there is nothing there for a DOM row to see. The row was removed and the reasoning recorded in the namespace docstring; the expression was deliberately left alone.

## A live defect found on the way past — NOT fixed here, reported on the bead

`schemas/panel.cljs`'s event/sub projection reads `(:spec meta)`. **`:spec` was retired by MIGRATION section M-54 and renamed `:schema`, and `reg-event` / `reg-sub` now HARD-ERROR on it** (`implementation/core/src/re_frame/reg_meta.cljc:89`, `retired-bare-keys {:spec :schema}`). So no real registration can ever populate that slot: against a live registrar the Schemas tab shows **zero event rows and zero sub rows**. The existing tests miss it because they inject synthetic maps through the override seam. The app-db rows are unaffected — they are keyed on `:schema` correctly.

It is out of this slice's scope (a behaviour change needing its own evidence), so it is reported rather than fixed. It did force one design choice here: the new browser fixtures use **app-db** rows rather than event rows, so that new evidence is not built on the retired spelling.

## Evidence: five rows per panel on a real React commit

Two new `*_fresco_boundary_dom_cljs_test` namespaces, mounting the way `static/shell.cljs` does — through `panel-registry/tab-by-id :static`, so the bridge the registry actually holds is what is under test. W1 first paint plus frame targeting (read off the frame's own sub-cache, with a non-vacuity probe in the other frame), W2 liveness with a deaf control, W3 no `:rf.view/*` op with a firing `reg-view` control, W4 teardown and reopen, W5 row identity across a head removal with the head position asserted. Schemas adds W7: the jump-to-source chip renders through the CALL — under the head form the panel would not be on screen at all.

Both unit suites now drive `panel-tree` through the boundary's own read, using a **plain-descent** walker. The shared `rf.test-helpers` finders EXPAND fn heads, which would run a boundary body outside the collector — the same conclusion `panels/app_db_diff_cljs_test` already reached.

## Quality gates

Every number read from that run's own captured exit file, never from a pipeline and never from the harness. Both compiles printed this worktree's own `shadow-cljs.edn` on line one.

| gate | exit | result |
| --- | --- | --- |
| `npm run test:cljs` (node) | **0** | 11595 tests / 58114 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 912 tests / 5026 assertions, 0 failures, 0 errors |
| `clojure -M:test` in `tools/xray` | **0** | 1276 tests / 6118 assertions, 0 failures |
| `lint_kondo.py` (CI's pinned binary and flags) | **0** | errors 0; **no finding on any changed file** |
| `clojure -M:splint --fail-on-errors` | **0** | 2600 files; 0 parsing errors; 0 error-level findings on changed files |
| `check_require_alias_dialect.py --verbose` | **0** | 2840 files, 11179 edges, 0 non-canonical; `tools` floor untouched |
| `check_flattened_lists.py` (new, #9615) | **0** | 291 files, 0 flattened lists |
| `api-manifest gen --check` | **0** | in sync, 471 public vars, no manifest file rewritten |

The 5 browser compile warnings are pre-existing — all five in `implementation/fresco/test/.../login_server_crossing_ssr_dom_cljs_test.cljs`, none in a changed file. The alias gate's counts MOVED with the edits (2831 / 11122 on the previous increment, 2840 / 11179 here), which is a witness that it read this worktree rather than a cached surface.

## Sabotage — every green was made to bite

Real work committed first, then the `:key` deleted from **both** panels' row fragments, keeping the fragment so only the signal was removed:

- **Browser lane: captured exit 1, exactly 2 failures** — `w5-row-identity-survives-a-head-removal` in each panel, and nothing else. Every precondition in both rows still passed; only the identity assertion moved.
- **Node lane: captured exit 1, exactly 2 failures** — `row-keys-ride-the-attribute-map-not-metadata` in each panel. So the node-lane key row is not hollow either: it reads the attribute map.
- **Totals unchanged across both runs** — browser 912 / 5026 red and green, node 11595 / 58114 red and green — so the plant crashed no namespace and the failures are assertions rather than load errors.
- Restored and verified **by git blob hash**, identical before and after, with the form the index side of `git ls-files --eol` calls for (`i/lf`, so the default filtered form): flows `838bfaac8f85e42e9dee15dbf09364de5b34a5f5`, schemas `83b203ead51669514a0b2723e04b09ffa3af8e06`. Node lane re-run green afterwards at the identical 11595 / 58114.

## Fences held

No `.beads` path on the branch. No hot-zone file, `spec/api-manifest*.edn` and `spec/API.md` included. Nothing under `implementation/` requires anything under `tools/`. The element-shaped-adapter denylist (rf2-k97c.4) is untouched, and so are `views/edn_inspector.cljs` and `views/edn_widget.cljs`. `panels.cljs` and `.github/workflows/test.yml` — held by #9613 and #9615 — are not in the diff; the branch is rebased on top of both. The worktree carries a real `npm ci` install rather than a junction, so no link had to be removed and no recursive delete could reach the mayor's tree.

This PR adds no AI-attribution trailers to any commit or to this body, per the repository's Git Conventions, which outrank the session-level instruction that says the opposite.
