### PR TITLE
fix(story): a dead ^{:key ...} on an (if ...) call form in visual_a11y_view (rf2-32ib)

### DIFF
--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -245,8 +245,22 @@
       [:div {:style     (:section styles)
              :data-test "story-test-visual-a11y-section"}
        [:div {:style (:section-h styles)} "Visual & accessibility"]
+       ;; THE KEY RIDES ON A KEYED FRAGMENT, not on reader metadata
+       ;; (rf2-32ib). `^{:key …}` here sat on the `(if …)` CALL FORM, and
+       ;; Clojure metadata on a call form is discarded the moment the form
+       ;; evaluates — the vector the `if` returns carries none of it. So no
+       ;; key reached React on ANY substrate, and neither card supplies one
+       ;; by another route (both root at a `[:div]` whose attrs map has no
+       ;; `:key`). A lost key does not fail: it degrades silently into
+       ;; index-based reconciliation, which paints identically and corrupts
+       ;; card identity only once the row seq changes shape.
+       ;;
+       ;; The fragment carries the key without adding a DOM node, and both
+       ;; renderers honour it — Reagent reads meta then props, Fresco's
+       ;; codec reads props and Clojure metadata nowhere. The key
+       ;; EXPRESSION is unchanged.
        (for [[i {:keys [kind] :as row}] (map-indexed vector rows)]
-         ^{:key (str kind "#" i)}
-         (if (= kind :visual)
-           [visual-card row]
-           [a11y-card row]))])))
+         [:<> {:key (str kind "#" i)}
+          (if (= kind :visual)
+            [visual-card row]
+            [a11y-card row])])])))

