### PR TITLE
fix(xray): resizable-table keyed its cells where Fresco reads nothing (rf2-fcy5)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -510,6 +510,59 @@
   [_left-id]
   [:div {:style body-spacer-style}])
 
+;; ---- React keys ride the ATTRS MAP, never metadata (rf2-fcy5) ------------
+;;
+;; Every woven cell, gutter and row below used to be keyed with `with-meta`
+;; on a vector literal. That reaches React under Reagent — `reagent.impl.
+;; template` reads meta FIRST and the props map second — and reaches it
+;; NOWHERE under Fresco: `re-frame.fresco.impl.codec`'s component-ABI table
+;; (HD-016) takes a literal `:key` from the ATTRIBUTE MAP for every head
+;; kind it accepts (native tag, `defview` boundary, host, fragment), and
+;; the words `meta` / `with-meta` do not occur anywhere in that file.
+;;
+;; So this is not the `^{:key …}`-on-a-call-form defect rf2-hxfy fixed —
+;; these keys DO work today. The hazard is that they stop working silently
+;; the moment the shared widget renders under a Fresco boundary: every row
+;; and every header cell in BOTH consumer panels (`panels/trace.cljs`,
+;; `panels/epoch/view.cljs`) would lose its key with no error and no
+;; warning, leaving React to reconcile by position.
+;;
+;; A `:key` in the attrs map is honoured by BOTH substrates, so moving it
+;; there is a no-op today and a fix on migration — which is why it is worth
+;; doing on its own terms, before anything migrates. Same repair rf2-hxfy
+;; and rf2-twil made at their own sites; this is the shared widget's half.
+
+(defn- keyed
+  "Return hiccup `node` carrying React key `k` in its ATTRIBUTE MAP — the
+  one place both substrates look (see the comment above).
+
+  `node` is frequently NOT ours. `weave-header` and `weave-body` key a
+  `cell` the CONSUMER built via `:row-cells`, whose second element may be
+  an attrs map, a string, a nested vector, or absent. So the obvious
+  `(assoc-in cell [1 :key] k)` is wrong: against `[:span \"txt\"]` it
+  would REPLACE the child with a map and the text would silently vanish.
+  Three cases instead:
+
+    - second element is a map        → `k` is assoc'd into that map;
+    - vector with no attrs map       → one is INSERTED at position 1 and
+                                       the children shift right;
+    - anything but a non-empty vector (a bare string child, nil, a seq)
+                                     → returned untouched, because there
+                                       is no attrs map to reach.
+
+  An existing `:key` is overwritten — the weavers own their children's
+  sibling keys. Note this deliberately does NOT clear a `:key` left in
+  Clojure metadata by a caller: Reagent would still prefer that stale meta
+  key over the attrs one, but no consumer puts key-meta on the cells it
+  hands in (checked at tip across both panels), so policing it here would
+  be machinery for a case that does not exist."
+  [node k]
+  (if (and (vector? node) (seq node))
+    (if (map? (nth node 1 nil))
+      (assoc-in node [1 :key] k)
+      (into [(nth node 0) {:key k}] (subvec node 1)))
+    node))
+
 ;; ---- Header + body row weavers -------------------------------------------
 
 (defn- weave-header
@@ -524,15 +577,19 @@
              (fn [i cell]
                (let [col-id (:id (nth columns i))]
                  (if (< i (dec n))
-                   [(with-meta cell {:key (str "h-" (name col-id))})
-                    (with-meta
-                      [header-gutter
-                       {:table-id    table-id
-                        :left-id     col-id
-                        :right-id    (:id (nth columns (inc i)))
-                        :dispatch-fn dispatch-fn}]
-                      {:key (str "g-" (name col-id))})]
-                   [(with-meta cell {:key (str "h-" (name col-id))})])))
+                   [(keyed cell (str "h-" (name col-id)))
+                    ;; The gutter's key rides the PROPS map of the
+                    ;; component call form. `header-gutter` destructures
+                    ;; named opts and never spreads them, so the extra
+                    ;; entry is inert for its body — the same shape
+                    ;; rf2-hxfy used for `flat-row-list`.
+                    (keyed [header-gutter
+                            {:table-id    table-id
+                             :left-id     col-id
+                             :right-id    (:id (nth columns (inc i)))
+                             :dispatch-fn dispatch-fn}]
+                           (str "g-" (name col-id)))]
+                   [(keyed cell (str "h-" (name col-id)))])))
              header-cells))))
 
 (defn- weave-body
@@ -545,10 +602,9 @@
              (fn [i cell]
                (let [col-id (:id (nth columns i))]
                  (if (< i (dec n))
-                   [(with-meta cell {:key (str "c-" (name col-id))})
-                    (with-meta (body-spacer col-id)
-                               {:key (str "s-" (name col-id))})]
-                   [(with-meta cell {:key (str "c-" (name col-id))})])))
+                   [(keyed cell (str "c-" (name col-id)))
+                    (keyed (body-spacer col-id) (str "s-" (name col-id)))]
+                   [(keyed cell (str "c-" (name col-id)))])))
              row-cells))))
 
 ;; ---- Top-level view ------------------------------------------------------
