### PR TITLE
fix(xray): wire the managed-fx record panel section disclosure (rf2-s6m6)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -440,11 +440,26 @@
   is a `reg-view` so the React-context tier resolves to the wrapping
   frame-provider per Spec 006 §706."
   []
-  (let [records @(rf/subscribe [:rf.xray/managed-fx-for-focused-event])]
+  (let [focused  @(rf/subscribe [:rf.xray/managed-fx-for-focused-event])
+        ;; The panel's per-section disclosure state. Read HERE because
+        ;; `records-list` / `record-panel` are plain fns, and per Spec 006
+        ;; §Plain-fn footgun an ambient `subscribe` inside one raises
+        ;; `:rf.error/no-frame-context` — it carries no `:contextType`
+        ;; wiring and so cannot resolve the surrounding frame. A `reg-view`
+        ;; can, so the read happens at this boundary and the map is threaded
+        ;; down as plain data (the same shape `views/edn-inspector` uses for
+        ;; its own expansion slot).
+        expanded @(rf/subscribe [:rf.xray/managed-fx-expanded-sections])]
     ;; Thread the reg-view-injected frame-aware dispatch so the panel's
-    ;; context-menu / focus affordances land on the surrounding instance
-    ;; frame, not a `{:frame :rf/xray}` literal.
-    (managed-fx/records-list dispatch records)))
+    ;; context-menu / focus / disclosure affordances land on the surrounding
+    ;; instance frame, not a `{:frame :rf/xray}` literal.
+    ;;
+    ;; `:records` — the composite sub answers
+    ;; `{:dispatch-id … :frame … :records […]}`, and `records-list` takes the
+    ;; RECORDS VECTOR. Handing it the whole map made `(for [rec records] …)`
+    ;; walk map entries, so `(name (:status rec))` got nil and threw before
+    ;; the panel could paint (rf2-90kv).
+    (managed-fx/records-list dispatch expanded (:records focused))))
 
 (defn mount-managed-fx!
   "Mount the managed-fx wire-boundary diff list in isolation at

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_helpers.cljc
@@ -689,3 +689,76 @@
    :F.9  [:status]                       ;; skipped-on-platform visibility
    :F.10 [:surface]                      ;; surface badge taxonomy
    :F.11 [:cancel-cause]})               ;; cross-surface stale-suppression
+
+;; ---- section disclosure state -------------------------------------------
+;;
+;; `theme/section/section-row` draws the `▶`/`▼` glyph but wires no click:
+;; its own docstring states the contract deliberately — "No interactivity.
+;; Click-to-toggle wiring is the caller's responsibility." The primitive is
+;; shared with `panels/fresco` and `panels/module_view`, so the open/closed
+;; state belongs to THIS panel and not to the widget.
+;;
+;; Shape copied from the edn-inspector widget's own expansion slot
+;; (`views/edn_inspector_state.cljs`): a SPARSE override map plus a pure
+;; `resolve-expanded?` projection that falls back to a static default.
+;; Sparse-with-default is what lets the panel paint correctly before the
+;; operator has touched anything — an absent entry means "at its default",
+;; which is not the same as "closed", and two of the five sections default
+;; open.
+;;
+;; Pure data, JVM-portable — no tokens, no hiccup, no re-frame registration.
+;; The `reg-sub` / `reg-event` that own the slot live in `managed_fx_subs`.
+
+(def expansion-slot
+  "App-db slot holding the record panel's per-section expansion
+  overrides — a sparse map of `(expansion-key …)` → boolean."
+  :rf.xray.managed-fx/expanded-sections)
+
+(def section-defaults
+  "First-paint `:expanded?` for each of the record panel's five sections,
+  per `record-panel`'s documented contract: WIRE TIMING and APP-DB SLICE
+  TOUCHED open, REQUEST / RESPONSE / HANDLER DISPATCHED closed so the
+  panel stays scannable until the operator drills in.
+
+  Read by BOTH the renderer (to paint the untouched section) and the
+  toggle event (to know what the first click must invert). One map, so
+  the two cannot disagree — the edn-inspector widget has to pass the
+  rendered state through the dispatch payload precisely because its
+  defaults are computed per node rather than fixed per section."
+  {:request  false
+   :wire     true
+   :response false
+   :handler  false
+   :app-db   true})
+
+(defn record-key
+  "Stable per-record identity — `\"<surface>-<origin-event-id>-<fx-id>\"`.
+
+  One composer for two consumers that MUST agree: the React `:key` the
+  panel carries in its `:section` attribute map, and the expansion key
+  below. If they drifted, toggling a section on one record would move a
+  different record's disclosure."
+  [record]
+  (str (:surface record) "-" (:origin-event-id record) "-" (:fx-id record)))
+
+(defn expansion-key
+  "Compose the per-section override key. Pure data, JVM-portable.
+
+  Keyed per RECORD as well as per section: an event-bundle can carry
+  several managed-fx records, and opening REQUEST on one of them must
+  not open it on all of them."
+  [rec-key section-id]
+  [rec-key section-id])
+
+(defn resolve-expanded?
+  "Pure projection — does this record's `section-id` render expanded?
+  The operator's stored override wins; absent one, the section's
+  `section-defaults` entry does.
+
+  `overrides` is the value of `expansion-slot` (nil before the operator
+  has touched anything, which resolves every section to its default)."
+  [overrides rec-key section-id]
+  (let [override (get overrides (expansion-key rec-key section-id))]
+    (if (some? override)
+      (boolean override)
+      (boolean (get section-defaults section-id)))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_subs.cljs
@@ -16,6 +16,15 @@
   event list, scrubs through history, or a new event-bundle lands at head
   in LIVE mode.
 
+  ## Section disclosure
+
+  This ns also owns the record panel's per-section open/closed state —
+  the `:rf.xray/managed-fx-expanded-sections` read and the
+  `:rf.xray/managed-fx-toggle-section` write. `theme/section/section-row`
+  draws the disclosure glyph but deliberately wires no click, so the
+  state is the caller's; it is held per `[record-key section-id]` pair so
+  one record's REQUEST opens independently of its siblings'.
+
   ## Cross-link
 
   Records carry `:origin-event-id` so the panel's HANDLER DISPATCHED
@@ -54,7 +63,42 @@
          :frame       (:frame focus)
          :records     (if event-bundle
                         (h/event-bundle->managed-fx-records event-bundle)
-                        [])}))))
+                        [])})))
+
+  ;; ---- section disclosure ----------------------------------------------
+  ;;
+  ;; `theme/section/section-row` renders the disclosure glyph and nothing
+  ;; else — "Click-to-toggle wiring is the caller's responsibility" — so the
+  ;; open/closed state is the panel's, held here. The vocabulary
+  ;; (`expansion-slot`, `expansion-key`, `resolve-expanded?`,
+  ;; `section-defaults`) is pure data in `managed_fx_helpers`; this ns owns
+  ;; only the registration.
+  ;;
+  ;; The slot is read at the panel's reactive boundary (`panels/ManagedFxList`)
+  ;; and threaded down as plain data — `record-panel` and `records-list` are
+  ;; plain fns, and per Spec 006 §Plain-fn footgun an ambient `subscribe`
+  ;; inside one raises `:rf.error/no-frame-context` rather than resolving the
+  ;; surrounding frame. Same shape the edn-inspector widget uses: its
+  ;; `reg-view` reads `@(subscribe [expansion-slot])` once and hands the map
+  ;; to the pure renderers.
+
+  (rf/reg-sub :rf.xray/managed-fx-expanded-sections
+    (fn [db _query]
+      (get db h/expansion-slot)))
+
+  ;; Toggle ONE section of ONE record.
+  ;;
+  ;; The next value is computed through `resolve-expanded?` rather than by
+  ;; flipping the stored entry, so the FIRST click inverts what the operator
+  ;; can actually SEE. Flipping a nil override from an assumed `false` would
+  ;; be a silent no-op on the two sections that default OPEN.
+  (rf/reg-event :rf.xray/managed-fx-toggle-section
+    (fn [{:keys [db]} [_ rec-key section-id]]
+      {:db (assoc-in db [h/expansion-slot (h/expansion-key rec-key section-id)]
+                     (not (h/resolve-expanded? (get db h/expansion-slot)
+                                               rec-key section-id)))}))
+
+  nil)
 
 ;; The HANDLER DISPATCHED row's `:on-click` dispatches the spine's
 ;; canonical `:rf.xray/focus-event` directly (managed_fx_template.cljs)

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -12,13 +12,18 @@
   ┌─ MANAGED FX [HTTP] · :user/load-profile · 250ms ──────────────┐
   │ STATUS: ✓ 200 OK · correlation: c-abc12 · phase: completed     │
   │                                                                │
