### PR TITLE
docs(method): move the escaped continuation blocks back into their list items (rf2-fwlj)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -41,96 +41,96 @@ word block file, against workers that finished comparable items in a third of th
 four hundred.
 
 1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by
-   position, and not by dates written in the prose. The full mechanics are spelled out
-   for the worker under *Common preamble* below: the description is usually the oldest
-   text but the bottom is not reliably the newest either, a date in the prose is content
-   rather than a mutation time, the plain history listing names no changed field, you
-   walk adjacent snapshot pairs newest-first to the first text-bearing change, and you
-   re-enumerate a bead's children before concluding a decision is absent. Every one of
-   those binds the mayor writing the brief exactly as it binds the worker reading it.
+    position, and not by dates written in the prose. The full mechanics are spelled out
+    for the worker under *Common preamble* below: the description is usually the oldest
+    text but the bottom is not reliably the newest either, a date in the prose is content
+    rather than a mutation time, the plain history listing names no changed field, you
+    walk adjacent snapshot pairs newest-first to the first text-bearing change, and you
+    re-enumerate a bead's children before concluding a decision is absent. Every one of
+    those binds the mayor writing the brief exactly as it binds the worker reading it.
 
-   **And one cheap query tells you which items are most likely to punish skipping the walk:
-   has this item ever been CLOSED and reopened?** The rule above is unconditional, which is
-   why it gets skipped — an unconditional instruction competes with every other unconditional
-   instruction. A closed-to-open transition is the strongest cheap signal there is that the
-   description is no longer the live instruction: it was written about the defect as originally
-   found, and something later disagreed enough to reopen the item. Nothing about the rendered
-   item says so — the description still reads as a current bug report, because it once was one.
-   Measured across one session: three briefs written from descriptions whose work had already
-   merged, and **all three items showed a closed-to-open transition in their status history
-   while the control, never closed, showed none**. Ask the tracker for the item's status over
-   time rather than its status now.
+    **And one cheap query tells you which items are most likely to punish skipping the walk:
+    has this item ever been CLOSED and reopened?** The rule above is unconditional, which is
+    why it gets skipped — an unconditional instruction competes with every other unconditional
+    instruction. A closed-to-open transition is the strongest cheap signal there is that the
+    description is no longer the live instruction: it was written about the defect as originally
+    found, and something later disagreed enough to reopen the item. Nothing about the rendered
+    item says so — the description still reads as a current bug report, because it once was one.
+    Measured across one session: three briefs written from descriptions whose work had already
+    merged, and **all three items showed a closed-to-open transition in their status history
+    while the control, never closed, showed none**. Ask the tracker for the item's status over
+    time rather than its status now.
 
-   **It is a signal to do the walk, though, not a substitute for it, and the two ways of
-   over-reading it are worth naming because both are natural.** *Closed* does not mean
-   *shipped* — a project whose items close when a change is opened for review will have closed
-   items whose work is still unmerged, so "the closing work has landed" is an inference about
-   this project's conventions rather than a fact about the transition. And a reopening does not
-   always supersede: an item reopened because the same defect REGRESSED has a description that is
-   accurate, and treating it as stale sends the worker looking for a newer instruction that does
-   not exist. **What decides currency is the history and the tree**, which is what the rule above
-   already says; the query tells you where that reading is most likely to change your brief.
+    **It is a signal to do the walk, though, not a substitute for it, and the two ways of
+    over-reading it are worth naming because both are natural.** *Closed* does not mean
+    *shipped* — a project whose items close when a change is opened for review will have closed
+    items whose work is still unmerged, so "the closing work has landed" is an inference about
+    this project's conventions rather than a fact about the transition. And a reopening does not
+    always supersede: an item reopened because the same defect REGRESSED has a description that is
+    accurate, and treating it as stale sends the worker looking for a newer instruction that does
+    not exist. **What decides currency is the history and the tree**, which is what the rule above
+    already says; the query tells you where that reading is most likely to change your brief.
 
-   **The three consequences differ, and only the first is obvious.** The dispatch may re-do
-   finished work; it may point a worker at a defect that no longer exists, whose deliverable is
-   then a refutation; or — the expensive one — it may describe a *smaller* problem than the one
-   the reopening found, so the worker fixes what you asked and the real defect survives with an
-   item now closed over it. The worker's own history walk catches all three, which is why this
-   costs a dispatch rather than a defect. **Do not let that safety net become the plan**: it
-   spends a worker's context re-deriving what one query answers, and the mayor learns nothing,
-   because a brief refuted politely reads much like a brief fulfilled.
+    **The three consequences differ, and only the first is obvious.** The dispatch may re-do
+    finished work; it may point a worker at a defect that no longer exists, whose deliverable is
+    then a refutation; or — the expensive one — it may describe a *smaller* problem than the one
+    the reopening found, so the worker fixes what you asked and the real defect survives with an
+    item now closed over it. The worker's own history walk catches all three, which is why this
+    costs a dispatch rather than a defect. **Do not let that safety net become the plan**: it
+    spends a worker's context re-deriving what one query answers, and the mayor learns nothing,
+    because a brief refuted politely reads much like a brief fulfilled.
 