@@ -661,7 +717,7 @@
                     cells (row-cells row i)
                     extras (when row-extras (row-extras row i))
                     woven (into [:<>] (weave-body cells columns))]
-                (with-meta
+                (keyed
                   (if (some? extras)
                     ;; Extras path — outer wrapper carries the consumer's
                     ;; attrs untouched (preserves border-bottom, click
@@ -676,5 +732,5 @@
                     [:div (-> attrs
                               (assoc :style (merge (:style attrs) grid-style)))
                      woven])
-                  {:key (row-key row i)})))
+                  (row-key row i))))
             rows))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_key_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_key_cljs_test.cljs
@@ -1,0 +1,326 @@
+(ns day8.re-frame2-xray.views.resizable-table-key-cljs-test
+  "rf2-fcy5 — the shared resizable-table's React keys must ride the
+  ATTRIBUTE MAP, not Clojure metadata.
+
+  ## What is being pinned, and why it is not the rf2-hxfy defect
+
+  rf2-hxfy fixed `^{:key …}` sitting on a CALL form, where the reader
+  meta attaches to the source list and the returned value carries none
+  of it — those keys reached React on NO substrate. These seven sites
+  are the OTHER half of the class: `with-meta` on a vector LITERAL,
+  which Reagent DOES honour (`reagent.impl.template` reads meta first,
+  the props map second). So they work today, and moving them is a no-op
+  today.
+
+  They stop working, silently, the moment this shared widget renders
+  under a Fresco boundary. `re-frame.fresco.impl.codec`'s component-ABI
+  table (HD-016) takes a literal `:key` from the ATTRIBUTE MAP for every
+  head kind it accepts — native tag, `defview` boundary, host, fragment
+  — and the words `meta` / `with-meta` do not occur anywhere in that
+  file. Both consumer panels (`panels/trace.cljs`,
+  `panels/epoch/view.cljs`) would lose every row key and every header
+  cell key with no error and no warning, leaving React to reconcile by
+  position.
+
+  ## TWO renderers, because ONE of them cannot see this defect
+
+  Every key row below reads BOTH doors:
+
+    - `reagent-key` — `(.-key (r/as-element node))`, today's substrate.
+      This is the rf2-hxfy instrument, and against THIS defect it is
+      HOLLOW BY ITSELF: Reagent honours meta AND props, so it returns
+      the same key before and after the change. It is kept because it
+      is the half that pins the change as a NO-OP today.
+
+    - `fresco-key` — `(.-key (rf.fresco.impl.codec/as-element node))`,
+      the codec's own hiccup→element door, which reads what a Fresco
+      boundary would actually commit. This is the half that goes RED
+      on a revert to `with-meta`, and so the half that makes these rows
+      a gate rather than a description.
+
+  Asserting on `(:key (meta node))` would be hollow in both directions
+  — it passes on metadata Fresco reads nowhere, and FAILS on an
+  attrs-map key that works perfectly. `meta-is-not-where-the-key-lives`
+  states that as an executable claim instead of a comment.
+
+  ## The gutter is deliberately not graded by the codec
+
+  `[header-gutter {…}]` is a plain `defn` in head position, which the
+  codec grades `:invalid` and refuses outright — that refusal is
+  rf2-fcy5's REMAINING work (the Fresco sibling), not this change's.
+  Its key is graded at the Reagent door and in the props map, which is
+  where a boundary would later read it from.
+
+  ## The helper's three cases
+
+  `weave-header` / `weave-body` key a `cell` the CONSUMER built, whose
+  second element may be an attrs map, a string, a nested vector, or
+  absent — so the obvious `(assoc-in cell [1 :key] k)` would REPLACE a
+  child with a map and silently delete it. `consumer-cell-*` drives all
+  five shapes through `:row-cells` and asserts both that the key reaches
+  React and that the cell's own children SURVIVE."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (rt/clear!)
+                   (rt/set-storage-key! nil))}))
+
+(defn- xray-setup!
+  "Register Xray handlers + the `:rf/xray` frame. Mirrors
+  `resizable_table_persistence_cljs_test`'s helper of the same name."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray}))
+
+;; ---- the two renderer doors ---------------------------------------------
+
+(defn- reagent-key
+  "The key Reagent hands React. Honours meta AND props, so this alone
+  cannot see the defect — see the ns docstring."
+  [node]
+  (.-key (r/as-element node)))
+
+(defn- fresco-key
+  "The key a Fresco boundary would commit. `as-element` is the codec's
+  own hiccup→element door, so this reads what the substrate commits
+  rather than what the hiccup happens to be carrying (the instrument
+  `cancellation_cascade_cljs_test/emitted-key` uses). Reads nil for a
+  meta-only key, which is the whole point."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element node)))
+
+;; ---- structural navigation ----------------------------------------------
+;;
+;; Navigated by INDEX rather than through `rf.test-helpers/expand-tree`:
+;; that helper rebuilds nested vectors with `mapv`, which would rewrite
+;; the very vectors under test. Each step asserts the landmark it expects
+;; so a layout drift fails loudly here instead of turning a key assertion
+;; into a confusing nil.
+
+(defn- render
+  "Render the shared widget for `opts` inside the `:rf/xray` frame."
+  [opts]
+  (rf/with-frame :rf/xray
+    (rt/resizable-table opts)))
+
+(defn- container-children
+  "The container's children: header hiccup first (nil when `:header?
+  false`), body rows after it."
+  [tree]
+  (is (vector? tree) "the view returned a hiccup vector")
+  (is (= :div (nth tree 0)) "container is a :div")
+  (is (some? (:data-rf-xray-resizable-table (nth tree 1)))
+      "structural navigation landed on the resizable-table container")
+  (vec (drop 2 tree)))
+
+(defn- header-woven
+  "The (2N-1) woven header nodes — header cells interleaved with gutters."
+  [tree]
+  (let [header (first (container-children tree))]
+    (is (vector? header) "header hiccup is present")
+    (is (= "grid" (get-in header [1 :style :display]))
+        "header carries the grid layout")
+    (vec (drop 2 header))))
+
+(defn- body-rows
+  "The body-row wrapper nodes."
+  [tree]
+  (vec (rest (container-children tree))))
+
+(defn- row-woven
+  "The (2N-1) woven cell/spacer nodes inside one DEFAULT-path body row.
+  That row is `[:div attrs woven]` and `woven` is a `[:<> …]` fragment,
+  so the nodes start at index 1 of the fragment."
+  [row]
+  (let [woven (nth row 2)]
+    (is (= :<> (nth woven 0)) "row cells are wrapped in a fragment")
+    (vec (rest woven))))
+
+;; ---- fixtures for the widget --------------------------------------------
+
+(def ^:private three-columns
+  [{:id :a :label "a" :default-flex "1fr"}
+   {:id :b :label "b" :default-flex "1fr"}
+   {:id :c :label "c" :default-flex "1fr"}])
+
+(defn- three-column-opts
+  [extra]
+  (merge {:table-id  :rf.xray.test/keys
+          :columns   three-columns
+          :rows      [{:v 1} {:v 2}]
+          :row-key   (fn [_row i] (str "row-" i))
+          :row-attrs (fn [_row i] {:data-testid (str "r-" i)})
+          :row-cells (fn [row _i]
+                       (for [col three-columns]
+                         [:div {:data-col (name (:id col))} (str (:v row))]))}
+         extra))
+
+;; ---- (1) header cells reach BOTH renderers with keys ---------------------
+
+(deftest header-cells-reach-both-renderers-with-keys
+  (testing "rf2-fcy5 — the three header cells carry their key where BOTH
+            substrates look. The Fresco reading is the one that goes red
+            on a revert to `with-meta`; the Reagent reading pins the
+            change as a no-op today."
+    (xray-setup!)
+    (let [woven (header-woven (render (three-column-opts {})))
+          cells (vec (take-nth 2 woven))]
+      (is (= 5 (count woven)) "3 header cells interleaved with 2 gutters")
+      (is (= ["h-a" "h-b" "h-c"] (mapv reagent-key cells))
+          "REAGENT — unchanged by this fix, and that is the point")
+      (is (= ["h-a" "h-b" "h-c"] (mapv fresco-key cells))
+          "FRESCO — reads nil for every one of these under `with-meta`")
+      (is (= 3 (count (distinct (mapv fresco-key cells))))
+          "sibling keys are distinct"))))
+
+;; ---- (2) gutters: Reagent + props map only ------------------------------
+
+(deftest header-gutters-carry-their-key-in-the-props-map
+  (testing "rf2-fcy5 — the gutter is a component call form, so its key
+            rides the PROPS map `header-gutter` receives (it destructures
+            named opts and never spreads them, so the entry is inert for
+            its body — the shape rf2-hxfy used for `flat-row-list`).
+            NOT graded at the Fresco door: a plain `defn` in head
+            position is `:invalid` to the codec and is refused, which is
+            this bead's remaining work, not this change's."
+    (xray-setup!)
+    (let [woven   (header-woven (render (three-column-opts {})))
+          gutters (vec (take-nth 2 (rest woven)))]
+      (is (= 2 (count gutters)) "N-1 gutters for N columns")
+      (is (= ["g-a" "g-b"] (mapv reagent-key gutters)))
+      (is (= ["g-a" "g-b"] (mapv #(:key (nth % 1)) gutters))
+          "the key is in the props map, where a boundary would read it")
+      (is (every? #(contains? (nth % 1) :dispatch-fn) gutters)
+          "the gutter's own props survive the key injection"))))
+
+;; ---- (3) body cells + spacers reach BOTH renderers with keys ------------
+
+(deftest body-cells-and-spacers-reach-both-renderers-with-keys
+  (testing "rf2-fcy5 — every woven body node (3 cells + 2 spacers) on
+            every row carries its key in the attrs map."
+    (xray-setup!)
+    (let [rows (body-rows (render (three-column-opts {})))]
+      (is (= 2 (count rows)) "two body rows")
+      (doseq [row rows]
+        (let [woven (row-woven row)]
+          (is (= 5 (count woven)) "3 cells interleaved with 2 spacers")
+          (is (= ["c-a" "s-a" "c-b" "s-b" "c-c"] (mapv reagent-key woven))
+              "REAGENT")
+          (is (= ["c-a" "s-a" "c-b" "s-b" "c-c"] (mapv fresco-key woven))
+              "FRESCO — all nil under `with-meta`")
+          (is (= 5 (count (distinct (mapv fresco-key woven))))
+              "sibling keys are distinct"))))))
+
+;; ---- (4) row wrappers reach BOTH renderers with the consumer's key ------
+
+(deftest row-wrappers-reach-both-renderers-with-keys
+  (testing "rf2-fcy5 — the row weaver's own key (the consumer's
+            `:row-key`) reaches both doors, on the default path AND on
+            the `:row-extras` path, which builds a different wrapper."
+    (xray-setup!)
+    (let [plain  (body-rows (render (three-column-opts {})))
+          extras (body-rows (render (three-column-opts
+                                      {:row-extras (fn [_row i]
+                                                     [:div (str "extra-" i)])})))]
+      (is (= ["row-0" "row-1"] (mapv reagent-key plain)) "default path, REAGENT")
+      (is (= ["row-0" "row-1"] (mapv fresco-key plain))  "default path, FRESCO")
+      (is (= ["row-0" "row-1"] (mapv reagent-key extras)) "extras path, REAGENT")
+      (is (= ["row-0" "row-1"] (mapv fresco-key extras))  "extras path, FRESCO")
+      (is (= "r-0" (:data-testid (nth (first extras) 1)))
+          "the consumer's row attrs survive the key injection"))))
+
+;; ---- (5) the helper's three cases, driven through the public view -------
+
+(def ^:private shape-columns
+  [{:id :attrs  :label "attrs"}
+   {:id :bare   :label "bare"}
+   {:id :string :label "string"}
+   {:id :nested :label "nested"}
+   {:id :novec  :label "novec"}])
+
+(defn- shape-cells
+  "One cell per shape the helper must handle:
+     :attrs  — a vector WITH an attrs map
+     :bare   — a vector with no second element at all
+     :string — a vector whose second element is a string
+     :nested — a vector whose second element is a nested vector
+     :novec  — not a vector at all"
+  [_row _i]
+  [[:div {:data-testid "with-attrs"} "A"]
+   [:div]
+   [:span "txt"]
+   [:div [:span "nested"]]
+   "bare string"])
+
+(defn- shape-tree []
+  (render {:table-id  :rf.xray.test/shapes
+           :columns   shape-columns
+           :rows      [{:v 1}]
+           :row-key   (fn [_row i] (str "row-" i))
+           :row-cells shape-cells}))
+
+(deftest consumer-cell-shapes-reach-react-with-keys
+  (testing "rf2-fcy5 — `:row-cells` is the CONSUMER's fn, so a woven cell
+            may or may not carry an attrs map. Every VECTOR shape reaches
+            both renderers with its key; the non-vector is returned
+            untouched, because it has no attrs map to reach and wrapping
+            one round it would change the consumer's markup."
+    (xray-setup!)
+    (let [cells (vec (take-nth 2 (row-woven (first (body-rows (shape-tree))))))]
+      (is (= 5 (count cells)) "five cells, one per column")
+      (is (= ["c-attrs" "c-bare" "c-string" "c-nested"]
+             (mapv reagent-key (subvec cells 0 4)))
+          "REAGENT — every vector shape, attrs map or not")
+      (is (= ["c-attrs" "c-bare" "c-string" "c-nested"]
+             (mapv fresco-key (subvec cells 0 4)))
+          "FRESCO — every vector shape, attrs map or not")
+      (is (= "bare string" (nth cells 4))
+          "a non-vector cell is returned untouched"))))
+
+(deftest consumer-cell-children-survive-the-key-injection
+  (testing "rf2-fcy5 — the guard against `(assoc-in cell [1 :key] k)`. On
+            `[:span \"txt\"]` that expression REPLACES the string child
+            with a map and the text vanishes with nothing thrown. These
+            rows pin that each shape's own children survive."
+    (xray-setup!)
+    (let [cells (vec (take-nth 2 (row-woven (first (body-rows (shape-tree))))))]
+      (is (= [:div {:data-testid "with-attrs" :key "c-attrs"} "A"]
+             (nth cells 0))
+          "an existing attrs map is preserved and merely gains :key")
+      (is (= [:div {:key "c-bare"}] (nth cells 1))
+          "a vector with no attrs map gains one")
+      (is (= [:span {:key "c-string"} "txt"] (nth cells 2))
+          "THE REGRESSION ROW — the string child survives; assoc-in would
+           have deleted it")
+      (is (= [:div {:key "c-nested"} [:span "nested"]] (nth cells 3))
+          "a nested-vector child survives and is not mistaken for attrs"))))
+
+;; ---- (6) the hollow-gate claim, stated executably -----------------------
+
+(deftest meta-is-not-where-the-key-lives
+  (testing "rf2-fcy5 — the reason no row above asserts on `(meta …)`.
+            After this change the key rides the attrs map, so `(meta
+            node)` carries NO key while both renderers receive one. A
+            metadata assertion would therefore FAIL on correct code —
+            and, before the change, PASSED on keys Fresco reads nowhere.
+            Hollow in both directions."
+    (xray-setup!)
+    (let [cell (first (header-woven (render (three-column-opts {}))))]
+      (is (= "h-a" (reagent-key cell)) "Reagent receives the key")
+      (is (= "h-a" (fresco-key cell))  "Fresco receives the key")
+      (is (nil? (:key (meta cell)))
+          "…and Clojure metadata does not carry it — so a `(meta …)`
+           assertion would be a hollow gate here")
+      (is (= "h-a" (:key (nth cell 1)))
+          "the key lives in the attrs map, the one place BOTH Reagent
+           and Fresco's codec look"))))


### PR DESCRIPTION
Slice 1 of rf2-fcy5 — the shared widget only. The two consumer panels are slices 2 and 3 and are untouched here, per the bead's own "DO NOT dispatch the two panels in parallel with the widget".

## The change

`views/resizable_table.cljs` keyed all **seven** of its woven nodes with `with-meta` on a vector literal — three in `weave-header` (header cell, gutter, last header cell), three in `weave-body` (body cell, spacer, last body cell), and the row weaver. Re-counted at the base commit and the count is seven.

**This is not the rf2-hxfy defect, and the difference is the whole point.** Reader meta on a vector *literal* rides the vector Reagent later inspects, so these keys reach React today in both consumer panels. rf2-hxfy's sites were meta on a *call* form, which reached React on no substrate at all.

They reach Fresco nowhere. `re-frame.fresco.impl.codec`'s component-ABI table (HD-016) takes a literal `:key` from the **attribute map** for every head kind it accepts — native tag, `defview` boundary, host, fragment — and the words `meta` / `with-meta` do not occur anywhere in that file. So the moment this shared widget renders under a Fresco boundary, every row and every header cell in `panels/trace.cljs` and `panels/epoch/view.cljs` silently loses its key: no error, no warning, React reconciling by position.

A `:key` in the attrs map is honoured by both substrates, so this is a no-op today and a fix on migration.

### Why it needed a helper rather than a search-and-replace

At `weave-header` and `weave-body` the keyed thing is a `cell` the **consumer** built via `:row-cells`, whose second element may be an attrs map, a string, a nested vector, or absent. `(assoc-in cell [1 :key] k)` is wrong wherever element 1 is not a map — against `[:span "txt"]` it replaces the string child with a map and the text vanishes with nothing thrown. All seven sites therefore go through one `keyed` helper that assocs into an existing attrs map, **inserts** one where there is none, and returns a non-vector untouched.

That last arm also fixes a latent robustness bug: the previous code handed whatever the consumer returned straight to `with-meta`, which throws on a string cell. The revert run below demonstrates it (`No protocol method IWithMeta.-with-meta defined for type string`).

### The tests read TWO renderer doors, because one of them cannot see this defect

- `(.-key (r/as-element node))` — the rf2-hxfy instrument. **Hollow by itself here**: Reagent honours meta *and* props, so it returns the same key before and after. Kept because it pins the change as a no-op today.
- `(.-key (codec/as-element node))` — the codec's own hiccup-to-element door, reading what a Fresco boundary would commit. This is the half that goes red.

That is measured, not asserted: in the revert run the Reagent assertion on line 179 **passed** while the Fresco assertion on line 181 failed with `[nil nil nil]`. A Reagent-only renderer assertion would have shipped a green hollow gate.

No row asserts on `(meta ...)` — hollow in both directions, passing on metadata Fresco reads nowhere and failing on an attrs-map key that works perfectly. `meta-is-not-where-the-key-lives` states that executably.

The gutter is graded at the Reagent door and in its props map only: `[header-gutter {...}]` is a plain `defn` in head position, which the codec grades `:invalid` and refuses. That refusal is this bead's remaining work, not this change's.

## Quality gates

**`npm run test:cljs` (surface `cljs_node_test`) — PASS.** `Ran 11637 tests containing 58351 assertions. 0 failures, 0 errors.` Build: 1942 files, **0 warnings**.

**Hollow-gate check (delete the signal, keep the fault).** Source reverted to the base `with-meta` version, new test kept:

| | tests | assertions | failures | errors | exit |
|---|---|---|---|---|---|
| fix present | 11637 | 58351 | 0 | 0 | 0 |
| fix reverted | 11637 | 58337 | 12 | 2 | 1 |

**Test totals are identical (11637 both sides)**, so this is a genuine runtime failure and not a load error that shrank the suite. All 14 failures/errors are in the new namespace; nothing else in the suite moved. The 14-assertion gap is the two *errors* — an exception aborts the remaining assertions in those two deftests, and the exception is the non-vector-cell `with-meta` throw described above. The source file was restored from the commit and verified byte-clean (`git diff --quiet HEAD` exit 0).

**`cd tools/xray && clojure -M:test` — PASS but NOT the gate for the new test.** `Ran 1276 tests containing 6118 assertions. 0 failures, 0 errors.` This is a JVM run over `:extra-paths ["test"]`, so it can only load `.clj` / `.cljc`; it never loads a `_cljs_test.cljs` file, and a grep of its output for the new namespace returns 0. It is reported because it *does* grade the source change — `frame_singleton_guard_test.clj` text-scans `src/**/*.cljs` — but it cannot be the gate for the deliverable's test row. See "Correction" below.

Not run locally, left to CI: `cljs_browser`, `examples_compile`, `mcp_conformance`, `story_xray_browser`. The classifier arms six surfaces for these paths (verified by handing both paths as arguments to `report-changed-surfaces.sh`); running the browser and conformance tiers locally is gate time spent on evidence the merge criterion reads from CI anyway.

## Correction to the dispatch brief: the nominated local gate does not cover this file

The brief nominated `cd tools/xray && clojure -M:test` as "the gate for this file" and ruled out `npm run test:cljs` on the grounds that `implementation/shadow-cljs.edn`'s `:node-test` build "contains no `tools/` or `xray/` entry at all". **Both halves are wrong, and they invert.** That build's `:source-paths` contain `../tools/xray/src` and `../tools/xray/test`, under a comment that says in terms it exists *"so the :node-test build picks up `tools/xray/test/day8/re_frame2_xray/*_cljs_test.cljs`"*. So `npm run test:cljs` is the covering gate, and the nominated one returns green having never loaded the test. Test namespaces must end `cljs-test` to match that build's `:ns-regexp "cljs-test$"`.

## Deliverable 2 — the Fresco sibling is mechanical, but it needs one file outside this PR

No code for this half, per the brief. Measured at tip.

**1. Component-local-state sites: exactly one.** `header-gutter` — `(let [hover? (r/atom false)] (fn [...] ...))`, a Form-2 Reagent component holding one boolean. The file's other two atoms are *not* component-local state: `storage-key` and `drag-state` are module-level `defonce` plain CLJS atoms, non-reactive, and migrate unchanged. `r/` occurs exactly once in the whole file, and `resizable_table.cljs` is the **only** file under all of `tools/xray/src` that uses `r/atom`.

**2. Fresco's replacement for Form-2 local state: `rf.fresco/reg-state` (HD-009)** — state at `[:ui ::concern ikey]` via ordinary `reg-sub`/`reg-event`, no hook, no context. **But it consumes an instance key; it does not mint one.** `views/edn_inspector.cljs` is the in-repo precedent and states the constraint outright: `edn-inspector-view` *requires* a `:mount-id` and hard-throws without one, because "a React function component has no such body: everything here runs on EVERY render". So keeping the hover as state would force the widget to demand a stable instance key from all **five** consumer call sites — an API change across two panels, not mechanical.

**3. Is the hover reachable with no state at all? Yes — decisively, with a near-identical precedent.** `theme/global_styles.cljs` injects a global `<style>` block already carrying a family of `[data-testid^="..."]:hover` rules, each commented "inline styles can't carry a `:hover` pseudo-class". One of them is `[data-testid^="rf-xray-event-list-col-divider-"]:hover`, which paints a **column-divider drag handle** with `var(--rf-xray-accent)` on hover, by pure CSS, with no state anywhere — functionally the same widget as this gutter. The sibling `resize_handle.cljs` solves it both ways (its vertical handle deliberately drops hover for an always-visible accent; its seam handle delegates hover to `global-styles`). The gutter already stamps `data-testid="rf-xray-resizable-gutter-…"`, so the selector exists today with no markup change.

**And it removes more than the state — it removes the component.** With the Ratom gone, `header-gutter` becomes a pure function returning `[:div ...]`, so it can be *called* like its neighbour `body-spacer` already is rather than sitting in head position. That deletes the only codec-`:invalid` head inside the widget, so the gutter needs no boundary and no instance key, and its `keyed` call then keys a native tag that the codec can grade. It also retires the file's only `reagent.core` usage — which `tools/xray/deps.edn` names as the reason Xray declares the stock `reagent/reagent` dependency at all.

**4. Anything else resisting `defview`? Three of four are free.**
- `:contextType frame-context` — set by `reg-view*` via `build-frame-aware-view`; a `defview` resolves its frame through the boundary instead. Replaced, not lost.
- Injected `subscribe` / `dispatch` — `reg-view` binds them from one `make-capture-frame` handle; `defview` "binds NO name inside your body". Replacement is the settled house idiom `rf.fresco/sub` + `(:dispatch (rf/capture-frame))`, used by roughly ten Xray defviews. Two lines in the body, and the `some-> reaction deref` nil-guard can go.
- Raw window-listener drag flow — **already substrate-neutral**: `on-pointer-down` takes `dispatch-fn` as an explicit parameter and touches nothing Reagent-specific.
- `install!` / `hydrate!` — **zero coupling**. They register an fx, a sub and four events and dispatch into a frame; neither mentions the view, the registration id, or `reg-view`. A sibling needs no change at either call site.

**Verdict: slice 1b is mechanical and needs no ruling, provided the hover moves to CSS.** It was not built here because the load-bearing half is a CSS rule in `theme/global_styles.cljs`, which is outside this PR's editable surface — so the brief's condition for folding it in ("mechanical AND zero callers") could not be met without touching a fenced file.

**One stale claim on the bead, for slice 2/3:** rf2-fcy5 says `edn/inspect-view` "has ZERO callers today". It has real callers at tip — `static/flows/panel.cljs` (two) and `static/schemas/panel.cljs` (one), both already migrated to `defview`. The rest of that paragraph stands; only the caller count is stale.
