### PR TITLE
feat(xray): the Static Machines sub-tab becomes three Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
@@ -18,8 +18,24 @@
   ## Empty state
 
   When no `:rf/machine?` registration is found: 'No machines registered. reg-
-  machine to add the first.'"
+  machine to add the first.'
+
+  ## Substrate (rf2-k97c.3)
+
+  [[browse-list]] is an `rf.fresco/defview` — a real React function
+  component whose three reads are `rf.fresco/sub`, recorded by Fresco's
+  own collector rather than by the installed adapter's observer. Frame
+  isolation still comes from the enclosing
+  `[rf/frame-provider {:frame :rf/xray}]` in `static/shell.cljs`, which
+  the boundary reads out of React context exactly as the `reg-view` did.
+
+  Every helper below is CALLED rather than used as a hiccup head. A plain
+  function in head position is a loud error under Fresco (HD-016) and the
+  throw escapes with no error boundary above it, so it presents as a pane
+  that never appears; calling a helper that answers hiccup is the repair,
+  and every helper here answers hiccup."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
@@ -33,22 +49,21 @@
   "Top-of-list search input. Incremental filtering — every keystroke
   dispatches `:rf.xray.static.machines/set-search`. Esc clears.
 
-  `dispatch` is the frame-aware dispatcher threaded from the
-  `browse-list` reg-view (a plain fn invoked as a Reagent component
-  renders in its own cycle, so it cannot recover the frame itself).
+  `dispatch` is the frame-aware dispatcher threaded from
+  [[browse-list-tree]], which takes it from the boundary's
+  `(:dispatch (rf/capture-frame))`.
 
-  `query` is the current search string, threaded from the `browse-list`
-  reg-view's own subscribe — this helper is a plain fn invoked as a
-  Reagent component, so it renders in its OWN cycle and CANNOT recover
-  the `:rf/xray` frame to `rf/subscribe` itself (Spec 000 §Plain Reagent
-  fns do not pick up the surrounding frame; a bare `subscribe` here
-  throws `:rf.error/no-frame-context` and crashes the whole Static
-  surface). The reg-view body already derefs the same
-  `:rf.xray.static.machines/search` sub — pass that value down.
-  The markup lives in the shared `search-box` component's `:pane`
-  variant."
+  `query` is the current search string, threaded down the same way. This
+  helper is a plain fn — it reads nothing itself and holds no frame, so
+  every value it renders arrives as an argument. The markup lives in the
+  shared `search-box` component's `:pane` variant."
   [dispatch query]
-  [search-box/search-box
+  ;; CALLED, not headed. The shared component is a plain fn answering
+  ;; hiccup, and a plain fn in hiccup head position is a loud error under
+  ;; Fresco (HD-016) whose throw escapes with no error boundary above it
+  ;; — the whole Xray root unmounts and the pane presents as one that
+  ;; never appears.
+  (search-box/search-box
    {:variant          :pane
     :testid-prefix    "rf-xray-static-machines"
     :dispatch         dispatch
@@ -56,7 +71,7 @@
     :on-clear-event   :rf.xray.static.machines/clear-search
     :placeholder      "Search machines…"
     :input-aria-label "Search registered machines"
-    :value            query}])
+    :value            query}))
 
 ;; ---- sort cycle button --------------------------------------------------
 
@@ -65,14 +80,9 @@
   Name…`. The label shows the current axis so the affordance is self-
   describing.
 
-  `sort-key` is the current sort axis, threaded from the `browse-list`
-  reg-view's own subscribe — this helper is a plain fn invoked as a
-  Reagent component, so it renders in its OWN cycle and
-  CANNOT recover the `:rf/xray` frame to `rf/subscribe` itself (Spec 000 §Plain Reagent
-  §Plain Reagent fns do not pick up the surrounding frame; a bare
-  `subscribe` here throws `:rf.error/no-frame-context` and crashes the
-  whole Static surface). The reg-view body derefs the sub and passes the
-  value down."
+  `sort-key` is the current sort axis, threaded from
+  [[browse-list-tree]] — this helper is a plain fn that reads nothing
+  itself, so the value arrives as an argument."
   [dispatch sort-key]
   (let [label (get h/sort-key-labels sort-key "Name")]
     [:button
@@ -139,9 +149,15 @@
                             :align-items  "center"
                             :gap          "2px"
                             :margin-left  "6px"}}]
+            ;; THE KEY RIDES IN THE ATTRIBUTE MAP, not on reader metadata
+            ;; (rf2-k97c.3). `^{:key …}` on this vector literal is read by
+            ;; Reagent and by Fresco's codec NOWHERE — the codec reads
+            ;; `:key` from the attribute map and reads Clojure metadata
+            ;; nowhere — so it would reach React as nothing once this pane
+            ;; renders through a boundary. The key EXPRESSION is unchanged.
             (for [i (range count)]
-              ^{:key i}
-              [:span {:style {:display       "inline-block"
+              [:span {:key   i
+                      :style {:display       "inline-block"
                               :width         "5px"
                               :height        "5px"
                               :border-radius "50%"
@@ -161,8 +177,8 @@
   tab with this machine selected — same handler the right-pane
   Instances pill uses (centralised in `instances_jump`).
 
-  `dispatch` is the frame-aware dispatcher threaded from the
-  `browse-list` reg-view (via `row`)."
+  `dispatch` is the frame-aware dispatcher threaded from
+  [[browse-list-tree]] (via `row`)."
   [dispatch machine-id]
    [:button
    {:data-testid (str "rf-xray-static-machines-row-jump-"
@@ -188,7 +204,7 @@
 
 (defn- row
   "Render one browse-list row. `dispatch` is threaded from
-  the `browse-list` reg-view."
+  [[browse-list-tree]]."
   [dispatch {:keys [machine-id state-count live-count source-coord] :as r} active?]
   (let [glyph (if active? "◉" "○")]
     [:button
@@ -266,56 +282,113 @@
 
 ;; ---- the list -----------------------------------------------------------
 
-(rf/reg-view browse-list
-  "L4-left pane of the Static Machines sub-tab — search + sort +
-  scrollable rows. `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
-  []
-  (let [{:keys [rows total visible selected-id]}
-        @(rf/subscribe [:rf.xray.static.machines/data])
-        query    @(rf/subscribe [:rf.xray.static.machines/search])
-        ;; Deref the sort axis HERE (in the reg-view body, where the
-        ;; `:rf/xray` frame is in context) and thread it into the plain-fn
-        ;; `sort-button` helper, which renders in its own cycle and cannot
-        ;; recover the frame to subscribe itself.
-        sort-key @(rf/subscribe [:rf.xray.static.machines/sort-key])]
-    [:div {:data-testid "rf-xray-static-machines-browse-list"
-           :style {:display        "flex"
-                   :flex-direction "column"
-                   :height         "100%"
-                   :background     (:bg-1 tokens)}}
-     [search-box dispatch query]
-     [:div {:data-testid "rf-xray-static-machines-toolbar"
-            :style {:display       "flex"
-                    :align-items   "center"
-                    :gap           "8px"
-                    :padding       "6px 10px"
-                    :background    (:bg-1 tokens)
-                    :border-bottom (str "1px solid " (:border-subtle tokens))
-                    :font-family   sans-stack
-                    :font-size     (:caption type-scale)
-                    :color         (:text-tertiary tokens)}}
-      [sort-button dispatch sort-key]
-      [:span {:data-testid "rf-xray-static-machines-count"
-              :style {:margin-left "auto"}}
-       (if (= total visible)
-         (str total " machine" (when-not (= total 1) "s"))
-         (str visible " / " total))]]
-     [:div {:data-testid "rf-xray-static-machines-rows"
-            :role "listbox"
-            :aria-label "Registered machines"
-            :style {:flex     "1 1 auto"
-                    :min-height "0"
-                    :overflow "auto"}}
-      (cond
-        (zero? total)
-        (empty-state)
+(defn browse-list-tree
+  "The L4-left pane's WHOLE body, as a pure function of the three values
+  [[browse-list]] reads plus the frame-bound `dispatch` the search box,
+  the sort button and every row need.
 
-        (zero? visible)
-        (no-results-state query)
+  SPLIT OUT OF [[browse-list]] BY rf2-k97c.3, and the split is
+  `defview`'s own documented extract-a-helper spelling rather than an
+  invention. A boundary's body may only run inside a React render
+  window, so `(browse-list)` is no longer a callable that answers
+  hiccup — while the projection from row values to markup is ordinary
+  data → data and is worth testing in the fast node lane.
+  `test-helpers.static-machines-tree` drives THIS fn with the values it
+  takes from the same subs; the boundary's own behaviour — first paint,
+  liveness, frame targeting, evidence isolation, teardown and row
+  identity — is `panel_fresco_boundary_dom_cljs_test`'s subject.
 
-        :else
-        (into [:div]
-              (for [{:keys [machine-id] :as r} rows]
-                ^{:key (str machine-id)}
-                [row dispatch r (= machine-id selected-id)])))]]))
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [rows total visible selected-id]} query sort-key dispatch]
+  [:div {:data-testid "rf-xray-static-machines-browse-list"
+         :style {:display        "flex"
+                 :flex-direction "column"
+                 :height         "100%"
+                 :background     (:bg-1 tokens)}}
+   (search-box dispatch query)
+   [:div {:data-testid "rf-xray-static-machines-toolbar"
+          :style {:display       "flex"
+                  :align-items   "center"
+                  :gap           "8px"
+                  :padding       "6px 10px"
+                  :background    (:bg-1 tokens)
+                  :border-bottom (str "1px solid " (:border-subtle tokens))
+                  :font-family   sans-stack
+                  :font-size     (:caption type-scale)
+                  :color         (:text-tertiary tokens)}}
+    (sort-button dispatch sort-key)
+    [:span {:data-testid "rf-xray-static-machines-count"
+            :style {:margin-left "auto"}}
+     (if (= total visible)
+       (str total " machine" (when-not (= total 1) "s"))
+       (str visible " / " total))]]
+   [:div {:data-testid "rf-xray-static-machines-rows"
+          :role "listbox"
+          :aria-label "Registered machines"
+          :style {:flex     "1 1 auto"
+                  :min-height "0"
+                  :overflow "auto"}}
+    (cond
+      (zero? total)
+      (empty-state)
+
+      (zero? visible)
+      (no-results-state query)
+
+      :else
+      (into [:div]
+            ;; THE KEY RIDES ON A KEYED FRAGMENT (rf2-k97c.3) — the same
+            ;; move the pip seq above makes in its attribute map, for the
+            ;; same reason: Fresco's codec reads `:key` from the
+            ;; attribute map and reads Clojure metadata nowhere, so the
+            ;; old `^{:key …}` on this vector literal would reach React
+            ;; as nothing. The fragment carries the key without adding a
+            ;; DOM node, which keeps `row` the presentational helper it
+            ;; is; the key expression is unchanged and identity stays
+            ;; domain-shaped (the machine-id).
+            (for [{:keys [machine-id] :as r} rows]
+              [:<> {:key (str machine-id)}
+               (row dispatch r (= machine-id selected-id))])))]])
+
+(rf.fresco/defview browse-list
+  "The L4-left pane of the Static Machines sub-tab — a FRESCO BOUNDARY
+  (rf2-k97c.3), not an `rf/reg-view`. Reads the browse composite, the
+  search text and the sort axis, and hands their values plus a
+  frame-bound dispatcher to [[browse-list-tree]].
+
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. That is the third of the epic's three
+  couplings, and the one a first-paint smoke test cannot see.
+
+  The FRAME the reads resolve against comes from React context, which
+  the enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context — so this resolves
+  `:rf/xray` identically under today's Reagent-rendered Static shell and
+  under the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the `dispatch` name `reg-view` used to inject lexically (`defview`
+  binds no name inside the body, so that injected name is simply
+  unresolved — a loud compile error rather than a silent frame leak).
+  Every keystroke, sort click, row select and per-row JUMP therefore
+  still lands on THIS Xray instance's frame after render scope unwinds.
+
+  ONE BOUNDARY for this pane, and it is where the reads are. Boundary
+  count tracks reads and head-position use, not file size: `search-box`,
+  `sort-button`, `row`, `empty-state` and `no-results-state` are all
+  CALLED, never used as a hiccup head, so Fresco's \"a plain function in
+  head position is a loud error\" rule never meets one.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This pane reads nothing from props — `static.machines.panel`'s
+  own boundary mounts it with none — so it is destructured away."
+  [_props]
+  (browse-list-tree (rf.fresco/sub [:rf.xray.static.machines/data])
+                    (rf.fresco/sub [:rf.xray.static.machines/search])
+                    (rf.fresco/sub [:rf.xray.static.machines/sort-key])
+                    (:dispatch (rf/capture-frame))))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -43,8 +43,45 @@
 
   When no `:rf/machine?` registration is found the browse-list renders the
   empty-state hint; the right pane mounts a matching empty surface
