### PR TITLE
fix(xray): remove the dead call-form key meta in the epoch cascade, gate the real key at the renderer (rf2-wvch)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3532,7 +3532,12 @@
         outcome-lbl (fmt/cascade-outcome-label row)
         long?       (and (number? duration-ms)
                          (> duration-ms proj/long-step-threshold-ms))]
-    [:div {:key (str "cascade-row-" step)
+    [:div {;; rf2-wvch — LOAD-BEARING, and the only place this row's React key
+           ;; can live: `machine-cascade-view` CALLS this fn from inside a
+           ;; `for`, so a `^{:key …}` at the call site would be discarded on
+           ;; return. `:step` is re-numbered 1..N by `projection/machine-
+           ;; cascade-rows`, so it is unique across the rendered siblings.
+           :key (str "cascade-row-" step)
            :data-testid (str "rf-xray-epoch-machine-cascade-row-" step)
            :data-cascade-kind (when (keyword? kind) (name kind))
            :data-cascade-phase (when (keyword? phase) (name phase))
@@ -3679,8 +3684,20 @@
         "— (no machine cascade events fired)"]
        (into [:div {:data-testid "rf-xray-epoch-handler-machine-cascade-rows"
                     :style machine-cascade-rows-style}]
+             ;; rf2-wvch — NO `^{:key …}` rides this call form. `cascade-row-view`
+             ;; is a plain `defn-`, so reader metadata here would sit on the
+             ;; SOURCE LIST and be discarded the moment the form is evaluated —
+             ;; the vector it returns would carry none of it. That is the
+             ;; strictly-dead member of the family: unlike metadata on a vector
+             ;; LITERAL (which Reagent still reads, and which only dies at a
+             ;; Fresco boundary), metadata on a CALL FORM reaches React on NO
+             ;; substrate. The sibling key therefore rides the ATTRIBUTE MAP of
+             ;; the `[:div]` `cascade-row-view` returns — `:key (str
+             ;; "cascade-row-" step)`, the one spelling every renderer honours
+             ;; (Reagent reads meta then props; Fresco's codec reads props and
+             ;; Clojure metadata nowhere). `machine-cascade-rows-reach-react-
+             ;; with-distinct-keys` in the view test grades it at the renderer.
              (for [row cascade-rows]
-               ^{:key (str "cascade-row-wrap-" (:step row))}
                (cascade-row-view machine-meta row))))]))
 
 (defn- event-handler-orientation-line

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -7,6 +7,7 @@
   every step body."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as string]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
@@ -1354,6 +1355,102 @@
 ;; GUARDS / LIFECYCLE / AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF /
 ;; FX) with a single time-ordered cascade view. Each row interleaves
 ;; source code (always visible) with phase + duration + outcome.
