### PR TITLE
fix(xray): per-panel mount seats the frame it provides; drop the epoch view's retired :spec fallback (rf2-hg3j, rf2-hqti)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -74,12 +74,13 @@
 
   1. Calls `(registry/register-xray-handlers!)` — idempotent, registers
      every panel's subs + events + fxs under `:rf.xray/*`.
-  2. Calls `mount/ensure-xray-frame!` so the state-isolation frame exists
-     and first-mount seed hooks have run.
+  2. Calls `mount/ensure-xray-frame!` for `opts :frame` — the SAME frame
+     step 3 provides (rf2-hg3j) — so the state-isolation frame exists and
+     its first-mount seed hooks have run.
   3. Wraps the panel's `Panel` (or equivalent) view in a
-     `rf/frame-provider` for `opts :frame` (default `:rf/xray`) so
-     descendant subscribes and dispatches do not inherit the host's
-     ambient React context accidentally.
+     `rf/frame-provider` for `opts :frame` (default
+     `shell/default-frame-id`) so descendant subscribes and dispatches do
+     not inherit the host's ambient React context accidentally.
   4. Delegates to `rf.substrate.adapter/render` with the wrapped tree +
      the supplied mount-point. The substrate adapter is the host's
      (installed via `rf/init!`); the panels are substrate-agnostic
@@ -232,12 +233,25 @@
     panel's subscribes would route to `:rf/default`).
   - `mount-point` — a DOM element (or substrate-equivalent mount
     target).
-  - `opts` — `{:frame <frame-id>}` minimum. Defaults to `:rf/xray`.
-    The frame the `frame-provider` resolves to. Hosts embedding a
-    panel to observe a specific app frame pass that frame id; the
-    panel's own Xray state still lives on `:rf/xray` (the panel
-    facade always opens with its own `frame-provider :rf/xray`
-    when its body subscribes to `:rf.xray/*` data).
+  - `opts` — `{:frame <frame-id>}` minimum, defaulting to
+    `shell/default-frame-id`. Xray's OWN frame for this panel — the
+    frame the `frame-provider` anchors, and therefore the frame the
+    panel's `:rf.xray/*` subscribes and dispatches resolve to. NOT the
+    inspected host target, which the frame-picker chooses and which
+    lives in `:rf.xray/target-frame` inside that own frame's db
+    (`008-Embedding-Contract.md` §Own frame vs target frame). The
+    frame is SEATED on the way through — the caller is not asked to
+    pre-create it, symmetric with `mount-shell!`.
+
+    rf2-hg3j — this used to call `ensure-xray-handlers-installed!` at
+    its ZERO arity, which always seats `shell/default-frame-id`, and
+    then provide `opts :frame`. On an override those are two different
+    frames and every descendant subscribe anchored at one nothing had
+    seated or seeded. The docstring's old claim that a panel facade
+    opens its own inner `frame-provider :rf/xray` was the reasoning
+    that made that look safe, and it is false: no panel view opens a
+    provider at all — each one's docstring says its isolation comes
+    from the ENCLOSING provider, which is this one.
   - `props` — OPTIONAL (rf2-2n8q), and it is the PANEL's props map, not
     the mount opts. nil — every caller but `mount-app-db-diff!` — mounts
     `[panel-view]`, the element this fn has always built. A map mounts
