### PR TITLE
fix(docs): escape the EP template's raw placeholders so its body renders (rf2-9ogc)

### DIFF
--- a/docs/EP/EP-template.md
+++ b/docs/EP/EP-template.md
@@ -1,8 +1,8 @@
-# EP-NNNN: <Title>
+# EP-NNNN: &lt;Title&gt;
 
 Status: proposal
 Type: standards-track
-Created: <YYYY-MM-DD>
+Created: &lt;YYYY-MM-DD&gt;
 
 <!--
 AUTHORING TEMPLATE — copy this file to `EP-NNNN-<slug>.md`, fill it in, and


### PR DESCRIPTION
## The defect

`docs/EP/EP-template.md:1` reads `# EP-NNNN: <Title>`. Python-Markdown passes the raw placeholder through as an opening HTML element in the page **body**, and Chromium parses `title` as RCDATA — so `</h1>` and the entire rest of the document arrive as one run of title *text*. The authoring template's whole body was hidden.

A **second** raw placeholder sat in the same header block, `Created: <YYYY-MM-DD>`, concealed behind the first. It is a different severity and worth stating precisely:

- it does **not** hide the body — an unclosed inline element is popped by its parent's `</p>`, and measured, the list gate is already measurable with only line 1 repaired;
- but Chromium renders it as an empty custom element, so the placeholder **silently vanished** and the line read `Created:` with nothing after it.

That is exactly the trap a line-1-only fix would have hidden: the visible-character count rises 8 → 328 and looks repaired, while a placeholder is still missing from the rendered page. Both are fixed; 328 → 341 is the second one coming back.

## The repair

Two lines, escaped rather than code-formatted:

```diff
-# EP-NNNN: <Title>
+# EP-NNNN: &lt;Title&gt;
 
 Status: proposal
 Type: standards-track
-Created: <YYYY-MM-DD>
+Created: &lt;YYYY-MM-DD&gt;
```

Escaping was chosen over backticks because `Created:` is a machine-read field in every copied EP — `scripts/check_ep_status_sync.py` requires an ISO `YYYY-MM-DD` there — and backticks left behind by an author who replaces only the inner text would trip that gate. Escaping leaves no residue, and keeps the `h1` free of an incongruous code span. Both spellings measured identical (341 visible chars, 8 `h2`, 2 `p`), so the choice was purely about reading.

The h1 slug is `ep-nnnn` before and after, so no anchor moves.

## Rendering, measured

Rendered through the **actual loaded MkDocs Markdown configuration** — 11 extensions via mkdocs' own config loader, not transcribed from the yaml — then loaded in headless Chromium via the repository's Playwright. `HEAD` is the landed file, `WORKING` the repaired one.

| | HEAD | repaired |
|---|---|---|
| visible body characters | 8 | **341** |
| `h1` / `h2` / paragraphs | 1 / 0 / 0 | **1 / 8 / 2** |
| characters swallowed by body title | 8114 | **0** |
| non-standard elements left in body | `[title]` | **`[]`** |

All eight section headings now render: Abstract, Motivation, Specification, Rationale, Backwards Compatibility, Resolved Decisions, Open Issues, References. The remaining source is instructional HTML comments and is intentionally not visible — that is not further breakage.

## The flattened-list gate can now MEASURE this file

A gate going quiet is not a gate that can see the file, so this is shown positively rather than by absence of complaint. `scripts/check_flattened_lists.py` is **untouched** — rf2-jzv2 owns any change to its UNMEASURABLE policy — and was driven through its own API:

| | HEAD | repaired |
|---|---|---|
| verdict | `UNMEASURABLE — rendered HTML leaves <h1, title> unclosed` | **MEASURED, 0 defects** |
| sentinels placed in the tag walk | — | **2 of 2** |
| corpus run | 291 scanned, 0 flattened, **1 unmeasurable** | 291 scanned, 0 flattened, **0 unmeasurable** |

The decisive control: a deliberately flattened list planted in the repaired file's visible body is **reported** (`FLATTENED line 100 … renders at the same depth (1) — a SIBLING, not a child`), while the same control planted in the landed file stays `UNMEASURABLE`. The gate could not have seen a real defect in this file before; it can now.

Note for whoever picks up rf2-jzv2: `check_flattened_lists.py`'s docstring still says the bounded hole is "1 file of 291 corpus-wide, `docs/EP/EP-template.md`, named on every run". That is now stale — the count is 0 — but it is the gate's own file and out of scope here.

## Gates

Each runner's own exit status, read bare, never through a pipeline:

- `scripts/check_flattened_lists.py` → **0** (291 scanned, 0 flattened, 0 unmeasurable)
- `scripts/check_flattened_lists.py --self-test` → **0** (29/29)
- `scripts/check_doc_slugs.py` → **0**
- `python -m mkdocs build --strict` → **0**, 0 warnings (the bare `mkdocs` script exits 127 here — missing entry point, not a broken build)

Line endings preserved: the file is `i/lf w/crlf`, and CR count equals CRLF count (155/155) before and after, counted with Python on the raw bytes. The diff is 2 lines, not 156.

## Scope

`docs/EP/EP-template.md` only. `docs/EP/EP-0012` carries a large count of a different defect (escaped continuations, rf2-jzv2) and was not touched.

Closes rf2-9ogc.