+
+;; ---- rf2-wvch — cascade rows reach React with a key ---------------------
+;;
+;; `machine-cascade-view` emits its rows from a `for`, which is exactly where
+;; sibling keys matter. The key used to be written as `^{:key …}` reader
+;; metadata on the `(cascade-row-view …)` CALL FORM. `cascade-row-view` is a
+;; plain `defn-`, so that metadata rode the source list and was discarded the
+;; moment the form was evaluated — the returned vector carried none of it.
+;;
+;; That is the STRICTLY-DEAD member of the family, and it is why this gate is
+;; not blocked on the Fresco migration: metadata on a vector LITERAL still
+;; reaches React under Reagent (it dies only at a Fresco boundary), whereas
+;; metadata on a CALL FORM reaches React on NO substrate.
+;;
+;; What actually carries the key — before this bead as well as after — is the
+;; attribute map of the `[:div]` `cascade-row-view` returns. All three
+;; renderers honour that spelling: Reagent reads meta then props, and Fresco's
+;; codec reads props and Clojure metadata nowhere. Removing the dead reader
+;; meta leaves the working key the single, findable one.
+;;
+;; Measured, so nobody re-reads this as a live-bug fix: this gate PASSES
+;; against the pre-repair source with the dead meta still in place (React
+;; already received all three keys), and FAILS `[nil nil nil]` the moment the
+;; attribute-map `:key` is deleted with everything else left alone. The dead
+;; meta was never what carried — it was a decoy sitting over a working key,
+;; and a future editor deleting the props `:key` because "the key is at the
+;; call site" is the regression this row exists to catch.
+;;
+;; Asserting `(meta node)` here would be a HOLLOW GATE in BOTH directions:
+;; `rf.test-helpers/expand-tree` rebuilds nested vectors with `mapv` and strips
+;; reader metadata (a false nil), and a correctly-keyed row reads nil anyway
+;; because its key lives in props. Hence the raw walk below and `r/as-element`,
+;; which grades what the RENDERER receives rather than how it is spelled.
+
+(defn- raw-children
+  "Children of a hiccup node WITHOUT rebuilding it. `expand-tree` would
+  `mapv` fresh vectors and strip reader metadata, so this gate could not see
+  a meta-spelled key if one were ever re-introduced — it would read a false
+  nil and fail for the wrong reason."
+  [node]
+  (cond
+    (and (vector? node) (fn? (first node))) [(apply (first node) (rest node))]
+    (vector? node)                          (if (map? (second node)) (drop 2 node) (rest node))
+    (seq? node)                             node
+    :else                                   nil))
+
+(defn- raw-find-by-testid
+  [tree testid]
+  (some (fn [node]
+          (when (and (vector? node) (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (tree-seq (some-fn vector? seq?) raw-children tree)))
+
+(defn- react-key
+  "The key REACT actually receives for one row. `r/as-element` runs Reagent's
+  own key resolution — metadata first, then the props map — so this reads the
+  rendered element rather than the authoring shape."
+  [node]
+  (.-key (r/as-element node)))
+
+(def ^:private cascade-key-fixture
+  "THREE rows, because a one-element sequence cannot distinguish a real key
+  from a missing one, and two cannot show a stable 1..N stamp."
+  [{:kind :guard      :step 1 :guard-id :ready? :outcome :pass}
+   {:kind :action     :step 2 :action-id :open-socket :phase :entry}
+   {:kind :transition :step 3 :machine-id :ws/conn
+    :from-state [:idle] :to-state [:connected] :microsteps 1}])
+
+(defn- cascade-row-nodes
+  "The row vectors `machine-cascade-view` emits, taken from the RAW tree.
+  `machine-cascade-mini-pipeline` is the public entry the Epoch panel's
+  EVENT HANDLER step and the Machine tab both render through."
+  [cascade]
+  (let [tree (view/machine-cascade-mini-pipeline cascade :ws/start)
+        rows (raw-find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows")]
+    (vec (filter vector? (drop 2 rows)))))
+
+(deftest machine-cascade-rows-reach-react-with-distinct-keys
+  (testing "rf2-wvch — every row the cascade `for` emits reaches React
+            carrying a key, and sibling keys are distinct. A lost key does
+            not fail, it DEGRADES into index-based reconciliation, which
+            paints identically and corrupts row identity only once the list
+            changes shape — so no assertion about the markup can see it."
+    (let [rows (cascade-row-nodes cascade-key-fixture)
+          ks   (mapv react-key rows)]
+
+      ;; Precondition — a vacuous pass is the failure mode here, so the row
+      ;; count is asserted before the keys are.
+      (is (= 3 (count rows)) "the fixture's three cascade rows each render")
+
+      (is (every? some? ks) "every cascade row reaches React with a key")
+      (is (= 3 (count (distinct ks))) "sibling keys are distinct")
+      (is (= ["cascade-row-1" "cascade-row-2" "cascade-row-3"] ks)
+          "the key React receives is the one `cascade-row-view` stamps into
+           its own attribute map, off the projection's 1..N `:step`"))))
 
 (deftest machine-handler-renders-cascade-view-test
   (testing "rf2-u69j7 — machine handler renders the time-ordered


### PR DESCRIPTION
## What this is

`machine-cascade-view` in `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` emitted its rows from a `for` with the sibling key written as `^{:key ...}` reader metadata on the `(cascade-row-view ...)` **call form**. `cascade-row-view` is a plain `defn-`, so that metadata rode the source list and was discarded the moment the form was evaluated — the returned vector carried none of it.

That is the strictly-dead member of the family. Metadata on a vector **literal** is still read by Reagent and dies only at a Fresco boundary; metadata on a **call form** reaches React on no substrate.

## Measured correction to the bead's premise

The bead concluded from that mechanism that "React receives no key for these siblings and reconciles the cascade rows BY INDEX". **That consequence is wrong, and I measured it in my own tree.**

`cascade-row-view`'s own returned `[:div ...]` has carried `:key (str "cascade-row-" step)` in its **attribute map** since `4d3ccc12f8` — the same commit that introduced the dead metadata — and all three renderers honour that spelling:

- **stock Reagent 2.0.1** (what `tools/xray/deps.edn` pins): `convert-props` copies every props entry into `jsprops`, `key` included, with no filtering, and `make-element` hands that to `createElement`, which extracts it.
- **reagent-slim** (`reagent2/impl/template.cljs`): `react-key-from-meta-or-props` states the rule itself — "`^{:key …}` meta on the hiccup vector wins; failing that, the props map's `:key`".
- **Fresco codec**: `codec_cljs_test.cljs` pins a props-map key landing on the element and being stripped from props.

So the dead meta was a **decoy sitting over a working key**, not a lost key. The rows have always reconciled by key. This is a clarity and regression-guard change, not a behaviour fix — nothing paints or reconciles differently.

## The repair

Delete the decoy and pin the key that actually carries, rather than "move the key into the attribute map", which was already done.

- `view.cljs` — drop the inert reader metadata at the call site; say at both ends (call site and attribute map) where the key really rides and why it can only live there. Notes that `:step` is re-numbered 1..N by `projection/machine-cascade-rows`, so it is unique across siblings.
- `view_cljs_test.cljs` — new `machine-cascade-rows-reach-react-with-distinct-keys`, reading `.-key` off **real React elements** via `r/as-element`, over a raw meta-preserving walk (not `find-by-testid`/`expand-tree`). Follows the merged rf2-hxfy precedent in `managed_fx_template_cljs_test.cljs`, and reaches the rows through the public `view/machine-cascade-mini-pipeline`.

It deliberately does **not** assert `(meta ...)`, which would be hollow in both directions: `expand-tree` rebuilds nested vectors with `mapv` and strips reader metadata, and a correctly-keyed row reads `nil` anyway because its key lives in props.

## Hollow-gate check — measured both ways

| tree | gate |
|---|---|
| pre-repair source, dead meta in place | **passes** — React already received all three keys |
| attribute-map `:key` deleted, everything else left alone | **fails** — `[nil nil nil]`, 3 of 4 assertions, row-count precondition still passing |

The second row is the "delete the signal, keep the fault" test: the gate is not hollow, and the precondition still passing proves the failure is about keys rather than a collapsed fixture.

## Verification

- Full CLJS node-test suite: **11583 tests, 58095 assertions, 0 failures, 0 errors**. Compile: 0 warnings.
- Worktree guard run before editing; `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/epochkey-a`.

## Census — reported, not swept

Run over the **full tracked roster** (`git ls-files '*.clj' '*.cljs' '*.cljc'`, 2956 files), classifying each hit by what the metadata actually attaches to rather than by the regex alone:

| | |
|---|---|
| `^{:key` hits | **333** across 128 files |
| vector literal | 271 — correct today; the rf2-twil class at a Fresco boundary |
| prose / other | 61 — docstrings and comments, several documenting prior repairs of this same class |
| **call form** | **1** |

The instrument is controlled in the positive direction, so a low count means absence rather than a broken pattern: run against the pre-fix copy of this PR's own file it reports `CALL-FORM 1` at line 3683 alongside 6 vector literals.

So repo-wide there were exactly **two** call-form sites before this change: the one repaired here, and one other, which **remains**.

### The remaining one is a genuinely dead key, and unlike this one has no working key under it

`tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs:249`

```clojure
(for [[i {:keys [kind] :as row}] (map-indexed vector rows)]
  ^{:key (str kind "#" i)}
  (if (= kind :visual)
    [visual-card row]
    [a11y-card row]))
```

The metadata rides the `(if ...)` form, so it is discarded and neither branch's vector carries it. **The fallback was checked, and that is what makes it different from this PR's site**: `visual-card` (line 204) and `a11y-card` (line 179) both return `[:div {:style ... :data-test ...}]` with **no** `:key` in the props map. There is no attribute-map key underneath to save it, so React really does receive no key for these siblings — the exact situation this bead's premise described, at a different address. It sits inside a `for`, and the branches are component-head vectors whose identity is what index-based reconciliation scrambles on a re-order.

**Not swept** — outside this bead's scope (`tools/story`, not `tools/xray`). Worth its own bead; the gate pattern shipped here transfers to it directly.

### Two multi-line metadata forms, both the rf2-twil class

- `tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs:1839` → `[render-overlay descriptor]`
- `tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs:274` → `[schema-row row]` (held file)

Both target vector literals, so both are correct under Reagent today and latent only if those panels become Fresco boundaries. Not touched.

### Four hollow `(meta ...)` key gates in xray tests

Green on broken code by this repo's own stated standard — reported for triage, not touched: `panels/machine_inspector_view_cljs_test.cljs:1284`, `static/machines/sim_cljs_test.cljs:835,869`, `static/flows/panel_cljs_test.cljs:357,367`.

## Scope

`tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` and its test only. The held files (`panels/trace.cljs`, `panels/managed_fx_template.cljs`, `static/flows/panel.cljs`, `static/schemas/panel.cljs`) were read as precedent and not modified.
