### PR TITLE
spec(xray): mount-fn step 2 names the orchestrator, not a direct make-frame (rf2-xhy9)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1932,10 +1932,24 @@ Every `mount-<panel>!` fn:
    of every panel's subs / events / fxs. The orchestrator's
    `defonce`-guarded sentinel collapses repeat installs across
    panel mounts and shadow-cljs `:after-load` cycles.
-2. Calls `(rf/make-frame {:id :rf/xray})` — idempotent register of
-   Xray's state-isolation frame. `make-frame`'s surgical-update-on-
-   re-register semantics (per Spec 002 §make-frame) keep this
-   idempotent.
+2. Calls `mount/ensure-xray-frame!` (via `panels.cljs`'s private
+   `ensure-xray-handlers-installed!`) so Xray's state-isolation frame
+   both **exists and is seeded** — its first-mount hook table has run.
+   The seeding is part of this contract, not an implementation detail:
+   the hooks populate Xray's trace-buffer slot and `:target-frame`
+   from what is already in the framework's per-frame rings. A mount fn
+   that calls `(rf/make-frame {:id …})` directly registers the frame
+   but skips the hooks, and the panel then renders against a frame
+   nothing populated — the empty-Xray-on-Story-RHS class of bug, where
+   a Story-embedded panel shows blank inputs though the host has been
+   dispatching all along. Go through the orchestrator. The frame
+   seated is `shell/default-frame-id` for the per-panel mounts;
+   `mount-shell!` seats the own frame its caller asked for (rf2-lffg).
+   `ensure-xray-frame!` is idempotent — `make-frame`'s surgical-update-
+   on-re-register semantics (per Spec 002 §make-frame), plus a
+   run-once hook guard keyed per frame-id. The hook keywords live in
+   `ensure-xray-handlers-installed!`'s docstring and are deliberately
+   not duplicated here.
 3. Wraps the panel's view in `[rf/frame-provider {:frame :rf/xray}
    [Panel]]` so descendant `subscribe` / `dispatch` re-anchor to
    `:rf/xray` regardless of the host's React-context. A mount fn that
@@ -1996,9 +2010,12 @@ of them.
 
 `register-xray-handlers!` is `defonce`-guarded so shadow-cljs
 `:after-load` cycles do not re-register handlers (which would emit
-`:rf.warning/handler-replaced` traces on every reload). `make-frame`
-is idempotent via surgical-update semantics. Mount fns can be called
-from a host's `init!` path at any frequency without risk.
+`:rf.warning/handler-replaced` traces on every reload).
+`ensure-xray-frame!` is idempotent on both halves — surgical-update
+semantics on the frame itself, and a run-once guard keyed per frame-id
+on the seed hooks — so repeat mounts collapse to one seed pass. Mount
+fns can be called from a host's `init!` path at any frequency without
+risk.
 
 ## Static mode (rf2-o5f5f)
 


### PR DESCRIPTION
Repairs `tools/xray/spec/007-UX-IA.md` §`The mount-fn contract` step 2, which named a call no mount fn makes and omitted the half that matters.

## The defect

Step 2 of the universal "Every `mount-<panel>!` fn:" read:

    2. Calls `(rf/make-frame {:id :rf/xray})` — idempotent register of
       Xray's state-isolation frame.

No mount fn does that. The real path is `panels.cljs`'s private `ensure-xray-handlers-installed!` routing through `mount/ensure-xray-frame!`; the only occurrence of `make-frame` in `panels.cljs` is at :197, inside a comment explaining why a direct call would be **wrong**. The frame id was hard-coded too — it is `shell/default-frame-id` for the per-panel mounts (`render-panel!` calls the zero-arity, which defaults to it), and the caller's own frame for `mount-shell!` (rf2-lffg).

## Why it was worth repairing rather than shrugging at

The step's *effect* claim was still true — the frame does get idempotently registered. That is exactly what made it dangerous. Someone implementing a new mount fn from this spec would call `rf/make-frame` directly, **satisfy the step as written**, register the frame but skip the first-mount hook table, and ship the empty-Xray-on-Story-RHS bug the code comment exists to prevent: the panel renders against a frame whose trace-buffer slot was never seeded and whose `:target-frame` is still pinned to the default, so a Story-embedded panel shows blank inputs though the host has been dispatching all along. The spec would have told them to do it.

## The repair

Step 2 now says the fn ensures the frame **exists and is seeded**, via the orchestrator; names the hook-table seeding as part of the contract rather than an implementation detail; says in terms that a direct `make-frame` is not the contract and why; and corrects the frame id. Wording is taken from `panels.cljs`'s own §"What every mount fn does" step 2, which already had it right — the spec was the side that lagged.

The five hook keywords are deliberately **not** pasted in. `panels.cljs` already carries them, and a second enumeration is the drift mechanism this very section keeps falling to (rf2-jw2ny's four-way coordinated set, rf2-uyn1). The step points at the docstring instead.

One adjacent line repaired for the same defect: §`Hot-reload + idempotency`, one heading down, explained mount-fn safety by "`make-frame` is idempotent via surgical-update semantics" — the same "call `make-frame` directly" implication, one paragraph below the fix. It now names `ensure-xray-frame!` and both halves of its idempotency: surgical update on the frame, plus the run-once seed-hook guard keyed per frame-id (`panels.cljs`'s docstring and `mount.cljs`'s rf2-n4p5it reset fn are the sources for that second half).

## Verification

- `scripts/check_doc_slugs.py` — the gate that covers `tools/*/spec` — run **bare and unpiped**, reading its own exit status: **exit 0**.
- Controlled in **both directions**, not trusted on a green: planted one broken in-page anchor and one broken cross-file anchor in prose in this file, re-ran, got **exit 1** naming both files and both lines (`007-UX-IA.md:1929` and `:1930`); removed the plants, re-ran, **exit 0**, and confirmed the diff is exactly the intended change and nothing else.
- `mkdocs build --strict` is **not** nominated and was never a candidate: `docs_dir` is `docs` and `tools/` sits outside it.
- **By hand, because nothing validates it:** no heading was added, removed or renamed and no link was added, so no anchor targets moved; no table was touched, so no column counts moved. The one pre-existing link in this numbered list (step 3's `008-Embedding-Contract.md`) is untouched and the gate resolves it.
- Line endings verified with **Python reading raw bytes**, not `grep -c`: CR 2262 == CRLF 2262, zero bare CR — matching the file's `i/lf w/crlf` classification. Diff is 24 insertions / 7 deletions, so no whole-file reclassification.

## Scope

One file, docs only. No code touched — several workers are live in `tools/xray/src`. Steps 1, 3, 4 and 5 were re-read at this base and remain accurate; no further drift found in them.

Re-derived every line number at this base rather than trusting the brief's: `panels.cljs:197` (the `make-frame` comment) and `mount.cljs:380` (`(ensure-xray-frame!)`) both held.

Closes rf2-xhy9.
