### PR TITLE
docs(method): give five swallowed list markers their own list items (rf2-n5as, rf2-v44k)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -115,6 +115,7 @@ four hundred.
     and the structured field that is the durable answer where a project wants this machine-checkable, are
     under *Tracker mechanics* in [`loops.md`](loops.md#tracker-mechanics) — this step is the concrete
     instance and does not restate them.
+
 2. **Check every factual claim you are about to write.** Does the symbol resolve?
     Does the file say what you think? Is the count still true? Is the ruling you cite
     *ruled*, or only recommended? A recommendation and a decision read identically in
@@ -126,12 +127,15 @@ four hundred.
     common preamble below — inside the block you extract and paste without reading, because
     its audience looks like the worker. A dispatch went out for work that had merged the
     previous day, and the worker's deliverable was refuting the premise.
+
 3. **Establish the fence by asking who is live, not what is open.** A listing of open
     changes misses a worker that has not pushed yet. **And ask what each nominated gate
     COMPARES, here, not at dispatch** — a fence derived from files alone misses a gate that
     couples two surfaces (see *Fences*), and one mayor struck an item's fence and dispatched
     before asking, then re-fenced it five minutes later on exactly that ground.
+
 4. **Name the discriminator**, if the task is "find every X".
+
 5. **Then** assemble the standard blocks.
 
 ---

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -392,6 +392,7 @@ familiar fix:
     file — while rebasing onto the ref succeeded immediately on the same tree. **A remedy
     inherits the hazards of whatever it reads**, so choose it by what it reads, not by what it
     is called.
+
 * **A truncated abort, or a ref-level race** — re-fetch and re-read. Do not reach for
     any remedy above.
 


### PR DESCRIPTION
Repairs the five list markers in `docs/the-mayor-method/` that render as literal text, and reports the two beads' other findings as measured. Five inserted blank lines, nothing deleted.

## The defect

A list marker sitting directly beneath a paragraph line with no blank line is a LAZY CONTINUATION: python-markdown folds it into that paragraph, and the marker ships as literal text. The worst instance is the method's own dispatch checklist — the numbered procedure a mayor follows when assembling a brief — published as ONE instruction followed by four paragraphs of prose.

## Measured at the renderer, before and after

Nothing in this repo grades markdown list structure, so the rendering evidence is the gate. Rendered with python-markdown under the ELEVEN extensions mkdocs' own config loader produces, a unique sentinel injected into every source marker, and each sentinel asked which `<li>` INSTANCE it landed in.

| | before | after |
|---|---|---|
| `dispatch-prompt-template.md` opening `<ol>`, direct `<li>` | **1** | **5** |
| `loops.md` "familiar fix" `<ul>`, direct `<li>` | 2 | 3 |
| `dispatch-prompt-template.md` page total `<li>` | 60 | 64 |
| `loops.md` page total `<li>` | 37 | 38 |
| root lists per page | 10 / 11 | 10 / 11 |
| markers rendering as literal text, this tree | 5 | **0** |

Root-list counts do not move, so the lists were not fragmented into pieces — the failure mode #9633 measured on `spec/009-Instrumentation.md` when blank lines went in without the matching reindentation. Here the continuation blocks were already at their content column, so no reindentation was needed; the class-2 probe reads 0 escaped continuations on both pages.

## The instance test, and why a bare in-`<li>` test is not enough

Giving an item a continuation block makes its list LOOSE, so python-markdown wraps every item's own text in a `<p>` — and a marker swallowed into item 1 is still inside item 1's `<li>`. Both readings mislead, in opposite directions:

- asking *`<li>` or `<p>`?* reports healthy loose items as broken;
- asking *any `<li>` ancestor?* reports swallowed ones as fine.

Asking which `<li>` INSTANCE each marker landed in separates them, and it agrees with a direct `<ol>`/`<li>` count on every site here. It found two markers (`4.` and `5.`) the first reading missed, and cleared four sites it had flagged — `dispatch-prompt-template.md:43`, `:949`, `:959` and `loops.md:1112`, `:1139`, each verified by hand in the rendered HTML to open its own `<li>`.

## Prose invariant

Word-stream diff over both rendered pages: 38,971 → 38,966 words, **five removed and none added**, being exactly the literal `2.` `3.` `4.` `5.` and `*` that stopped being text and became markers. Non-vacuity control in the same run: `README.md` 34 markers / 0 literal, `bootstrap.md` 3 / 0, and every other list on both edited pages keeps its exact `<li>` count.

Both pages are `i/lf w/crlf` and stay so: CR == CRLF == 1293 and 1838, zero bare CR.

## rf2-v44k: both findings on `docs/EP/EP-template.md` are refuted

Source lines 7–92 of that file are a single HTML comment — the authoring guidance an EP author deletes before opening a PR. Both cited markers (`:46`, `:52`) and all eight cited continuation lines (`:47`–`:50`, `:53`–`:56`) sit inside it.

- **Finding 2, "2 markers render as literal text in a `<p>`":** they render as nothing at all. Verified in the BUILT page, not only in the probe: in `site/EP/EP-template/index.html` the nearest preceding `<!--` sits after the nearest preceding `-->`. And there is no lazy continuation to repair — source lines 45 and 51 are already blank.
- **Finding 1, "8 escaped continuation lines":** the file has exactly **8 CANDIDATE** continuation lines and **0** escapes, and the eight candidates are the continuation lines of those same two commented-out bullets. The relayed 8 looks like a candidate count read as an escape count.

So the file needs no change, and the corpus arithmetic the brief asked to re-check does not close at 13: the standing class-2 corpus is **5**, all in `spec/Design-TransducerRouter.md`, which #9628 deliberately left because they are not repairable by reindentation.

The class-2 instrument was rebuilt from scratch and self-tested against the independent acceptance control both ways before being trusted: over the nine `docs/api` files as they stood before #9620 it reads **84**, per file 27/26/18/4/3/2/2/1/1 — matching that PR's own census exactly — and **0** on the same nine files as #9620 merged them.

## The class is corpus-wide and much larger than either bead says

The corrected class-1 probe over the gate's own 291-file corpus reads **210 before this change, 205 after**, across 29 files once `docs/the-mayor-method/` drops off. Largest carriers: `spec/Cross-Cutting-Designs.md` 27, `spec/012-Routing.md` 26, `spec/Runtime-Architecture.md` 20, `spec/009-Instrumentation.md` 15, `spec/AI-Audit.md` 15, `migration/from-re-frame-v1/README.md` 14. Spot-checked at source and confirmed real. Most of the carriers are hot-zone files, so that sweep wants its own item and its own sequencing — filed as **rf2-2brt**, not attempted here.

## Gates

Each read on its own exit status, never a pipeline's:

- `python -m mkdocs build --strict` — **0**. `docs/the-mayor-method/` is inside `docs_dir` and absent from `exclude_docs`, so the build does reach these pages.
- `scripts/check_doc_slugs.py` — **0** (the anchor gate; the strict build grades anchors at INFO and `--strict` promotes only WARNING).
- `scripts/check_readme_links.py --ci` — **0**.
- `scripts/check_flattened_lists.py` — **0**: 291 scanned, 0 flattened, 0 unmeasurable.

No edit lands inside a fenced block, so the two link gates' fence-stripping does not bound this change. Nothing anywhere validates markdown list rendering, which is why this class survived; the before/after rendering above is the real gate.

No AI attribution is included in the commit or in this body, per `CLAUDE.md`.
