### PR TITLE
fix(xray): two latent Fresco-migration hazards in trace + managed-fx (rf2-twil)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -207,6 +207,31 @@
    (stub-pill stubbed?)])
 
 ;; ---- section bodies ----------------------------------------------------
+;;
+;; rf2-twil — `edn/inspect` IS CALLED, NEVER PUT IN HEAD POSITION.
+;;
+;; `views/edn-widget/inspect` is a plain `defn`. Under Reagent a plain
+;; function in hiccup head position is a form-1 component and renders
+;; happily, so `[edn/inspect v k]` worked; under Fresco it is a LOUD ERROR
+;; by design (HD-016, `:rf.error/fresco-bad-head`), and the throw escapes
+;; with no error boundary above it — React unmounts the entire Xray root,
+;; which presents as a panel that never appears rather than as an error.
+;; That is exactly the shape of the rf2-qhoj P1, one token wide.
+;;
+;; The four sites below were this tree's ONLY head-position users of
+;; `inspect`; the other six caller files already call it. Calling it is
+;; correct on BOTH substrates — the value rendered is the vector `inspect`
+;; RETURNS — so this is the shape that survives the migration, and the
+;; facade keeps its one-renderer-many-call-sites property because
+;; `inspect`'s own shape is untouched.
+;;
+;; NOT THE SAME THING AS BEING FRESCO-READY. `inspect` returns
+;; `[ei/edn-inspector …]`, a `reg-view` head, which Fresco's codec also
+;; refuses — `views/edn_inspector.cljs`'s own ns docstring puts it plainly:
+;; "Only `edn-inspector-view` is a head in a Fresco body." The day
+;; `panels/ManagedFxList` becomes a boundary, these four calls become
+;; `edn/inspect-view`, which exists for precisely that and takes the same
+;; `node-key`. Until then the Reagent head is the correct one.
 
 (defn- request-section
   [{:keys [req surface fx-id]}]
@@ -218,7 +243,7 @@
     [:span {:style {:color (:text-tertiary tokens)}} "(no request payload)"]
 
     :else
-    [edn/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req")]))
+    (edn/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req"))))
 
 (defn- wire-section
   "Wire timing section. When the surface emits per-phase wire data we
@@ -244,8 +269,8 @@
                     :font-weight 600
                     :margin-bottom "4px"}}
       (str "✗ " (or (some-> failure :kind name) "FAILURE"))]
-     [edn/inspect (or (:tags failure) failure)
-      (str "managed-fx/" (h/format-fx-id fx-id) "/failure")]]
+     (edn/inspect (or (:tags failure) failure)
+                  (str "managed-fx/" (h/format-fx-id fx-id) "/failure"))]
 
     (and (nil? res) (= surface :flow))
     [:span {:style {:color (:text-tertiary tokens)}}
@@ -256,7 +281,7 @@
      "(no response payload yet)"]
 
     :else