-  to keep the visual balance."
+  to keep the visual balance.
+
+  ## Substrate (rf2-k97c.3)
+
+  [[detail]] is an `rf.fresco/defview` — a real React function component
+  whose reads are `rf.fresco/sub`, recorded by Fresco's own collector
+  rather than by the installed adapter's observer. Frame isolation still
+  comes from the enclosing `[rf/frame-provider {:frame :rf/xray}]` in
+  `static/shell.cljs`, which the boundary reads out of React context
+  exactly as the `reg-view` did.
+
+  ## The Topology and Sim bodies stay REAGENT ISLANDS, and that is the
+  ## one thing about this pane worth knowing before editing it
+
+  Every helper in THIS file answers hiccup and is therefore CALLED rather
+  than headed — the standard HD-016 repair. The two per-mode bodies are
+  the exception: `topology/body` reaches `machine-canvas/Chart`, which is
+  still an `rf/reg-view`, and `sim/body` reaches `SimChart` which mounts
+  the same `Chart`. A `reg-view` in hiccup head position grades
+  `:invalid` under Fresco exactly as a plain `defn` does — `codec/
+  boundary-head?` reads one own property (`frescoBoundary`) and only
+  `rf.fresco/defview` sets it — so neither repair applies: heading is a
+  loud throw that unmounts the whole Xray root, and CALLING the body only
+  moves the problem one level down into `topology.cljs`'s own fn heads.
+
+  The door is Fresco's own ABI, and it is the one `panels/
+  machine_after_rings.cljs` already uses for the machines-viz overlay: a
+  React ELEMENT is a legal child anywhere (`codec`'s `child-kind`
+  classifies `react/isValidElement` as `:react-element`). So
+  [[detail-tree]] takes an `:as-child` function — `identity` for a
+  hiccup caller and for the node lane, `reagent.core/as-element` for the
+  boundary — and the whole Reagent subtree crosses as one finished
+  element, rendered by Reagent's own machinery under the SAME React
+  context the frame-provider wrote. MIGRATION SCAFFOLDING WITH A DEFINED
+  END: when `Chart` is itself a Fresco body the `as-child` seam goes and
+  the bodies are headed directly."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
+            [reagent.core :as r]
             [day8.re-frame2-machines-viz.grammar :as grammar]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.static.machines.cascade-dimmed
@@ -112,8 +149,8 @@
 
 (defn- header
   "Render the definition-detail header. Sticks at the top of the right
-  pane. `dispatch` is the frame-aware dispatcher threaded from the
-  `detail` reg-view (same convention as `sub-strip`) — the Copy Mermaid
+  pane. `dispatch` is the frame-aware dispatcher threaded from
+  [[detail-tree]] (same convention as `sub-strip`) — the Copy Mermaid
   button dispatches through it."
   [dispatch {:keys [machine-id source-coord state-count live-count
                     definition copy-status]}]
@@ -162,9 +199,9 @@
                             (:text-tertiary tokens))
                    :margin-left "auto"}}
     (str (or live-count 0) " live")]
-   [copy-mermaid-button dispatch {:machine-id  machine-id
+   (copy-mermaid-button dispatch {:machine-id  machine-id
                                   :definition  definition
-                                  :copy-status copy-status}]])
+                                  :copy-status copy-status})])
 
 ;; ---- sub-strip ----------------------------------------------------------
 
@@ -196,9 +233,9 @@
   "Render the 4-mode pill row. The strip is the same DOM as the Dynamic
   sub-strip (muscle-memory consistency), but Cascade is dimmed.
 
-  `dispatch` is the frame-aware dispatcher threaded from the `detail`
-  reg-view (a plain fn invoked as a Reagent component renders in its own
-  cycle, so it cannot recover the frame itself)."
+  `dispatch` is the frame-aware dispatcher threaded from
+  [[detail-tree]] — this helper reads nothing itself, so every value it
+  renders arrives as an argument."
   [dispatch {:keys [machine-id sub-mode live-count]}]
   (let [set-mode! (fn [mode]
                     (dispatch
@@ -212,40 +249,47 @@
                    :padding     "8px 16px"
                    :background  (:bg-2 tokens)
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     [topology-pill {:active?  (= sub-mode :topology)
-                     :on-click (fn [_] (set-mode! :topology))}]
-     [sim/pill {:active?  (= sub-mode :sim)
-                :on-click (fn [_] (set-mode! :sim))}]
-     [instances-jump/pill dispatch {:machine-id machine-id
+     (topology-pill {:active?  (= sub-mode :topology)
+                     :on-click (fn [_] (set-mode! :topology))})
+     (sim/pill {:active?  (= sub-mode :sim)
+                :on-click (fn [_] (set-mode! :sim))})
+     (instances-jump/pill dispatch {:machine-id machine-id
                                     :live-count live-count
-                                    :active?    false}]
-     [cascade-dimmed/pill]]))
+                                    :active?    false})
+     (cascade-dimmed/pill)]))
 
 ;; ---- body dispatch ------------------------------------------------------
 
 (defn- body
   "Dispatch to the per-mode body renderer. Topology + Sim render a
   body; Instances + Cascade do not (Instances is a JUMP affordance,
-  Cascade is dimmed). `dispatch` is threaded from `detail`.
+  Cascade is dimmed). `dispatch` is threaded from [[detail-tree]].
 
   The Sim sub-mode's plain-fn subtree (`sim/body` → `SimChart` /
-  `SimRail`) cannot recover the `:rf/xray` frame to subscribe (Spec
-  004), so its sub values (`sim-values`) are derefed in the `detail`
-  reg-view and threaded down through here (mirroring the browse-list
-  pattern)."
-  [dispatch {:keys [sub-mode machine-id definition source-coord fit-signal
-                    sim-values]}]
+  `SimRail`) reads nothing itself, so its sub values (`sim-values`) are
+  read in [[detail]] and threaded down through here (mirroring the
+  browse-list pattern).
+
+  `as-child` is how the two REAGENT ISLANDS are spelled for the calling
+  renderer — see the ns docstring. `identity` (the node lane, and any
+  Reagent caller) leaves each body as a fn-headed hiccup vector, which
+  is exactly what it has always been; `reagent.core/as-element` (the
+  boundary) answers a React element, a legal child anywhere per Fresco's
+  component ABI. The Instances and Cascade arms are pure keyword hiccup
+  and cross unchanged either way."
+  [dispatch as-child {:keys [sub-mode machine-id definition source-coord
+                             fit-signal sim-values]}]
   (case sub-mode
     :topology
-    [topology/body dispatch {:machine-id   machine-id
-                             :definition   definition
-                             :source-coord source-coord
-                             :fit-signal   fit-signal}]
+    (as-child [topology/body dispatch {:machine-id   machine-id
+                                       :definition   definition
+                                       :source-coord source-coord
+                                       :fit-signal   fit-signal}])
 
     :sim
-    [sim/body dispatch (merge {:machine-id machine-id
-                               :definition definition}
-                              sim-values)]
+    (as-child [sim/body dispatch (merge {:machine-id machine-id
+                                         :definition definition}
+                                        sim-values)])
 
     ;; :instances + :cascade — no body. Render an explanatory placeholder
     ;; so the user understands the strip click landed.
@@ -278,55 +322,28 @@
 
 ;; ---- main view ----------------------------------------------------------
 
-(rf/reg-view detail
-  "L4-right pane — definition detail. Reads:
+(defn detail-tree
+  "The L4-right pane's WHOLE body, as a pure function of the values
+  [[detail]] reads, the frame-bound `dispatch` its controls need, and
+  the `as-child` spelling for the two Reagent islands (see the ns
+  docstring).
 
-    - `:rf.xray.static.machines/data` for the selected row +
-      enrichment (rows, total, visible, selected-id)
-    - `:rf.xray/machine-definitions` for the registrar spec map of
-      the selected machine
-    - `:rf.xray.static.machines/sub-mode` for the per-machine sub-
-      mode (defaults to :topology)
+  SPLIT OUT OF [[detail]] BY rf2-k97c.3, and the split is `defview`'s
+  own documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so
+  `(detail)` is no longer a callable that answers hiccup — while the
+  projection from read values to markup is ordinary data → data and is
+  worth testing in the fast node lane.
+  `test-helpers.static-machines-tree` drives THIS fn with the values it
+  takes from the same subs, and with `identity` as `as-child` so the
+  Topology / Sim subtrees stay fn-headed hiccup the node-lane walker can
+  expand exactly as it always has.
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
-  []
-  (let [{:keys [rows selected-id]}
-        @(rf/subscribe [:rf.xray.static.machines/data])
-        row (some #(when (= selected-id (:machine-id %)) %) rows)
-        definitions @(rf/subscribe [:rf.xray/machine-definitions])
-        sub-mode @(rf/subscribe [:rf.xray.static.machines/sub-mode selected-id])
-        ;; Fit-on-entry nonce (bumped by `:rf.xray.static/select-tab
-        ;; :machines`). Threaded down to the Topology body's
-        ;; `machine-canvas/Chart` `:fit-signal` so entering the Static
-        ;; Machines tab re-frames the topology to view.
-        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
-        ;; The Sim sub-mode's plain-fn subtree (`sim/body` →
-        ;; `SimChart` / `SimRail`) renders in its OWN React cycle and so
-        ;; cannot recover the `:rf/xray` frame to `rf/subscribe` itself
-        ;; (Spec 000 §Plain Reagent fns under non-default frames). Deref
-        ;; the sim sub family HERE (in this reg-view,
-        ;; where the frame IS in context) and thread the values down —
-        ;; mirroring the browse-list pattern. Only derefed on the
-        ;; `:sim` sub-mode so the Topology/Instances/Cascade modes don't
-        ;; subscribe to sim state. The subs short-circuit to nil when sim
-        ;; isn't active for the selected machine, so this is cheap.
-        ;; Copy-Mermaid settled outcome for the selected machine
-        ;; (rf2-sxw06) — nil unless a copy gesture on THIS machine has
-        ;; settled; cleared by `:rf.xray.static.machines/select`.
-        copy-status @(rf/subscribe
-                       [:rf.xray.static.machines/copy-mermaid-status
-                        selected-id])
-        sim-values (when (= sub-mode :sim)
-                     {:sim         @(rf/subscribe
-                                      [:rf.xray.static.machines/sim-state])
-                      :transitions @(rf/subscribe
-                                      [:rf.xray.static.machines/sim-available-transitions])
-                      :suggestions @(rf/subscribe
-                                      [:rf.xray.static.machines/sim-event-suggestions])
-                      :current     @(rf/subscribe
-                                      [:rf.xray.static.machines/sim-current-state])
-                      :last-trans  @(rf/subscribe
-                                      [:rf.xray.static.machines/sim-last-transition])})]
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [data definitions sub-mode fit-signal copy-status sim-values]}
+   dispatch as-child]
+  (let [{:keys [rows selected-id]} data
+        row (some #(when (= selected-id (:machine-id %)) %) rows)]
     (if (nil? row)
       (empty-detail)
       (let [{:keys [machine-id state-count live-count source-coord]} row
@@ -339,22 +356,95 @@
                        :height         "100%"
                        :background     (:bg-2 tokens)
                        :color          (:text-primary tokens)}}
-         [header dispatch {:machine-id   machine-id
+         (header dispatch {:machine-id   machine-id
                            :source-coord source-coord
                            :state-count  state-count
                            :live-count   live-count
                            :definition   definition
-                           :copy-status  copy-status}]
-         [sub-strip dispatch {:machine-id machine-id
+                           :copy-status  copy-status})
+         (sub-strip dispatch {:machine-id machine-id
                               :sub-mode   sub-mode
-                              :live-count live-count}]
+                              :live-count live-count})
          [:div {:data-testid "rf-xray-static-machines-detail-body"
                 :style {:flex     "1 1 auto"
                         :min-height "0"
                         :overflow "auto"}}
-          [body dispatch {:sub-mode     sub-mode
-                          :machine-id   machine-id
-                          :definition   definition
-                          :source-coord source-coord
-                          :fit-signal   fit-signal
-                          :sim-values   sim-values}]]]))))
+          (body dispatch as-child
+                {:sub-mode     sub-mode
+                 :machine-id   machine-id
+                 :definition   definition
+                 :source-coord source-coord
+                 :fit-signal   fit-signal
+                 :sim-values   sim-values})]]))))
+
+(rf.fresco/defview detail
+  "The L4-right pane — definition detail. A FRESCO BOUNDARY
+  (rf2-k97c.3), not an `rf/reg-view`. Reads:
+
+    - `:rf.xray.static.machines/data` for the selected row +
+      enrichment (rows, total, visible, selected-id)
+    - `:rf.xray/machine-definitions` for the registrar spec map of
+      the selected machine
+    - `:rf.xray.static.machines/sub-mode` for the per-machine sub-
+      mode (defaults to :topology)
+    - `:rf.xray/machine-tab-fit-signal` for the fit-on-entry nonce
+    - `:rf.xray.static.machines/copy-mermaid-status` for the header's
+      settled Copy-Mermaid outcome
+    - the five `sim-*` slots, on the `:sim` sub-mode ONLY
+
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for, and THE CONDITIONAL ONES STAY CONDITIONAL: the
+  collector records an edge WHERE THE READ HAPPENS, so a branch not
+  taken contributes no edge and the Topology / Instances / Cascade modes
+  still subscribe to no sim state at all. Two reads are also SEQUENCED
+  rather than independent — `sub-mode` and `copy-mermaid-status` are
+  parameterised by the `selected-id` the first read answers — which is
+  ordinary inside a body and is the read ORDER the node lane reproduces.
+
+  The FRAME comes from React context, which the enclosing frame boundary
+  writes; the DISPATCHER is `(:dispatch (rf/capture-frame))`, core's own
+  door, which answers the boundary's DECLARED frame inside a body and
+  replaces the name `reg-view` used to inject lexically.
+
+  `r/as-element` is the `as-child` spelling for the two Reagent islands
+  — the ns docstring records why neither of the migration's usual
+  repairs is available for them.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This pane reads nothing from props — `static.machines.panel`'s
+  own boundary mounts it with none — so it is destructured away."
+  [_props]
+  (let [{:keys [selected-id] :as data}
+        (rf.fresco/sub [:rf.xray.static.machines/data])
+        sub-mode (rf.fresco/sub [:rf.xray.static.machines/sub-mode selected-id])]
+    (detail-tree
+      {:data        data
+       :definitions (rf.fresco/sub [:rf.xray/machine-definitions])
+       :sub-mode    sub-mode
+       ;; Fit-on-entry nonce (bumped by `:rf.xray.static/select-tab
+       ;; :machines`). Threaded down to the Topology body's
+       ;; `machine-canvas/Chart` `:fit-signal` so entering the Static
+       ;; Machines tab re-frames the topology to view.
+       :fit-signal  (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])
+       ;; Copy-Mermaid settled outcome for the selected machine
+       ;; (rf2-sxw06) — nil unless a copy gesture on THIS machine has
+       ;; settled; cleared by `:rf.xray.static.machines/select`.
+       :copy-status (rf.fresco/sub
+                      [:rf.xray.static.machines/copy-mermaid-status
+                       selected-id])
+       ;; Only read on the `:sim` sub-mode, so the other three modes
+       ;; record no edge on sim state at all. The subs short-circuit to
+       ;; nil when sim isn't active for the selected machine.
+       :sim-values  (when (= sub-mode :sim)
+                      {:sim         (rf.fresco/sub
+                                      [:rf.xray.static.machines/sim-state])
+                       :transitions (rf.fresco/sub
+                                      [:rf.xray.static.machines/sim-available-transitions])
+                       :suggestions (rf.fresco/sub
+                                      [:rf.xray.static.machines/sim-event-suggestions])
+                       :current     (rf.fresco/sub
+                                      [:rf.xray.static.machines/sim-current-state])
+                       :last-trans  (rf.fresco/sub
+                                      [:rf.xray.static.machines/sim-last-transition])})}
+      (:dispatch (rf/capture-frame))
+      r/as-element)))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -57,8 +57,26 @@
 
   Same discipline as every other Static panel — the enclosing
   `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs` scopes
-  subscribes / dispatches to Xray's frame."
+  subscribes / dispatches to Xray's frame.
+
+  ## Substrate (rf2-k97c.3)
+
+  This sub-tab is THREE Fresco boundaries, not one: [[panel]] here plus
+  `browse-list/browse-list` and `definition-detail/detail`, each an
+  `rf.fresco/defview`. The count is not an accident of file layout — it
+  is the reactive granularity the three `reg-view`s already had, kept.
+  Collapsing the two panes into this one boundary would move their reads
+  up here, and every search keystroke would then re-render the Topology
+  chart. Boundary count tracks READS and head-position use.
+
+  [[panel]] itself reads NOTHING. It is pure two-pane chrome, and it
+  heads the two pane boundaries directly — which is legal, and is the
+  one hiccup head shape that IS: `codec/boundary-head?` reads one own
+  property (`frescoBoundary`) that only `rf.fresco/defview` sets, so a
+  plain `defn` AND an `rf/reg-view` both grade `:invalid` down the same
+  arm while a boundary heads a boundary cleanly."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-machines-viz.mermaid :as mermaid]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
@@ -74,13 +92,19 @@
 
 (def ^:private left-pane-width "280px")
 
-(rf/reg-view panel
-  "L4 detail-panel content for the Static Machines tab. Master-detail
-  with a browse-all list on the left and the per-machine definition
-  detail on the right.
+(defn panel-tree
+  "The Static Machines sub-tab's two-pane CHROME, as a pure function of
+  the two pane bodies. Genuinely shared between the two lanes rather
+  than reproduced for them: [[panel]] passes the two BOUNDARY-headed
+  vectors, and `test-helpers.static-machines-tree` passes the two panes'
+  already-expanded plain hiccup. The chrome — the testids, the widths,
+  the borders — is one definition either way, so a node-lane row that
+  walks it is walking the real thing.
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
-  []
+  SPLIT OUT OF [[panel]] BY rf2-k97c.3, for the reason every migrated
+  panel splits: a boundary's body may only run inside a React render
+  window, so `(panel)` is no longer a callable that answers hiccup."
+  [left right]
   [:div {:data-testid "rf-xray-static-machines-panel"
          :style {:display          "flex"
                  :flex-direction   "row"
@@ -100,14 +124,86 @@
                   :flex-direction "column"
                   :border-right  (str "1px solid " (:border-subtle tokens))
                   :background    (:bg-1 tokens)}}
-    [browse-list/browse-list]]
+    left]
    ;; ---- right pane ----
    [:div {:data-testid "rf-xray-static-machines-right"
           :style {:flex        "1 1 auto"
                   :min-width   "0"
                   :overflow    "auto"
                   :background  (:bg-2 tokens)}}
-    [definition-detail/detail]]])
+    right]])
+
+(rf.fresco/defview panel
+  "L4 detail-panel content for the Static Machines tab — a FRESCO
+  BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Master-detail with a
+  browse-all list on the left and the per-machine definition detail on
+  the right.
+
+  IT READS NOTHING, and it is still a boundary rather than a plain fn
+  for two reasons. First, it is what the L4 registry mounts, so it is
+  where the Reagent→Fresco crossing has to sit — one bridge for the
+  whole sub-tab. Second, a boundary is the only legal hiccup head for
+  the two pane boundaries below it.
+
+  THE NAME IS LOWERCASE `panel`, deliberately and normatively. Every
+  other panel namespace exports a `Panel`; this one is the documented
+  exception (`tools/xray/spec/API.md` §Static-mode Panel reg-views), and
+  BOTH `spec/api-manifest.edn` and its curated
+  `spec/api-manifest-metadata.edn` sidecar row
+  `day8.re-frame2-xray.static.machines.panel/panel` with
+  `:runtime-verified? true`. Both are hot zone. Keeping the natural name
+  on the BOUNDARY — the #9581 spelling the mayor's RULING 1 fixed as the
+  surviving one — means neither file moves.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. The L4 registry mounts it with none, so it is destructured
+  away."
+  [_props]
+  (panel-tree [browse-list/browse-list] [definition-detail/detail]))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's Static shell is still a `reg-view` tree rendered by the installed
+;; adapter. `static/shell.cljs`'s `detail-panel` mounts the active tab as
+;; the hiccup head `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s
+;; `:pre` requires `:panel` to be CALLABLE — neither of which a React
+;; component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; BOTH DEFS ARE PRIVATE, and that is measured rather than defaulted:
+;; `panel` is named outside this file only in `static/shell.cljs`'s PROSE
+;; (a docstring listing the L4 tabs) and in the two `spec/api-manifest*.edn`
+;; rows — never mounted or called by name. The L4 registry is the only
+;; consumer, and `install!` below is the only thing that passes the bridge.
+;; A panel carrying a standalone `mount-*!` facade would need a PUBLIC
+;; bridge instead, because `panels/render-panel!` takes the view to mount
+;; as an argument and needs a name to pass; this panel has none —
+;; `panels.cljs` names no Static sub-tab, so no caller line changes and
+;; nothing outside `tools/xray/{src,test}/…/static/machines/` is touched.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the Static shell is itself
+;; a Fresco tree, `reg-l4-tab!` takes `panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private panel-component
+  "The React component `panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component panel))
+
+(defn ^:private panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the Static shell's enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
+  []
+  [:> panel-component {}])
 
 ;; ---- subs ---------------------------------------------------------------
 