-   **Do that read before the brief exists, and read it for two things: a HOLD, and SEQUENCING.** It is
-   a step rather than another note because the knowledge is already written down and already travelling —
-   the common preamble below orders the worker to read by tracker timestamps, at length and with the
-   reasoning, and the mayor pastes that into every dispatch and then does not do it. A hold is the newest
-   field often enough that the description cannot be trusted to mention it, so an item reads as an
-   ordinary defect report while the live instruction is *wait*. Sequencing is the mirror case and the
-   easier one to miss, because the brief's instinct is right by default: a triage note naming the
-   predecessors that had to land first is an **authorisation with a precondition**, so restating a
-   generic fence over it converts a satisfied precondition back into a blocker — which either strands
-   the work or, as measured here, costs the worker a justification round it should not have had to
-   write. Both shapes went out in real briefs, and the worker caught both.
+    **Do that read before the brief exists, and read it for two things: a HOLD, and SEQUENCING.** It is
+    a step rather than another note because the knowledge is already written down and already travelling —
+    the common preamble below orders the worker to read by tracker timestamps, at length and with the
+    reasoning, and the mayor pastes that into every dispatch and then does not do it. A hold is the newest
+    field often enough that the description cannot be trusted to mention it, so an item reads as an
+    ordinary defect report while the live instruction is *wait*. Sequencing is the mirror case and the
+    easier one to miss, because the brief's instinct is right by default: a triage note naming the
+    predecessors that had to land first is an **authorisation with a precondition**, so restating a
+    generic fence over it converts a satisfied precondition back into a blocker — which either strands
+    the work or, as measured here, costs the worker a justification round it should not have had to
+    write. Both shapes went out in real briefs, and the worker caught both.
 
-   **Read the INVERSE with more care than either, because it is the one that fails open.** A note
-   lifting a fence names *the fence it lifts*, not the item — so an item can carry a second sequencing
-   the lift says nothing about, and its newest layer then reads *released* while a live precondition
-   sits underneath. The two above merely re-block work that was already clear; this one dispatches into
-   a surface somebody else holds, or into one gated by a decision nobody has made. Measured: an item
-   whose fence had been lifted on the holder's own explicit words still sat behind an older note
-   sequencing it behind an unruled operator call — and the *other* half of that same older note had
-   genuinely cleared, which is exactly what made the whole of it look discharged. **Where the tracker
-   can express a precondition, encode it there rather than leaving it in prose**: a fence that exists
-   only in a note is re-derived every pass, and a fence re-derived every pass is eventually missed.
+    **Read the INVERSE with more care than either, because it is the one that fails open.** A note
+    lifting a fence names *the fence it lifts*, not the item — so an item can carry a second sequencing
+    the lift says nothing about, and its newest layer then reads *released* while a live precondition
+    sits underneath. The two above merely re-block work that was already clear; this one dispatches into
+    a surface somebody else holds, or into one gated by a decision nobody has made. Measured: an item
+    whose fence had been lifted on the holder's own explicit words still sat behind an older note
+    sequencing it behind an unruled operator call — and the *other* half of that same older note had
+    genuinely cleared, which is exactly what made the whole of it look discharged. **Where the tracker
+    can express a precondition, encode it there rather than leaving it in prose**: a fence that exists
+    only in a note is re-derived every pass, and a fence re-derived every pass is eventually missed.
 