-    [edn/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res")]))
+    (edn/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res"))))
 
 (defn- handler-section
   "Renders the dispatched handler event vector + a click-to-focus
@@ -269,7 +294,7 @@
                    :gap "12px"
                    :flex-wrap "wrap"}}
      [:div {:style {:flex 1 :min-width 0}}
-      [edn/inspect handler "managed-fx/handler"]]
+      (edn/inspect handler "managed-fx/handler")]
      [:button {:data-testid "rf-xray-managed-fx-focus-handler"
                :on-click    #(dispatch [:rf.xray/focus-event dispatch-id frame])
                :style       {:background  "transparent"

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -822,9 +822,21 @@
          ;; `:rf.xray.trace/ops` table-id; the flat row list renders its
          ;; own resizable-table with `:header? false` reading the SAME
          ;; slot, so a drag here re-aligns every row.
-         ^{:key "ops-header"}
+         ;; rf2-twil — the React key lives in this props map rather than as
+         ;; `^{:key "ops-header"}` reader meta on the vector below. The meta
+         ;; form was CORRECT here and is the sibling rf2-hxfy measured
+         ;; against (`REACT .-key ["ops-header" nil]`): reader meta rides a
+         ;; vector LITERAL, and Reagent reads meta THEN props. But Fresco's
+         ;; codec reads `:key` from the ATTRIBUTE MAP and reads Clojure
+         ;; metadata NOWHERE, so faithfully preserving the meta form through
+         ;; the migration would preserve a NO-OP — the key silently stops
+         ;; reaching React with nothing on screen to say so. The props map is
+         ;; the one place BOTH substrates read, which is why the sibling
+         ;; below already keys there. `resizable-table` destructures named
+         ;; opts and never spreads them, so `:key` is inert for its body.
          [rt/resizable-table
-          {:table-id        trace-ops-table-id
+          {:key             "ops-header"
+           :table-id        trace-ops-table-id
            :columns         trace-op-columns
            :rows            []
            :row-key         (fn [_ _] "")

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -15,7 +15,6 @@
             ;; requires it).
             [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [day8.re-frame2-xray.views.edn-widget :as edn-widget]
-            [day8.re-frame2-xray.views.edn-inspector :as edn-inspector]
             [day8.re-frame2-xray.panels.managed-fx-template :as template]
             [day8.re-frame2-xray.panels.managed-fx-helpers :as h]))
 
@@ -224,10 +223,25 @@
 ;; which the codec also refuses — `views/edn_inspector.cljs` says it
 ;; outright, "Only `edn-inspector-view` is a head in a Fresco body" — and
 ;; the panel's own mount, `panels/ManagedFxList`, is still a `reg-view`.
-;; So the repair below removes ONE of two blocking classes; the other is
-;; the migration's, and the day it happens these four calls become
+;; So the repair removes ONE of two blocking classes; the other is the
+;; migration's, and the day it happens these four calls become
 ;; `edn/inspect-view`. Asserting only what is actually true here is the
 ;; point: a row claiming Fresco-readiness would be the hollow one.
+;;
+;; AND WHAT THIS ROW CANNOT DO, STATED PLAINLY BECAUSE THE FIRST DRAFT OF
+;; IT LIED. All four sites sit inside sections `record-panel` builds with
+;; `:expanded? false`, and `theme/section/section-row` renders its body
+;; under `(when expanded? …)` — nothing in this tree wires a click, so the
+;; `▶` glyph opens nothing and a collapsed body is computed and then
+;; DISCARDED. The four vectors have therefore never appeared in any
+;; rendered tree, which is the blind spot all three tiers of coverage
+;; shared. So a revert to `[edn/inspect …]` would NOT turn this row red,
+;; and the row does not claim it would: the absence assertion is a FLOOR
+;; against a future head placed somewhere reachable, and the control above
+;; it is what stops the floor reading as a proof. Measured, not assumed —
+;; the draft that asserted the returned inspector was present in the tree
+;; read zero, and that is how the discard was found. rf2-fcy5 carries what
+;; would make these four gradeable.
 
 (defn- hiccup-vectors
   "Every hiccup vector in `node`, root included, walked structurally.
@@ -244,31 +258,32 @@
 (defn- hiccup-heads [node]
   (map first (hiccup-vectors node)))
 
-(deftest inspect-is-called-never-placed-in-head-position
-  (testing "rf2-twil — the four `edn/inspect` sites are CALLS. In head
-            position they are four HD-016 throws the day this panel's
-            mount becomes a Fresco boundary; called, they are correct on
-            both substrates and the rendered value is unchanged."
+(deftest no-plain-fn-sits-in-hiccup-head-position
+  (testing "rf2-twil — a plain function in hiccup head position is a loud
+            error under Fresco (HD-016) and the throw escapes with no error
+            boundary above this render path. `edn/inspect` was this tree's
+            only head-position user of the widget facade; it is called now.
+            This row is the FLOOR for the panel's REACHABLE tree — see the
+            section comment for what it deliberately does not claim."
     (let [r     (record {:surface     :http
                          :fx-id       :rf.http/managed
                          :status      :ok
                          :http-status 200
                          :handler     [:user/profile-loaded {:id 1}]})
           heads (hiccup-heads (template/record-panel r))]
-      ;; Positive control, taken from the renderer itself: the plain fn IS
-      ;; a bad head under Fresco. Without this the zero below could mean
-      ;; a dead probe just as easily as an absent head.
+      ;; Two controls, because the assertion below is an ABSENCE and an
+      ;; absence is what a dead instrument also reports.
       (is (= :invalid (rf.fresco.impl.codec/head-kind edn-widget/inspect))
           "Fresco's own classifier grades the plain fn an invalid head")
-      ;; The repair.
-      (is (zero? (count (filter #(identical? edn-widget/inspect %) heads)))
-          "`edn/inspect` appears in head position nowhere in this panel")
-      ;; And the value is still rendered — the vector `inspect` RETURNS is
-      ;; in the tree. Pre-repair this read zero, because `inspect` was
-      ;; never called; so the pair moves red→green together and neither
-      ;; passes on an empty tree.
-      (is (pos? (count (filter #(identical? edn-inspector/edn-inspector %) heads)))
-          "the inspector the call form returns is present in the tree"))))
+      (is (< 20 (count heads))
+          "the walker reached a populated tree, so a zero below means absence")
+      ;; No plain function anywhere in head position — stated over the
+      ;; whole reachable tree rather than named against `inspect` alone,
+      ;; so a DIFFERENT facade helper (`ei/mini`, `edn/inspect-inline`)
+      ;; put in head position here is caught too. That is the mistake
+      ;; rf2-qhoj actually made, one file over.
+      (is (empty? (filter fn? heads))
+          "no plain function is in head position in the rendered panel"))))
 
 ;; ---- "app-db wasn't updated" highlight: OK status + empty paths-touched ----
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -230,18 +230,27 @@
 ;;
 ;; AND WHAT THIS ROW CANNOT DO, STATED PLAINLY BECAUSE THE FIRST DRAFT OF
 ;; IT LIED. All four sites sit inside sections `record-panel` builds with
-;; `:expanded? false`, and `theme/section/section-row` renders its body
-;; under `(when expanded? …)` — nothing in this tree wires a click, so the
-;; `▶` glyph opens nothing and a collapsed body is computed and then
-;; DISCARDED. The four vectors have therefore never appeared in any
-;; rendered tree, which is the blind spot all three tiers of coverage
-;; shared. So a revert to `[edn/inspect …]` would NOT turn this row red,
-;; and the row does not claim it would: the absence assertion is a FLOOR
-;; against a future head placed somewhere reachable, and the control above
-;; it is what stops the floor reading as a proof. Measured, not assumed —
-;; the draft that asserted the returned inspector was present in the tree
-;; read zero, and that is how the discard was found. rf2-fcy5 carries what
-;; would make these four gradeable.
+;; `:expanded? false` — a LITERAL — and `theme/section/section-row` renders
+;; its body under `(when expanded? …)`, so a collapsed body is computed
+;; (it is a positional argument) and then DISCARDED. The four vectors have
+;; therefore never appeared in any rendered tree, which is the blind spot
+;; all three tiers of coverage shared. So a revert to `[edn/inspect …]`
+;; would NOT turn this row red, and the row does not claim it would: the
+;; absence assertion is a FLOOR against a future head placed somewhere
+;; reachable, and the controls above it are what stop the floor reading as
+;; a proof. Measured, not assumed — the draft that asserted the returned
+;; inspector was present in the tree read zero, and that is how the
+;; discard was found.
+;;
+;; THE PRIMITIVE IS NOT AT FAULT, AND SAYING SO MATTERS because the first
+;; version of this comment blamed it. `section-row` is non-interactive BY
+;; DESIGN — `theme/section.cljc` states the contract in terms: "No
+;; interactivity. Click-to-toggle wiring is the caller's responsibility."
+;; Expansion state exists in this tree and has a working caller
+;; (`panels/cancellation_cascade.cljs:689` feeds `:expanded?` from a sub);
+;; this panel simply passes literals and never did that half. rf2-kfoq
+;; carries the repair, and it must land after or with the head-form fix,
+;; since wiring the disclosure is exactly what makes these four reachable.
 
 (defn- hiccup-vectors
   "Every hiccup vector in `node`, root included, walked structurally.

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -9,6 +9,13 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [reagent.core :as r]
+            ;; rf2-twil — the HD-016 row's positive control is the
+            ;; renderer's own head classifier, so the codec is the
+            ;; instrument (same reason `cancellation_cascade_cljs_test`
+            ;; requires it).
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
+            [day8.re-frame2-xray.views.edn-widget :as edn-widget]
+            [day8.re-frame2-xray.views.edn-inspector :as edn-inspector]
             [day8.re-frame2-xray.panels.managed-fx-template :as template]
             [day8.re-frame2-xray.panels.managed-fx-helpers :as h]))
 
@@ -195,6 +202,73 @@
       ;; presence here too rather than letting this pass on absence.
       (is (every? some? once))
       (is (= once twice)))))
+
+;; ---- HD-016: `edn/inspect` is CALLED, never a hiccup head (rf2-twil) -------
+;;
+;; `views/edn-widget/inspect` is a plain `defn`. Under Reagent a plain
+;; function in hiccup head position is a form-1 component, so the four
+;; `[edn/inspect …]` sites this file used to carry rendered happily; under
+;; Fresco a plain function in head position is a LOUD ERROR by design
+;; (HD-016), and on this panel's render path there is no error boundary
+;; above it — the throw escapes and React unmounts the entire Xray root,
+;; which presents as a panel that never appears rather than as an error.
+;; That is the rf2-qhoj P1, and it was one token wide there too.
+;;
+;; The instrument is Fresco's OWN head classifier rather than a shape
+;; assertion of ours, so the zero below is the renderer's answer and not
+;; a claim about what we think the renderer would say.
+;;
+;; WHY THIS IS NOT A FRESCO DOM ROW. A DOM row would mount the panel
+;; through the codec, which is not reachable for this file today: the
+;; value `inspect` returns is `[ei/edn-inspector …]`, a `reg-view` head,
+;; which the codec also refuses — `views/edn_inspector.cljs` says it
+;; outright, "Only `edn-inspector-view` is a head in a Fresco body" — and
+;; the panel's own mount, `panels/ManagedFxList`, is still a `reg-view`.
+;; So the repair below removes ONE of two blocking classes; the other is
+;; the migration's, and the day it happens these four calls become
+;; `edn/inspect-view`. Asserting only what is actually true here is the
+;; point: a row claiming Fresco-readiness would be the hollow one.
+
+(defn- hiccup-vectors
+  "Every hiccup vector in `node`, root included, walked structurally.
+  Deliberately NOT through `rf.test-helpers/expand-tree`, which rebuilds
+  nested vectors with `mapv` — it would substitute its own vectors for
+  the ones under test and `identical?` below would answer about the
+  rebuild rather than about the panel."
+  [node]
+  (cond
+    (vector? node) (cons node (mapcat hiccup-vectors (rest node)))
+    (seq? node)    (mapcat hiccup-vectors node)
+    :else          nil))
+
+(defn- hiccup-heads [node]
+  (map first (hiccup-vectors node)))
+
+(deftest inspect-is-called-never-placed-in-head-position
+  (testing "rf2-twil — the four `edn/inspect` sites are CALLS. In head
+            position they are four HD-016 throws the day this panel's
+            mount becomes a Fresco boundary; called, they are correct on
+            both substrates and the rendered value is unchanged."
+    (let [r     (record {:surface     :http
+                         :fx-id       :rf.http/managed
+                         :status      :ok
+                         :http-status 200
+                         :handler     [:user/profile-loaded {:id 1}]})
+          heads (hiccup-heads (template/record-panel r))]
+      ;; Positive control, taken from the renderer itself: the plain fn IS
+      ;; a bad head under Fresco. Without this the zero below could mean
+      ;; a dead probe just as easily as an absent head.
+      (is (= :invalid (rf.fresco.impl.codec/head-kind edn-widget/inspect))
+          "Fresco's own classifier grades the plain fn an invalid head")
+      ;; The repair.
+      (is (zero? (count (filter #(identical? edn-widget/inspect %) heads)))
+          "`edn/inspect` appears in head position nowhere in this panel")
+      ;; And the value is still rendered — the vector `inspect` RETURNS is
+      ;; in the tree. Pre-repair this read zero, because `inspect` was
+      ;; never called; so the pair moves red→green together and neither
+      ;; passes on an empty tree.
+      (is (pos? (count (filter #(identical? edn-inspector/edn-inspector %) heads)))
+          "the inspector the call form returns is present in the tree"))))
 
 ;; ---- "app-db wasn't updated" highlight: OK status + empty paths-touched ----
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -952,3 +952,48 @@
         (is (every? some? ks) "both feed children reach React with a key")
         (is (= 2 (count (distinct ks))) "sibling keys are distinct")))))
 
+;; ---- both feed keys live where BOTH substrates read (rf2-twil) -----------
+
+(deftest trace-feed-children-keys-live-in-the-attribute-map
+  (testing "rf2-twil — the `ops-header` key was CORRECT and is the sibling
+            rf2-hxfy measured against: `^{:key \"ops-header\"}` rode a
+            vector LITERAL, and Reagent reads meta THEN props, so React
+            received it. Fresco's codec reads `:key` from the ATTRIBUTE MAP
+            and reads Clojure metadata NOWHERE — so carrying the meta form
+            faithfully through the migration would have carried a NO-OP,
+            with the key silently ceasing to reach React and nothing on
+            screen to say so. It now rides the props map, which is the one
+            place both substrates read.
+
+            The row above pins the REAGENT renderer and stays green either
+            way, so it cannot see this move; that is why this row exists
+            and why its first assertion is the attribute map. A
+            `(meta child)` assertion would be hollow in BOTH directions —
+            it reads nil at a repaired site precisely because the key is in
+            props — so metadata appears here only as the negative below.
+
+            Not a Fresco DOM row: `rt/resizable-table` is a `reg-view`, a
+            head Fresco's codec refuses, so neither child can be handed to
+            `codec/as-element` until that widget grows a boundary."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})])])
+      (focus! 1)
+      (let [kids  (feed-children (trace/Panel))
+            props (mapv second kids)]
+        (is (= 2 (count kids)))
+        ;; The Fresco-side read. RED before the repair: `[nil "rows"]`.
+        (is (= ["ops-header" "rows"] (mapv :key props))
+            "each feed child carries :key in its attribute map")
+        ;; The Reagent-side read, kept beside it so one attribute is shown
+        ;; to satisfy both rather than trading one substrate for the other.
+        (is (= ["ops-header" "rows"] (mapv #(.-key (r/as-element %)) kids))
+            "and React still receives it under Reagent")
+        ;; Guard the guard: neither key is also in metadata, so the
+        ;; assertion above cannot be passing on a shape Fresco can't see.
+        (is (every? nil? (mapv #(:key (meta %)) kids))
+            "no feed child depends on reader metadata")))))
+


### PR DESCRIPTION
Closes rf2-twil.

Two sites that are correct on Reagent today and break the day their panel becomes a Fresco
boundary. Neither is a defect on trunk right now, which is why the value here is as much in
what was measured as in the two diffs.

## 1 — four HD-016 sites

`views/edn-widget/inspect` is a plain `defn`. `managed_fx_template` was this tree's only
head-position user of it: four `[edn/inspect …]` against zero call-form, where the other six
caller files already call it. Under Reagent a plain function in hiccup head position is a
form-1 component; under Fresco it is a loud error by design, and on this render path there is
no error boundary above it, so the throw escapes and React unmounts the entire Xray root — it
presents as a panel that never appears rather than as an error. That is the shape of the
rf2-qhoj P1, one token wide there too.

The four are now **calls to `edn/inspect`**, not to `edn/inspect-view`. Both spellings exist;
the choice is forced by which substrate renders the tree. `inspect-view` emits
`[ei/edn-inspector-view …]`, a Fresco boundary — a real React function component — which in a
Reagent head position is the mirror failure of the one being fixed. This panel's mount,
`panels/ManagedFxList`, is still an `rf/reg-view`, so the tree is painted by Reagent and
`inspect` is the correct head today. `inspect-view` becomes correct the day that mount
migrates, and it is waiting with zero callers for exactly that; the source comment says so at
the site. Either way `inspect`'s own shape is untouched, so the other six callers and the
facade's one-renderer-many-call-sites property are unaffected, and this stays a one-file
change.

## 2 — a `^{:key …}` that survived only by riding a vector literal

`trace.cljs`'s `ops-header` key was CORRECT, and is the sibling rf2-hxfy measured its dead key
against: reader meta rides a vector literal and Reagent reads meta then props, so React
receives it. Fresco's codec reads `:key` from the attribute map and reads Clojure metadata
nowhere, so preserving the meta form faithfully through the migration would preserve a no-op —
the key silently stops reaching React with nothing on screen to say so. It now rides the props
map, as its already-repaired sibling does.

## Three things measured on the way, each of which changes something

**The bead's "those heads are FINE" claim does not hold.** rf2-twil rated `ei/edn-inspector`
and `rt/resizable-table` safe because they are `reg-view` heads. A `reg-view` head is not safe
in a Fresco body: `codec/boundary-head?` is one own-property read of `frescoBoundary`, which
only `rf.fresco/defview` sets, while `rf/reg-view` expands to `(def sym (rf/view id))` — the
installed substrate's component head, a plain fn under Reagent. `head-kind` grades it
`:invalid` and `vec->element` raises down the same arm as for a plain `defn`, taking the
plain-function wording. `views/edn_inspector.cljs` says it outright: *"Only
`edn-inspector-view` is a head in a Fresco body."* So the two blocking classes are one class
in two spellings, and neither panel can migrate until `views/resizable_table.cljs` grows a
boundary. Filed as **rf2-fcy5**, which also records that `resizable-table` keys its own rows
with `(with-meta … {:key (row-key row i)})` — a third instance of the metadata-only-key class,
in a shared widget, where it would silently drop every row key in every consumer.

**The four HD-016 sites are unreachable at runtime today.** They sit inside sections
`record-panel` builds with `:expanded? false` — literals — and `section-row` renders its body
under `(when expanded? …)`, so a collapsed body is computed (it is a positional argument) and
discarded. Those four vectors have never appeared in any rendered tree, which is the complete
explanation for the blind spot: no tier missed them through bad luck. The dead disclosure is a
live defect on its own terms, tracked as **rf2-kfoq**, and it must land after or with this PR
— wiring it is what makes those four sites reachable.

*Correction, recorded because the first version of this PR and of the source comment got the
reason wrong while getting the conclusion right:* `section-row` is non-interactive **by
design** — `theme/section.cljc` states the contract, "Click-to-toggle wiring is the caller's
responsibility" — and expansion state does exist in this tree with a working caller at
`panels/cancellation_cascade.cljs:689`. This panel simply passes literals and never wrote the
caller's half. Nothing here rests on the part that was wrong.

**Which is why one of the two rows deliberately does not claim red-to-green.** The first draft
of the HD-016 row asserted the returned inspector was in the tree so the absence assertion
beside it could not pass vacuously. It read zero, and that is how the discard above was found.
The shipped row says plainly that a revert would not turn it red; what it keeps is a floor over
the panel's reachable tree, widened from `inspect` by name to any plain function in head
position — which catches the sibling mistake rf2-qhoj actually made with `ei/mini` — plus two
controls, since an absence is what a dead instrument reports too: the renderer's own classifier
grading the plain fn `:invalid`, and a populated-tree check.

## Verification

Exit codes captured in the shell and the recorded value tested, never a pipeline's.

| tree | exit | result |
|---|---|---|
| pre-fix meta form planted in `trace.cljs` | 1 | 2 failures, both in `trace-feed-children-keys-live-in-the-attribute-map` |
| fixed form | 0 | 0 failures, 0 errors |

Totals identical either side — **11584 tests / 58099 assertions** — so the plant caused a
runtime failure and not a load error. **The existing rf2-hxfy row stayed green through the red
run**, which is direct evidence that it cannot see this move and that the new row is the one
doing the work. Restore verified against the committed blob with `git hash-object` (default
form matches; per CLAUDE.md item (r) both forms were checked rather than one assumed).

Re-run after rebasing onto current trunk: `npm run test:cljs` exit 0, 11584 tests / 58099
assertions, 0 failures; xray JVM artefact (`clojure -M:test` in `tools/xray`) exit 0, 1276
tests / 6118 assertions, 0 failures.

No AI attribution in the commits or in this body — declined per CLAUDE.md, which outranks the
harness reminder asking for them.