@@ -332,7 +428,11 @@
      :mnem  "m"
      :modes #{:static}
      :order 0
-     :panel panel})
+     ;; rf2-k97c.3 — `panel-bridge`, not `panel`. `panel` is now a React
+     ;; component (a Fresco boundary) and the Static shell mounts
+     ;; `:panel` as a Reagent hiccup head; the bridge is the one line
+     ;; between them and goes when the shell is a Fresco tree.
+     :panel panel-bridge})
   nil)
 
 ;; ---- test-only override seam --------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
@@ -59,11 +59,14 @@
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.test-helpers :as rf.test-helpers]
             [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
             [day8.re-frame2-xray.static.shell :as static-shell]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as e2e]
             [day8.re-frame2-xray.test-helpers.host-fixtures.deep-machine
-             :as deep-machine]))
+             :as deep-machine]
+            [day8.re-frame2-xray.test-helpers.static-machines-tree
+             :as machines-tree]))
 
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
@@ -71,8 +74,8 @@
 ;; ---- helpers -------------------------------------------------------------
 
 (defn- render-static-surface
-  "Render the Static surface under `:rf/xray`. Flips Xray's mode
-  slot to `:static` first so the surface composer + tab bar +
+  "Render the Static SHELL under `:rf/xray`. Flips Xray's mode slot to
+  `:static` first so the surface composer + tab bar +
   `static-shell/detail-panel` case-switch on the right axis. Returns
   the expanded hiccup tree.
 
@@ -83,6 +86,30 @@
   (rf/dispatch-sync [:rf.xray/set-mode :static] {:frame :rf/xray})
   (rf/with-frame :rf/xray
     (rf.test-helpers/expand-tree [static-shell/surface])))
