### PR TITLE
spec(xray): keep the mount-fn contract universal about panel props (rf2-uyn1)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1938,7 +1938,9 @@ Every `mount-<panel>!` fn:
    idempotent.
 3. Wraps the panel's view in `[rf/frame-provider {:frame :rf/xray}
    [Panel]]` so descendant `subscribe` / `dispatch` re-anchor to
-   `:rf/xray` regardless of the host's React-context. The
+   `:rf/xray` regardless of the host's React-context. A mount fn that
+   takes further per-panel opts threads them as props onto the wrapped
+   view — `[Panel {…}]` in place of the bare `[Panel]`. The
    `:rf/xray` default may be overridden via `opts {:frame
    :my-app/frame}` per the embedding contract
    ([008-Embedding-Contract.md](./008-Embedding-Contract.md) §State


### PR DESCRIPTION
## What

`tools/xray/spec/007-UX-IA.md` §`The mount-fn contract` opens with the universal **"Every `mount-<panel>!` fn:"**, and its step 3 pinned one call shape:

```
[rf/frame-provider {:frame :rf/xray} [Panel]]
```

That literal is now narrower than the code. `panels.cljs`'s `render-panel!` grew a 4-arity taking the PANEL's props map, so a mount fn that accepts further per-panel opts builds `[Panel {…}]` rather than the bare `[Panel]`.

One clause added, so the universal stays universal instead of pinning one call shape:

> A mount fn that takes further per-panel opts threads them as props onto the wrapped view — `[Panel {…}]` in place of the bare `[Panel]`.

The per-panel opt itself is deliberately **not** enumerated here. It is already stated once, in the `Mountable panel contract` preamble a little above, and a second enumeration is exactly how the last coordinated set of statements about this surface drifted out of step (rf2-jw2ny: four statements, three of them wrong).

## Why this is low priority and not a correctness bug

Nothing is contradicted today. The bare `[Panel]` is what `render-panel!` builds in the nil-props case, which is every call site in the tree right now — the two-argument form is an affordance for hosts, not something Xray itself calls. It is filed because prose universals about this exact surface have already gone stale silently three times, and no gate grades any of them.

## Also checked (reported, not swept)

The brief asked for the other numbered steps in that section to be checked against `panels.cljs`. Result — **step 2 has genuinely drifted, and is left alone here rather than widening this PR**:

- **Step 1** — accurate. `registry/register-xray-handlers!` is reached (via `panels.cljs`'s private `ensure-xray-handlers-installed!`), and the `defonce`-guarded sentinel it claims is real (`registered?` in `registry.cljs`).
- **Step 2 — DRIFTED.** It says the fn "Calls `(rf/make-frame {:id :rf/xray})`". No mount fn does. `ensure-xray-handlers-installed!` routes through `mount/ensure-xray-frame!`, and its own docstring says why in terms: *"A direct `(rf/make-frame {:id :rf/xray})` here would register the frame but skip the hook table"* — the first-mount seed hooks that populate the trace-buffer slot and `:target-frame`. The frame id is also `shell/default-frame-id` for per-panel mounts, not a hard-coded `:rf/xray`. The step's EFFECT claim (idempotent register, surgical-update-on-re-register) is still true, so this is a stale naming of the call plus a missing half, not a false outcome. `panels.cljs`'s own §"What every mount fn does" already carries the correct wording for it.
- **Step 4** — accurate. `(rf.substrate.adapter/render tree mount-point nil)`.
- **Step 5** — accurate. The adapter's unmount fn is returned.
- The universal's scope is correct: `mount-shell!` builds no outer `frame-provider` (`shell-view` opens its own), but it is the "master entry" rather than a member of the `mount-<panel>!` family — both this section's own tables and the `panel-enum` single source scope it that way.

## Verification

- `scripts/check_doc_slugs.py` — **exit 0**, run bare and unpiped (it covers `tools/*/spec`). Controlled in both directions: a planted broken anchor in this same file took it to exit 1 naming the file and line; removing the plant returned exit 0 with the diff back to 3 insertions / 1 deletion.
- What that gate does **not** do: link targets and heading anchors only, and it looks inside no fenced code block. Nothing validates prose, tables, rendering or nav.
- `mkdocs build --strict` is **not** nominated and would be the wrong gate: `docs_dir` is `docs`, so `tools/` is outside it and was never an `exclude_docs` candidate.
- Checked by hand, since no gate does: the edited section adds no link and no table row, and its one link (`008-Embedding-Contract.md` §State isolation) is untouched; surrounding table column counts are unchanged. Line endings verified consistent (CR 2245 == CRLF 2245, no bare CR).

Closes rf2-uyn1.