@@ -253,12 +267,18 @@
   ([panel-view mount-point opts]
    (render-panel! panel-view mount-point opts nil))
   ([panel-view mount-point opts props]
-   (ensure-xray-handlers-installed!)
-   (let [frame (get opts :frame :rf/xray)
+   ;; rf2-hg3j — resolve the frame FIRST, then seat that one. The seated
+   ;; frame and the provided frame are now the same value by construction,
+   ;; so an overriding caller cannot get a provider anchored at an unseated
+   ;; frame. `shell/default-frame-id` IS `:rf/xray`, so the default path is
+   ;; unchanged; naming it also keeps `defaults/default-frame-id` the single
+   ;; permitted bare `:rf/xray` literal (008 §Parameterized shell frame-id).
+   (let [frame (get opts :frame shell/default-frame-id)
          tree  [rf/frame-provider {:frame frame}
                 (if props
                   [panel-view props]
                   [panel-view])]]
+     (ensure-xray-handlers-installed! frame)
      (rf.substrate.adapter/render tree mount-point nil))))
 
 ;; ---- per-panel mount fns ------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2085,11 +2085,25 @@
     (let [machine-meta (try (rf/handler-meta {:source :store :kind :event :id machine-id})
                             (catch :default _ nil))
           ;; Resolve the machine spec: the stamped spec lives under
-          ;; `:rf/machine`, with fixture-shape fallbacks for unit tests
-          ;; (mirrors the cascade path's `projection/machine-spec-from-meta`).
+          ;; `:rf/machine`, with legacy-shape fallbacks (mirrors the cascade
+          ;; path's `machine-spec-from-meta` below).
+          ;;
+          ;; rf2-hqti — a bare `:spec` alternative used to sit between the
+          ;; two below. `machine-meta` comes off a REAL `:event`
+          ;; registration, and `reg-meta/retired-bare-keys` carries
+          ;; `{:spec :schema}` (MIGRATION §M-54), so a registration
+          ;; declaring bare `:spec` throws `:rf.error/retired-registration-key`
+          ;; at registration time — in dev AND prod. The branch was therefore
+          ;; satisfiable only by a hand-built fixture, and per rf2-t8a8's
+          ;; ruling a fallback unreachable from production BY CONSTRUCTION is
+          ;; what lets a fixture written on a retired spelling stay green
+          ;; while the real path is empty. The two survivors stay: neither
+          ;; `:machine-spec` (bare, legacy, NOT retired — an unknown bare key
+          ;; is a dev-gated warning, so it can exist) nor the namespaced
+          ;; `:rf.machine/spec` (the retired-BARE-key rule does not reach a
+          ;; namespaced key) is unreachable the same way.
           spec         (or (:rf/machine machine-meta)
                            (:machine-spec machine-meta)
-                           (:spec machine-meta)
                            (:rf.machine/spec machine-meta))
           spec-path    (proj/state-spec-path-prefix state-path)
           c            (proj/state-node-source-coords spec spec-path)]

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -358,6 +358,44 @@
           (is (= {:frame :my-app/cart} (second tree))
               "explicit :frame opt overrides the default :rf/xray"))))))
 