+
+(defn- render-machines-panel
+  "Render the Machines sub-tab's own tree under `:rf/xray`, off the LIVE
+  subs — the same reads `static.machines.panel/panel` performs.
+
+  RE-POINTED BY rf2-k97c.3, and the suite's subject is unchanged. The
+  three views are now Fresco boundaries, so the shell walk above stops
+  at the bridge's `[:>]` interop head and cannot reach the panel's
+  interior; but what this suite exists to walk is the REAL INGRESS —
+  the host registers a machine through `rf/reg-machine`, Xray's
+  `registered-machines` sub sees it, and the projection reaches the
+  markup — and that ingress runs identically here.
+  `test-helpers.static-machines-tree` reproduces the boundaries' reads
+  exactly (same subs, same order, same `:sim` conditional), so every
+  assertion below is still about the shipped projection.
+
+  What moved out is the shell MOUNT, which is now asserted directly in
+  the first test rather than implied by a walk that reaches through it;
+  and the boundaries' React behaviour, which is
+  `static/machines/panel_fresco_boundary_dom_cljs_test`'s subject."
+  []
+  (rf/dispatch-sync [:rf.xray/set-mode :static] {:frame :rf/xray})
+  (rf/with-frame :rf/xray
+    (rf.test-helpers/expand-tree (machines-tree/panel-tree))))
 
 (defn- row-buttons
   "Pull the per-row outer `<button>` nodes out of the expanded tree.
@@ -122,7 +149,11 @@
     (e2e/with-host-and-xray-frames
       {:install-host deep-machine/install-and-init!}
       (fn []
-        (let [tree    (render-static-surface)
+        (let [shell   (render-static-surface)
+              slot    (rf.test-helpers/find-by-attr shell :data-testid
+                                       "rf-xray-static-detail-panel-machines")
+              mount   ((:panel (panel-registry/tab-by-id :static :machines)))
+              tree    (render-machines-panel)
               panel   (rf.test-helpers/find-by-attr tree :data-testid
                                        "rf-xray-static-machines-panel")
               rows    (row-buttons tree)
@@ -130,8 +161,14 @@
                                        "rf-xray-static-machines-topology-chart")
               chart-inner (rf.test-helpers/find-by-attr tree :data-testid
                                            "rf-xray-static-machines-topology-svg")]
+          (is (some? slot)
+              "Static Machines L4 slot did not render — :rf.xray/mode :static + default :machines sub-tab should yield the slot")
+          (is (= (last slot) mount)
+              (str "the L4 slot mounts exactly the registry's :panel — the "
+                   "Fresco boundary's bridge (rf2-k97c.3). Got: "
+                   (pr-str (last slot))))
           (is (some? panel)
-              "Static Machines L4 panel did not mount — :rf.xray/mode :static + default :machines sub-tab should yield the panel")
+              "Static Machines panel tree did not project — the live registrar ingress should yield the panel's own root")
           (is (pos? (count rows))
               (str "browse-list rendered zero machine rows — expected ≥ 1 row "
                    "for the host's :deep/main registration"))
@@ -152,7 +189,7 @@
     (e2e/with-host-and-xray-frames
       {:install-host deep-machine/install-and-init!}
       (fn []
-        (let [tree      (render-static-surface)
+        (let [tree      (render-machines-panel)
               topology  (rf.test-helpers/find-by-attr tree :data-testid
                                          "rf-xray-static-machines-pill-topology")
               sim       (rf.test-helpers/find-by-attr tree :data-testid
@@ -180,7 +217,7 @@
     (e2e/with-host-and-xray-frames
       {:install-host deep-machine/install-and-init!}
       (fn []
-        (let [tree        (render-static-surface)
+        (let [tree        (render-machines-panel)
               rows        (row-buttons tree)
               first-row   (first rows)
               machine-id-str (some-> first-row rf.test-helpers/attrs :data-machine-id)

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/browse_list_cljs_test.cljs
@@ -16,12 +16,12 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
-            [day8.re-frame2-xray.static.machines.panel :as panel]
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
+            [day8.re-frame2-xray.test-helpers.static-machines-tree
+             :as machines-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (use-fixtures :each
@@ -74,7 +74,7 @@
   (seed-machines! [:m/a])
   (seed-snapshots! {}) ;; no live instances
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-row-pips"))
           "no pip cluster when live-count is zero"))))
 
@@ -83,7 +83,7 @@
   (seed-machines! [:m/a])
   (seed-snapshots! {:m/a {:state :idle}})
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           pips (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-row-pips")]
       (is (some? pips) "pip cluster mounts for live machine"))))
 
@@ -95,13 +95,13 @@
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           btn  (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-sort")
           text (->> btn hiccup-seq (filter string?) (apply str))]
       (is (re-find #"Name" text) "default sort axis is Name")))
   (frame-dispatch [:rf.xray.static.machines/cycle-sort])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           btn  (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-sort")
           text (->> btn hiccup-seq (filter string?) (apply str))]
       (is (re-find #"States" text)))))
@@ -136,7 +136,7 @@
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
-    (let [tree   (panel/panel)
+    (let [tree   (machines-tree/panel-tree)
           rows-el (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-rows")
           attrs  (second rows-el)]
       (is (= "listbox" (:role attrs)))
@@ -147,7 +147,7 @@
   (seed-machines! [:m/a :m/b])
   (frame-dispatch [:rf.xray.static.machines/select :m/a])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           row-a (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-row-a")
           attrs (second row-a)]
       ;; Note: machine-id is :m/a so name = "a", testid suffix matches.
@@ -161,13 +161,13 @@
   (xray-setup!)
   (seed-machines! [:foo/a :foo/b :bar/c])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           count-el (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-count")
           text (->> count-el hiccup-seq (filter string?) (apply str))]
       (is (re-find #"3 machines" text))))
   (frame-dispatch [:rf.xray.static.machines/set-search "foo"])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           count-el (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-count")
           text (->> count-el hiccup-seq (filter string?) (apply str))]
       (is (re-find #"2 / 3" text)))))
@@ -181,5 +181,67 @@
   (seed-machines! [:foo/a :foo/b])
   (frame-dispatch [:rf.xray.static.machines/set-search "nonexistent"])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-no-results"))))))
+
+;; -------------------------------------------------------------------------
+;; React keys ride the ATTRIBUTE MAP, never Clojure metadata (rf2-k97c.3)
+;; -------------------------------------------------------------------------
+;;
+;; Both of this pane's seqs used to key with reader metadata — `^{:key …}`
+;; on a vector literal. Reagent reads that; Fresco's codec reads `:key`
+;; from the ATTRIBUTE MAP and reads Clojure metadata NOWHERE, so once the
+;; pane renders through a boundary the metadata spelling reaches React as
+;; nothing at all.
+;;
+;; THIS ROW DOES NOT ASSERT WITH `meta`, and that is deliberate: `(meta …)`
+;; reads nil at a REPAIRED site too, because the key now lives in the
+;; attribute map — so a metadata assertion is hollow in BOTH directions,
+;; green on broken code and red on fixed code. It asserts the codec-readable
+;; spelling instead. The other half of the evidence is the browser lane's
+;; W5, which asserts the row key REACHES REACT by surviving a head removal;
+;; the pip key cannot have a row like that, because its expression is
+;; positional (`i`) and a positional key is indistinguishable from no key
+;; under exactly that operation.
+
+(defn- vectors-under [tree]
+  (filter vector? (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest row-and-pip-keys-ride-the-attribute-map-not-metadata
+  (xray-setup!)
+  (seed-machines! [:foo/alpha :foo/beta])
+  (seed-snapshots! {:foo/alpha {:state :idle}})
+  (rf/with-frame :rf/xray
+    (let [tree      (machines-tree/browse-list-tree)
+          rows-node (rf.test-helpers/find-by-testid
+                      tree "rf-xray-static-machines-rows")
+          fragments (filterv #(= :<> (first %)) (vectors-under rows-node))
+          pips-node (rf.test-helpers/find-by-testid
+                      tree "rf-xray-static-machines-row-pips")
+          pip-spans (filterv #(and (= :span (first %))
+                                   (map? (second %)))
+                             (rest pips-node))]
+      ;; ---- the row seq ----
+      (is (= 2 (count fragments))
+          "NON-VACUITY: one keyed fragment per registered machine — a zero
+           here would make every assertion below vacuous")
+      (is (every? #(map? (second %)) fragments)
+          "each row fragment carries an ATTRIBUTE MAP, which is the only
+           place Fresco's codec looks for a key")
+      (is (= #{":foo/alpha" ":foo/beta"}
+             (set (map #(:key (second %)) fragments)))
+          "and the keys are the unchanged domain-shaped expressions
+           `(str machine-id)`, distinct within the seq")
+
+      ;; ---- the pip seq ----
+      (is (some? pips-node)
+          "NON-VACUITY: the live machine's pip cluster is on screen, so the
+           pip assertions below have something to read")
+      (is (= 1 (count pip-spans))
+          "one pip span for the one live instance")
+      (is (every? #(contains? (second %) :key) pip-spans)
+          "each pip carries `:key` in its attribute map rather than on
+           reader metadata")
+      (is (= [0] (mapv #(:key (second %)) pip-spans))
+          "and the key expression is unchanged — the positional index the
+           site has always used"))))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/copy_mermaid_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/copy_mermaid_cljs_test.cljs
@@ -48,9 +48,10 @@
             [day8.re-frame2-machines-viz.mermaid :as mermaid]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.static.machines.panel :as panel]
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
+            [day8.re-frame2-xray.test-helpers.static-machines-tree
+             :as machines-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
@@ -124,7 +125,7 @@
     (seed-definitions! {:m/a fixture-definition})
     (frame-dispatch [:rf.xray.static.machines/select :m/a])
     (rf/with-frame :rf/xray
-      (let [tree  (panel/panel)
+      (let [tree  (machines-tree/panel-tree)
             btn   (find-copy-button tree)
             attrs (rf.test-helpers/attrs btn)]
         (is (some? btn) "the Copy Mermaid control renders")
@@ -145,7 +146,7 @@
     (seed-definitions! {})
     (frame-dispatch [:rf.xray.static.machines/select :m/a])
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid
                      tree "rf-xray-static-machines-detail-header"))
             "header still renders")
@@ -162,7 +163,7 @@
     (seed-definitions! {:m/a {:states {:idle {}}}})
     (frame-dispatch [:rf.xray.static.machines/select :m/a])
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid
                      tree "rf-xray-static-machines-detail-header"))
             "header still renders")
@@ -181,7 +182,7 @@
     (frame-dispatch [:rf.xray.static.machines/select :m/a])
     (let [captured (capture-copy!)
           on-click (rf/with-frame :rf/xray
-                     (:on-click (rf.test-helpers/attrs (find-copy-button (panel/panel)))))]
+                     (:on-click (rf.test-helpers/attrs (find-copy-button (machines-tree/panel-tree)))))]
       (is (fn? on-click) "sanity: the rendered control is wired")
       ;; Activate the REAL control. The reg-view-injected dispatcher is
       ;; the queued (async) frame dispatch, so the event lands on the
@@ -205,7 +206,7 @@
                                   :m/a]))
                 "no settled status while the write is in flight")
             (rf/with-frame :rf/xray
-              (is (nil? (find-status-span (panel/panel)))
+              (is (nil? (find-status-span (machines-tree/panel-tree)))
                   "no feedback span while the write is in flight"))
             ;; Settle success — the exact vector the real fx dispatches
             ;; when the writeText Promise resolves.
@@ -214,7 +215,7 @@
                    (frame-sub [:rf.xray.static.machines/copy-mermaid-status
                                :m/a])))
             (rf/with-frame :rf/xray
-              (let [span (find-status-span (panel/panel))]
+              (let [span (find-status-span (machines-tree/panel-tree))]
                 (is (some? span) "feedback span renders on success")
                 (is (= "status" (:role (rf.test-helpers/attrs span)))
                     "non-modal accessible status feedback")
@@ -246,7 +247,7 @@
              (frame-sub [:rf.xray.static.machines/copy-mermaid-status :m/a]))
           "rejection lands as :failed")
       (rf/with-frame :rf/xray
-        (let [span (find-status-span (panel/panel))]
+        (let [span (find-status-span (machines-tree/panel-tree))]
           (is (= "Copy failed" (rf.test-helpers/text-content span)))
           (is (not= "Copied" (rf.test-helpers/text-content span))
               "a failed write is never reported as copied"))))))
@@ -311,7 +312,7 @@
       (is (nil? (frame-sub [:rf.xray.static.machines/copy-mermaid-status
                             :m/b])))
       (rf/with-frame :rf/xray
-        (is (nil? (find-status-span (panel/panel)))
+        (is (nil? (find-status-span (machines-tree/panel-tree)))
             "no feedback span survives onto another machine's header")))))
 
 (deftest late-settlement-after-reselect-does-not-repopulate
@@ -333,4 +334,4 @@
                             :m/a]))
           "stale settlement is dropped, not recorded")
       (rf/with-frame :rf/xray
-        (is (nil? (find-status-span (panel/panel))))))))
+        (is (nil? (find-status-span (machines-tree/panel-tree))))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -32,12 +32,14 @@
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
-            [day8.re-frame2-xray.static.machines.panel :as panel]
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-machines-tree
+             :as machines-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
@@ -94,13 +96,43 @@
 
 (deftest static-shell-mounts-machines-panel-on-machines-tab
   (testing "Selecting the :machines sub-tab mounts the Static Machines
-            panel (replaces the placeholder from rf2-o5f5f.1)"
+            panel (replaces the placeholder from rf2-o5f5f.1).
+
+            RE-AUTHORED ONE LEVEL UP BY rf2-k97c.3. The panel is now a
+            Fresco boundary behind an `as-component` bridge, so the
+            hiccup walk stops at the bridge's `[:>]` interop head and
+            `rf-xray-static-machines-panel` is committed by React rather
+            than present in the tree — asserting it here would now be
+            asserting the walker's reach, not the mount. What the shell
+            actually owes is that the `:machines` slot renders and
+            mounts THE REGISTRY'S `:panel`, and that the placeholder is
+            gone; that the boundary behind it paints
+            `rf-xray-static-machines-panel` is W1's subject in
+            `panel_fresco_boundary_dom_cljs_test`, off a real React
+            commit."
     (xray-setup!)
     (seed-machines! [:m/a :m/b])
     (rf/with-frame :rf/xray
-      (let [tree (static-shell/surface)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-panel"))
-            "panel mounts on default :machines tab")
+      (let [tree  (static-shell/surface)
+            slot  (rf.test-helpers/find-by-testid
+                    tree "rf-xray-static-detail-panel-machines")
+            tab   (panel-registry/tab-by-id :static :machines)
+            mount ((:panel tab))]
+        (is (some? slot)
+            "the :machines L4 slot renders on the default Static tab")
+        (is (and (vector? mount) (= :> (first mount)) (= 3 (count mount)))
+            (str "the registry's :panel is the bridge — it answers a "
+                 "Reagent `[:>]` interop head, which is exactly what the "
+                 "shell's `[(:panel tab)]` mounts. Got: " (pr-str mount)))
+        (is (some? (second mount))
+            "and the interop head names a real component rather than nil")
+        (is (= {} (nth mount 2))
+            "the bridge crosses an empty props map — this panel reads
+             nothing from props")
+        (is (= (last slot) mount)
+            "NON-VACUITY: the node the shell actually mounted in the
+             :machines slot IS that bridge's return, so this row is
+             about the live wiring and not about the registry alone")
         ;; Placeholder card MUST be gone now that the panel is live.
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-static-placeholder-machines"))
             "placeholder no longer mounts")))))
@@ -117,7 +149,7 @@
                         :foo/checkout {:states {:a {} :b {} :c {}}}
                         :bar/upload   {:states {:x {}}}})
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)
+      (let [tree (machines-tree/panel-tree)
             rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-static-machines-row-")
             ;; Filter rows-only — the row testid prefix matches the
             ;; per-row id chips too, so we keep only the outer row buttons
@@ -130,7 +162,7 @@
     (xray-setup!)
     (seed-machines! [])
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-empty"))
             "empty-state card present")
         (is (re-find #"No machines registered"
@@ -203,7 +235,7 @@
                             :source-coord {:file "src/a.cljs" :line 7}}})
   (seed-snapshots! {:m/a {:state :a}})
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-detail-header")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-detail-title")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-detail-source-coord")))
@@ -219,7 +251,7 @@
   (seed-machines! [:m/a])
   (seed-definitions! {:m/a {:states {:a {}}}}) ;; no :source-coord
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-detail-source-coord"))
           "source-coord chip is suppressed when the slot is missing"))))
 
@@ -231,7 +263,7 @@
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-topology")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-sim")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-instances")))
@@ -241,7 +273,7 @@
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           pill (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-topology")]
       (is (= "true" (:aria-selected (second pill)))
           "Topology is the default active pill"))))
@@ -251,7 +283,7 @@
   (seed-machines! [:m/a])
   (frame-dispatch [:rf.xray.static.machines/set-sub-mode :m/a :sim])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           sim  (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-sim")
           topo (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-topology")]
       (is (= "true"  (:aria-selected (second sim))))
@@ -265,7 +297,7 @@
   (xray-setup!)
   (seed-machines! [:m/a])
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)
+    (let [tree (machines-tree/panel-tree)
           pill (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-pill-cascade")
           attrs (second pill)]
       (is (= true (:disabled attrs))
@@ -288,7 +320,7 @@
     (seed-machines! [:m/a])
     (frame-dispatch [:rf.xray.static.machines/set-sub-mode :m/a :sim])
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         ;; The old placeholder is gone.
         (is (nil? (rf.test-helpers/find-by-testid
                     tree "rf-xray-static-machines-sim-placeholder"))
@@ -327,7 +359,7 @@
                                      :data    {:counter 0}
                                      :states  {:idle {:on {:start :running}}
                                                :running {}}}}])
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-sim-body"))
             "real Sim body wrapper mounts")
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-sim-rail"))
@@ -371,7 +403,7 @@
   (seed-definitions! {:m/a {:initial :idle
                             :states  {:idle {} :done {}}}})
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-topology"))
           "Topology mode mounts as the default body")
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-topology-chart"))
@@ -387,7 +419,7 @@
   ;; No definition seeded — machine-definitions sub returns {}
   (seed-definitions! {})
   (rf/with-frame :rf/xray
-    (let [tree (panel/panel)]
+    (let [tree (machines-tree/panel-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree
                                  "rf-xray-static-machines-topology-no-definition"))))))
 
@@ -403,7 +435,7 @@
     (seed-definitions! {:m/a {:initial :idle
                               :states  {:idle {} :done {}}}})
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-machine-canvas-host"))
             "the chart is now wrapped in the interactive canvas-host")
         ;; rf2-gpzb4 (xyflow migration): the host-side controls toolbar
@@ -425,7 +457,7 @@
     (seed-definitions! {:m/a {:initial :idle
                               :states  {:idle {} :done {}}}})
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (nil? (rf.test-helpers/find-by-testid tree
                                   "rf-xray-machine-canvas-view-mode-toggle"))
             "the retired view-mode toggle never mounts on static")))))
@@ -441,7 +473,7 @@
                               :states  {:idle {} :done {}}
                               :source-coord {:file "src/m_a.cljs" :line 12}}})
     (rf/with-frame :rf/xray
-      (let [tree (panel/panel)]
+      (let [tree (machines-tree/panel-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree
                                    "rf-xray-static-machines-topology-toolbar"))
             "static chart-toolbar still mounts above the canvas")

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,764 @@
+(ns day8.re-frame2-xray.static.machines.panel-fresco-boundary-dom-cljs-test
+  "The Static Machines sub-tab re-authored in the re-frame-native view
+  layer, read off a real React commit (rf2-k97c.3).
+
+  `static.machines.panel/panel`, `…browse-list/browse-list` and
+  `…definition-detail/detail` are now `rf.fresco/defview`s reading
+  through Fresco's shipped collector rather than `rf/reg-view`s reading
+  through whatever view build the installed substrate adapter supplies.
+  This file is the behavioural evidence for that swap.
+
+  The rows are the template `static/flows/panel_fresco_boundary_dom
+  _cljs_test` established, adapted to this sub-tab's THREE boundaries,
+  its own dependency lever, its own key site — and one row no earlier
+  slice needed.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1, and it is a THREE-boundary claim:
+                                    the panel's chrome, the left pane and
+                                    the right pane each commit their own
+                                    DOM, so the two nested boundary heads
+                                    really did mount
+    2 UPDATES ON A REAL CHANGE    — W2 for the LEFT pane (with the deaf
+                                    control that makes the update mean
+                                    liveness) and W2b for the RIGHT, off a
+                                    read only that pane performs
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, in BOTH directions, and SCOPED to
+                                    the three boundaries' own renders — see
+                                    the last paragraph below
+    6 CLEAN TEARDOWN              — W4
+
+  Criterion 3 (Xray's own interactions) has no row of its own here: the
+  affordances this sub-tab owns — row select, sort cycle, search
+  keystroke, the per-row JUMP, Copy Mermaid — all reach the frame
+  through the ONE dispatcher `(:dispatch (rf/capture-frame))` hands the
+  tree, and W2's phase 3 fires one of them (`cycle-sort`) through the
+  live frame to move the panel. A per-control row would re-assert the
+  same dispatcher five times.
+
+  ## W5 — the row key, and why the PIP key gets no row like it
+
+  The migration moved React keys out of Clojure metadata, which Fresco's
+  codec reads NOWHERE, at TWO sites in `browse_list.cljs`: the per-row
+  seq and each row's live-instance pip seq. Only the FIRST is witnessable
+  by a reorder, and the reason generalises (it is #9622's finding, met
+  again here): the pip key expression is `i`, POSITIONAL, so removing a
+  pip shifts the survivor's key and React correctly reuses the removed
+  node — a positional key and no key at all are indistinguishable under
+  exactly the operation a reorder-identity row performs. The row key is
+  `(str machine-id)`, DOMAIN-shaped, so W5 works for it. The pip site's
+  evidence stays in the node lane, where the claim (the key is present IN
+  THE ATTRIBUTE MAP) is real — `browse_list_cljs_test`'s
+  `row-and-pip-keys-ride-the-attribute-map-not-metadata`.
+
+  ## W6 — the REAGENT ISLAND, and no earlier slice has this row
+
+  This is the first migrated panel whose interior must reach code that
+  CANNOT be a Fresco head: `topology/body` bottoms out in
+  `machine-canvas/Chart`, an `rf/reg-view`, which grades `:invalid` in
+  hiccup head position exactly as a plain `defn` does. `detail-tree`
+  therefore crosses it as a React ELEMENT through `reagent.core/
+  as-element` — Fresco's documented `:as-child` door, the same one
+  `panels/machine_after_rings.cljs` uses. W6 is that crossing measured:
+  three nodes that exist ONLY if Reagent rendered fn heads inside the
+  boundary's subtree, plus the canvas host, which exists only if the
+  `reg-view` inside that island rendered too.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `static/shell.cljs`'s `detail-panel` mounts the active tab as the
+  hiccup head `[(:panel tab)]` inside the shell's
+  `[rf/frame-provider {:frame …}]`. [[mount-panel!]] does exactly that,
+  and it reaches `:panel` THROUGH `panel-registry/tab-by-id :static`
+  rather than naming the var — so the bridge the registry actually holds
+  is the thing under test. A bridge that regressed to something the
+  shell cannot mount reddens here rather than in a browser.
+
+  Nothing below ever calls a panel view a second time. Every assertion
+  after the mount reads `container.querySelector…` — the DOM React
+  committed on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundaries are INDIFFERENT to
+  it. It is also the adapter W6's island genuinely needs.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient scope is still in effect during a
+  synchronous `flushSync`, and tier 1 of the frame resolver is the
+  dynamic var, so an ambient frame would SHADOW the React-context tier
+  W1's frame-targeting row is about and that row would pass while
+  measuring nothing.
+
+  ## W3's ZERO IS SCOPED, AND THE SCOPE WAS MEASURED RATHER THAN CHOSEN
+
+  Criterion 5 is a claim about the BOUNDARIES: a Fresco boundary is not a
+  substrate view render, so it emits no `:rf.view/*` op. That holds, and
+  W3 shows it. What does NOT hold for this sub-tab, and would be a false
+  claim if W3 were written without a fixture, is that the whole rendered
+  SUB-TREE is trace-silent: the Reagent island W6 measures contains
+  `machine-canvas/Chart`, an `rf/reg-view`, and a reg-view emits view
+  trace wherever it renders. Written against the page's ambient machine
+  list, W3's first run read `[:rf.view/render :rf.view/rendered]` — the
+  island, faithfully doing what a Reagent tree does.
+
+  So W3 pins the machine list EMPTY, which means no machine is selected,
+  which means no Topology body and therefore no island; and it ASSERTS
+  that absence rather than assuming it, so the zero cannot quietly become
+  a zero about a tree that was not there for a different reason. The
+  island's trace emission is a KNOWN CONSEQUENCE of the migration
+  scaffolding, not a regression, and it goes when `Chart` is itself a
+  Fresco body — the same commit that deletes the `as-child` seam.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing
+  silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.machines]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private data-q
+  "The read BOTH pane boundaries share — `browse-list` for its rows and
+  `detail` for the selected row. Named once because four rows key off
+  it; the sub-cache is keyed by the query vector itself, so this value IS
+  the cache key. Its ref-count is 2 under a full mount, which is what
+  makes W4's `=`-on-reopen a real number rather than a boolean."
+  [:rf.xray.static.machines/data])
+
+;; ---- probe registrations --------------------------------------------------
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit as the panel — so the only variable between it and
+  the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+(def ^:private probe-machine
+  "W2's late registration, and W6's definition. Two states and one
+  transition — enough for `grammar/valid-definition?` to pass so the
+  Topology body renders a chart rather than the no-definition hint."
+  {:initial :idle
+   :states  {:idle   {:on {:go :active}}
+             :active {:on {:reset :idle}}}})
+
+;; ---- W5's two-row fixture -------------------------------------------------
+;;
+;; Sorted by machine-id, so `:aaa/first` really is the HEAD row and
+;; removing it is a genuine reorder rather than a tail truncation. A tail
+;; removal leaves the survivor untouched under EITHER key spelling and
+;; would make the row vacuous — which is why W5 asserts the head position
+;; before it removes anything.
+
+(def ^:private two-machines [:aaa/first :bbb/second])
+(def ^:private one-machine  [:bbb/second])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of these panes', and a row written that way reads a DOM that
+;; has not moved and reports a live panel as dead. Mount is committed with
+;; `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the static-machines
+  sub family and the `:static` L4 tab entry the mount reads — and make
+  the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- setup-with-overrides!
+  "[[setup!]] plus the test-only override seam, which re-registers
+  `:rf.xray/registered-machines` and the definition map to read injected
+  values. W5 and W6 need the row list under their own hand; the rows that
+  do not, do not install it."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- override-machines!
+  "Pin the registered-machine list the panes project.
+
+  MEASURED NECESSITY, not tidiness: `:rf.xray/registered-machines`
+  computes from the PROCESS-GLOBAL registrar, so what a row sees depends
+  on what every other suite sharing this page has registered — the first
+  run of this file found `:auth.login/flow` on screen where it expected a
+  cold start. Any row asserting an ABSENCE, or asserting on the whole row
+  set, pins the list first. Rows that assert about ONE named probe do not
+  need to, and W2 deliberately does not: its lever is a real registration
+  that the override would shadow."
+  ([ids] (override-machines! :rf/xray ids))
+  ([frame ids]
+   (rf/dispatch-sync
+     [:rf.xray/set-registered-machines-override-for-test (vec ids)]
+     {:frame frame})))
+
+(defn- override-definitions!
+  ([defs] (override-definitions! :rf/xray defs))
+  ([frame defs]
+   (rf/dispatch-sync
+     [:rf.xray/set-machine-definitions-override-for-test defs]
+     {:frame frame})))
+
+(defn- mount-panel!
+  "Mount the Machines tab the way `static/shell.cljs`'s `detail-panel`
+  mounts it: the registry's `:panel` value as a hiccup head, inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and phase 1 would assert against an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :static :machines)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid [container id]
+  (q container (str "[data-testid=\"" id "\"]")))
+
+(defn- row-node
+  "The committed row `<button>` for one machine-id's `name`, or nil. The
+  row button is the node carrying `data-machine-id`; the per-row jump
+  chip shares the testid STEM but not that attribute, so the exact
+  selector here cannot collide with it."
+  [container row-name]
+  (q container (str "[data-testid=\"rf-xray-static-machines-row-"
+                    row-name "\"]")))
+
+(defn- row-nodes
+  "Every committed row BUTTON — filtered on `data-machine-id`, which the
+  row button carries and its per-row children do not."
+  [container]
+  (vec (.from js/Array
+              (.querySelectorAll
+                container
+                "[data-testid^=\"rf-xray-static-machines-row-\"][data-machine-id]"))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display of all THREE boundaries, and the reads land in the
+;;      frame the tree named
+;; ===========================================================================
+
+(deftest w1-three-boundaries-paint-and-their-reads-land-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Static Machines sub-tab commits real
+            DOM through the registry entry the Static shell mounts, its two
+            nested pane boundaries mount under it, and their
+            `rf.fresco/sub` reads resolve against the frame the enclosing
+            `frame-provider` named rather than the ambient one. Epic
+            criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup-with-overrides!)
+            ;; PIN THE LIST EMPTY. The registered-machine read is computed
+            ;; from the process-global registrar, so a cold start is a
+            ;; property of the whole page rather than of this row — see
+            ;; `override-machines!`. Pinning it makes the two empty-state
+            ;; assertions below decisions rather than coincidences.
+            _ (override-machines! [])
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (testid container "rf-xray-static-machines-panel"))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          ;; ---- the two NESTED boundaries, which is this panel's own claim --
+          (is (some? (testid container "rf-xray-static-machines-browse-list"))
+              "the LEFT pane boundary mounted — `panel` heads `browse-list`
+               directly, and a boundary is the one hiccup head shape that is
+               legal inside a Fresco body")
+          (is (some? (testid container "rf-xray-static-machines-detail-empty"))
+              "the RIGHT pane boundary mounted too, and with no machines
+               registered it committed its own empty surface — so the body
+               really ran through `detail-tree` rather than painting an
+               empty shell")
+          (is (some? (testid container "rf-xray-static-machines-empty"))
+              "and the left pane committed the cold-start empty state, which
+               only `browse-list-tree` emits")
+
+          ;; ---- criterion 4: the reads are where the tree said they were ----
+          (is (pos? (ref-count-of :rf/xray data-q))
+              (str "the panes' shared read holds a reference in :rf/xray's "
+                   "sub-cache — the frame the enclosing frame-provider named. "
+                   "Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panes re-render themselves and commit new
+            DOM when a read's value really changes, and do NOT when nothing
+            they watch moved. Epic criterion 2, with the control that makes
+            the update mean liveness rather than a commit that simply had not
+            happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              pane   (testid container "rf-xray-static-machines-browse-list")
+              probe? (fn [] (some? (row-node container "late-machine")))]
+          (is (some? pane)
+              "PRECONDITION: the left pane is on screen at all")
+          (is (not (probe?))
+              "NON-VACUITY: the machine this row drives in is NOT on screen
+               before it is registered. The claim is about THIS probe row
+               rather than about an empty list — the registered-machine read
+               computes from the process-global registrar, so what else is on
+               screen belongs to the page, not to this row")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; `:rf.xray/registered-machines` computes from the PROCESS-GLOBAL
+          ;; registrar (`rf/registrations {:source :store :kind :event}`), not
+          ;; from Xray's app-db. Registering a real machine therefore changes
+          ;; what the read WOULD compute while invalidating nothing it
+          ;; watches — the honest "the world moved" pulse.
+          (rf/reg-machine :probe/late-machine probe-machine)
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (probe?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the probe's row. A pane that
+                       re-rendered here would make phase 3 pass for a reason
+                       that is not liveness")
+                  ;; ---- phase 3: a real input of the read moves ------------
+                  ;; `cycle-sort` is one of the panel's OWN affordances, fired
+                  ;; through the live frame: it writes Xray's app-db, which
+                  ;; invalidates the db-backed `registered-machines` read and
+                  ;; the `sort-key` read the toolbar renders.
+                  (rf/dispatch-sync [:rf.xray.static.machines/cycle-sort]
+                                    {:frame :rf/xray})
+                  (rf.test-support/poll-until probe?
+                    {:label "the left pane committed the new machine's row"})))
+              (.then
+                (fn [_]
+                  (is (probe?)
+                      "the pane re-rendered on a real invalidation of its own
+                       read and committed the new machine's row")
+                  (is (identical?
+                        pane
+                        (testid container "rf-xray-static-machines-browse-list"))
+                      "and it is the SAME pane node: React reconciled the live
+                       tree in place, so the row did not arrive by the pane
+                       being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+(deftest w2b-the-right-pane-updates-on-a-read-only-it-performs
+  (testing "rf2-k97c.3 — the RIGHT pane is independently live, and this row is
+            what makes the three-boundary claim mean something rather than
+            being a fact about file layout. Its lever is
+            `:rf.xray.static.machines/sub-mode`, a read ONLY `detail`
+            performs: the left pane never touches it, so a commit here can
+            only have come from the right pane's own boundary re-rendering.
+
+            The reactive granularity is the reason the migration kept three
+            boundaries instead of hoisting both panes' reads into `panel` —
+            with one boundary, every search keystroke would re-render this
+            Topology chart."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override-machines! [:probe/topology])
+        (override-definitions! {:probe/topology probe-machine})
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              panel-root (testid container "rf-xray-static-machines-panel")
+              left       (testid container "rf-xray-static-machines-browse-list")
+              instances? (fn [] (some? (testid container
+                                         "rf-xray-static-machines-instances-body")))]
+          (is (some? (testid container "rf-xray-static-machines-topology"))
+              "PRECONDITION: the default `:topology` sub-mode is on screen")
+          (is (not (instances?))
+              "NON-VACUITY: the body this row drives in is NOT on screen before
+               the sub-mode changes")
+          (rf/dispatch-sync [:rf.xray.static.machines/set-sub-mode
+                             :probe/topology :instances]
+                            {:frame :rf/xray})
+          (-> (rf.test-support/poll-until instances?
+                {:label "the right pane committed the :instances body"})
+              (.then
+                (fn [_]
+                  (is (nil? (testid container "rf-xray-static-machines-topology"))
+                      "the Topology body left the committed DOM, so the body
+                       really swapped rather than the new one being appended")
+                  (is (identical? panel-root
+                                  (testid container "rf-xray-static-machines-panel"))
+                      "the panel chrome is the SAME node — `panel` reads
+                       nothing, so it had no reason to re-render and React
+                       reconciled in place")
+                  (is (identical? left
+                                  (testid container "rf-xray-static-machines-browse-list"))
+                      "and so is the LEFT pane, which reads none of what
+                       moved — the update was scoped to the boundary whose
+                       read changed, which is the whole point of keeping
+                       three")))
+              (.catch (fn [e]
+                        (is false (str "W2b never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own render is not application view evidence
+;; ===========================================================================
+
+(deftest w3-the-boundarys-render-emits-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated sub-tab
+            contributes NOTHING to the substrate's view-trace stream, even
+            when it is mounted INSIDE an application frame. Epic criterion 5,
+            proven structurally rather than by the `:rf/xray` frame gate: a
+            Fresco boundary is not a substrate view render, so there is no
+            event to gate. The control is an ordinary `reg-view` in the same
+            root, the same frame and the same commit."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_        (setup-with-overrides!)
+            ;; PIN THE LIST EMPTY IN THE FRAME THE SUBJECT MOUNTS IN, and
+            ;; the scope of the zero below turns on it — see the docstring's
+            ;; last paragraph. The override slot is per-frame, so this is
+            ;; `app-frame`'s and not `:rf/xray`'s.
+            _        (override-machines! app-frame [])
+            traces   (atom [])
+            view-op? #(and (keyword? (:operation %))
+                           (= "rf.view" (namespace (:operation %))))]
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the panel, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-panel! app-frame)
+                subject-views (filterv view-op? @traces)]
+            (try
+              (is (some? (testid container "rf-xray-static-machines-panel"))
+                  "precondition: the panel really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (some? (testid container "rf-xray-static-machines-browse-list"))
+                  "precondition: and so did the nested pane boundaries, so the
+                   zero covers all three renders and not just the outermost")
+              (is (nil? (testid container "rf-xray-static-machines-topology"))
+                  "SCOPE, asserted rather than assumed: no Topology body is on
+                   screen, so no Reagent island rendered in this commit and the
+                   zero below is about the three BOUNDARIES' own renders")
+              (is (zero? (count subject-views))
+                  (str "the three boundaries' renders put NO :rf.view/* op in "
+                       "the trace stream while rendering inside an application "
+                       "frame. Ops seen: "
+                       (pr-str (mapv :operation subject-views))))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [control-views (filterv view-op? @traces)]
+                (is (some? (testid container "rf-xray-probe-reg-view"))
+                    "precondition: the control really did render")
+                (is (pos? (count control-views))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES emit a :rf.view/* op, so the subject's zero "
+                         "is a property of the boundary and not of a dead "
+                         "instrument. Ops seen: "
+                         (pr-str (mapv :operation control-views)))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray data-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the sub-tab releases its subscription
+            references completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE COUNT IS TWO HERE, not one — both pane boundaries read
+            `:rf.xray.static.machines/data` — which is what makes the
+            reopen assertion a real number rather than a boolean, and what
+            would catch one pane releasing while the other leaked.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray data-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray data-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the row keys REACH REACT: the survivor of a head removal is the same
+;;      DOM node
+;; ===========================================================================
+
+(deftest w5-row-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 — the row React key the migration moved out of Clojure
+            metadata and onto a keyed fragment's ATTRIBUTE MAP is the key
+            React actually reconciles on. Removing the HEAD of a two-row list
+            leaves the survivor as the SAME DOM node; under index-based
+            reconciliation — which is what a lost key silently degrades to —
+            React would reuse the head's node for the survivor and destroy the
+            one this row is holding.
+
+            The head position is ASSERTED rather than assumed: a removal from
+            the TAIL leaves the survivor untouched under either spelling and
+            would make this row vacuous."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup-with-overrides!)
+        (override-machines! two-machines)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              head     (row-node container "first")
+              survivor (row-node container "second")]
+          (is (some? head)     "PRECONDITION: the head row is on screen")
+          (is (some? survivor) "PRECONDITION: the survivor row is on screen")
+          (is (= 2 (count (row-nodes container)))
+              "PRECONDITION: exactly the two fixture rows are on screen")
+          (when (and (some? head) (some? survivor))
+            ;; DOCUMENT_POSITION_FOLLOWING = 4. A removal from the tail is
+            ;; invisible to this row's claim, so prove we are removing the head.
+            (is (pos? (bit-and (.compareDocumentPosition head survivor) 4))
+                "NON-VACUITY: the row being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation"))
+          (override-machines! one-machine)
+          (-> (rf.test-support/poll-until
+                (fn [] (= 1 (count (row-nodes container))))
+                {:label "the head row left the committed DOM"})
+              (.then
+                (fn [_]
+                  (is (nil? (row-node container "first"))
+                      "the removed row is gone from the committed DOM")
+                  (is (identical? survivor (row-node container "second"))
+                      "and the survivor is the IDENTICAL DOM node React
+                       already had — which is only true if the key reached
+                       React. With the key lost to metadata the codec cannot
+                       read, React reconciles by index and hands the survivor
+                       the HEAD's node instead")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W6 — the Reagent island really crosses, and the reg-view inside it renders
+;; ===========================================================================
+
+(deftest w6-the-topology-body-crosses-as-a-reagent-island
+  (testing "rf2-k97c.3 — `detail-tree` hands the Topology body to
+            `reagent.core/as-element`, so it reaches React as a finished
+            ELEMENT — a legal child anywhere per Fresco's component ABI —
+            and everything inside it renders under REAGENT rather than under
+            Fresco's codec.
+
+            The three toolbar nodes below exist ONLY if Reagent expanded fn
+            HEADS (`[chart-toolbar …]`, `[popout-affordance …]`, `[chart …]`
+            in `topology.cljs`), each of which Fresco's codec would refuse
+            outright as HD-016; and the canvas host exists only if
+            `machine-canvas/Chart` — an `rf/reg-view`, which grades
+            `:invalid` in a Fresco head position exactly as a plain `defn`
+            does — rendered too, resolving its own frame from the SAME React
+            context the boundary read.
+
+            This is the row no earlier panel slice needed, and the door it
+            measures is the one `panels/machine_after_rings.cljs` documents."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup-with-overrides!)]
+        (override-machines! [:probe/topology])
+        (override-definitions! {:probe/topology probe-machine})
+        (let [{:keys [container root]} (mount-panel! :rf/xray)]
+          (try
+            (is (some? (testid container "rf-xray-static-machines-detail-header"))
+                "PRECONDITION: the right pane selected the machine and painted
+                 its header — without a selection there is no Topology body to
+                 cross at all")
+            (is (some? (testid container "rf-xray-static-machines-topology"))
+                "the Topology body committed — the island crossed")
+            (is (some? (testid container "rf-xray-static-machines-topology-toolbar"))
+                "and `[chart-toolbar …]`, a PLAIN FN in hiccup head position,
+                 rendered inside it — Fresco's codec would have refused that
+                 head, so this node is the crossing itself")
+            (is (some? (testid container "rf-xray-static-machines-topology-popout"))
+                "as did `[popout-affordance …]` one level deeper, so the island
+                 is a whole Reagent subtree rather than one converted node")
+            (is (some? (testid container "rf-xray-machine-canvas-host"))
+                "and `machine-canvas/Chart` — an `rf/reg-view`, the head shape
+                 the codec grades `:invalid` down the same arm as a plain
+                 `defn` — rendered its canvas host, so a reg-view survives
+                 inside the island and resolves its frame from React context")
+            (is (nil? (testid container "rf-xray-static-machines-topology-no-definition"))
+                "NON-VACUITY: the no-definition hint is ABSENT, so the chart
+                 arm is the arm that ran")
+            (finally
+              (teardown! root container))))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -39,6 +39,7 @@
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
@@ -267,13 +268,30 @@
 
 (deftest static-machines-mounts-live-panel
   (testing "rf2-o5f5f.2 — the :machines sub-tab mounts the live Static
-            Machines panel"
+            Machines panel.
+
+            RE-AUTHORED ONE LEVEL UP BY rf2-k97c.3. `static.machines.
+            panel/panel` is now an `rf.fresco/defview` behind an
+            `as-component` bridge, so this hiccup walk reaches the
+            bridge's `[:>]` interop head and stops — `rf-xray-static-
+            machines-panel` is committed by React, not present in the
+            tree. Asserting the testid here would from now on be
+            asserting the walker's reach rather than the mount, which is
+            the hollow-gate shape. What the shell owes is that the slot
+            mounts the REGISTRY's `:panel` and that no placeholder
+            renders; the boundary's own first paint is W1 in
+            `static/machines/panel_fresco_boundary_dom_cljs_test`."
     (xray-setup!)
     (rf/with-frame :rf/xray
       (frame-dispatch [:rf.xray.static/select-tab :machines])
-      (let [tree (static-shell/surface)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-machines-panel"))
-            "live Machines panel mounts")
+      (let [tree  (static-shell/surface)
+            slot  (rf.test-helpers/find-by-testid
+                    tree "rf-xray-static-detail-panel-machines")
+            mount ((:panel (panel-registry/tab-by-id :static :machines)))]
+        (is (some? slot) "the :machines L4 slot renders")
+        (is (= (last slot) mount)
+            (str "the slot mounts exactly the registry's :panel value. "
+                 "Got: " (pr-str (last slot))))
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-static-placeholder-machines"))
             "no placeholder card renders for :machines")))))
 

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/static_machines_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/static_machines_tree.cljs
@@ -1,0 +1,112 @@
+(ns day8.re-frame2-xray.test-helpers.static-machines-tree
+  "The node lane's door onto the Static Machines sub-tab (rf2-k97c.3).
+
+  ## Why this exists
+
+  The sub-tab's three views are now Fresco boundaries — `panel/panel`,
+  `browse-list/browse-list` and `definition-detail/detail` are
+  `rf.fresco/defview`s, i.e. real React function components. A
+  boundary's body may only run inside a React render window, so
+  `(panel/panel)` is no longer a callable that answers hiccup and the
+  ~30 existing node-lane rows that walked its return value could not
+  survive unchanged.
+
+  The repair is `defview`'s own documented extract-a-helper spelling:
+  each of the three files exports a PURE `*-tree` fn of its read's
+  values, the boundary is the thin thing that reads and calls it, and
+  the node lane drives the tree fns. This ns is the composer that does
+  that driving.
+
+  ## It REPRODUCES THE BOUNDARIES' READS — same subs, same order
+
+  That is what makes a node-lane row evidence about the shipped panel
+  rather than about a parallel fixture. Each fn below is a line-for-line
+  mirror of the boundary beside it, with `rf.fresco/sub` swapped for
+  `rf/subscribe` (the node lane has no React render window and no
+  collector extent) and nothing else changed:
+
+    * the `detail` composer keeps the two SEQUENCED reads — `sub-mode`
+      and `copy-mermaid-status` are parameterised by the `selected-id`
+      the `data` read answers;
+    * it keeps the `:sim` CONDITIONAL — the five sim slots are read only
+      on that sub-mode, exactly as the boundary reads them;
+    * it passes `identity` as `detail-tree`'s `as-child`, so the
+      Topology and Sim bodies stay fn-headed hiccup vectors that
+      `rf.test-helpers/expand-tree` walks precisely as it always has.
+      The boundary passes `reagent.core/as-element` there; that
+      crossing's evidence is the browser lane's, not this one's.
+
+  SINGLE-SOURCED ON PURPOSE. Four suites need this composition
+  (`panel_cljs_test`, `browse_list_cljs_test`, `copy_mermaid_cljs_test`
+  and the multi-frame e2e). Four private copies of a read reproduction
+  is four things to keep in step with one boundary, and the failure mode
+  when one drifts is a row that stays green while measuring a tree the
+  panel does not render.
+
+  ## Call these INSIDE a frame scope
+
+  Every fn here subscribes ambiently, so each call belongs inside
+  `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
+  bodies had, and the same one every existing caller already satisfies."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
+            [day8.re-frame2-xray.static.machines.definition-detail
+             :as definition-detail]
+            [day8.re-frame2-xray.static.machines.panel :as panel]))
+
+(defn browse-list-tree
+  "The L4-LEFT pane's hiccup, read the way `browse-list/browse-list`
+  reads it. `dispatch` defaults to
+  `(:dispatch (rf/capture-frame))` — the SAME door the boundary uses, so
+  a handler this lane pulls off the tree and fires later carries the
+  frame exactly as the shipped one does."
+  ([] (browse-list-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (browse-list/browse-list-tree
+     @(rf/subscribe [:rf.xray.static.machines/data])
+     @(rf/subscribe [:rf.xray.static.machines/search])
+     @(rf/subscribe [:rf.xray.static.machines/sort-key])
+     dispatch)))
+
+(defn detail-tree
+  "The L4-RIGHT pane's hiccup, read the way `definition-detail/detail`
+  reads it — including the two selected-id-parameterised reads and the
+  `:sim`-only sim family. `as-child` is `identity` here: the node lane
+  wants the Topology / Sim bodies left as fn-headed hiccup."
+  ([] (detail-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (let [{:keys [selected-id] :as data}
+         @(rf/subscribe [:rf.xray.static.machines/data])
+         sub-mode @(rf/subscribe [:rf.xray.static.machines/sub-mode
+                                  selected-id])]
+     (definition-detail/detail-tree
+       {:data        data
+        :definitions @(rf/subscribe [:rf.xray/machine-definitions])
+        :sub-mode    sub-mode
+        :fit-signal  @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
+        :copy-status @(rf/subscribe
+                        [:rf.xray.static.machines/copy-mermaid-status
+                         selected-id])
+        :sim-values  (when (= sub-mode :sim)
+                       {:sim         @(rf/subscribe
+                                        [:rf.xray.static.machines/sim-state])
+                        :transitions @(rf/subscribe
+                                        [:rf.xray.static.machines/sim-available-transitions])
+                        :suggestions @(rf/subscribe
+                                        [:rf.xray.static.machines/sim-event-suggestions])
+                        :current     @(rf/subscribe
+                                        [:rf.xray.static.machines/sim-current-state])
+                        :last-trans  @(rf/subscribe
+                                        [:rf.xray.static.machines/sim-last-transition])})}
+       dispatch
+       identity))))
+
+(defn panel-tree
+  "The WHOLE sub-tab's hiccup — the shipped two-pane chrome from
+  `panel/panel-tree` with both panes' bodies expanded into it. This is
+  what `(panel/panel)` used to answer, and it is the drop-in every
+  migrated node-lane row takes."
+  ([] (panel-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (panel/panel-tree (browse-list-tree dispatch)
+                     (detail-tree dispatch))))


### PR DESCRIPTION
Step 2 of the rf2-k97c fan-out: the Static Machines sub-tab is re-authored in the re-frame-native view layer. Three `rf/reg-view`s become three `rf.fresco/defview` boundaries, reading through Fresco's shipped collector rather than through whatever view build the installed substrate adapter supplies. **The bead is NOT closed** — this is one slice of a long-running owner.

Branch rebased onto `f7d6c8e37a`. Six files under `tools/xray/{src,test}/…/static/machines/`, one new shared test helper, and three lines in one neighbouring test file, flagged under FENCES below.

## Three boundaries, not one, and the count IS the reactive granularity

`panel/panel`, `browse-list/browse-list` and `definition-detail/detail` each become a boundary. That is what the three reg-views already were: hoisting both panes' reads into one boundary would re-render the Topology chart on every search keystroke. `panel` reads nothing at all — it is pure two-pane chrome — and heads the two pane boundaries directly, which is the one hiccup head shape legal inside a Fresco body. **W2b is the row that makes the count mean something** rather than being a fact about file layout: it moves the right pane off `sub-mode`, a read only that pane performs, and asserts the panel chrome and the left pane are the IDENTICAL DOM nodes afterwards.

**The boundary keeps the natural name in each file, and for `panel` that is normative rather than preferred.** The name is LOWERCASE `panel`, and both `spec/api-manifest.edn` and its curated `spec/api-manifest-metadata.edn` sidecar row `day8.re-frame2-xray.static.machines.panel/panel` with `:runtime-verified? true` — the sidecar even carrying a comment naming this as the one panel namespace exporting a lowercase name, against `tools/xray/spec/API.md` §Static-mode Panel reg-views. Both files are hot zone. Keeping the name on the boundary is what leaves them untouched: `api-manifest gen --check` exit 0, in sync, 471 public vars, no file rewritten; `xray-spec-check` exit 0, 38 references checked.

The L4 tab registry's `:pre` requires a CALLABLE `:panel`, so a private `panel-bridge` crosses `rf.fresco/as-component`. Scaffolding with a defined end; it goes when the Static shell is itself a Fresco tree. `panels.cljs` names no Static sub-tab, so no caller line moves.

## Two shapes no earlier slice in this fan-out met

**1. THE TOPOLOGY AND SIM BODIES STAY REAGENT ISLANDS.** `topology/body` bottoms out in `machine-canvas/Chart`, an `rf/reg-view` — and a `reg-view` head grades `:invalid` under Fresco down the same arm as a plain `defn`, because `codec/boundary-head?` reads one own property (`frescoBoundary`) that only `defview` sets. So neither usual repair applies: heading it throws, and CALLING it only moves the problem one level down into `topology.cljs`'s own fn heads. `detail-tree` takes an `:as-child` fn — `identity` for a hiccup caller and the node lane, `reagent.core/as-element` for the boundary — and the whole Reagent subtree crosses as one React element, which Fresco's ABI accepts as a legal child anywhere. This is the door `panels/machine_after_rings.cljs` already documents, reached from the other side.

**W6 MEASURES that crossing rather than asserting it**: three nodes that exist only if Reagent expanded fn HEADS the codec would refuse (`[chart-toolbar …]`, `[popout-affordance …]`, `[chart …]`), plus `rf-xray-machine-canvas-host`, which exists only if the `reg-view` inside the island rendered and resolved its frame from the same React context the boundary read.

**2. THE NODE LANE GETS ONE SHARED COMPOSER.** Four suites drove `(panel/panel)`, which a boundary can no longer answer. Each file now exports a pure `*-tree` fn, and `test-helpers.static-machines-tree` reproduces the boundaries' reads ONCE — same subs, same order, the two `selected-id`-parameterised reads still sequenced, the `:sim` family still conditional. Four private copies would be four things to keep in step with one boundary, and the failure mode when one drifts is a row that stays green while measuring a tree the panel does not render.

## The key sweep (RULING 2): TWO sites, both repaired, reported with a live control

`^{:key ...}` reader metadata on a vector literal, at both of `browse_list.cljs`'s seqs. Key EXPRESSIONS unchanged, per the ruling.

| site | was | now |
|---|---|---|
| per-row seq | reader meta on a vector literal | keyed fragment, `:key (str machine-id)` |
| pip seq | reader meta on a vector literal | `:key i` in the span's attribute map |

No `with-meta` key site and no call-form key site in any of the three files. Control taken with the same instrument over `tools/xray/src` **and re-measured here rather than relayed** — the sibling slices' figures were 59/26 and 27/14, and trunk has moved since: **60 hits / 26 files for `^{:key`, 26 hits / 14 files for `with-meta`**. So the instrument is known to bite and these zeros read as absence.

**The `^{:key` count over `browse_list.cljs` itself reads 2, and BOTH ARE PROSE** — comment lines quoting the retired spelling to explain the repair. That is instrument item (g) in miniature: a census that treats prose as the evidence is contaminated in both directions, so the two hits were read before being counted rather than after. Live `^{:key` sites in the three files: **zero**.

**The pip site gets no W5-style reorder row, and the reason is #9622's finding met again.** Its key expression is `i`, POSITIONAL, so removing a pip shifts the survivor's key and React correctly reuses the removed node — a positional key and no key at all are indistinguishable under exactly the operation a reorder-identity row performs. Its evidence stays in the node lane, where the claim (the key is in the codec-readable place) is real. The row key is `(str machine-id)`, domain-shaped, so W5 works for it.

**The node-lane key row does not assert with `(meta ...)`.** That reads nil at a REPAIRED site too, because the key now lives in the attribute map — hollow in both directions, green on broken code and red on fixed code.

## HD-016 census — every symbol-headed hiccup vector in the three files

**Run over the WHOLE FILE rather than line by line, and that is not a detail: the line-oriented first pass MISSED `[search-box/search-box` because the head ENDS ITS LINE**, and that missing repair is what made the first browser run throw inside `browse-list` and unmount the whole root — HD-016's documented symptom, met live. It is the same class the bead notes already record ("A LINE-ORIENTED GREP MISSED A REAL SITE TWICE OVER"), reached through a Python scanner instead of a grep.

Live control on two files still carrying Reagent heads: `topology.cljs` reads **4** (including `[machine-canvas/Chart`, itself an end-of-line head) and `static/routes/panel.cljs` reads **2**.

After the repairs the three files carry exactly THREE non-docstring symbol-headed vectors, all intended:

* `(as-child [topology/body …])` and `(as-child [sim/body …])` — the two Reagent islands
* `(panel-tree [browse-list/browse-list] [definition-detail/detail])` — a boundary heading boundaries, legal

Everything else is CALLED: `search-box`, `search-box/search-box`, `sort-button`, `row`, `source-coord-chip`, `state-count-chip`, `pip-cluster`, `runtime-jump-chip`, `empty-state`, `no-results-state`, `copy-mermaid-button`, `header`, `sub-strip`, `body`, `topology-pill`, `sim/pill`, `instances-jump/pill`, `cascade-dimmed/pill`, `empty-detail`, `open-in-editor/open-chip`. Every one of them answers hiccup, which is what makes the call repair available; the two that do not are the two islands.

## Three shell-walk rows re-authored one level up

The walk now stops at the bridge's `[:>]` head, so `rf-xray-static-machines-panel` is committed by React rather than present in the tree. Asserting the testid through the walk would from now on be asserting the WALKER'S REACH — the hollow-gate shape. Each row now asserts the L4 slot mounts EXACTLY the registry's `:panel` value, and first paint moves to W1. The multi-frame e2e keeps its subject — the real `rf/reg-machine` ingress — and drives the composer instead of the shell walk.

## Two things measured rather than assumed, both recorded where the next reader meets them

**A COLD START IS A PROPERTY OF THE PAGE, NOT OF A ROW.** `:rf.xray/registered-machines` computes from the PROCESS-GLOBAL registrar, so this file's first run found another suite's `:auth.login/flow` on screen where it expected an empty list. Rows asserting an ABSENCE now pin the list through the override seam; W2 deliberately does NOT, and asserts about one named probe instead, because its lever is a real registration the override would shadow.

**W3's ZERO IS SCOPED, AND THE ROW SAYS SO.** A Fresco boundary emits no view trace — that is criterion 5, and it holds. The whole rendered sub-tree is NOT trace-silent, because the Reagent island contains a `reg-view` and a `reg-view` emits view trace wherever it renders: W3's first run read `[:rf.view/render :rf.view/rendered]` from exactly that. It now pins the list empty so no island renders, and ASSERTS that absence, so the zero cannot quietly become a zero about a tree that was not there for another reason. The island's emission is a known consequence of the migration scaffolding and goes with the `as-child` seam.

## Captured exit codes — each read from that run's own file, never a pipeline, never the harness

All re-run on the FINAL rebased base `f7d6c8e37a`.

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` (node) | 0 | 11610 tests / 58175 assertions, 0 failures |
| `npm run test:browser` | 0 | 920 tests / 5070 assertions, 0 failures |
| `clojure -M:test` in `tools/xray` | 0 | 1276 tests / 6118 assertions, 0 failures |
| `lint_kondo.py` (CI's pinned binary + flags) | 0 | errors 0; **no NEW finding on any changed file** — see below |
| `clojure -M:splint --fail-on-errors` | 0 | 2602 files, 0 parsing errors, no finding on a changed file |
| `check_require_alias_dialect.py --verbose` | 0 | 2842 files, 11189 edges, 0 non-canonical |
| `check_flattened_lists.py` | 0 | 291 files, 0 flattened lists |
| `api-manifest gen --check` | 0 | in sync, 471 public vars, no file rewritten |
| `api-manifest xray-spec-check` | 0 | in sync, 38 references |
| `check-commit-attribution.sh` (commits) | 0 | 2 commits from `f7d6c8e37a` |

The alias gate's counts MOVED with the edits (2840/11179 on #9622, 2842/11189 here), which is a witness it read THIS worktree rather than a cached surface.

**THE KONDO ROW SAYS "no NEW finding" RATHER THAN "no finding", AND THAT IS A CORRECTION TO MY OWN FIRST READING.** My first pass grepped the kondo log with a regex that matched nothing and I read the zero as clean — the reassuring-zero shape this repo's instrument notes warn about. Re-checked per file against a live control (`gallery_diff_mode_3.cljs`, a file kondo does report on, reads 1), five of the ten changed files carry warnings. **Every one of them PRE-DATES this branch**, verified at source against `origin/main` rather than inferred:

* `browse_list.cljs` — `open-in-editor` required but never used (0 uses of `open-in-editor/` in BOTH the old and new file) and `unused binding r` in `row`'s arglist (the `:as r` destructuring is present in both)
* `browse_list_cljs_test.cljs` — `re-frame.frame` and `static.machines.helpers` required but never used (0 uses of `rf.frame/` and `h/` in both), and `seed-definitions!` an unused private var (defined once, called never, in both)
* `panel_cljs_test.cljs` and `static/shell_cljs_test.cljs` — `re-frame.frame` required but never used, the same warning four other `static/*/panel_cljs_test.cljs` files already carry

`definition_detail.cljs`, `static/machines/panel.cljs`, `copy_mermaid_cljs_test.cljs`, the multi-frame e2e and BOTH new files carry **zero** kondo findings. Errors 0 throughout, which is the level the gate fails on. The pre-existing warnings are left alone: cleaning them is not this slice's business and would widen the diff for no behavioural reason.

## Sabotage — two plants, three lanes bit, and the totals held

Real work committed FIRST, both times.

**PLANT 1 — the `:key` deleted from BOTH sites, keeping the fragment and the attribute map so only the SIGNAL was removed.**

* **Node lane** EXIT 1, exactly **3** failures, all in `row-and-pip-keys-ride-the-attribute-map-not-metadata`, and nothing else. **Totals 11605 / 58150 — IDENTICAL to the green run**, so the plant crashed no namespace and these are assertion failures rather than load errors.
* **Browser lane** EXIT 1, exactly **1** failure: `w5-row-identity-survives-a-head-removal`. Every PRECONDITION in that row still passed — both rows on screen, exactly two of them, the removed row proven to PRECEDE the survivor — only the identity assertion moved. **Totals 920 / 5070, identical to green.**

**PLANT 2 — `r/as-element` changed to `identity` in the `detail` boundary, i.e. the island reaches the codec as a fn-headed hiccup vector.** One token.

* **Browser lane** EXIT 1, **14** failures: W6 (5), W5 (4), W2 (2), W2b (2), W4 (1). **Test count 920 UNCHANGED** — no namespace failed to load — while the assertion count read 5065 against 5070, which is the runtime consequence of assertions sitting after a timed-out poll inside a `.then`.
* **The blast radius IS the finding, and it is HD-016 measured rather than quoted:** the throw escapes with no error boundary above it and takes the whole root down, so every row that renders a SELECTED machine died — not just W6. **W1 and W3 stayed GREEN**, and that is a confirmation rather than a gap: both pin the machine list empty, so no machine is selected, so no island renders — exactly what their docstrings claim their fixtures do.

**Both restores verified BY GIT BLOB HASH, identical before and after**, using the form the INDEX side of `git ls-files --eol` calls for (`i/lf` on both files, so the DEFAULT filtered form is the one that matches): `browse_list.cljs` `69822221190f79dce973d49a50edfa248b678596`, `definition_detail.cljs` `d8516bcf527d8ac18bb4a6f4b2698079fe88a98e`. `git diff --quiet HEAD -- <path>` exit 0 as a second independent instrument. Both lanes re-run green afterwards at the identical totals.

## One flake seen once, not mine, reported rather than swept

The FIRST browser run of the session carried one unrelated failure — `an-ordinary-dispatch-under-a-hosted-view-transition-animates-nothing`, in `re-frame.fresco`'s view-transition suite, a file this branch does not touch. It did not recur in the five subsequent browser runs, green and sabotaged.

## Fences held

`panels.cljs` (not one line, `render-panel!` included), `shell.cljs`, `static/shell.cljs`, `mount.cljs`, `panel_enum.cljc`, every existing `*-bridge`, and this sub-tab's neighbours `topology.cljs`, `sim.cljs`, `instances_jump.cljs`, `cascade_dimmed.cljs`, `helpers.cljc`, `persistence.cljs` — all untouched. The element-shaped-adapter denylist untouched (rf2-k97c.4 stays fenced). No hot-zone file; `spec/API.md` and both `spec/api-manifest*.edn` untouched. No `.beads` path on the branch. Nothing under `implementation/` requires anything under `tools/`. The worktree carries a REAL `npm ci` install rather than a junction — canary 103 immediate entries / 27 in `.bin`, counted with `ls -A` — so no link had to be removed and no recursive delete could reach the mayor's tree.

**ONE FILE OUTSIDE THE SLICE'S THREE FAMILIES WAS TOUCHED, AND IS FLAGGED RATHER THAN SWEPT.** `tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs`, three lines: its `static-machines-mounts-live-panel` row walks the Static shell into this panel and cannot reach past the bridge. It is a TEST file, not one of the fenced SOURCES, and the Static shell has no other live slice; the change is the same one-level-up re-authoring described above. Reported here so a coordinator can rule on it rather than discover it.

No AI-attribution trailers in either commit or in this body, per CLAUDE.md's Git Conventions over the session-level instruction that says the opposite.