-   **And where you sweep a whole board for hold markers, that sweep is a candidate filter and never a
-   verdict.** It narrows the open items to a handful; the hold is then established by READING each
-   candidate, which is affordable at that size and is the only thing that separates a live banner from
-   one quoted, discussed, or already struck. Write the question the sweep answers beside the question you
-   are asking — *does this text contain these characters* against *is this item currently held* — because
-   the gap is invisible in the answer. Measured: a sweep reported eleven of twenty-seven open items held
-   and the number reached the operator before anyone read a candidate; the first two falsified were an
-   item quoting another item's banner and an item whose own text said its banner was struck. Why the
-   sweep fails in both directions, why a second sweep built to tell live from struck fails the same way,
-   and the structured field that is the durable answer where a project wants this machine-checkable, are
-   under *Tracker mechanics* in [`loops.md`](loops.md#tracker-mechanics) — this step is the concrete
-   instance and does not restate them.
+    **And where you sweep a whole board for hold markers, that sweep is a candidate filter and never a
+    verdict.** It narrows the open items to a handful; the hold is then established by READING each
+    candidate, which is affordable at that size and is the only thing that separates a live banner from
+    one quoted, discussed, or already struck. Write the question the sweep answers beside the question you
+    are asking — *does this text contain these characters* against *is this item currently held* — because
+    the gap is invisible in the answer. Measured: a sweep reported eleven of twenty-seven open items held
+    and the number reached the operator before anyone read a candidate; the first two falsified were an
+    item quoting another item's banner and an item whose own text said its banner was struck. Why the
+    sweep fails in both directions, why a second sweep built to tell live from struck fails the same way,
+    and the structured field that is the durable answer where a project wants this machine-checkable, are
+    under *Tracker mechanics* in [`loops.md`](loops.md#tracker-mechanics) — this step is the concrete
+    instance and does not restate them.
 2. **Check every factual claim you are about to write.** Does the symbol resolve?
-   Does the file say what you think? Is the count still true? Is the ruling you cite
-   *ruled*, or only recommended? A recommendation and a decision read identically in
-   a summary and are opposite in force.
-   **Then one question of a different kind: is this work still OUTSTANDING?** The four
-   above ask whether a claim is TRUE. A note saying "X is all that remains" was true when
-   it was written and says nothing about now, so checking it at source confirms the wrong
-   thing. Check the TREE. The sentence that says so is addressed to you and sits in the
-   common preamble below — inside the block you extract and paste without reading, because
-   its audience looks like the worker. A dispatch went out for work that had merged the
-   previous day, and the worker's deliverable was refuting the premise.
+    Does the file say what you think? Is the count still true? Is the ruling you cite
+    *ruled*, or only recommended? A recommendation and a decision read identically in
+    a summary and are opposite in force.
+    **Then one question of a different kind: is this work still OUTSTANDING?** The four
+    above ask whether a claim is TRUE. A note saying "X is all that remains" was true when
+    it was written and says nothing about now, so checking it at source confirms the wrong
+    thing. Check the TREE. The sentence that says so is addressed to you and sits in the
+    common preamble below — inside the block you extract and paste without reading, because
+    its audience looks like the worker. A dispatch went out for work that had merged the
+    previous day, and the worker's deliverable was refuting the premise.
 3. **Establish the fence by asking who is live, not what is open.** A listing of open
-   changes misses a worker that has not pushed yet. **And ask what each nominated gate
-   COMPARES, here, not at dispatch** — a fence derived from files alone misses a gate that
-   couples two surfaces (see *Fences*), and one mayor struck an item's fence and dispatched
-   before asking, then re-fenced it five minutes later on exactly that ground.
+    changes misses a worker that has not pushed yet. **And ask what each nominated gate
+    COMPARES, here, not at dispatch** — a fence derived from files alone misses a gate that
+    couples two surfaces (see *Fences*), and one mayor struck an item's fence and dispatched
+    before asking, then re-fenced it five minutes later on exactly that ground.
 4. **Name the discriminator**, if the task is "find every X".
 5. **Then** assemble the standard blocks.
 

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -375,25 +375,25 @@ familiar fix:
   first, *then* clear, *then* retry. Clearing before checkpointing reverts whatever the
   tracker just recorded.
 * **"Not possible to fast-forward"** — genuine divergence, usually your own checkpoint
-  against commits that landed while you made it. Rebase, then **push**: the rebase
-  replays your commit on top and leaves you ahead by one, and the equality check cannot
-  pass until it lands. **That intermediate state is expected, not a second failure.**
-  Both obvious reflexes are wrong — repeating the pull stays ahead, and forcing equality
-  discards the very checkpoint the drill exists to protect.
+    against commits that landed while you made it. Rebase, then **push**: the rebase
+    replays your commit on top and leaves you ahead by one, and the equality check cannot
+    pass until it lands. **That intermediate state is expected, not a second failure.**
+    Both obvious reflexes are wrong — repeating the pull stays ahead, and forcing equality
+    discards the very checkpoint the drill exists to protect.
 
-  **Rebase onto the remote-tracking REF, not with a pull.** *Rebase* names an outcome, and
-  the command that first comes to hand for it is a pull carrying a rebase flag — which reads
-  the same shared scratch file this drill just retired for the fast-forward. The argument two
-  paragraphs up applies here unchanged and is easy to miss, because it was made about the
-  step rather than about the remedy for that step's own failure: retiring the reading command
-  in one place and readmitting it in the next is no protection at all. Measured under a
-  saturated fleet: with remote and branch both named, the pull form aborted a second time
-  wearing the contamination message — peers adding worktrees had left several refs in that
-  file — while rebasing onto the ref succeeded immediately on the same tree. **A remedy
-  inherits the hazards of whatever it reads**, so choose it by what it reads, not by what it
-  is called.
+    **Rebase onto the remote-tracking REF, not with a pull.** *Rebase* names an outcome, and
+    the command that first comes to hand for it is a pull carrying a rebase flag — which reads
+    the same shared scratch file this drill just retired for the fast-forward. The argument two
+    paragraphs up applies here unchanged and is easy to miss, because it was made about the
+    step rather than about the remedy for that step's own failure: retiring the reading command
+    in one place and readmitting it in the next is no protection at all. Measured under a
+    saturated fleet: with remote and branch both named, the pull form aborted a second time
+    wearing the contamination message — peers adding worktrees had left several refs in that
+    file — while rebasing onto the ref succeeded immediately on the same tree. **A remedy
+    inherits the hazards of whatever it reads**, so choose it by what it reads, not by what it
+    is called.
 * **A truncated abort, or a ref-level race** — re-fetch and re-read. Do not reach for
-  any remedy above.
+    any remedy above.
 
 **Never wire a remedy behind a pipe.** `pull … | tail -1 || fallback` never runs the
 fallback, because the pipeline's status is the filter's and the filter succeeded.
@@ -989,188 +989,188 @@ in-progress, read it too — a real signal, never the complete one.
 and both readings went wrong in a single day here, in opposite directions.
 
 1. **Has the *tip revision* on that item's branch changed since the last tick?** Record the revision
-   id, never a count of changes: **an *ahead* count survives a rebase unchanged**, and rebasing onto a
-   moved trunk is what a briefed worker does constantly, so a count fails on the common case. A
-   healthy worker here was called unchanged across two ticks, having rebased two minutes before the
-   second read with all its work committed.
+    id, never a count of changes: **an *ahead* count survives a rebase unchanged**, and rebasing onto a
+    moved trunk is what a briefed worker does constantly, so a count fails on the common case. A
+    healthy worker here was called unchanged across two ticks, having rebased two minutes before the
+    second read with all its work committed.
 
-   **Read the tip from whichever ref the worker's commit updates DIRECTLY, and prefer a read that
-   performs no refresh** — a refresh exposes the shared fetch-head trap under *After each merge*,
-   which is on this path too and is silent here. Where workers share one repository metadata
-   directory, the local ref moves the moment a worker commits while the *published* ref moves only
-   when that worker pushes: the published one lags, in the direction that reads as death.
+    **Read the tip from whichever ref the worker's commit updates DIRECTLY, and prefer a read that
+    performs no refresh** — a refresh exposes the shared fetch-head trap under *After each merge*,
+    which is on this path too and is silent here. Where workers share one repository metadata
+    directory, the local ref moves the moment a worker commits while the *published* ref moves only
+    when that worker pushes: the published one lags, in the direction that reads as death.
 
-   **An unchanged tip says nothing on its own** — a worker inside a long gate commits nothing by
-   design, so a still tip is the *expected* reading for the commonest healthy state. Corroborate with
-   worktree activity, and note that **the corroboration is a WRITE clock, so a worker that is only
-   READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
-   on twenty-three minutes of no writes. **So look for a signal OUTSIDE the worktree too — where your
-   tracker records that a worker claimed its item, only a running agent could have done that, and it
-   lands in the tracker rather than the tree, where no file-activity clock can ever see it.** That is
-   the one positive signal a purely reading worker still produces, and the opening minutes of every
-   dispatch are exactly when you need it, because the first thing every brief tells a worker to do is
-   read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
-   the worktrees in the first place.
+    **An unchanged tip says nothing on its own** — a worker inside a long gate commits nothing by
+    design, so a still tip is the *expected* reading for the commonest healthy state. Corroborate with
+    worktree activity, and note that **the corroboration is a WRITE clock, so a worker that is only
+    READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
+    on twenty-three minutes of no writes. **So look for a signal OUTSIDE the worktree too — where your
+    tracker records that a worker claimed its item, only a running agent could have done that, and it
+    lands in the tracker rather than the tree, where no file-activity clock can ever see it.** That is
+    the one positive signal a purely reading worker still produces, and the opening minutes of every
+    dispatch are exactly when you need it, because the first thing every brief tells a worker to do is
+    read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
+    the worktrees in the first place.
 
-   **And if your tooling maintains a live status for a running agent, read THAT before any of these.**
-   Every signal in this step is indirect — it infers a worker from the traces it leaves — and they
-   share a blind spot wide enough to matter: a worker in its **final minutes**, running a last gate and
-   then tidying scratch files and shared-dependency links, works outside the worktree and outside
-   version control and is too busy to answer. Tip, fetch clock, write clock and a direct message then
-   read as dead *together*, for one cause, which is why corroborating one with another does not help
-   here. **So frozen on every clock, across any number of readings, is AMBIGUOUS — it is exactly what
-   healthy foreground work looks like, and exactly what a stopped worker looks like.** It cannot
-   identify either, and no amount of re-reading the same four clocks converts it into evidence; a
-   freeze that has run an hour is still the same non-signal it was in the first minute. Measured twice
-   in one day: five workers were called dormant and **three of them completed alive, two were never
-   explained either way**; a sixth, recorded later as another instance, also completed. **Do not count
-   a live control among them** — one moving worker was the control for that measurement, and folding
-   it into the numerator is how this count was first written down wrong. On the second occasion the
-   supervisor's own one-line progress string named the phase outright while the four clocks said
-   otherwise. Where no direct
-   status exists, declare a window and re-read rather than acting: not because waiting resolves the
-   ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
-   costs a duplicate worker in a live worktree.
+    **And if your tooling maintains a live status for a running agent, read THAT before any of these.**
+    Every signal in this step is indirect — it infers a worker from the traces it leaves — and they
+    share a blind spot wide enough to matter: a worker in its **final minutes**, running a last gate and
+    then tidying scratch files and shared-dependency links, works outside the worktree and outside
+    version control and is too busy to answer. Tip, fetch clock, write clock and a direct message then
+    read as dead *together*, for one cause, which is why corroborating one with another does not help
+    here. **So frozen on every clock, across any number of readings, is AMBIGUOUS — it is exactly what
+    healthy foreground work looks like, and exactly what a stopped worker looks like.** It cannot
+    identify either, and no amount of re-reading the same four clocks converts it into evidence; a
+    freeze that has run an hour is still the same non-signal it was in the first minute. Measured twice
+    in one day: five workers were called dormant and **three of them completed alive, two were never
+    explained either way**; a sixth, recorded later as another instance, also completed. **Do not count
+    a live control among them** — one moving worker was the control for that measurement, and folding
+    it into the numerator is how this count was first written down wrong. On the second occasion the
+    supervisor's own one-line progress string named the phase outright while the four clocks said
+    otherwise. Where no direct
+    status exists, declare a window and re-read rather than acting: not because waiting resolves the
+    ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
+    costs a duplicate worker in a live worktree.
 
-   **Say what the window is FOR, though, because a rule that only forbids leaves the interval empty
-   and a coordinator fills an empty interval with more measurement.** The re-read catches exactly one
-   thing — movement, which is proof of life and needs no corroboration — so read it twice, record the
-   freeze, and go do something else; the tenth reading answers what the second did. And carry a sense
-   of the scale, because that is what makes the non-signal bearable rather than ominous: **a freeze
-   measured in hours is unremarkable on a heavyweight gate.** Measured across one session — six
-   readings over ninety minutes, every one identical, while five workers whose transcripts had not
-   gained a byte were all alive and all completed normally, at durations from an hour and forty
-   minutes to nearly three hours. The coordinator who knows that stops after the second reading; the
-   one who does not keeps going, because silence that long feels like it has to mean something.
+    **Say what the window is FOR, though, because a rule that only forbids leaves the interval empty
+    and a coordinator fills an empty interval with more measurement.** The re-read catches exactly one
+    thing — movement, which is proof of life and needs no corroboration — so read it twice, record the
+    freeze, and go do something else; the tenth reading answers what the second did. And carry a sense
+    of the scale, because that is what makes the non-signal bearable rather than ominous: **a freeze
+    measured in hours is unremarkable on a heavyweight gate.** Measured across one session — six
+    readings over ninety minutes, every one identical, while five workers whose transcripts had not
+    gained a byte were all alive and all completed normally, at durations from an hour and forty
+    minutes to nearly three hours. The coordinator who knows that stops after the second reading; the
+    one who does not keeps going, because silence that long feels like it has to mean something.
 
-   **That clock says "no activity" in four voices and you can only tell them apart with a control.**
-   Besides the reading worker and the poller treated just below, a path that resolves to nothing
-   answers identically — and so does a span shorter than the worktree's own age, where every file is
-   recent and the count is the checkout rather than the worker. That last one is the counter-intuitive
-   half, because it returns a large number that reads as proof of life: measured once at *the same
-   count* over fifteen minutes and over six hours. **And the age itself is the worktree's CREATION
-   time, not its last-modification time**, which the very writes you are trying to detect keep
-   bumping: the wrong clock reads right on an idle tree, where the age does not matter, and seconds
-   old on a live one, where the age is the whole question. Run the clock twice at different spans
-   before believing either reading.
+    **That clock says "no activity" in four voices and you can only tell them apart with a control.**
+    Besides the reading worker and the poller treated just below, a path that resolves to nothing
+    answers identically — and so does a span shorter than the worktree's own age, where every file is
+    recent and the count is the checkout rather than the worker. That last one is the counter-intuitive
+    half, because it returns a large number that reads as proof of life: measured once at *the same
+    count* over fifteen minutes and over six hours. **And the age itself is the worktree's CREATION
+    time, not its last-modification time**, which the very writes you are trying to detect keep
+    bumping: the wrong clock reads right on an idle tree, where the age does not matter, and seconds
+    old on a live one, where the age is the whole question. Run the clock twice at different spans
+    before believing either reading.
 
-   **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
-   nothing and commits nothing, so both clocks above stay still for hours — but a fetch ordinarily
-   writes as it reads, into exactly one place: the fetch-head file in that item's OWN metadata
-   directory, which each linked worktree gets its own copy of the first time a fetch writes that
-   clock there. Read that file twice, thirty to sixty seconds apart. **Movement is proof of life and
-   needs no corroboration**, which makes this the one test in this section that answers without a
-   control; stillness restores the ambiguity rather than resolving it, so it only ever answers in one
-   direction. **Its PRESENCE says nothing about life** — a stopped worker leaves its copy behind,
-   frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **And
-   its ABSENCE says less than it looks like saying**: only that no fetch has written that clock
-   there, which is not the same as no fetch having run, because the write is suppressible by a flag
-   on the fetch itself — a poller configured that way is invisible to this test altogether. So read
-   absence as a reason to reach for another signal rather than as a history of the tree, though it
-   stays a hint about one you did not create: measured here at four of seven, the three without being
-   trees this method did not make. Measured on a poller that six consecutive sweeps had read as
-   silent, on both of the other clocks, while it fetched every forty-two seconds. **And do not let
-   the fetch-head trap under *After each merge* talk you out of it**: that rule is about the SHARED
-   file being unusable as a merge TARGET because any concurrent process rewrites it. The per-item
-   copy is unusable for that same reason and useful for precisely it — here you are reading the
-   rewriting, not the contents.
+    **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
+    nothing and commits nothing, so both clocks above stay still for hours — but a fetch ordinarily
+    writes as it reads, into exactly one place: the fetch-head file in that item's OWN metadata
+    directory, which each linked worktree gets its own copy of the first time a fetch writes that
+    clock there. Read that file twice, thirty to sixty seconds apart. **Movement is proof of life and
+    needs no corroboration**, which makes this the one test in this section that answers without a
+    control; stillness restores the ambiguity rather than resolving it, so it only ever answers in one
+    direction. **Its PRESENCE says nothing about life** — a stopped worker leaves its copy behind,
+    frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **And
+    its ABSENCE says less than it looks like saying**: only that no fetch has written that clock
+    there, which is not the same as no fetch having run, because the write is suppressible by a flag
+    on the fetch itself — a poller configured that way is invisible to this test altogether. So read
+    absence as a reason to reach for another signal rather than as a history of the tree, though it
+    stays a hint about one you did not create: measured here at four of seven, the three without being
+    trees this method did not make. Measured on a poller that six consecutive sweeps had read as
+    silent, on both of the other clocks, while it fetched every forty-two seconds. **And do not let
+    the fetch-head trap under *After each merge* talk you out of it**: that rule is about the SHARED
+    file being unusable as a merge TARGET because any concurrent process rewrites it. The per-item
+    copy is unusable for that same reason and useful for precisely it — here you are reading the
+    rewriting, not the contents.
 
-   **The most convincing false signature is on none of the discredited lists: a change fully green at
-   the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads
-   as a worker that finished and forgot to publish — a real state, and the one step 2 exists to catch
-   — but a worker presenting exactly so was on attempt three of its local gate. **A green rollup is
-   evidence about the PUSHED tree, not about the worker**, and a clean tree is what you see *between*
-   edits. It belongs on the list because it reads strong and not one of its four parts observes the
-   agent.
+    **The most convincing false signature is on none of the discredited lists: a change fully green at
+    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads
+    as a worker that finished and forgot to publish — a real state, and the one step 2 exists to catch
+    — but a worker presenting exactly so was on attempt three of its local gate. **A green rollup is
+    evidence about the PUSHED tree, not about the worker**, and a clean tree is what you see *between*
+    edits. It belongs on the list because it reads strong and not one of its four parts observes the
+    agent.
 
-   **A change carries two clocks recording two different EVENTS, so name the event before you read a
-   clock.** The *authored* time is the author timestamp recorded on the change; the *committed* time is
-   the committer timestamp on the object as it currently stands, and it moves every time that object is
-   rewritten. A rebase rewrites the second and replays the first unchanged, so where a project merges by
-   rebase they differ on essentially every landed change — two honest readers called one change
-   forty-three minutes old and seventy-five seconds old, and neither had misread.
+    **A change carries two clocks recording two different EVENTS, so name the event before you read a
+    clock.** The *authored* time is the author timestamp recorded on the change; the *committed* time is
+    the committer timestamp on the object as it currently stands, and it moves every time that object is
+    rewritten. A rebase rewrites the second and replays the first unchanged, so where a project merges by
+    rebase they differ on essentially every landed change — two honest readers called one change
+    forty-three minutes old and seventy-five seconds old, and neither had misread.
 
-   Liveness asks *did this worker do something recently*, which is the rewrite event, so it reads the
-   committed time. A date in prose asks something else, and **which** something else is the whole
-   question — a record that says only "dated" has not been specified. **Name the event in the sentence**
-   — "authored on", "last rewritten on" — and where that event is one the change itself records, the
-   clock follows from it. Do not write a rule that says prose takes one clock: that trades a defect for
-   its mirror, and the error is invisible once made, because both are real timestamps on the same change
-   and each is correct for its own event.
+    Liveness asks *did this worker do something recently*, which is the rewrite event, so it reads the
+    committed time. A date in prose asks something else, and **which** something else is the whole
+    question — a record that says only "dated" has not been specified. **Name the event in the sentence**
+    — "authored on", "last rewritten on" — and where that event is one the change itself records, the
+    clock follows from it. Do not write a rule that says prose takes one clock: that trades a defect for
+    its mirror, and the error is invisible once made, because both are real timestamps on the same change
+    and each is correct for its own event.
 
-   **Where the event is not one the change records, no clock on the change answers.** Rebase is not the
-   only rewrite: amending, or squashing a fixup, moves the committed time while carrying the original
-   author timestamp forward, and an author date can be set explicitly to any value — so the authored
-   time is no proof of when content was written, and a queued or deferred integration leaves the
-   committed time recording a rewrite rather than an arrival. Ancestry is sound where the fields are
-   not, and it settles ORDER only. **A date tying a change to an EXTERNAL event — a run, a measurement,
-   an outage — therefore needs an anchor that event itself recorded, or a chronology you declare and
-   stand behind.** One change here called its first commit a pre-run registration: authored nine seconds
-   before the first sample, committed twenty minutes after the last, and neither number establishes the
-   claim.
+    **Where the event is not one the change records, no clock on the change answers.** Rebase is not the
+    only rewrite: amending, or squashing a fixup, moves the committed time while carrying the original
+    author timestamp forward, and an author date can be set explicitly to any value — so the authored
+    time is no proof of when content was written, and a queued or deferred integration leaves the
+    committed time recording a rewrite rather than an arrival. Ancestry is sound where the fields are
+    not, and it settles ORDER only. **A date tying a change to an EXTERNAL event — a run, a measurement,
+    an outage — therefore needs an anchor that event itself recorded, or a chronology you declare and
+    stand behind.** One change here called its first commit a pre-run registration: authored nine seconds
+    before the first sample, committed twenty minutes after the last, and neither number establishes the
+    claim.
 
 2. **Is there a live task to message?** Message first — resuming beats redispatching, because the
-   worker's context is still there. **The commonest strand by far is a worker that detached a long gate
-   and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
-   day; every one recovered intact the moment somebody asked for a status.
+    worker's context is still there. **The commonest strand by far is a worker that detached a long gate
+    and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
+    day; every one recovered intact the moment somebody asked for a status.
 
-   **Where the harness itself delivers an agent-stopped event, that event outranks every clock in this
-   section for that agent.** An event defined to fire only when nothing of the agent's remains alive is
-   not one more signal to weigh: arriving from a worker whose last message says it is WAITING for
-   something, it is the diagnosis itself — the awaited wake no longer exists, whatever the worker
-   believed it had armed. Resume without further discrimination; the clocks above are for workers whose
-   harness reports nothing.
+    **Where the harness itself delivers an agent-stopped event, that event outranks every clock in this
+    section for that agent.** An event defined to fire only when nothing of the agent's remains alive is
+    not one more signal to weigh: arriving from a worker whose last message says it is WAITING for
+    something, it is the diagnosis itself — the awaited wake no longer exists, whatever the worker
+    believed it had armed. Resume without further discrimination; the clocks above are for workers whose
+    harness reports nothing.
 
-   **But whether that question has an answer depends on your messaging tool, and it may not.**
-   Measured twice here, a send to an agent stopped mid-turn was ACCEPTED — success returned and
-   delivery promised at the agent's *next tool round*, which for a stopped agent never comes.
-   Acceptance is a queue confirmation, not a liveness report. **The reply is the read; the send is
-   not**, and the asymmetry is total: a reply proves life, while silence proves only that nothing
-   has been delivered yet.
+    **But whether that question has an answer depends on your messaging tool, and it may not.**
+    Measured twice here, a send to an agent stopped mid-turn was ACCEPTED — success returned and
+    delivery promised at the agent's *next tool round*, which for a stopped agent never comes.
+    Acceptance is a queue confirmation, not a liveness report. **The reply is the read; the send is
+    not**, and the asymmetry is total: a reply proves life, while silence proves only that nothing
+    has been delivered yet.
 
-   So the clause below is UNSATISFIABLE if you read *no live task* as something the tool reports
-   — where it behaves this way it never will, and a precondition that cannot be met either blocks
-   a legitimate redispatch forever or gets discharged by an invented proxy, which is the failure
-   this section exists to prevent. Read it instead as a request left unanswered across a window you
-   declare and stand behind, corroborated by the other discriminators. **The error is cheap in one
-   direction only, and it favours waiting**: a late reply costs nothing, because a live worker
-   resumes, while acting on a wrong *no task* destroys the run.
+    So the clause below is UNSATISFIABLE if you read *no live task* as something the tool reports
+    — where it behaves this way it never will, and a precondition that cannot be met either blocks
+    a legitimate redispatch forever or gets discharged by an invented proxy, which is the failure
+    this section exists to prevent. Read it instead as a request left unanswered across a window you
+    declare and stand behind, corroborated by the other discriminators. **The error is cheap in one
+    direction only, and it favours waiting**: a late reply costs nothing, because a live worker
+    resumes, while acting on a wrong *no task* destroys the run.
 
 3. **Only with no live task AND no tip movement:** push any existing commits — pure durability — then
-   set the item back to open with a note on what was found and salvaged, and redispatch.
+    set the item back to open with a note on what was found and salvaged, and redispatch.
 
-   **Read WHY the worker stopped before acting on that last word.** Where the stop reason names an
-   exhausted allowance with a stated reset, redispatch is not a remedy: *a remedy that draws on the
-   resource whose exhaustion caused the failure is not a remedy*, so every attempt fails identically
-   until the reset and every attempt spends. Salvage still applies in full — record the reason and the
-   reset time, and stop dispatching rather than retrying. **Merging is unaffected**, and that is the
-   half that still pays: integrating a finished change draws on none of that allowance, and a change
-   whose author has already stopped can still be the one unblocking everything queued behind it. So
-   the order is salvage, merge whatever is green, then stop. **The reason text, not the symptom,
-   chooses the remedy** — a quota death, a crash, a timeout and step 2's detached-gate strand look
-   identical from outside.
+    **Read WHY the worker stopped before acting on that last word.** Where the stop reason names an
+    exhausted allowance with a stated reset, redispatch is not a remedy: *a remedy that draws on the
+    resource whose exhaustion caused the failure is not a remedy*, so every attempt fails identically
+    until the reset and every attempt spends. Salvage still applies in full — record the reason and the
+    reset time, and stop dispatching rather than retrying. **Merging is unaffected**, and that is the
+    half that still pays: integrating a finished change draws on none of that allowance, and a change
+    whose author has already stopped can still be the one unblocking everything queued behind it. So
+    the order is salvage, merge whatever is green, then stop. **The reason text, not the symptom,
+    chooses the remedy** — a quota death, a crash, a timeout and step 2's detached-gate strand look
+    identical from outside.
 
-   **But the stated reset is a floor, not the only release.** An allowance can be restored by an
-   operator act — re-authenticating, changing plan — well before the clock the harness quoted, and
-   nothing tells the mayor it happened. So before holding the fleet for the whole interval, spend ONE
-   resume message on the worker with the most context to lose: a refusal confirms the hold at no
-   cost beyond what the hold was already costing, and an answer means the interval was over. Measured
-   here: three workers died on a stated reset an hour away; the operator re-authenticated within
-   minutes; one probe resumed all three. Hold on the clock only once the probe has refused.
+    **But the stated reset is a floor, not the only release.** An allowance can be restored by an
+    operator act — re-authenticating, changing plan — well before the clock the harness quoted, and
+    nothing tells the mayor it happened. So before holding the fleet for the whole interval, spend ONE
+    resume message on the worker with the most context to lose: a refusal confirms the hold at no
+    cost beyond what the hold was already costing, and an answer means the interval was over. Measured
+    here: three workers died on a stated reset an hour away; the operator re-authenticated within
+    minutes; one probe resumed all three. Hold on the clock only once the probe has refused.
 
-   **But a probe's ANSWER is not the only reading of it, and its LIVENESS arrives far sooner.**
-   The rule above is written around a reply, and a reply is what step 2 rightly calls the read —
-   yet a resumed worker that is *working* has not replied and will not for many minutes, so a
-   mayor waiting for words waits out most of the interval the probe existed to cut short. Ask the
-   harness whether that agent is RUNNING instead. It costs one call, and it is decisive in one
-   direction: an agent under an exhausted allowance dies within seconds of being resumed, so
-   minutes of running is positive evidence the allowance came back. **Stillness is not the
-   converse** — an empty listing restores the ambiguity rather than settling it — so read this
-   exactly as the per-item fetch-head clock is read under *The stranded sweep*: movement proves
-   life and needs no corroboration, absence only sends you to another signal. Measured here: six
-   workers died together on a reset two and a half hours out, the operator re-authenticated, and
-   the probe read *running* five minutes in; all six were resumed on that reading, none
-   redispatched, and every one kept its context.
+    **But a probe's ANSWER is not the only reading of it, and its LIVENESS arrives far sooner.**
+    The rule above is written around a reply, and a reply is what step 2 rightly calls the read —
+    yet a resumed worker that is *working* has not replied and will not for many minutes, so a
+    mayor waiting for words waits out most of the interval the probe existed to cut short. Ask the
+    harness whether that agent is RUNNING instead. It costs one call, and it is decisive in one
+    direction: an agent under an exhausted allowance dies within seconds of being resumed, so
+    minutes of running is positive evidence the allowance came back. **Stillness is not the
+    converse** — an empty listing restores the ambiguity rather than settling it — so read this
+    exactly as the per-item fetch-head clock is read under *The stranded sweep*: movement proves
+    life and needs no corroboration, absence only sends you to another signal. Measured here: six
+    workers died together on a reset two and a half hours out, the operator re-authenticated, and
+    the probe read *running* five minutes in; all six were resumed on that reading, none
+    redispatched, and every one kept its context.
 
 **A finished change is not a strand — but publishing it is still not yours to infer.** Everything
 above prices redispatch, and prices it to favour waiting because acting on a wrong *no task* destroys


### PR DESCRIPTION
Group 1 of rf2-fwlj — the `docs/the-mayor-method/` tree, deliberately left out of PR #9628's corpus sweep. Group 2 (the hot-zone residue) is a separate worker's; this PR touches none of those files and does not close the item.

## What moved

Python-Markdown's four-column rule governs CONTINUATION content as well as child items, and neither of this tree's two marker widths reaches it: a paragraph two columns under a `* parent`, or three columns under a `1. parent`, has not lost a nesting level, it has left the list item altogether. The list CLOSES, the prose renders at document level, and a new list opens after it, so one list is shown to the reader as two halves with body text stranded between them.

Escaped continuation lines, **re-measured at my branch point e541f662ea rather than relayed from the item**, before -> after:

| file | before | after |
|---|---|---|
| `docs/the-mayor-method/loops.md` | 166 | 0 |
| `docs/the-mayor-method/dispatch-prompt-template.md` | 75 | 0 |
| **total** | **241** | **0** |

They agree with the figures recorded on the item. `README.md` and `bootstrap.md` carry none and are untouched.

## This tree was REVIEWED, not swept

That is the whole reason it wanted its own pass: its fenced blocks are pasteable deliverables, and a doc link inside a fence here is itself reported where everywhere else in the corpus a fence is skipped. Every fenced block the transform touched was read before the change was kept. **It touched none.**

- `loops.md` has **no fenced blocks at all**. That is a zero, so it is controlled rather than asserted: counting fence-delimiter-shaped lines directly reads 0.
- `dispatch-prompt-template.md` has exactly **2**, at lines 763-819 (`WORKTREE BOUNDARY — MANDATORY`) and 828-909 (the common preamble, `You are implementing <ITEM_ID> ...`). Both are **byte-identical**; the change is confined to lines 44-133, entirely above them.

Neither file contains an **indented** code block either, which is the shape a fence census would miss here. The complete column histogram of non-blank lines is `{0, 2, 3}` before and `{0, 2, 3, 4}` after, for both files — there is nothing at a code-block depth to disturb. Every moved line is prose: none is free of lowercase words, so no ASCII art, table row or command line moved. The rendered `<pre>` count is unchanged (0 -> 0, 2 -> 2) and every `<pre>` **body** is byte-identical.

## How it was measured

By rendering, never by counting spaces — python-markdown under the exact extension list `mkdocs.yml` produces, loaded through mkdocs' own config loader, reusing `scripts/check_flattened_lists.py`'s renderer, fence scanner and HTML walker so the two instruments cannot disagree about what a fence is.

A sentinel goes into every list MARKER line and every candidate CONTINUATION line, and a candidate is flagged when its sentinel lands **shallower than its own owner's** OR **outside every `li`**. Both halves are needed. The first alone misses the case where an earlier escape has already closed the list, so the marker below it becomes a lazy continuation of the stranded paragraph and owner and candidate read depth 0 together — that shape is 27 of the 84 known `docs/api` escapes, and without it the instrument reads 57.

**The acceptance test the item asked for passes.** Run against the nine `docs/api` files as they stood before PR #9620, the probe reads **84**, per file 27/26/18/4/3/2/2/1/1 — matching that PR's own census exactly. The repair run on those same pre-#9620 inputs produces all **9/9 byte-identical** to what #9620 merged.

Getting there corrected three things in my own transform, each pinned by a specific file in that control:

- the unit of repair is the item **body**, not the escaped line (#9620's own words: *"THE REPAIR IS SCOPED TO THE BODIES THAT CARRY A MEASURED ESCAPE"*). `re-frame.test-helpers.md:206` and `re-frame.core.md:761` are two identical column-2 fences under two identical `- **Example**:` items, and exactly one moves — the one whose item carries an escape.
- a list marker starts a new block even with no blank line above it, and carries its own body (`re-frame.routing.md:140`, `re-frame.ssr.md:116`: the paragraph moves, the 4-column sub-list under it stays).
- the shift can flatten a sub-list, which is `check_flattened_lists.py`'s own class, so the repair re-nests and loops until both instruments read zero — and the **whole sibling run** moves, because that gate's pair rule returns early once `cur.indent <= prev.indent` (`re-frame.ssr.ring.md:33`).

Second control, from rf2-jzv2: `spec/Design-TransducerRouter.md` reads 5 -> 5, changed `False`. Reindentation cannot repair it, and the file is left alone by the empirical did-it-help test rather than by a guard on the owner — which rf2-jzv2 measured wrong in the other direction.

Rendered confirmation at `dispatch-prompt-template.md:43`, before -> after:

    </li></ol><p>PROSE</p>   ->   <li><p>...</p><p>PROSE</p></li>

## Invariants

#9620's four hold on both files. I1' is keyed on the unit **text** with whitespace normalised: a soft line break carries the source line's leading spaces into the HTML text node, so an un-normalised compare reports a violation on every line the repair fixes while the reader sees nothing — HTML collapses that run, and I2 grades the same text the same way.

- **I1'** ordered sequence of block-level text units — unchanged (858 and 530 units).
- **I2** whole-document text content — unchanged.
- **I3** non-list HTML with `ul`/`ol`/`li`/`p` stripped — unchanged.
- **I4** `<pre>` count — unchanged (0 -> 0, 2 -> 2), and every `<pre>` body byte-identical.

Plus: `<li>` counts hold **exactly** (37 -> 37, 60 -> 60) while root list elements **fall** where a split list is rejoined (`loops.md` 13 -> 11) — the signature #9620 recorded, and the reason a reader should not expect element counts to move one-per-site. 179 heading anchors unchanged. Both files keep CR == CRLF with zero bare CR, counted in Python off the bytes.

`git diff -w` is **empty**: leading whitespace and nothing else, 284 insertions against 284 deletions with no line added or removed. 261 lines are actually reindented (17 from column 2, 244 from column 3); the remaining 23 are byte-identical blank lines riding inside merged hunks.

## Gates

Nominated by path, and each one checked against what it actually reads:

- **`python -m mkdocs build --strict`** — exit 0, zero WARNINGs, 29.5s. It **does** cover these paths: `docs_dir` is `docs`, and `exclude_docs` lists only `tools/playground/`, the two codemod trees and `design/{freehand,fresco,retirement}/` — I read the block rather than trusting a prose list. Both pages appear in the build log.
- **`scripts/check_doc_slugs.py`** — exit 0. This is the anchor-and-link gate for `docs/`, and it is the one that applies this tree's stricter rule: `docs/the-mayor-method` is in `FENCED_DOC_LINK_TREES`, so a doc link inside a fence here is itself reported.
- **`scripts/check_flattened_lists.py`** — exit 0, `291 file(s) scanned, 0 flattened list(s), 0 unmeasurable`. Directly relevant: the re-nesting pass exists because this transform can create its class.

Not nominated, and why: `scripts/check_readme_links.py --ci` does not read these paths (`docs/` is the other gate's roots), and `scripts/check_provenance_pins.py` is scoped to `docs/design/fresco/`. **No gate in the repository grades the escaped-continuation class itself** — that is rf2-jzv2's undecided half — so the change is verified by the rendering evidence above.

## Not committed, deliberately

The probe and the repair live in the worker's scratchpad and are **not** in this PR. Whether this class becomes a permanent gate obligation is rf2-jzv2's own open decision, and committing a probe would settle it by the back door. If that half is ever ruled to extend the gate, the instrument plus the nine-file byte-identical reproduction is the acceptance test to keep.