+;; ---- rf2-hg3j — the per-panel mount SEATS the frame it PROVIDES --------
+;;
+;; The deftest above pins the WRAPPER, and the wrapper was always right. What
+;; was wrong sat one line above it: `render-panel!` called
+;; `ensure-xray-handlers-installed!` at its ZERO arity, which always seats
+;; `shell/default-frame-id`, and then anchored the provider at `opts :frame`.
+;; On an override those are two different frames, and since no panel view
+;; opens an inner provider of its own — every panel's docstring says its
+;; isolation comes from the ENCLOSING one — the panel body's whole
+;; `:rf.xray/*` surface resolved into a frame nothing had seated or seeded.
+;;
+;; So this row is deliberately NOT taken off the captured tree: the stubbed
+;; `adapter/render` observes the wrapper, which passes either way. It reads
+;; the frame REGISTRY, which the real `ensure-xray-handlers-installed!` wrote
+;; on the way past the stub. Same assertion shape rf2-lffg used for
+;; `mount-shell!`, which has threaded its resolved frame through all along.
+
+(def ^:private panel-cell-frame :review/xray-panel-cell)
+
+(deftest mount-panel-seats-the-own-frame-it-provides
+  (testing "rf2-hg3j — a per-panel mount given an explicit `:frame` seats
+            THAT frame. Pre-fix `mount-epoch-panel!` seated
+            `shell/default-frame-id` and provided the override, so the
+            first row below read nil and the panel's subscribes landed in
+            an empty frame."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-epoch-panel! :mount-point {:frame panel-cell-frame}))
+      (is (some? (rf.frame/frame panel-cell-frame))
+          "the requested own frame is SEATED — the mount contract does not
+           ask the host to pre-seat one (008 §Frame-provider wraps the shell)")
+      (is (= panel-cell-frame (:frame (second (captured-tree capture))))
+          "and it is the SAME frame the provider anchors — seated and
+           provided are one value by construction")
+      (is (some? (read-in-frame panel-cell-frame [:rf.xray/selected-tab]))
+          "and the seed hooks ran in it, so a panel body's `:rf.xray/*`
+           subscribe resolves there rather than reading an empty frame"))))
+
 ;; ---- contract — instance-id opt (rf2-2n8q) ----------------------------
 ;;
 ;; THE EVIDENCE THAT TWO NAMED MOUNTS ARE ACTUALLY SEPARATED IS NOT HERE. It


### PR DESCRIPTION
Two latent defects in `tools/xray`'s panel surface. Neither breaks anything a user
can see today; both are hardening. Separate commits, scoped tight.

## rf2-hg3j — `render-panel!` seated one frame and provided another

`render-panel!` — the shared helper every `mount-<panel>!` delegates to — called
`ensure-xray-handlers-installed!` at its **zero** arity, which always seats and
seeds `shell/default-frame-id`, and then wrapped the view in a frame-provider
anchored at `(get opts :frame)`. Default path: they agree. Override: two different
frames, and every descendant subscribe anchors at one nothing seated or seeded.
`mount-shell!` never had this shape — it has threaded its resolved frame through
since rf2-lffg.

The fix resolves the frame first and seats *that* one, so seated and provided are
one value by construction.

### The census, re-derived on this tree

The falsifying question is whether anything actually overrides `:frame` on a
per-panel mount.

| | |
|---|---|
| per-panel `mount-<panel>!` callers passing `:frame` | **1**, and it is a test — `panels_mount_cljs_test.cljs:355` |
| shipped hosts / examples / testbeds doing so | **0** |
| control: `mount-shell!` callers passing `:frame` | **4** — the instrument is live |

Swept over `tools`, `examples`, `testbeds`, `implementation`, `docs`, `spec` on
two axes: a single-line pattern and a multiline `mount-…!(.|\n){0,200}?:frame`
window, so a `:frame` on a continuation line could not hide. The multiline sweep
surfaced one extra file — `app_db_diff_mount_instance_id_dom_cljs_test.cljs` —
which passes `:instance-id` only; its `:frame` hit is a `rf/dispatch` opts map.
Story's `xray_embed.cljs`, the only shipped consumer, calls `(mount-fn container)`
at the 1-arity.

So the consequence does not currently obtain. This is P4 on the strength of that,
not on the mechanism.

### Is the per-panel `:frame` override supported at all?

The bead asks this before choosing a fix, and the **spec settles it** — no need to
weigh the docstring:

- `007-UX-IA.md` §Mountable panel contract: the opts vocabulary is "`:frame` on
  every mount fn, defaulting to `:rf/xray`, and `:instance-id` on
  `mount-app-db-diff!` alone".
- `008-Embedding-Contract.md` §Frame-provider wraps the shell: "Every Xray mount fn
  (the master `mount-shell!` and every per-panel `mount-<panel>!` …) opens with an
  internal `[rf/frame-provider {:frame <frame-id>} ...]`", and that frame is where
  the descendants' app-db, subs, dispatches and machines all live. The
  `mount-shell!` paragraph adds "the requested own frame is seated on the way
  through — the host is not asked to pre-create it".

The option is supported and the installer call was the wrong half. **No spec edit:
the spec was already right.**

The **docstring** was not. It claimed the panel facade "always opens with its own
`frame-provider :rf/xray` when its body subscribes to `:rf.xray/*` data" — which is
exactly what makes seating a different frame look harmless. There is no such inner
provider. The only frame-providers constructed anywhere in `tools/xray/src` are
this one, `shell-view`'s, and `mount.cljs`'s two; every panel's own docstring says
its isolation comes from the **enclosing** one. The docstring is corrected here.

Resolving the frame first also lets the default read `shell/default-frame-id`
rather than a second bare `:rf/xray` literal — same value, and
`defaults/default-frame-id` stays the single permitted one per 008 §Parameterized
shell frame-id.

### The test, and proof it is not hollow

The existing suite stubs `rf.substrate.adapter/render`, so anything read off the
captured tree observes the **wrapper** — which was correct before the fix and would
pass either way. The new row therefore reads the frame **registry** and a
`:rf.xray/*` subscribe inside the overridden frame instead, the same assertion
shape rf2-lffg used for `mount-shell!`.

Reverted the fix (installer back to its zero arity), kept the test:

```
FAIL (mount-panel-seats-the-own-frame-it-provides) :389
  expected: (some? (rf.frame/frame panel-cell-frame))
    actual: (not (some? nil))                        <- frame never seated

FAIL (mount-panel-seats-the-own-frame-it-provides) :395
  expected: (some? (read-in-frame panel-cell-frame [:rf.xray/selected-tab]))
    actual: (not (some? nil))                        <- seed hooks never ran in it
```

Restored: green. The third row (provided == seated) passed both ways, as expected —
it is a stated control, not the signal.

## rf2-hqti — a fixture-only fallback onto the RETIRED bare `:spec` key

`machine-state-path-coord` resolved the machine spec with

```clojure
(or (:rf/machine m) (:machine-spec m) (:spec m) (:rf.machine/spec m))
```

over metadata read off a **real `:event` registration**. `reg_meta.cljc` carries
`{:spec :schema}` in `retired-bare-keys` (MIGRATION §M-54) and `events.cljc:958`
runs `validate-registration-metadata!` on every `reg-event`, so a registration
declaring bare `:spec` throws `:rf.error/retired-registration-key` — hard, in dev
**and** prod. The alternative was satisfiable only by a hand-built fixture.

It goes per rf2-t8a8's merged ruling (#9629): a fallback unreachable from
production by construction is what lets a fixture written on a retired spelling
stay green while the real path is empty. Here the live path works, so it was only
latent cover — a tidy, not a repair.

**Scoped to the one dead alternative**, as the bead directs:

| alternative | disposition |
|---|---|
| `:rf/machine` | live wrapper shape — kept |
| `:machine-spec` | bare and legacy but **not** in the retired map; an unknown bare key is a dev-gated warning and the key is still stored, so such a registration can exist — kept |
| `:spec` | retired, throws at registration — **removed** |
| `:rf.machine/spec` | namespaced, so the retired-BARE-key rule does not reach it; named in `machine-spec-from-meta`'s docstring as supported legacy — kept |

**No new test.** The removed branch is unreachable by construction, so the only
thing that could exercise it is the hand-built fixture the ruling is against. The
surviving path is already covered end to end by `view_cljs_test.cljs`'s
`dispatch-source-after-timer-state-path-*` rows, which register a real
`rf/reg-event` carrying `:rf/machine` and drive the resolver. Measured while
scoping: every existing epoch-view fixture already uses `:rf/machine`, and
`:machine-spec` / `:rf.machine/spec` are read in these two functions and **written
nowhere in the repo**.

**One correction to the bead**, recorded in the commit: it reports the same
four-alternative shape at the second site (`machine-spec-from-meta`, ~:2803). That
site has three alternatives plus an identity fallback and never carried a bare
`:spec`. Repo-wide there is exactly one `(:spec ` form under `tools/xray`, and this
removes it.

## Gates

`report-changed-surfaces.sh` on the three changed paths arms `cljs_node_test`,
`cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`,
`story_xray_browser`. Run locally, each runner's own exit status read directly (no
pipelines):

| gate | result |
|---|---|
| `npm run test:cljs` (`cljs_node_test` — `tools/xray/{src,test}` are on the `:node-test` classpath) | exit 0 — 11620 tests, 58248 assertions, 0 failures |
| `tools/xray` `clojure -M:test` (`tools_jvm`) | exit 0 — 1276 tests, 6118 assertions, 0 failures |
| `npm run test:xray-feature-gate:smoke` (`story_xray_browser`, PR tier) | exit 0 — 5 scenarios, 0 failures, 10 matrix rows; compiled `:testbeds/panel-gallery` |
| `npm run test:examples-compile` (`examples_compile`) | exit 0 — full derived sweep |

`panel_enum_guard_cljs_test` (the mount-facade / enum / api-manifest single-source
guard) runs inside the node-test suite; no mount fn was added, removed or renamed,
so nothing drifted.

Not run locally: `cljs_browser` and `mcp_conformance`, left to CI — the diff adds no
DOM surface and no MCP surface.

Docs gates are not nominated: no path under `docs/`, `spec/`, `migration/` or
`skills/` is touched, so `check_doc_slugs.py` and `mkdocs build --strict` would
inspect nothing changed here.