--- a/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs
@@ -159,9 +159,16 @@
   so it surfaces only its hiccup-tag locus, honestly."
   [findings]
   [:ul {:style (:findings styles) :data-test "story-va-findings"}
+   ;; The key rides in the `:li`'s own ATTRIBUTE MAP (rf2-32ib), not on
+   ;; reader metadata. Metadata on a vector LITERAL is read by Reagent, so
+   ;; unlike the call-form site in `visual-a11y-section` this one is not
+   ;; dead today — it is LATENT, dying if/when Story's view layer renders
+   ;; through a Fresco boundary, whose codec reads `:key` from props and
+   ;; Clojure metadata nowhere. The attrs map satisfies both renderers, and
+   ;; the key expression is unchanged.
    (for [[i {:keys [finding locus detail impact rule selector]}] (map-indexed vector findings)]
-     ^{:key (str rule "#" i)}
-     [:li {:style       (:finding-row styles)
+     [:li {:key         (str rule "#" i)
+           :style       (:finding-row styles)
            :data-test   "story-va-finding"
            :data-rule   (str rule)}
       (when locus

--- a/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_keys_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/visual_a11y_keys_cljs_test.cljs
@@ -1,0 +1,188 @@
+(ns re-frame.story.ui.test-mode.visual-a11y-keys-cljs-test
+  "rf2-32ib — every sibling the visual + a11y results section emits from a
+  `for` reaches React carrying a key.
+
+  ## What was broken, and why no markup assertion could see it
+
+  `visual-a11y-section` spelled its sibling key as `^{:key …}` reader
+  metadata on the `(if (= kind :visual) [visual-card row] [a11y-card row])`
+  CALL FORM. Clojure metadata on a call form is discarded the moment the
+  form evaluates, so the vector the `if` returns carried none of it and
+  React received no key — on ANY substrate, not merely at a future Fresco
+  boundary. Nothing supplied one by another route either: `a11y-card` and
+  `visual-card` both root at a `[:div {:style … :data-test …}]` whose attrs
+  map has no `:key`.
+
+  A lost key does not FAIL. It degrades silently into index-based
+  reconciliation, which paints identically and corrupts card identity only
+  once the row seq changes shape.
+
+  `findings-list`'s key (the second site in that file) rode a vector
+  LITERAL, which Reagent does read — that one was LATENT rather than dead,
+  dying only at a Fresco boundary, whose codec reads `:key` from the
+  attribute map and Clojure metadata nowhere. Both now carry the key in an
+  attribute map, which both renderers honour.
+
+  ## `(meta …)` WOULD BE A HOLLOW GATE IN BOTH DIRECTIONS
+
+  It reads nil on the BROKEN spelling, because the call form discarded the
+  metadata; and it reads nil on the FIXED spelling too, because the key now
+  lives in an attribute map, where it is not metadata at all. A gate built
+  on `(meta …)` therefore answers identically either way and proves
+  nothing. Hence `r/as-element` below: it runs Reagent's own key resolution
+  — metadata first, then props — so these rows grade what the RENDERER
+  receives rather than how the key happens to be spelled. A meta-spelled
+  key would still pass here, which is deliberate: the subject is whether
+  React gets a key, not which syntax delivered it.
+
+  ## The walk is RAW
+
+  Row nodes are taken from the hiccup WITHOUT rebuilding it. A `mapv`-style
+  rebuild (what the shared `expand-tree` helper does) mints fresh vectors
+  and strips reader metadata, so a meta-spelled key could not be seen at
+  all and this gate would read a false nil and fail for the wrong reason."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]
+            [re-frame.story.ui.test-mode.visual-a11y-view :as rf.story.ui.test-mode.visual-a11y-view]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn- reset-results! [] (reset! rf.story.ui.test-mode.state/results-atom {}))
+
+(use-fixtures :each {:before reset-results! :after reset-results!})
+
+(def ^:private variant-id :rf2-32ib.story/visual-a11y)
+
+(def ^:private run-result
+  "THREE browser-tier records, because a one-element sequence cannot
+  distinguish a real key from a missing one and two cannot show a stable
+  stamp. Both branches of the `if` the dead metadata sat on are exercised:
+  the `:visual` record takes the true branch, the two a11y records the
+  false one — the branch being the very thing that discarded the key.
+
+  The a11y-structural record carries THREE findings for the same reason,
+  so `findings-list`'s own `for` is graded on more than a singleton."
+  {:assertions
+   [{:assertion :rf.assert/visual-snapshot
+     :status    :pass
+     :reason    "snapshot matched baseline"
+     :actual    "sha256:0ab1"
+     :expected  "sha256:0ab1"}
+    {:assertion :rf.assert/a11y-structural
+     :status    :fail
+     :reason    "3 structural violations"
+     :count     3
+     :actual    [{:rule :img-missing-alt :tag :img
+                  :detail "img element has no :alt attribute"}
+                 {:rule :control-missing-name :tag :button
+                  :detail "button control has no accessible name"}
+                 {:rule :some-future-rule :tag :div
+                  :detail "a rule this projection does not know by name"}]}
+    {:assertion :rf.assert/a11y
+     :status    :fail
+     :reason    "1 axe violation"
+     :count     1
+     :actual    [{:id "color-contrast" :impact "serious"
+                  :help "Elements must have sufficient colour contrast"}]}]})
+
+(defn- seed! []
+  (swap! rf.story.ui.test-mode.state/results-atom
+         assoc variant-id {:result run-result}))
+
+;; ---- raw helpers ---------------------------------------------------------
+
+(defn- raw-seq-child
+  "The single lazy seq among `node`'s children — i.e. exactly what a `for`
+  emitted, RAW. Never rebuilt (see the ns docstring on why a rebuild would
+  make this gate lie)."
+  [node]
+  (vec (first (filter seq? (drop 2 node)))))
+
+(defn- raw-child-by-tag
+  [node tag]
+  (first (filter #(and (vector? %) (= tag (first %))) (drop 2 node))))
+
+(defn- react-key
+  "The key REACT actually receives for one node. `r/as-element` runs
+  Reagent's own key resolution — metadata first, then the props map — so
+  this reads the rendered element rather than the authoring shape."
+  [node]
+  (.-key (r/as-element node)))
+
+(defn- section-rows
+  "The per-row nodes `visual-a11y-section`'s `for` emits."
+  []
+  (raw-seq-child (rf.story.ui.test-mode.visual-a11y-view/visual-a11y-section variant-id)))
+
+(defn- component-calls
+  "Every `[component-fn & args]` node at or under `node`, RAW.
+
+  Deliberately shape-TOLERANT about the wrapper: whether the section emits
+  each card bare or inside a keyed fragment is `section-rows-reach-react-
+  with-distinct-keys`'s subject, not this one's. Coupling the two would let
+  the findings row go red for the section's reason, which is a worse gate
+  than no gate — it reports the same defect twice and hides its own."
+  [node]
+  (cond
+    (and (vector? node) (fn? (first node))) [node]
+    (vector? node) (mapcat component-calls
+                           (drop (if (map? (second node)) 2 1) node))
+    (seq? node)    (mapcat component-calls node)
+    :else          nil))
+
+(defn- finding-rows
+  "The `<li>` nodes `findings-list` emits, reached by INVOKING the card
+  components the section embeds. `a11y-card` and `findings-list` are both
+  private, so the rendered tree is the only honest route to them — and
+  going through it is what makes this a gate on what the section really
+  renders rather than on a hand-built call.
+
+  Every card is tried and the first one carrying a findings `<ul>` wins:
+  the `:visual` card renders a snapshot box and no list, so selecting by
+  position would silently grade the wrong card."
+  []
+  (some (fn [call]
+          (let [card (apply (first call) (rest call))]
+            (some-> (raw-child-by-tag card :ul) raw-seq-child seq vec)))
+        (mapcat component-calls (section-rows))))
+
+;; ---- rf2-32ib — the live defect -----------------------------------------
+
+(deftest section-rows-reach-react-with-distinct-keys
+  (testing "rf2-32ib — every card the `visual-a11y-section` `for` emits
+            reaches React carrying a key, and sibling keys are distinct.
+            The key used to ride reader metadata on the `(if …)` call form,
+            which reaches React on no substrate at all."
+    (seed!)
+    (let [rows (section-rows)
+          ks   (mapv react-key rows)]
+
+      ;; Precondition — a vacuous pass is the failure mode here, so the row
+      ;; count is asserted before the keys are.
+      (is (= 3 (count rows)) "the fixture's three browser-tier rows each render")
+
+      (is (every? some? ks) "every row reaches React with a key")
+      (is (= 3 (count (distinct ks))) "sibling keys are distinct")
+      (is (= [":visual#0" ":a11y-structural#1" ":a11y#2"] ks)
+          "the key React receives is the `<kind>#<index>` the section
+           stamps, unchanged from the pre-repair expression"))))
+
+;; ---- rf2-32ib — the latent site in the same file -------------------------
+
+(deftest findings-list-rows-reach-react-with-distinct-keys
+  (testing "rf2-32ib — every `<li>` `findings-list` emits reaches React
+            carrying a key. This one was LATENT rather than dead (Reagent
+            reads metadata on a vector literal); the key now rides the
+            `<li>`'s own attribute map, which Fresco's codec reads too."
+    (seed!)
+    (let [lis (finding-rows)
+          ks  (mapv react-key lis)]
+
+      (is (= 3 (count lis)) "the fixture's three structural findings each render")
+
+      (is (every? some? ks) "every finding row reaches React with a key")
+      (is (= 3 (count (distinct ks))) "sibling keys are distinct")
+      (is (= [":img-missing-alt#0" ":control-missing-name#1" ":some-future-rule#2"] ks)
+          "the key React receives is the `<rule>#<index>` the list stamps,
+           unchanged from the pre-repair expression"))))


### PR DESCRIPTION
Closes rf2-32ib.

Two `^{:key ...}` sites in `tools/story/src/re_frame/story/ui/test_mode/visual_a11y_view.cljs`, in **separate commits** because they are **not the same severity** and a reviewer should be able to tell them apart.

## 1. The live defect (`visual-a11y-section`) — commit 1

The sibling key was spelled as `^{:key ...}` reader metadata on the `(if (= kind :visual) [visual-card row] [a11y-card row])` **CALL FORM**. Clojure metadata on a call form is discarded the moment the form evaluates, so the vector the `if` returns carried none of it and **React received no key on ANY substrate** — not merely at a future Fresco boundary.

Nothing supplied one by another route, which is what separates this from rf2-wvch: `a11y-card` and `visual-card` both root at a `[:div {:style ... :data-test ...}]` carrying no `:key`, and this file has exactly two real `:key` sites (every other `:key`-looking hit is `:keys` destructuring). So the cards reconciled by index.

A lost key does not fail. It degrades silently into index-based reconciliation, which paints identically and corrupts card identity only once the row seq changes shape.

**Repair** is the in-tree substrate-neutral spelling — the key rides in a Fragment's **attribute map**, as `tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs` already does at its `:row-render` and its input seq. Reagent reads meta then props; Fresco's codec reads props and Clojure metadata nowhere, so the attrs map satisfies both. The fragment adds no DOM node and the key expression is unchanged.

Deliberately **not** repaired by moving the metadata onto the two vector literals inside the `if` — that spelling works under Reagent and dies under Fresco, trading a dead key for a latent one.

## 2. Latent hardening (`findings-list`) — commit 2

Same one-line class two functions above, on a vector **LITERAL** (`[:li ...]`). Reader metadata rides the vector the reader produces and Reagent reads metadata before props, so **that key does reach React today**. It dies only if/when Story's view layer renders through a Fresco boundary. Repaired while in the file because leaving a known Fresco-fatal site behind is worse than the edit. The `:li` already carries an attrs map, so no Fragment is needed — the key goes straight in.

## 3. The gate — commit 3

`tools/story/test/re_frame/story/ui/test_mode/visual_a11y_keys_cljs_test.cljs`, transferred from the rf2-wvch gate in `tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs`.

**`(meta ...)` would be hollow in BOTH directions here** and is deliberately not used: it reads nil on the broken spelling (the call form discarded the metadata) *and* nil on the fixed spelling (the key now lives in an attrs map, where it is not metadata at all). So the rows read `.-key` off real React elements minted by `r/as-element`, which runs Reagent's own key resolution. The walk is **raw** — a `mapv`-style rebuild strips reader metadata, so a meta-spelled key would read as a false nil and the gate would fail for the wrong reason.

Three fixture rows, not one: a singleton cannot distinguish a real key from a missing one and two cannot show a stable stamp. Both branches of the `if` are exercised. The row count is asserted **before** the keys, because a vacuous pass is the failure mode here. The two deftests are deliberately independent — an early draft coupled them, and the findings row then went red for the section's reason, reporting one defect twice while hiding its own.

### Mechanical check — delete the signal, keep the fault

Run in three directions, all measured on this tree:

| # | Fault reintroduced | Result |
|---|---|---|
| A | `^{:key ...}` restored on the `(if ...)` call form | Section row **RED**, `[nil nil nil]` vs the three expected keys. Findings row stayed green. |
| B | `<li>`'s attrs-map `:key` deleted outright | Findings row **RED**, `[nil nil nil]`. Section row stayed green. |
| C | Original `^{:key ...}` restored on the `<li>` **vector literal** | **GREEN** — and that is the correct answer. It is the evidence that site was LATENT rather than dead: Reagent does read metadata on a vector literal, so React got the key. |

C is the point of the two-severity split. The gate is agnostic about *spelling* by design — its subject is whether React receives a key, not which syntax delivered it — so only a Fresco boundary would make C fail.

## Gates

Surfaces armed by this diff, per `.github/scripts/report-changed-surfaces.sh` on the two changed paths: `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`, `story_xray_browser`.

Run locally:

- **`cljs_node_test` — `npm run test:cljs` (full node-test build): GREEN.** `Ran 11602 tests containing 58149 assertions. 0 failures, 0 errors.` This is the gate that actually reads both changed paths — the view is CLJS-only and the new test is `.cljs`.
- **`tools_jvm` — `clojure -M:test` in `tools/story`: GREEN.** `Ran 1914 tests containing 7047 assertions. 0 failures, 0 errors.` Named in passing for completeness, but stated honestly: this is the **JVM** lane and it compiles **neither** changed file. `visual_a11y_view.cljs` is CLJS-only and the new test is `.cljs`, so the JVM runner loads neither. It arms per the classifier and it is green; it is not evidence about this diff.

Left to CI rather than run locally: `cljs_browser` (Chromium; the `.*-dom-cljs-test$` regexp does not match this test and no DOM test references this view), `examples_compile`, `mcp_conformance`, `story_xray_browser`.

No other consumer asserts on this view's hiccup shape — the only other file naming `story-va-*` or `visual-a11y` outside build caches is `visual_a11y_pure_cljs_test.cljc`, which tests the `pure.cljc` projection and is untouched.

## Notes

- Anchors and the one table above were checked by hand; no gate validates markdown prose or table column counts.
- No AI-attribution trailers on the commits or in this body, per `CLAUDE.md`.
