### PR TITLE
fix(xray): Static Flows and Schemas inspector node keys carry the owning frame (rf2-uyg0)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -169,12 +169,34 @@
 
 ;; ---- row -----------------------------------------------------------------
 
+(defn- row-identity
+  "One row's identity — the OWNING FRAME plus the flow-id.
+
+  ONE derivation with TWO consumers, and that shared derivation IS the
+  rf2-uyg0 repair. The catalogue's React key already carried the frame;
+  the inspector node keys below were built from the flow-id ALONE, so
+  under the browse-all projection (`scope-to-frame` with a nil frame-id,
+  which passes every frame's flows through) the same flow-id registered
+  against two frames produced two rows in ONE render frame carrying the
+  SAME `:mount-id`. That is not cosmetic: `edn-widget/inspect-view` hands
+  the node-key straight to the boundary as its `:mount-id`, and
+  `edn-inspector/container-ref-for` MEMOISES the ref callback on it — so
+  the two rows shared one ResizeObserver entry and detaching either row
+  released the SURVIVOR's. Deriving both keys here is what keeps them from
+  drifting apart again.
+
+  Both components keep their leading `:`, which is what makes the join
+  unambiguous — frame `:a/b` + flow `:c` reads `:a/b/:c`, never the
+  `:a/:b/c` that frame `:a` + flow `:b/c` reads."
+  [{:keys [flow-id frame]}]
+  (str frame "/" flow-id))
+
 (defn- flow-row
   ;; Non-interactive `li` chrome via the shared `catalogue-row`; the flow
   ;; rows are catalogue entries (no row-level dispatch). The interactive
   ;; Static surface that earns keyboard activation is the Routes list
   ;; (whose rows toggle an expand surface — see static/routes/browse_list.cljs).
-  [{:keys [flow-id frame inputs output-path doc] :as _row}]
+  [{:keys [flow-id frame inputs output-path doc] :as row}]
   (catalogue/catalogue-row
    {:testid (str "rf-xray-static-flows-row-" (subs (pr-str flow-id) 1))}
    [:div {:style {:display     "flex"
@@ -198,11 +220,15 @@
    ;; `[ei/edn-inspector …]` (a Reagent component). rf2-k97c.3 made the
    ;; swap mandatory rather than stylistic: `ei/edn-inspector` is a plain
    ;; fn, and a plain fn in hiccup head position is a loud error inside a
-   ;; Fresco body. Each value keeps its stable per-flow `node-key`, which
+   ;; Fresco body. Each value keeps its stable per-ROW `node-key`, which
    ;; is now load-bearing twice over — it is the panel-id keying expand
    ;; state AND the boundary's required `:mount-id`, so two mounts sharing
    ;; one node-key would share a width slot and a projection cache.
-   (let [flow-key (subs (pr-str flow-id) 1)]
+   ;;
+   ;; rf2-uyg0 — the qualifier is [[row-identity]] (frame + flow-id), not
+   ;; the flow-id alone. A flow-id is unique per FRAME, not per catalogue,
+   ;; and the browse-all projection lists every frame's flows at once.
+   (let [flow-key (row-identity row)]
      [:div {:style {:margin-left  "12px"
                     :color        (:text-secondary tokens)
                     :font-size    "11px"
@@ -282,11 +308,16 @@
     ;; and by Fresco's codec NOWHERE, so it would reach React as nothing
     ;; once the panel renders through a boundary. The fragment carries the
     ;; key without adding a DOM node, which is what keeps `catalogue-row`'s
-    ;; `li` chrome the shared presentational helper it is; the key
-    ;; expression is unchanged and identity stays domain-shaped and local,
-    ;; exactly as `catalogue-panel`'s `:row-render` contract asks.
+    ;; `li` chrome the shared presentational helper it is; identity stays
+    ;; domain-shaped and local, exactly as `catalogue-panel`'s `:row-render`
+    ;; contract asks.
+    ;;
+    ;; The key EXPRESSION is now [[row-identity]] — the same string the row's
+    ;; inspector node keys are built from (rf2-uyg0). It computes exactly
+    ;; what the inline `(str (:frame row) "/" (:flow-id row))` here computed;
+    ;; naming it is what stops the two key sites diverging again.
     :row-render (fn [row]
-                  [:<> {:key (str (:frame row) "/" (:flow-id row))}
+                  [:<> {:key (row-identity row)}
                    (flow-row row)])}))
 
 ;; ---- root view -----------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -238,11 +238,38 @@
                           :text-align    "center"}}
      letter]))
 
+(defn- row-identity
+  "One row's identity — the kind, the OWNING FRAME, and the id.
+
+  ONE derivation with TWO consumers, and that shared derivation IS the
+  rf2-uyg0 repair. The catalogue's React key already carried the frame;
+  the inspector node key below was built from `(kind, id)` ALONE, even
+  though `frame` was destructured by name one line above it. Under the
+  browse-all projection (`scope-app-schemas-to-frame` with a nil frame-id,
+  which passes every frame's app-db schemas through) the same path
+  registered against two frames produced two rows in ONE render frame
+  carrying the SAME `:mount-id`. That is not cosmetic:
+  `edn-widget/inspect-view` hands the node-key straight to the boundary as
+  its `:mount-id`, and `edn-inspector/container-ref-for` MEMOISES the ref
+  callback on it — so the two rows shared one ResizeObserver entry and
+  detaching either row released the SURVIVOR's. Deriving both keys here is
+  what keeps them from drifting apart again.
+
+  `pr-str` rather than `str` on both variable components: a `:frame` of
+  nil is the honest answer for the process-global `:event` / `:sub` rows
+  (Spec 001 — the registrar is per-process), and an app-db `:id` is a PATH
+  vector rather than a keyword.
+
+  DELIBERATELY NOT the `row-id` the testids use. Those name a row for a
+  human and a browser selector; this names a MOUNT."
+  [{:keys [kind id frame]}]
+  (str (name kind) "/" (pr-str frame) "/" (pr-str id)))
+
 (defn- schema-row
   ;; Non-interactive catalogue entry (the only row-level affordance is the
   ;; focusable `open-chip` jump-to-source); the shared `catalogue-row` owns
   ;; the `role=listitem` `li` chrome.
-  [{:keys [kind id frame schema doc source-coord] :as _row}]
+  [{:keys [kind id frame schema doc source-coord] :as row}]
   (let [id-text (pr-str id)
         row-id  (str (name kind) "-" id-text)]
     (catalogue/catalogue-row
@@ -281,10 +308,13 @@
      ;; `[ei/edn-inspector …]` (a Reagent component). rf2-k97c.3 made the
      ;; swap mandatory rather than stylistic: `ei/edn-inspector` is a
      ;; plain fn, and a plain fn in hiccup head position is a loud error
-     ;; inside a Fresco body. The `node-key` is stable per (kind,id) so
-     ;; expand state survives reloads and doesn't collide across rows —
-     ;; now load-bearing twice over, since it is also the boundary's
-     ;; required `:mount-id`.
+     ;; inside a Fresco body. The `node-key` is stable per ROW — per
+     ;; (kind, frame, id), via [[row-identity]] — so expand state survives
+     ;; reloads and doesn't collide across rows. It is load-bearing twice
+     ;; over, since it is also the boundary's required `:mount-id`, which is
+     ;; why (kind,id) alone was not enough: the browse-all projection lists
+     ;; every frame's app-db schemas at once, so one path registered against
+     ;; two frames gave two rows ONE mount id (rf2-uyg0).
      [:div {:data-testid (str "rf-xray-static-schemas-schema-" row-id)
             :style {:margin-left "20px"
                     :margin-top  "2px"
@@ -292,7 +322,7 @@
                     :font-size   "11px"
                     :white-space "pre-wrap"
                     :word-break  "break-word"}}
-      (edn/inspect-view schema (str "static-schemas/" row-id))]
+      (edn/inspect-view schema (str "static-schemas/" (row-identity row)))]
      (when doc
        [:div {:style {:margin-left "20px"
                       :margin-top  "2px"
@@ -337,11 +367,15 @@
     ;; lost key does not fail, it degrades silently into index-based
     ;; reconciliation. The fragment carries the key without adding a DOM
     ;; node, so `catalogue-row`'s `li` chrome stays the shared
-    ;; presentational helper it is; the key expression is unchanged.
+    ;; presentational helper it is.
+    ;;
+    ;; The key EXPRESSION is now [[row-identity]] — the same string the
+    ;; row's inspector node key is built from (rf2-uyg0). It computes
+    ;; exactly what the inline `(str (name (:kind row)) "/" (pr-str (:frame
+    ;; row)) "/" (pr-str (:id row)))` here computed; naming it is what stops
+    ;; the two key sites diverging again.
     :row-render (fn [row]
-                  [:<> {:key (str (name (:kind row)) "/"
-                                  (pr-str (:frame row)) "/"
-                                  (pr-str (:id row)))}
+                  [:<> {:key (row-identity row)}
                    (schema-row row)])}))
 
 ;; ---- root view -----------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/flows/panel_cljs_test.cljs
@@ -367,6 +367,107 @@
              per-mount identity defect rf2-d2aj records")))))
 
 ;; -------------------------------------------------------------------------
+;; (5a) ONE FLOW-ID, TWO FRAMES, ONE RENDER FRAME (rf2-uyg0)
+;; -------------------------------------------------------------------------
+;;
+;; THE ROW ABOVE CANNOT SEE THIS, and that is why this section exists rather
+;; than an extra `is` up there. `sample-flows` is ONE frame carrying two
+;; DIFFERENT ids, so its mount ids are distinct on the flow-id alone and stay
+;; distinct however the node key is built. The browser lane's W5 is no help
+;; either — it removes differently named rows from one frame. So neither
+;; fixture exercises the case the flows registry explicitly supports:
+;; frame-divergence per id (Spec 013), surfaced all at once by the browse-all
+;; projection.
+
+(def one-flow-id-two-frames
+  "ONE flow-id registered against TWO frames — the fixture nothing else in
+  this file reaches.
+
+  `scope-to-frame` with a nil frame-id (the default OBSERVED-target state,
+  `defaults/default-target-frame` = UNSELECTED) passes every frame's flows
+  through, so these two registrations project to TWO rows inside the ONE
+  `:rf/xray` render frame the panel paints in.
+
+  Each row carries its own `:inputs` / `:output-path`, which is the point of
+  frame-divergence: they are two different flows that happen to share a
+  name."
+  {:app/a {:shared/flow {:id          :shared/flow
+                         :inputs      [[:a :in]]
+                         :output-path [:a :out]}}
+   :app/b {:shared/flow {:id          :shared/flow
+                         :inputs      [[:b :in]]
+                         :output-path [:b :out]}}})
+
+(def two-flow-ids-one-frame
+  "THE NON-VACUITY CONTROL, and it is taken from the target in the same run
+  rather than reasoned about: same row COUNT, same input/output shape, same
+  walker, ids that genuinely differ. A `row-identity` that answered a
+  constant — or a walker that silently found nothing — reads red here while
+  the fixture above would read green, so the pair separates \"the panel
+  distinguishes these rows\" from \"this test distinguishes anything\"."
+  {:app/a {:flow/one {:id          :flow/one
+                      :inputs      [[:a :in]]
+                      :output-path [:a :out]}
+           :flow/two {:id          :flow/two
+                      :inputs      [[:b :in]]
+                      :output-path [:b :out]}}})
+
+(defn- mount-ids-for-override [fixture]
+  (rf/dispatch-sync
+    [:rf.xray.static.flows/set-registered-flows-override-for-test fixture])
+  (let [data  @(rf/subscribe [:rf.xray.static.flows/tab-data])
+        heads (inspector-view-forms (panel/panel-tree data nil))]
+    {:rows      (:flows data)
+     :forms     (count heads)
+     :mount-ids (mapv #(:mount-id (second %)) heads)}))
+
+(deftest two-rows-sharing-a-flow-id-across-frames-get-distinct-mount-ids
+  (testing "rf2-uyg0 — the inspector node key is qualified by the row's
+            OWNING FRAME, so two rows sharing a flow-id across two frames do
+            not collide on one `:mount-id`.
+
+            WHY A COLLIDING `:mount-id` IS NOT COSMETIC. `edn-widget/
+            inspect-view` hands the node key straight to the boundary as its
+            `:mount-id` and derives the expansion `:panel-id` from the same
+            string, and the Fresco head TRUSTS that id — unlike the Reagent
+            head, which mints a UUID per mount and so cannot collide.
+            `edn-inspector/container-ref-for` then MEMOISES the ref callback
+            on `[render-frame mount-id]`, and the render frame is `:rf/xray`
+            for both rows, so a shared node key means one ResizeObserver
+            entry for two live mounts: the second never installs an observer,
+            and detaching either row calls `release-mount!` for the
+            SURVIVOR."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (let [{:keys [rows forms mount-ids]} (mount-ids-for-override
+                                             one-flow-id-two-frames)]
+        (is (= [:shared/flow :shared/flow] (mapv :flow-id rows))
+            (str "PRECONDITION: two rows sharing ONE flow-id reached the "
+                 "tree. Rows: " (pr-str (mapv (juxt :frame :flow-id) rows))))
+        (is (= #{:app/a :app/b} (set (map :frame rows)))
+            "PRECONDITION: and they carry DIFFERENT owning frames — the
+             browse-all projection is what puts both in one catalogue")
+        (is (= 4 forms)
+            (str "PRECONDITION: 2 rows x (1 input + 1 output) = 4 inspector "
+                 "mounts. Mount ids: " (pr-str mount-ids)))
+        (is (= 4 (count (set mount-ids)))
+            (str "THE CLAIM: four mounts, four DISTINCT `:mount-id`s. Two "
+                 "rows sharing a flow-id would collapse to 2 without the "
+                 "frame in the key. Mount ids: " (pr-str mount-ids))))
+      (testing "NON-VACUITY CONTROL — distinct ids in ONE frame still separate"
+        (let [{:keys [rows forms mount-ids]} (mount-ids-for-override
+                                               two-flow-ids-one-frame)]
+          (is (= [:flow/one :flow/two] (mapv :flow-id rows))
+              "control fixture projects two genuinely distinct ids")
+          (is (= 4 forms) "same shape as the case above")
+          (is (= 4 (count (set mount-ids)))
+              (str "and they were already distinct — so a red above is the "
+                   "frame qualifier, not a broken walker. Mount ids: "
+                   (pr-str mount-ids)))))
+      (rf/dispatch-sync
+        [:rf.xray.static.flows/set-registered-flows-override-for-test nil]))))
+
+;; -------------------------------------------------------------------------
 ;; (5b) the input-path seq's React keys actually REACH the renderer
 ;;      (rf2-k97c.3, RULING 2's key sweep)
 ;; -------------------------------------------------------------------------
@@ -377,10 +478,11 @@
 
   Keyed off the boundary's `:mount-id`, which `edn-widget/inspect-view`
   derives from the node-key the panel passes —
-  `rf-xray-inspect-static-flows/<flow>/input/<i>` for an input,
-  `…/output` for the single output value. The output value is not in a seq
-  and needs no key, so including it would make the claim below false for a
-  correct panel."
+  `rf-xray-inspect-static-flows/<frame>/<flow>/input/<i>` for an input,
+  `…/output` for the single output value. The FRAME is in there since
+  rf2-uyg0: a flow-id is unique per frame, not per catalogue. The output
+  value is not in a seq and needs no key, so including it would make the
+  claim below false for a correct panel."
   [tree]
   (filterv (fn [node]
              (and (vector? node)

--- a/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/schemas/panel_cljs_test.cljs
@@ -456,6 +456,104 @@
              per-mount identity defect rf2-d2aj records")))))
 
 ;; -------------------------------------------------------------------------
+;; (5a) ONE APP-DB PATH, TWO FRAMES, ONE RENDER FRAME (rf2-uyg0)
+;; -------------------------------------------------------------------------
+;;
+;; THE ROW ABOVE CANNOT SEE THIS. `sample-registry` is one frame's app-db
+;; schema plus two process-global rows, so every row differs on `(kind, id)`
+;; and the mount ids stay distinct however the node key is built. The browser
+;; lane's W5 is no help either — it removes differently named rows from one
+;; frame. Neither reaches the case the app-db schema registry explicitly
+;; supports: per-frame registration, surfaced all at once by the browse-all
+;; projection.
+
+(def one-path-two-frames
+  "ONE app-db schema path registered against TWO frames — the fixture
+  nothing else in this file reaches.
+
+  `scope-app-schemas-to-frame` with a nil frame-id (the default
+  OBSERVED-target state, `defaults/default-target-frame` = UNSELECTED)
+  passes every frame's app-db schemas through, so these two registrations
+  project to TWO rows inside the ONE `:rf/xray` render frame the panel
+  paints in. Each carries its own schema — they are two different
+  registrations that happen to share a path.
+
+  No event / sub rows: those are process-global and carry `:frame nil`
+  unconditionally, so they cannot exercise a frame qualifier."
+  {:schemas-by-frame {:app/a {[:shared] {:schema [:map [:a :int]]}}
+                      :app/b {[:shared] {:schema [:map [:b :int]]}}}
+   :events {}
+   :subs   {}})
+
+(def two-paths-one-frame
+  "THE NON-VACUITY CONTROL, taken from the target in the same run rather
+  than reasoned about: same row count, same walker, paths that genuinely
+  differ. A `row-identity` answering a constant — or a walker finding
+  nothing — reads red here while the fixture above would read green."
+  {:schemas-by-frame {:app/a {[:one] {:schema [:map [:a :int]]}
+                              [:two] {:schema [:map [:b :int]]}}}
+   :events {}
+   :subs   {}})
+
+(defn- mount-ids-for-override [fixture]
+  (rf/dispatch-sync
+    [:rf.xray.static.schemas/set-registry-override-for-test fixture])
+  (let [data  @(rf/subscribe [:rf.xray.static.schemas/tab-data])
+        heads (inspector-view-forms (panel/panel-tree data nil))]
+    {:rows      (:schemas data)
+     :forms     (count heads)
+     :mount-ids (mapv #(:mount-id (second %)) heads)}))
+
+(deftest two-rows-sharing-a-schema-path-across-frames-get-distinct-mount-ids
+  (testing "rf2-uyg0 — the inspector node key is qualified by the row's
+            OWNING FRAME, so two rows sharing an app-db schema path across
+            two frames do not collide on one `:mount-id`.
+
+            The frame was already destructured BY NAME in `schema-row`, one
+            line above the key that omitted it.
+
+            WHY A COLLIDING `:mount-id` IS NOT COSMETIC. `edn-widget/
+            inspect-view` hands the node key straight to the boundary as its
+            `:mount-id` and derives the expansion `:panel-id` from the same
+            string, and the Fresco head TRUSTS that id — unlike the Reagent
+            head, which mints a UUID per mount and so cannot collide.
+            `edn-inspector/container-ref-for` then MEMOISES the ref callback
+            on `[render-frame mount-id]`, and the render frame is `:rf/xray`
+            for both rows, so a shared node key means one ResizeObserver
+            entry for two live mounts: the second never installs an observer,
+            and detaching either row calls `release-mount!` for the
+            SURVIVOR."
+    (setup-xray!)
+    (rf/with-frame :rf/xray
+      (let [{:keys [rows forms mount-ids]} (mount-ids-for-override
+                                             one-path-two-frames)]
+        (is (= [[:shared] [:shared]] (mapv :id rows))
+            (str "PRECONDITION: two rows sharing ONE app-db path reached the "
+                 "tree. Rows: " (pr-str (mapv (juxt :frame :id) rows))))
+        (is (= #{:app/a :app/b} (set (map :frame rows)))
+            "PRECONDITION: and they carry DIFFERENT owning frames — the
+             browse-all projection is what puts both in one catalogue")
+        (is (= 2 forms)
+            (str "PRECONDITION: one schema value per row, two rows. Mount "
+                 "ids: " (pr-str mount-ids)))
+        (is (= 2 (count (set mount-ids)))
+            (str "THE CLAIM: two mounts, two DISTINCT `:mount-id`s. Without "
+                 "the frame in the key both rows are `static-schemas/"
+                 "app-db-[:shared]`. Mount ids: " (pr-str mount-ids))))
+      (testing "NON-VACUITY CONTROL — distinct paths in ONE frame still separate"
+        (let [{:keys [rows forms mount-ids]} (mount-ids-for-override
+                                               two-paths-one-frame)]
+          (is (= [[:one] [:two]] (mapv :id rows))
+              "control fixture projects two genuinely distinct paths")
+          (is (= 2 forms) "same shape as the case above")
+          (is (= 2 (count (set mount-ids)))
+              (str "and they were already distinct — so a red above is the "
+                   "frame qualifier, not a broken walker. Mount ids: "
+                   (pr-str mount-ids)))))
+      (rf/dispatch-sync
+        [:rf.xray.static.schemas/set-registry-override-for-test nil]))))
+
+;; -------------------------------------------------------------------------
 ;; (6) row React keys reach the RENDERER, not just the reader (rf2-k97c.3)
 ;; -------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-uyg0 (mayor closes on merge).

## The defect

The Static **Flows** and **Schemas** panels built their `edn/inspect-view`
node keys without the row's owning frame, while the frame-inclusive identity
already existed one level up in the same files as the catalogue's React key.

Both registries are per-frame, and the browse-all projection (a nil observed
frame — `defaults/default-target-frame` = UNSELECTED) lists every frame at
once. So one flow-id registered against `:app/a` and `:app/b`, or one app-db
schema path registered in both, produces two rows **inside the one `:rf/xray`
render frame** carrying the **same node key**.

## Why the node key is not decorative — verified at source, every link

The bead traced a downstream chain through the shipped store code. I checked
each link at trunk `3d8cd72b41` rather than relying on the trace, and every
one holds:

| Claim | Where | Holds? |
| --- | --- | --- |
| the node key becomes `:mount-id` **and** `:panel-id` verbatim | `views/edn_widget.cljs:139-143` + `inspect-opts` :93-99 | yes |
| the Reagent head mints a UUID per mount, so it cannot collide | `views/edn_inspector.cljs:4135` (`gen-mount-id` → `random-uuid`), 2-arity `container-ref-for` at :4158 | yes |
| the Fresco head instead **trusts** the caller's explicit id | `edn-inspector-view` throws unless `:mount-id` is a string, :4243-4252 | yes |
| lifecycle identity is qualified by the **render** frame | `lkey (lifecycle-key (:frame (rf/capture-frame)) mount-id)`, :4259-4262 | yes — and the render frame is `:rf/xray` for both rows, so the rf2-d2aj qualifier cannot separate them |
| `container-ref-for` is memoised on that key, so a shared id means one observer and detaching either row releases the survivor | :3238-3260 | yes — its **own docstring** states it: "Two panels rendering the same stable `mount-id` at the same time are two mounts and want two refs; memoised on that name they get one function, so the second element never installs an observer, and detaching it releases the FIRST mount's entry" |

Width identity is shared too: `release-mount!` clears the width slot keyed by
the logical `mount-id`, and expansion state is keyed by the derived
`:panel-id`.

## The fix

A private `row-identity` in each panel — **one derivation, two consumers**.
It computes byte-for-byte what each panel's `:row-render` React key already
computed inline; naming it is what stops the node key and the row key
drifting apart again. No new public API, no general identity framework.

- flows: `(str frame "/" flow-id)`. Both keywords keep their leading `:`,
  which is what makes the join unambiguous — frame `:a/b` + flow `:c` reads
  `:a/b/:c`, never the `:a/:b/c` that frame `:a` + flow `:b/c` reads.
- schemas: `(str (name kind) "/" (pr-str frame) "/" (pr-str id))`. `pr-str`
  because a `:frame` of nil is the honest answer for the process-global
  `:event` / `:sub` rows and an app-db `:id` is a PATH VECTOR.

**`data-testid`s are untouched.** Schemas' `row-id` still spells them; the
new binding is separate. A testid names a row for a human and a browser
selector, a mount id names a mount, and the two have different jobs.

## The test, and proof it is not hollow

The shipped unit tests assert mount-id uniqueness only on
single-frame/different-id fixtures, and browser W5 removes differently named
rows from one frame — so neither reaches the supported case. Each panel's
test file gains one row that does: two rows sharing a flow-id (resp. an
app-db path) across two frames, rendered in one render frame, asserting
distinct `:mount-id`s. Preconditions pin that the fixture really reaches the
case rather than projecting to fewer rows.

**Delete the signal, keep the fault.** Reverting only the two node-key
derivations (leaving the tests and the React keys in place), recompiling and
re-running:

```
FAIL two-rows-sharing-a-flow-id-across-frames-get-distinct-mount-ids
  Mount ids: ["rf-xray-inspect-static-flows/shared/flow/input/0"
              "rf-xray-inspect-static-flows/shared/flow/output"
              "rf-xray-inspect-static-flows/shared/flow/input/0"
              "rf-xray-inspect-static-flows/shared/flow/output"]
  expected: (= 4 (count (set mount-ids)))
    actual: (not (= 4 2))

FAIL two-rows-sharing-a-schema-path-across-frames-get-distinct-mount-ids
  Mount ids: ["rf-xray-inspect-static-schemas/app-db-[:shared]"
              "rf-xray-inspect-static-schemas/app-db-[:shared]"]
  expected: (= 2 (count (set mount-ids)))
    actual: (not (= 2 1))
```

2 failures, 0 errors — and **only** the two new claim assertions; every
precondition still passed, so the fixtures demonstrably reach the case.
Restoring the fix returns 0 failures.

**Non-vacuity controls, taken from the target in the same run**: a pair of
rows with genuinely distinct ids reads 4 forms / 4 mount ids (flows) and 2 / 2
(schemas), and **passed under the fault too** — so a red above is the frame
qualifier and not a broken walker. Those figures independently reproduce the
audit's Babashka probe (4/2 and 2/1 for the faults, 4/4 and 2/2 for the
controls).

## Gates run locally (each runner's own exit status)

| Gate | Result |
| --- | --- |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | exit 0, 0 warnings |
| `node out/node-test.js` (full `npm run test:cljs` suite) | **11604 tests / 58168 assertions, 0 failures, 0 errors**, exit 0 |
| `clojure -M:test` in `tools/xray` | **1276 tests / 6118 assertions, 0 failures, 0 errors**, exit 0 |
| `npm run test:xray-feature-gate:smoke` | **5 scenarios, 0 failures, 10 matrix rows covered**, exit 0 |

The two panel suites focused: 40 tests / 135 assertions, 0 failures.

**No gate is being over-claimed.** A repo-wide search for dependents on the
node-key strings (`rf-xray-inspect-static*`, `static-flows/`,
`static-schemas/`) returns only these four files — the feature-gate scenarios
select the panels' ROOT testids (`rf-xray-static-flows`,
`rf-xray-static-schemas`), never a node key — so the mount-id change reaches
no other consumer. The panels are CLJS-only, so `tools/xray`'s JVM gate does
not read the changed lines; it is listed because the classifier arms it for
`tools/xray/**` and it is clean.

## Out of scope, noted rather than fixed

Two rows sharing a flow-id in one catalogue also share their row
`data-testid`. That is a selector-collision question, not the mount-identity
one this bead names, and repairing it would move handles the browser lane
reaches for. Left alone deliberately.