-  │ ▼ REQUEST                                                      │
+  │ ▶ REQUEST                                                      │
   │ ▼ WIRE TIMING                                                  │
-  │ ▼ RESPONSE                                                     │
-  │ ▼ HANDLER DISPATCHED                                           │
+  │ ▶ RESPONSE                                                     │
+  │ ▶ HANDLER DISPATCHED                                           │
   │ ▼ APP-DB SLICE TOUCHED                                         │
   └────────────────────────────────────────────────────────────────┘
   ```
+
+  Every section header is a disclosure: clicking one toggles it. The
+  first-paint state is `managed-fx-helpers/section-defaults` (three shut,
+  two open, as drawn above); the operator's overrides live in app-db,
+  keyed per record so sibling panels open independently.
 
   ## Five surfaces, one template
 
@@ -346,6 +351,52 @@
         [:span {:style {:color (:accent tokens)}}
          (pr-str path)]])]))
 
+;; ---- disclosure ---------------------------------------------------------
+;;
+;; `theme/section/section-row` renders the `▶`/`▼` glyph from `:expanded?`
+;; and renders its body under `(when expanded? …)`, but it attaches no
+;; handler — "No interactivity. Click-to-toggle wiring is the caller's
+;; responsibility", stated in its own docstring, and it is shared with
+;; `panels/fresco` and `panels/module_view`, so the wiring is OURS to do.
+;;
+;; The caller's half is a wrapper carrying the click. Two details in it are
+;; load-bearing:
+;;
+;;   - The BODY stops propagation. The wrapper has to enclose the whole
+;;     section (the primitive renders its own header, so there is no inner
+;;     header node to hang the handler on), which would otherwise make every
+;;     click inside an opened payload collapse it again — including the
+;;     '→ focus event ↗' button and the edn-inspector's own expand chevrons.
+;;   - `:expanded?` is passed THROUGH to the primitive, so the glyph and the
+;;     body agree by construction. The primitive stays the single source of
+;;     truth for the visual state; this wrapper only decides what that state is.
+
+(defn- disclosing-section
+  "One `section-row` plus the click-to-toggle the primitive deliberately
+  omits. `expanded?` is the resolved state (see
+  `managed-fx-helpers/resolve-expanded?`); clicking dispatches the panel's
+  toggle for `[rec-key section-id]`."
+  [{:keys [dispatch rec-key section-id label testid expanded?]} body]
+  [:div {:data-testid   (str testid "-toggle")
+         :on-click      (fn [_]
+                          (dispatch [:rf.xray/managed-fx-toggle-section
+                                     rec-key section-id]))
+         :aria-expanded (if expanded? "true" "false")
+         :title         (if expanded?
+                          "Click to collapse this section"
+                          "Click to expand this section")
+         :style         {:cursor "pointer"}}
+   (section/section-row
+     {:label             label
+      :expanded?         expanded?
+      :testid            testid
+      :container-padding "8px 0"}
+     ;; Clicks on the payload belong to the payload, not to the disclosure.
+     [:div {:data-testid (str testid "-body-inner")
+            :on-click    (fn [^js e] (.stopPropagation e))
+            :style       {:cursor "auto"}}
+      body])])
+
 ;; ---- one record's panel ------------------------------------------------
 
 (defn record-panel
@@ -360,12 +411,29 @@
       (one click reveals the payload — keeps the panel scannable on
       first paint).
 
+  Those defaults live in `managed-fx-helpers/section-defaults`, and every
+  section is now a real disclosure: the panel owns the open/closed state
+  and each header toggles it. Before rf2-s6m6 the five `:expanded?` values
+  were literals, so the three collapsed sections drew a `▶` nothing could
+  operate and their payloads — request, response (and the failure tags),
+  and the dispatched handler vector — were unreachable in the UI.
+
+  `expanded` is the per-section override map (the value of
+  `managed-fx-helpers/expansion-slot`), read at the panel's reactive
+  boundary and threaded down. `nil` — the shape the short arities pass —
+  resolves every section to its `section-defaults` value, which is the
+  first-paint state. This fn stays a PURE fn of `(dispatch, expanded,
+  record)`: per Spec 006 §Plain-fn footgun an ambient `subscribe` in a
+  plain fn raises `:rf.error/no-frame-context`, so the read cannot happen
+  here and the sub is read by the `reg-view` that mounts this panel.
+
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
   `panels/ManagedFxList` `reg-view` body, threaded to the header /
-  handler affordances. Defaults to `rf/dispatch` so the test seam (and
-  any pre-sweep caller) renders without a captured dispatcher."
-  ([record] (record-panel rf/dispatch record))
-  ([dispatch record]
+  handler / disclosure affordances. Defaults to `rf/dispatch` so the test
+  seam (and any pre-sweep caller) renders without a captured dispatcher."
+  ([record] (record-panel rf/dispatch nil record))
+  ([dispatch record] (record-panel dispatch nil record))
+  ([dispatch expanded record]
   ;; rf2-hxfy — the React key lives in this ATTRIBUTE MAP rather than as
   ;; `^{:key …}` reader meta on the `(record-panel …)` call in
   ;; `records-list` below. Reader meta on a CALL form attaches to the
@@ -377,7 +445,20 @@
   ;; Reagent reads meta THEN props — so one attribute satisfies both
   ;; substrates. The composed value is unchanged from the call site's:
   ;; the same three record fields, same order, same separator.
-  [:section {:key         (str (:surface record) "-" (:origin-event-id record) "-" (:fx-id record))
+  (let [rec-key (h/record-key record)
+        ;; One `section` per row: resolve this record's stored state for
+        ;; the section (falling back to its default) and hand the whole
+        ;; lot to the disclosure wrapper.
+        section (fn [section-id label testid body]
+                  (disclosing-section
+                    {:dispatch   dispatch
+                     :rec-key    rec-key
+                     :section-id section-id
+                     :label      label
+                     :testid     testid
+                     :expanded?  (h/resolve-expanded? expanded rec-key section-id)}
+                    body))]
+  [:section {:key         rec-key
              :data-testid (str "rf-xray-managed-fx-record-"
                                (name (:surface record))
                                "-" (or (:origin-event-id record) "x"))
@@ -389,31 +470,16 @@
                            :background    (:bg-2 tokens)}}
    (panel-header dispatch record)
    [:div {:style {:padding "8px 12px"}}
-    (section/section-row
-      {:label "REQUEST" :expanded? false
-       :testid "rf-xray-managed-fx-section-request"
-       :container-padding "8px 0"}
-      (request-section record))
-    (section/section-row
-      {:label "WIRE TIMING" :expanded? true
-       :testid "rf-xray-managed-fx-section-wire"
-       :container-padding "8px 0"}
-      (wire-section record))
-    (section/section-row
-      {:label "RESPONSE" :expanded? false
-       :testid "rf-xray-managed-fx-section-response"
-       :container-padding "8px 0"}
-      (response-section record))
-    (section/section-row
-      {:label "HANDLER DISPATCHED" :expanded? false
-       :testid "rf-xray-managed-fx-section-handler"
-       :container-padding "8px 0"}
-      (handler-section dispatch record))
-    (section/section-row
-      {:label "APP-DB SLICE TOUCHED" :expanded? true
-       :testid "rf-xray-managed-fx-section-app-db"
-       :container-padding "8px 0"}
-      (app-db-slice-section record))]]))
+    (section :request  "REQUEST"
+             "rf-xray-managed-fx-section-request"  (request-section record))
+    (section :wire     "WIRE TIMING"
+             "rf-xray-managed-fx-section-wire"     (wire-section record))
+    (section :response "RESPONSE"
+             "rf-xray-managed-fx-section-response" (response-section record))
+    (section :handler  "HANDLER DISPATCHED"
+             "rf-xray-managed-fx-section-handler"  (handler-section dispatch record))
+    (section :app-db   "APP-DB SLICE TOUCHED"
+             "rf-xray-managed-fx-section-app-db"   (app-db-slice-section record))]])))
 
 ;; ---- list panel --------------------------------------------------------
 
@@ -424,9 +490,14 @@
   a deterministic stack against canned records.
 
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded to each
-  `record-panel`. Defaults to `rf/dispatch` for the test seam."
-  ([records] (records-list rf/dispatch records))
-  ([dispatch records]
+  `record-panel`. Defaults to `rf/dispatch` for the test seam.
+
+  `expanded` is the per-section override map threaded to each
+  `record-panel`; `nil` renders every section at its default. Keyed per
+  record, so opening one panel's REQUEST leaves its siblings shut."
+  ([records] (records-list rf/dispatch nil records))
+  ([dispatch records] (records-list dispatch nil records))
+  ([dispatch expanded records]
   (when (seq records)
     [:div {:data-testid "rf-xray-managed-fx-list"
            :style {:padding "8px 0"
@@ -442,4 +513,4 @@
      ;; attribute map `record-panel` returns (see the comment there).
      ;; Reader meta here would attach to the CALL form and be lost.
      (for [rec records]
-       (record-panel dispatch rec))])))
+       (record-panel dispatch expanded rec))])))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
@@ -8,8 +8,12 @@
   `trace-collector/seed-trace-for-test!` path, then read the composite via
   `subscribe`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            ;; rf2-90kv — the reg-view that composes the sub with the renderer
+            ;; is itself the defect surface, so it is the instrument.
+            [day8.re-frame2-xray.panels]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -221,3 +225,92 @@
         (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rk :request])
         (is (true? (shown?))
             "one toggle later the request payload is in the rendered tree")))))
+
+;; ---- the reg-view's own composition (rf2-90kv) ----------------------------
+;;
+;; `panels/ManagedFxList` is the ONLY caller of `records-list`, and it is where
+;; the composite sub's value meets the renderer. Nothing graded that seam:
+;; `panels_mount_cljs_test`'s `mount-managed-fx-wraps-ManagedFxList` stubs
+;; `rf.substrate.adapter/render`, so the view's BODY never executes, and every
+;; template test calls `records-list` / `record-panel` directly with a vector
+;; already in hand. Both tiers were blind to the one line that composes them,
+;; which is how the panel came to throw before painting without a red row
+;; anywhere.
+
+(defn- cascade-evs-two-managed-fx
+  "One cascade carrying TWO managed-fx invocations.
+
+  Two is what makes this row discriminating: the composite map has THREE
+  entries (`:dispatch-id`, `:frame`, `:records`), so a renderer handed the
+  map instead of the vector cannot answer 2.
+
+  Seeded through the production trace path and read back through the real
+  composite sub rather than a stub — a stub is not available here, and the
+  refusal is the framework's rather than a limitation of the fixture:
+  re-registering `:rf.xray/managed-fx-for-focused-event` from this ns makes
+  `rf/make-frame` refuse image assembly with
+  `:rf.error/image-duplicate-id`, because the id would then be selected from
+  two source namespaces with different implementations. Measured."
+  [dispatch-id id-base]
+  [{:id (+ id-base 1) :op-type :rf.event :operation :rf.event/dispatched
+    :tags {:rf.trace/dispatch-id dispatch-id :rf.event/v [:user/load]}}
+   {:id (+ id-base 2) :op-type :rf.fx :operation :rf.fx/do-fx
+    :tags {:rf.trace/dispatch-id dispatch-id}}
+   {:id (+ id-base 3) :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/1"}
+                        :request-id :req-a
+                        :on-success [:user/loaded]}}}
+   {:id (+ id-base 4) :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/2"}
+                        :request-id :req-b
+                        :on-success [:user/loaded]}}}])
+
+(defn- record-panel-testids
+  "Every record-panel `data-testid` in a rendered tree. One per record."
+  [tree]
+  (->> (tree-nodes tree)
+       (keep (fn [n]
+               (when (and (vector? n) (map? (second n)))
+                 (:data-testid (second n)))))
+       (filter #(string/starts-with? % "rf-xray-managed-fx-record-"))))
+
+(deftest managed-fx-list-renders-one-panel-per-record
+  (testing "rf2-90kv — the composite sub answers
+            `{:dispatch-id … :frame … :records […]}`, and `records-list` takes
+            the RECORDS VECTOR. Handing it the whole MAP made `(seq records)`
+            truthy, `(count records)` read the map's ENTRY COUNT — 3, whatever
+            the real record count — and `(for [rec records] …)` walk map
+            entries, so `(name (:status rec))` got nil and threw before the
+            panel could paint. No error boundary sits above this render path,
+            so it presented as a panel that never appears (the rf2-qhoj shape).
+
+            TWO records is what separates a pass from the bug: 2 panels against
+            the map's 3 entries. Measured against the old binding
+            `(managed-fx/records-list dispatch focused)` — it goes red by
+            THROWING inside `record-panel` before the count is ever read, which
+            is red either way and is why the count assertion is stated over a
+            tree that has to have been built at all.
+
+            The view's body is invoked headlessly through `((rf/view id))`,
+            which runs the real reg-view render path under the plain-atom
+            substrate the Xray suite installs."
+    (seed-buffer! (cascade-evs-two-managed-fx 600 0))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/focus-event 600 :rf/default])
+      ;; CONTROL FIRST, so a zero below is the renderer's answer and not the
+      ;; seeding's — without it the two readings are indistinguishable, and a
+      ;; seeding that quietly produced no records would read exactly like a
+      ;; renderer that dropped them.
+      (is (= 2 (count (:records @(rf/subscribe
+                                   [:rf.xray/managed-fx-for-focused-event]))))
+          "control: the composite really answers two records")
+      (let [tree    ((rf/view :day8.re-frame2-xray.panels/ManagedFxList))
+            testids (record-panel-testids tree)]
+        (is (= 2 (count testids))
+            "one record panel per RECORD, not one per entry of the composite map")
+        (is (= 2 (count (distinct testids)))
+            "and the two panels are distinct, so this is not one record twice")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
@@ -13,7 +13,12 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            ;; rf2-s6m6 — the disclosure rows below close the loop between the
+            ;; state this ns owns and the renderer that consumes it, so the
+            ;; template and its pure helpers are the instruments.
+            [day8.re-frame2-xray.panels.managed-fx-helpers :as h]
+            [day8.re-frame2-xray.panels.managed-fx-template :as template]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -115,3 +120,104 @@
         (is (= 400 (:dispatch-id focus)))
         (is (= :rf/default (:frame focus)))
         (is (= :retro (:mode focus)))))))
+
+;; ---- section disclosure state (rf2-s6m6) ---------------------------------
+;;
+;; The record panel's five sections each draw a `▶`/`▼` glyph that
+;; `theme/section/section-row` renders from `:expanded?` and nothing else —
+;; "Click-to-toggle wiring is the caller's responsibility". This ns holds the
+;; caller's half: the slot's read and its toggle write.
+
+(def ^:private rec-key
+  "The record key `managed-fx-helpers/record-key` composes for the HTTP
+  fixture — `\"<surface>-<origin-event-id>-<fx-id>\"`, keyword prefixes and
+  all. Written out rather than derived so a drift in the composer shows up
+  here as a failure rather than being silently tracked."
+  ":http-99-:rf.http/managed")
+
+(defn- expanded-map []
+  @(rf/subscribe [:rf.xray/managed-fx-expanded-sections]))
+
+(defn- tree-nodes
+  "Every node in a hiccup tree, payload values included. Walked structurally
+  rather than through `rf.test-helpers/expand-tree`, which rebuilds nested
+  vectors with `mapv` and would substitute its own vectors for the ones under
+  test (it strips reader metadata besides)."
+  [node]
+  (cond
+    (vector? node) (cons node (mapcat tree-nodes node))
+    (seq? node)    (cons node (mapcat tree-nodes node))
+    :else          [node]))
+
+(deftest expanded-sections-slot-starts-empty
+  (testing "Nothing is stored before the operator touches a disclosure, and
+            an empty slot resolves every section to its default — which is
+            NOT the same as every section closed, since two default open."
+    (seed-buffer! [])
+    (rf/with-frame :rf/xray
+      (is (nil? (expanded-map)))
+      (is (false? (h/resolve-expanded? (expanded-map) rec-key :request)))
+      (is (true?  (h/resolve-expanded? (expanded-map) rec-key :wire))))))
+
+(deftest toggle-inverts-the-state-the-operator-can-see
+  (testing "The first click must invert what is RENDERED, not a hard-coded
+            assumption. A reducer flipping a nil override from `false` would
+            be a silent no-op on the two sections that default OPEN — the
+            operator clicks `▼ WIRE TIMING` and nothing happens. The event
+            resolves through `section-defaults`, so both directions work.
+
+            Not hollow: replace the resolve with a bare `(not (get …))` and
+            the WIRE assertions below go red."
+    (seed-buffer! [])
+    (rf/with-frame :rf/xray
+      ;; default-CLOSED section: first click opens, second shuts
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rec-key :request])
+      (is (true? (h/resolve-expanded? (expanded-map) rec-key :request)))
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rec-key :request])
+      (is (false? (h/resolve-expanded? (expanded-map) rec-key :request)))
+      ;; default-OPEN section: first click SHUTS it
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rec-key :wire])
+      (is (false? (h/resolve-expanded? (expanded-map) rec-key :wire)))
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rec-key :wire])
+      (is (true? (h/resolve-expanded? (expanded-map) rec-key :wire))))))
+
+(deftest toggle-is-keyed-per-record-and-per-section
+  (testing "One event-bundle can carry several managed-fx records, and each
+            record has five sections. A toggle must move exactly one pair."
+    (seed-buffer! [])
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rec-key :request])
+      (let [m (expanded-map)]
+        (is (= 1 (count m)) "exactly one override was written")
+        (is (true? (h/resolve-expanded? m rec-key :request)))
+        ;; a sibling SECTION of the same record is untouched
+        (is (false? (h/resolve-expanded? m rec-key :response)))
+        ;; and so is the same section of a DIFFERENT record
+        (is (false? (h/resolve-expanded? m ":flow-99-:rf.fx/reg-flow" :request)))))))
+
+(deftest toggling-puts-the-request-payload-in-the-rendered-tree
+  (testing "rf2-s6m6 end-to-end, across the two namespaces: the real event
+            writes the slot, the real sub reads it back, and the renderer
+            turns that into a payload the operator can actually see. Before
+            the repair `record-panel` passed `:expanded? false` as a literal,
+            so no state anywhere could put this payload in a tree."
+    (seed-buffer! [])
+    (rf/with-frame :rf/xray
+      (let [req  {:method :get :url "/api/users/42"}
+            rec  {:surface :http :fx-id :rf.http/managed
+                  :req req
+                  :res nil :handler nil :status :ok :phase :completed
+                  :http-status 200 :duration-ms 250 :paths-touched []
+                  :origin-event-id 99 :dispatch-id 7 :frame :rf/default}
+            rk   (h/record-key rec)
+            ;; Render through the panel exactly as `panels/ManagedFxList`
+            ;; does — the sub's value threaded in as plain data.
+            shown? (fn [] (->> (template/record-panel (fn [_]) (expanded-map) rec)
+                               (tree-nodes)
+                               (some #{req})
+                               boolean))]
+        (is (false? (shown?))
+            "REQUEST is shut on first paint, so its payload is not in the tree")
+        (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section rk :request])
+        (is (true? (shown?))
+            "one toggle later the request payload is in the rendered tree")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -228,29 +228,33 @@
 ;; `edn/inspect-view`. Asserting only what is actually true here is the
 ;; point: a row claiming Fresco-readiness would be the hollow one.
 ;;
-;; AND WHAT THIS ROW CANNOT DO, STATED PLAINLY BECAUSE THE FIRST DRAFT OF
-;; IT LIED. All four sites sit inside sections `record-panel` builds with
-;; `:expanded? false` — a LITERAL — and `theme/section/section-row` renders
-;; its body under `(when expanded? …)`, so a collapsed body is computed
-;; (it is a positional argument) and then DISCARDED. The four vectors have
-;; therefore never appeared in any rendered tree, which is the blind spot
-;; all three tiers of coverage shared. So a revert to `[edn/inspect …]`
-;; would NOT turn this row red, and the row does not claim it would: the
-;; absence assertion is a FLOOR against a future head placed somewhere
-;; reachable, and the controls above it are what stop the floor reading as
-;; a proof. Measured, not assumed — the draft that asserted the returned
-;; inspector was present in the tree read zero, and that is how the
-;; discard was found.
+;; WHAT THIS ROW CANNOT DO, STATED PLAINLY BECAUSE THE FIRST DRAFT OF IT
+;; LIED. It walks the DEFAULT tree, where three of the five sections are
+;; shut. `theme/section/section-row` renders its body under `(when expanded?
+;; …)`, so a collapsed body is computed (it is a positional argument) and
+;; then DISCARDED — three of the four `edn/inspect` sites are therefore
+;; absent from the tree this row walks, which is the blind spot all three
+;; tiers of coverage shared. So a revert to `[edn/inspect …]` in one of those
+;; three would NOT turn THIS row red, and it does not claim it would: the
+;; absence assertion is a FLOOR, and the controls above it are what stop the
+;; floor reading as a proof. Measured, not assumed — the draft that asserted
+;; the returned inspector was present in the tree read zero, and that is how
+;; the discard was found.
+;;
+;; THE GAP IS NOW COVERED ELSEWHERE IN THIS FILE. rf2-s6m6 wired the
+;; disclosure, so the sections can be opened, and
+;; `no-plain-fn-in-head-position-with-every-section-open` restates this floor
+;; over the FULLY OPEN tree — where all four sites really are present, as it
+;; asserts before reading the absence. Keep both: this row grades what the
+;; operator sees on first paint, that one grades what a click reveals.
 ;;
 ;; THE PRIMITIVE IS NOT AT FAULT, AND SAYING SO MATTERS because the first
 ;; version of this comment blamed it. `section-row` is non-interactive BY
 ;; DESIGN — `theme/section.cljc` states the contract in terms: "No
-;; interactivity. Click-to-toggle wiring is the caller's responsibility."
-;; Expansion state exists in this tree and has a working caller
-;; (`panels/cancellation_cascade.cljs:689` feeds `:expanded?` from a sub);
-;; this panel simply passes literals and never did that half. rf2-kfoq
-;; carries the repair, and it must land after or with the head-form fix,
-;; since wiring the disclosure is exactly what makes these four reachable.
+;; interactivity. Click-to-toggle wiring is the caller's responsibility." —
+;; and it is shared with `panels/fresco` and `panels/module_view`. The panel
+;; simply passed literals and never did the caller's half; rf2-s6m6 did it,
+;; in the panel, leaving the primitive untouched.
 
 (defn- hiccup-vectors
   "Every hiccup vector in `node`, root included, walked structurally.
@@ -362,6 +366,245 @@
   (doseq [[pat kind] internal-ref-patterns]
     (is (not (re-find pat text))
         (str label " leaks an internal " kind ": " (pr-str (re-find pat text))))))
+
+;; ---- section disclosure (rf2-s6m6) ---------------------------------------
+;;
+;; The defect: all five `:expanded?` values were LITERALS, so REQUEST,
+;; RESPONSE and HANDLER DISPATCHED drew a `▶` that nothing could operate and
+;; their payloads never reached a rendered tree. `theme/section/section-row`
+;; is not at fault and is unchanged — it is non-interactive by design and
+;; shared with two other panels — so the state and the click are the panel's.
+
+(def ^:private disclosure-record
+  (record {:surface :http :fx-id :rf.http/managed
+           :status  :ok   :http-status 200
+           :handler [:user/loaded {:id 1}]
+           :paths   [[:users 42]]}))
+
+(def ^:private section-ids [:request :wire :response :handler :app-db])
+
+(defn- section-testid [section-id]
+  (str "rf-xray-managed-fx-section-" (name section-id)))
+
+(defn- body-shown?
+  "Did `section-id`'s BODY reach the tree? `section-row` renders the body
+  div under `(when expanded? …)`, so its testid is present exactly when the
+  section is open."
+  [tree section-id]
+  (contains? (set (testids tree)) (str (section-testid section-id) "-body")))
+
+(defn- tree-nodes
+  "Every node in a hiccup tree, payload values included. Walked structurally
+  rather than through `rf.test-helpers/expand-tree`, which rebuilds nested
+  vectors with `mapv` — that would substitute its own vectors for the ones
+  under test, and strips reader metadata besides."
+  [node]
+  (cond
+    (vector? node) (cons node (mapcat tree-nodes node))
+    (seq? node)    (cons node (mapcat tree-nodes node))
+    :else          [node]))
+
+(defn- open-all
+  "Override map opening every section of one record."
+  [rec]
+  (let [rk (h/record-key rec)]
+    (into {} (for [s section-ids] [(h/expansion-key rk s) true]))))
+
+(defn- noop-dispatch [_])
+
+(deftest sections-paint-at-their-documented-defaults
+  (testing "`record-panel`'s docstring promises WIRE + APP-DB SLICE TOUCHED
+            open and REQUEST + RESPONSE + HANDLER DISPATCHED shut on first
+            paint. A nil override map is that first-paint state.
+
+            This row is a FLOOR for the defaults, not a gate for the repair —
+            it passed before it too, because the pre-repair literals painted
+            the same thing. The gate is the toggle rows below."
+    (let [tree (template/record-panel disclosure-record)
+          ids  (set (testids tree))]
+      ;; every section draws its header, open or shut
+      (doseq [s section-ids]
+        (is (contains? ids (str (section-testid s) "-header"))
+            (str (name s) " draws a header")))
+      (is (not (body-shown? tree :request)))
+      (is (not (body-shown? tree :response)))
+      (is (not (body-shown? tree :handler)))
+      (is (body-shown? tree :wire))
+      (is (body-shown? tree :app-db)))))
+
+(deftest opening-a-collapsed-section-puts-its-payload-in-the-tree
+  (testing "rf2-s6m6 — the deliverable. A section starts collapsed, the
+            expansion state changes, and the PAYLOAD is present afterwards.
+
+            Asserting the body testid alone would be half a gate: the
+            container can appear while the payload does not. Both are
+            asserted, and both are asserted ABSENT first, so neither reads
+            as present on a tree that never had it."
+    (let [rk     (h/record-key disclosure-record)
+          shut   (template/record-panel noop-dispatch nil disclosure-record)
+          opened (template/record-panel noop-dispatch
+                                        {(h/expansion-key rk :request) true}
+                                        disclosure-record)
+          req    {:method :get :url "/x"}]
+      (is (not (body-shown? shut :request)))
+      (is (not (some #{req} (tree-nodes shut)))
+          "the request payload is absent while the section is shut")
+      (is (body-shown? opened :request))
+      (is (some #{req} (tree-nodes opened))
+          "the request payload reaches the tree once the section is open")
+      ;; the sibling sections are untouched by opening this one
+      (is (not (body-shown? opened :response)))
+      (is (not (body-shown? opened :handler))))))
+
+(deftest opening-response-and-handler-puts-their-payloads-in-the-tree
+  (testing "The other two sections the defect hid. HANDLER DISPATCHED also
+            carries the '→ focus event ↗' cross-link button, which was
+            unreachable for the same reason."
+    (let [rk     (h/record-key disclosure-record)
+          opened (template/record-panel noop-dispatch (open-all disclosure-record)
+                                        disclosure-record)
+          shut   (template/record-panel noop-dispatch nil disclosure-record)]
+      (is (some #{{:ok true}} (tree-nodes opened))
+          "the response payload reaches the tree")
+      (is (not (some #{{:ok true}} (tree-nodes shut))))
+      (is (some #{[:user/loaded {:id 1}]} (tree-nodes opened))
+          "the dispatched handler vector reaches the tree")
+      (is (not (some #{[:user/loaded {:id 1}]} (tree-nodes shut))))
+      (is (contains? (set (testids opened)) "rf-xray-managed-fx-focus-handler")
+          "the cross-link button is reachable once HANDLER DISPATCHED opens")
+      (is (not (contains? (set (testids shut)) "rf-xray-managed-fx-focus-handler"))))))
+
+(deftest opening-response-on-a-failure-record-surfaces-the-failure-tags
+  (testing "The failure branch of RESPONSE is a distinct unreachable payload —
+            it is what the F.3 / F.7 diagnostics are read from."
+    (let [r      (assoc (record {:surface :http :fx-id :rf.http/managed
+                                 :status :error :http-status 500})
+                        :failure {:kind :rf.http/http-5xx
+                                  :tags {:status 500 :body "oops"}})
+          opened (template/record-panel noop-dispatch (open-all r) r)
+          shut   (template/record-panel noop-dispatch nil r)]
+      (is (some #{{:status 500 :body "oops"}} (tree-nodes opened)))
+      (is (not (some #{{:status 500 :body "oops"}} (tree-nodes shut)))))))
+
+(deftest a-default-open-section-can-be-shut
+  (testing "The disclosure runs both ways — WIRE TIMING and APP-DB SLICE
+            TOUCHED drew a `▼` that could not be closed, the same dead
+            affordance in the opposite direction."
+    (let [rk   (h/record-key disclosure-record)
+          tree (template/record-panel noop-dispatch
+                                      {(h/expansion-key rk :wire)   false
+                                       (h/expansion-key rk :app-db) false}
+                                      disclosure-record)]
+      (is (not (body-shown? tree :wire)))
+      (is (not (body-shown? tree :app-db)))
+      ;; and the stored `false` did not leak onto the sections that share
+      ;; the record key
+      (is (not (body-shown? tree :request))))))
+
+(deftest disclosure-state-is-per-record
+  (testing "An event-bundle can carry several managed-fx records. Opening
+            REQUEST on one must not open it on its siblings — which is why
+            the override key carries the record identity and not just the
+            section id."
+    (let [a         (record {:surface :http :fx-id :rf.http/managed
+                             :status :ok :http-status 200})
+          b         (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})
+          overrides {(h/expansion-key (h/record-key a) :request) true}]
+      (is (not= (h/record-key a) (h/record-key b))
+          "the two fixture records really do have distinct keys")
+      (is (body-shown? (template/record-panel noop-dispatch overrides a) :request))
+      (is (not (body-shown? (template/record-panel noop-dispatch overrides b) :request))))))
+
+(deftest each-section-header-dispatches-its-own-toggle
+  (testing "The caller's half of `section-row`'s contract — 'Click-to-toggle
+            wiring is the caller's responsibility'. Each section's wrapper
+            carries an :on-click dispatching the panel's toggle for
+            [record-key section-id].
+
+            Reading the handler off the tree and CALLING it is what makes
+            this a gate: a deleted :on-click is nil, and calling nil throws."
+    (doseq [s section-ids]
+      (let [seen   (atom [])
+            tree   (template/record-panel #(swap! seen conj %) nil disclosure-record)
+            node   (first (filter #(= (str (section-testid s) "-toggle")
+                                      (:data-testid (second %)))
+                                  (hiccup-vectors tree)))]
+        (is (some? node) (str (name s) " has a toggle wrapper"))
+        ((:on-click (second node)) nil)
+        (is (= [[:rf.xray/managed-fx-toggle-section
+                 (h/record-key disclosure-record) s]]
+               @seen)
+            (str (name s) " dispatches its own toggle"))))))
+
+(deftest a-click-inside-an-open-payload-does-not-collapse-the-section
+  (testing "The wrapper has to enclose the whole section, because
+            `section-row` renders its own header and there is no inner header
+            node to hang the handler on. Without a stop on the body, every
+            click inside an opened payload — the edn-inspector's chevrons,
+            the '→ focus event ↗' button — would bubble to the wrapper and
+            shut the section the operator just opened."
+    (let [tree  (template/record-panel noop-dispatch (open-all disclosure-record)
+                                       disclosure-record)
+          inner (first (filter #(= "rf-xray-managed-fx-section-request-body-inner"
+                                   (:data-testid (second %)))
+                               (hiccup-vectors tree)))
+          stopped (atom false)]
+      (is (some? inner) "the open body carries the propagation stop")
+      ((:on-click (second inner))
+       #js {:stopPropagation (fn [] (reset! stopped true))})
+      (is (true? @stopped) "a click on the payload is stopped before the wrapper"))))
+
+(deftest aria-expanded-agrees-with-the-rendered-body
+  (testing "The wrapper announces the state the primitive paints, so the two
+            cannot disagree — both are driven by the same resolved value."
+    (let [rk   (h/record-key disclosure-record)
+          tree (template/record-panel noop-dispatch
+                                      {(h/expansion-key rk :request) true}
+                                      disclosure-record)
+          aria (fn [s] (->> (hiccup-vectors tree)
+                            (filter #(= (str (section-testid s) "-toggle")
+                                        (:data-testid (second %))))
+                            first second :aria-expanded))]
+      (is (= "true" (aria :request)))
+      (is (= "true" (aria :wire)))
+      (is (= "false" (aria :response)))
+      (is (= "false" (aria :handler))))))
+
+;; ---- HD-016 on the tree the disclosure MAKES reachable (rf2-s6m6) ---------
+;;
+;; `no-plain-fn-sits-in-hiccup-head-position` above is a floor over the
+;; DEFAULT tree, and its own comment says plainly what it cannot do: with
+;; three sections shut, the four `edn/inspect` sites are constructed as
+;; positional arguments and then discarded by `section-row`'s `(when
+;; expanded? …)`, so they never appear in the tree it walks. Wiring the
+;; disclosure is exactly what makes them reachable — the risk this bead
+;; carries — so the same floor is restated over the FULLY OPEN tree, where
+;; all four are really present.
+
+(deftest no-plain-fn-in-head-position-with-every-section-open
+  (testing "rf2-twil repaired four `edn/inspect` head-position sites that no
+            tier of coverage could reach, because they sat inside collapsed
+            sections. With every section open they are in the rendered tree,
+            and a plain fn in head position is an HD-016 throw that escapes
+            with no error boundary above this panel — a panel that never
+            appears rather than an error (the rf2-qhoj shape)."
+    (let [tree  (template/record-panel noop-dispatch (open-all disclosure-record)
+                                       disclosure-record)
+          heads (hiccup-heads tree)]
+      ;; The tree really is open, so the absence below is not vacuous.
+      (doseq [s section-ids]
+        (is (body-shown? tree s) (str (name s) " is open")))
+      ;; And the inspector call sites really are in it — this is the half the
+      ;; default-tree row could not assert.
+      (is (some #{{:method :get :url "/x"}} (tree-nodes tree)))
+      (is (some #{[:user/loaded {:id 1}]} (tree-nodes tree)))
+      ;; Two controls, because the assertion below is an ABSENCE.
+      (is (= :invalid (rf.fresco.impl.codec/head-kind edn-widget/inspect))
+          "Fresco's own classifier grades the plain fn an invalid head")
+      (is (< 30 (count heads))
+          "the walker reached a populated tree, so a zero below means absence")
+      (is (empty? (filter fn? heads))
+          "no plain function is in head position in the fully-open panel"))))
 
 (deftest user-facing-text-carries-no-internal-refs
   (let [recs [(record {:surface :http :fx-id :rf.http/managed

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -598,13 +598,30 @@
       ;; default-tree row could not assert.
       (is (some #{{:method :get :url "/x"}} (tree-nodes tree)))
       (is (some #{[:user/loaded {:id 1}]} (tree-nodes tree)))
-      ;; Two controls, because the assertion below is an ABSENCE.
+      ;; Controls, because the assertions below are ABSENCES.
       (is (= :invalid (rf.fresco.impl.codec/head-kind edn-widget/inspect))
           "Fresco's own classifier grades the plain fn an invalid head")
       (is (< 30 (count heads))
           "the walker reached a populated tree, so a zero below means absence")
-      (is (empty? (filter fn? heads))
-          "no plain function is in head position in the fully-open panel"))))
+      ;; `(empty? (filter fn? heads))` — the shape the DEFAULT-tree row above
+      ;; can use — would be WRONG here, and measuring it is how that was
+      ;; found: it reads three `cljs.core.MetaFn`s, which are the three
+      ;; `edn/inspect` returns now in the tree. `inspect` answers
+      ;; `[ei/edn-inspector …]`, a REG-VIEW head, and a reg-view head IS a fn
+      ;; value on CLJS — `build-frame-aware-view` returns `(with-meta (fn …)
+      ;; {:contextType …})`. That head is the CORRECT one while this panel
+      ;; mounts under `reg-view`; `head-kind` cannot separate the two, since
+      ;; Fresco's codec grades a reg-view head `:invalid` as well.
+      ;;
+      ;; The discriminator is the metadata: a registered frame-aware view
+      ;; head carries some, a bare `defn` carries none.
+      (let [fn-heads (filter fn? heads)]
+        (is (pos? (count fn-heads))
+            "the inspector heads are in the tree, so `every?` below is not vacuous")
+        (is (not-any? #(identical? edn-widget/inspect %) heads)
+            "`edn/inspect` is a plain defn and is never itself a hiccup head")
+        (is (every? #(some? (meta %)) fn-heads)
+            "every fn in head position is a registered view head, not a plain fn")))))
 
 (deftest user-facing-text-carries-no-internal-refs
   (let [recs [(record {:surface :http :fx-id :rf.http/managed

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -268,6 +268,9 @@
    :rf.xray/machine-snapshots
    ;; rf2-uyp86 — managed-fx wire-boundary diff composite.
    :rf.xray/managed-fx-for-focused-event
+   ;; rf2-s6m6 — the record panel's per-section disclosure state. Read at
+   ;; `panels/ManagedFxList` and threaded to the pure renderers.
+   :rf.xray/managed-fx-expanded-sections
    ;; rf2-7hwwe — `:after` ring tick driver wall-clock surface + hover slot.
    :rf.xray/now-ms
    ;; rf2-39n8h discovered — focused-frame slot consumed across panels.
@@ -631,6 +634,8 @@
    :rf.xray/open-mute-manager
    :rf.xray/open-row-context-menu
    :rf.xray/unmute-event-id
+   ;; rf2-s6m6 — toggle one managed-fx record's section disclosure.
+   :rf.xray/managed-fx-toggle-section
    ;; Phase 4 (rf2-m7co9) — ELK chart layout pulse.
    :rf.xray/machine-chart-layout-pulse
    :rf.xray/machine-state-clicked


### PR DESCRIPTION
## What was broken

`panels/managed_fx_template/record-panel` built REQUEST, RESPONSE and HANDLER
DISPATCHED with `:expanded? false` as a **literal**, and
`theme/section/section-row` renders its body under `(when expanded? ...)`.
So the panel drew three disclosure triangles that nothing could operate, and the
payloads behind them were unreachable in the UI:

- the **request** payload,
- the **response** payload and its failure tags (what the F.3 / F.7 diagnostics are read from),
- the **dispatched handler** vector, together with its focus-event cross-link button.

The panel's own docstring already promised the opposite - *"one click reveals the
payload - keeps the panel scannable on first paint"*.

The two sections that default **open** had the mirror of the same dead affordance:
a glyph that could not be closed. All five are real disclosures now.

## What was NOT at fault

`theme/section.cljc` is **untouched**. It is non-interactive by design - its own
docstring states the contract, *"No interactivity. Click-to-toggle wiring is the
caller's responsibility"* - and it is shared with `panels/fresco` and
`panels/module_view`, so a handler added there would reach two consumers that
never asked for one. The panel simply never did the caller's half.

## The shape, copied rather than invented

After the in-tree exemplar, `views/edn_inspector_state.cljs`: a **sparse override
map** plus a pure `resolve-expanded?` that falls back to a static per-section
default.

- Sparse-with-default is what lets an untouched panel paint its documented
  first-paint state. An absent entry means *"at its default"*, which is not the
  same as *"closed"* - two of the five sections default open.
- Keyed by `[record-key section-id]`, so opening one record's REQUEST leaves its
  siblings shut. An event-bundle can carry several managed-fx records.
- The toggle event computes its next value **through** `resolve-expanded?` rather
  than flipping the stored entry, so the first click inverts what the operator can
  actually see. Flipping a nil override from an assumed `false` would be a silent
  no-op on the two sections that default open. (The exemplar has to pass the
  rendered state through the dispatch payload for this; here the defaults are
  static per section, so one shared map does it.)
- `record-key` is now composed once and used by **both** the React `:key` and the
  expansion key - if they drifted, toggling one record's section would move
  another's. The composed value is unchanged, and the existing key test pins it.

### Why the read is at the reg-view and not in the panel

`record-panel` and `records-list` are plain fns, and per Spec 006 section
"Plain-fn footgun" an ambient `subscribe` inside one raises
`:rf.error/no-frame-context` - a plain fn carries no `:contextType` wiring and
cannot resolve the surrounding frame. So the slot is read at the panel's reactive
boundary and threaded down as plain data, exactly as `views/edn-inspector`'s
`reg-view` does for its own expansion slot and as `cancellation_cascade`'s
`defview` does for `:expanded?`.

Both fns stay **pure**, so every pre-existing test renders unchanged through the
nil-overrides arities.

## A second defect fixed on the same two lines (rf2-90kv)

`ManagedFxList` handed `records-list` the composite sub's **whole result map**
where a records **vector** was expected. `:rf.xray/managed-fx-for-focused-event`
answers `{:dispatch-id ... :frame ... :records [...]}` - pinned by its own test - so
`(seq records)` was truthy, `(count records)` read 3 regardless of the real count,
and `(for [rec records] ...)` walked **map entries**; `(name (:status rec))` then got
nil and threw before the panel could paint. Same presentation as the rf2-qhoj
incident: a panel that never appears rather than a visible error.

Not a recent regression - `git log -L` shows the binding has passed the whole map
since before the Causa/Xray rename. It is fixed here because it is on the two lines
this change had to edit anyway, and because without it **none of this is reachable
in the running tool**, which is this bead's whole deliverable.

**It is pinned.** `managed-fx-list-renders-one-panel-per-record` invokes the
reg-view's body headlessly through `((rf/view id))` - the shape
`core/test/re_frame/adapter/react_shared_suite.cljs` already uses - against a
cascade seeded with **two** managed-fx invocations, and asserts one record panel
per record. Two is the discriminating count: the composite map has three entries,
so a renderer handed the map cannot answer two.

**Measured red both ways round, not assumed.** Against the old binding
`(records-list dispatch expanded focused)` the row ERRORS with `Doesn't support
name:` - CLJS `(name nil)` inside `record-panel`, walking a map entry - at 27
assertions, exit 1. Restored: 28 assertions, exit 0. The control assertion (the
composite really answers two records) **passes in both**, which is what isolates
the fault to the composition rather than to the seeding, and is why it is stated
first.

Two things the framework refused, recorded in the test because the next author will
reach for both: a **stub** of the composite sub id is unavailable (re-registering
it from a test ns makes `rf/make-frame` refuse image assembly with
`:rf.error/image-duplicate-id`), and a sub registered **after** `make-frame` is not
the one that frame reads - the frame resolves against the image generation captured
when it was allocated. The first draft hit the second and read a plausible zero.

rf2-90kv stays open for the mayor to close on merge.

## HD-016 and the reachability risk

Wiring the disclosure is what makes the four `edn/inspect` sites rf2-twil repaired
(PR #9624, trunk `58399caf58`) reachable for the first time - a collapsed body was
constructed as a positional argument and then discarded, which is why three tiers of
coverage missed the hazard.

Verified at this base before opening anything up: **all four sites are call-form**,
and `records-list`'s only caller is `ManagedFxList`, a `rf/reg-view` - not a Fresco
boundary - so the `reg-view` head `inspect` returns is the correct one here, as the
panel's own comment says. Nothing plain-fn or `reg-view`-headed is newly in head
position.

The existing `no-plain-fn-sits-in-hiccup-head-position` row walks the **default**
tree and its comment says plainly that it cannot reach three of the four sites. That
gap is now covered: `no-plain-fn-in-head-position-with-every-section-open` restates
the floor over the **fully open** tree, asserting the payloads really are present
*before* reading the absence, so the zero is not vacuous.

Writing that row surfaced a real distinction, measured rather than reasoned.
`(empty? (filter fn? heads))` - correct over the default tree - reads **three**
`cljs.core.MetaFn`s over the open tree, and they are the three `edn/inspect` returns
the disclosure now makes reachable. `inspect` answers `[ei/edn-inspector …]`, a
**reg-view** head, and a reg-view head *is* a fn value on CLJS:
`build-frame-aware-view` returns `(with-meta (fn …) {:contextType …})`. That head is
the correct one while this panel mounts under `reg-view`, and `head-kind` cannot
separate the two, since Fresco's codec grades a reg-view head `:invalid` as well.
The discriminator is the **metadata** - a registered frame-aware view head carries
some, a bare `defn` carries none - so the row names `edn/inspect` directly and floors
every fn head on having meta. Both halves still go red on a revert to
`[edn/inspect …]`.

## Tests

Renderer-level (`managed_fx_template_cljs_test`), all pure, no runtime needed:

- sections paint at their documented defaults (a floor, not a gate - stated as such)
- **opening a collapsed section puts its payload in the tree** - asserted absent
  first, and on the payload value, not merely the body container
- response and handler payloads and the focus-event button become reachable
- the failure-tags branch of RESPONSE becomes reachable
- a default-open section can be shut
- disclosure state is per-record
- each header dispatches its **own** toggle - the handler is read off the tree and
  **called**, so a deleted `:on-click` is nil and throws
- a click inside an open payload does not collapse the section
- `aria-expanded` agrees with the rendered body
- the HD-016 floor over the fully open tree

State-level (`managed_fx_subs_cljs_test`), through the real frame:

- the slot starts empty and resolves to defaults
- **the toggle inverts what the operator can see, in both directions** - the row
  that catches a reducer flipping from a hard-coded `false`
- the toggle moves exactly one record/section pair
- **end-to-end**: real event writes the slot, real sub reads it back, renderer turns
  it into a payload present in the tree
- **`managed-fx-list-renders-one-panel-per-record`** - the rf2-90kv row above

`registry_cljs_test`'s sorted-set snapshots gain the two ids this PR registers
(`:rf.xray/managed-fx-expanded-sections`, `:rf.xray/managed-fx-toggle-section`).
That is the file's designed per-PR update, order-independent so concurrent PRs
rebase cleanly.

### Suite

11614 CLJS tests / 58219 assertions, and 1276 Xray JVM tests / 6118 assertions.
Each runner's own exit status was read directly rather than a pipeline's.

### Hollow-gate pass

Applied per row - *delete the signal, keep the fault; does it still pass?* Two rows
are deliberately **not** gates for this repair and say so in their own text: the
defaults row (the pre-repair literals painted the same thing) and the existing
default-tree HD-016 floor. Every other row goes red on the corresponding deletion -
the toggle rows because the handler is invoked rather than merely inspected, the
payload rows because they assert absence first.

No probe navigates through `rf.test-helpers/expand-tree`; the walkers are structural,
because `expand-tree` rebuilds nested vectors with `mapv` and would substitute its own
vectors for the ones under test.

## Accessibility, stated as a deliberate boundary

The wrapper carries `aria-expanded`, a `:title` and a pointer cursor, matching this
file's existing affordance idiom. It is **not** `role="button"` with keyboard
activation: the wrapper has to enclose the whole section (the primitive renders its
own header, so there is no inner header node to hang a handler on), and an open body
contains real interactive children. A proper header button belongs in
`theme/section.cljc`, which is deliberately out of scope here.

## Scope note

`theme/section.cljc` and `views/resizable_table.cljs` are untouched. Beyond the
bead's named scope this touches `panels.cljs` for the `ManagedFxList` reg-view body
only - forced by the frame-context contract above, since that is the panel's only
reactive boundary - and `managed_fx_helpers.cljc`, the panel family's own pure-data
ns, for the expansion vocabulary. Neither reaches another panel.

Closes rf2-s6m6.
