### PR TITLE
docs: indent 12 splitting fences so lists stop restarting at 1 (rf2-tdlg)

### DIFF
--- a/docs/EP/EP-0004-subscription-inputs.md
+++ b/docs/EP/EP-0004-subscription-inputs.md
@@ -494,19 +494,19 @@ never rewrites it.
 1. Extend `parse-reg-sub-args` to recognize the two-function form.
 2. Store sub metadata with an input-kind discriminator:
 
-   ```clojure
-   {:handler-fn handler-fn
-    :input-kind :db | :static | :parametric
-    :input-signals [...]
-    :input-fn input-fn}
-   ```
+    ```clojure
+    {:handler-fn handler-fn
+     :input-kind :db | :static | :parametric
+     :input-signals [...]
+     :input-fn input-fn}
+    ```
 
 3. Add a pure input normalizer:
 
-   ```clojure
-   (normalize-sub-inputs input-return)
-   ;; => {:queries [query-v ...]}
-   ```
+    ```clojure
+    (normalize-sub-inputs input-return)
+    ;; => {:queries [query-v ...]}
+    ```
 
 4. Use the normalizer in both the reactive cache path and `compute-sub`.
 5. Store realized input query vectors on cache entries for disposal, trace, and

--- a/docs/core/flows.md
+++ b/docs/core/flows.md
@@ -374,19 +374,19 @@ Flows [fail loud](glossary.md#fail-loud-not-silent) and early. Almost everything
 - **`:rf.error/no-frame-context`** — a `reg-flow` with no surrounding `with-frame` scope and no `:frame` metadata key. The framework won't guess a frame; give it one.
 - **`:rf.error/flow-cycle`** — flow A reads B's output and B reads A's (directly or through a chain). The thrown `ex-data` carries `:cycle`, an ordered vector of flow ids with a closing repeat naming the loop, e.g. `[:a :b :a]`. Flows are a DAG; break the cycle.
 
-  ```clojure
-  (rf/reg-flow :a {:inputs [[:b]] :output-path [:a]} identity)
-  (rf/reg-flow :b {:inputs [[:a]] :output-path [:b]} identity)
-  ;; → ex-info ":rf.error/flow-cycle" {:cycle [:a :b :a]}
-  ```
+    ```clojure
+    (rf/reg-flow :a {:inputs [[:b]] :output-path [:a]} identity)
+    (rf/reg-flow :b {:inputs [[:a]] :output-path [:b]} identity)
+    ;; → ex-info ":rf.error/flow-cycle" {:cycle [:a :b :a]}
+    ```
 
 - **`:rf.error/flow-path-overlap`** — two flows in the same frame whose `:output-path`s stand in a prefix relationship (identical paths included). Two flows writing the same slot would race with no defined order, so the framework rejects the second at registration rather than let one silently clobber the other. Sibling paths under a shared parent — `[:x :y]` and `[:x :z]` — are *fine*; only a genuine prefix overlap is an error.
 
-  ```clojure
-  (rf/reg-flow :a {:inputs [[:w]] :output-path [:x]} identity)
-  (rf/reg-flow :b {:inputs [[:h]] :output-path [:x]} identity)
-  ;; → ex-info ":rf.error/flow-path-overlap"  ([:x] vs [:x])
-  ```
+    ```clojure
+    (rf/reg-flow :a {:inputs [[:w]] :output-path [:x]} identity)
+    (rf/reg-flow :b {:inputs [[:h]] :output-path [:x]} identity)
+    ;; → ex-info ":rf.error/flow-path-overlap"  ([:x] vs [:x])
+    ```
 
 - **`:rf.error/flow-frame-not-live`** — `reg-flow` against a frame that was never created or has already been destroyed. The framework won't seat flow state on a dead frame (a later frame reusing that id would inherit the ghost). `clear-flow`, by contrast, is permissive on an absent frame — it just no-ops, so teardown stays idempotent.
 - **`:rf.error/flow-bad-marks`** — a malformed `:sensitive` / `:large` declaration (a non-vector axis, a non-path entry, or the boolean `:sensitive?` spelling). Rejected fail-closed, as covered in [Classifying a flow's output](#classifying-a-flows-output).

--- a/docs/design/freehand/decisions/D004-state-identity-and-addressing.md
+++ b/docs/design/freehand/decisions/D004-state-identity-and-addressing.md
@@ -175,11 +175,11 @@ The recommended contract is:
    prevents a dropdown and field from accidentally interpreting the same record.
 3. Addresses should name causal ownership, for example:
 
-   ```clojure
-   [:invoice invoice-id :amount]
-   [:editor article-id :title]
-   [:route route-instance :filters :status]
-   ```
+    ```clojure
+    [:invoice invoice-id :amount]
+    [:editor article-id :title]
+    [:route route-instance :filters :status]
+    ```
 
 4. `:key` still identifies siblings for reconciliation. It may equal part of the
    semantic address, but Freehand never derives one from the other.

--- a/skills/re-frame-migration/references/guided-handlers-state.md
+++ b/skills/re-frame-migration/references/guided-handlers-state.md
@@ -157,10 +157,10 @@ The retired app-db root `:rf/runtime` is now a **hard error**. A `:db` value car
 
 1. **Strip any `:rf/runtime` key from the fresh db (always).** A wholesale reset is now safe by construction — `{:db fresh-db}` replaces app-db and leaves machines / routing / SSR untouched in runtime-db. Just ensure `fresh-db` carries **no** `:rf/runtime` key (it would hard-error). If a v1-shaped `fresh-db` or an older preview rewrite still stashes runtime state there, drop it:
 
-   ```clojure
-   (rf/reg-event :initialize-db
-     (fn [_ _] {:db fresh-db}))   ; fresh-db carries NO :rf/runtime — the runtime-db partition is left alone
-   ```
+    ```clojure
+    (rf/reg-event :initialize-db
+      (fn [_ _] {:db fresh-db}))   ; fresh-db carries NO :rf/runtime — the runtime-db partition is left alone
+    ```
 
 2. **Genuinely need to write runtime state? Use the `:rf.db/runtime` effect, never an app-db key.** Framework/extension code that must seed or replace runtime-db emits the reserved `:rf.db/runtime` effect, keeping application data under `:db`. Outside a handler, the one facade mutator is `re-frame.epoch`'s `replace-frame-state!` — `(replace-frame-state! frame-id {:rf.db/runtime v})` is the runtime-only injection. (`re-frame.frame/replace-runtime-db!` is **not** on the facade; the earlier four-mutator family collapsed to this one fn, so a call site that requires it is an M-1 off-contract-namespace hit.) App code rarely needs this — boot machines install their own snapshots when they start.
 

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -165,9 +165,9 @@ Two per-adapter React-context components, one verb each — **roots ensure; prov
 
 - **`frame-provider {:frame existing-id}`** — **SCOPE-only**. Wraps a Reagent / UIx subtree so descendants resolve `current-frame-id` to a frame that **already exists** (created elsewhere by `make-frame`, a tool runtime, or an enclosing boundary). It creates / refreshes / destroys nothing, and **fails loud if the frame is absent** (`:rf.error/frame-provider-frame-absent`):
 
-  ```clojure
-  [rf/frame-provider {:frame :stories} [my-story-shell]]
-  ```
+    ```clojure
+    [rf/frame-provider {:frame :stories} [my-story-shell]]
+    ```
 
 - **`frame-root {:id the-id …}`** — **ENSURE**, a commit-owned boundary (creation runs in a client `useLayoutEffect`, never during render). **Creates the frame if absent, reuses it without re-seeding if present** (idempotent re-mount preserves durable state and does NOT replay `:initial-events`), and provides its id to descendants; **no destroy-on-unmount**. It takes the **same constructor opts as `make-frame`** (`:id` / `:images` / `:initial-events` / record-config) — for view-driven named-frame lifetimes: comparison pages, Story canvases, embedded widgets:
 

--- a/skills/reagent-migration/references/catalog-judgment.md
+++ b/skills/reagent-migration/references/catalog-judgment.md
@@ -176,9 +176,9 @@ Fresco gives you exactly one escape and it is deliberately plain:
   other return, `nil` included, is ignored. That *is* the guard, expressed as
   data-with-a-filter:
 
-  ```clojure
-  {:on-click (h/event [e] (.preventDefault e) (when ok? [:save]))}
-  ```
+    ```clojure
+    {:on-click (h/event [e] (.preventDefault e) (when ok? [:save]))}
+    ```
 
 - **Pure imperative work whose return is irrelevant → a plain function.** It
   crosses to React by identity and Fresco does not touch it. This is legal and

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -3809,10 +3809,10 @@ Two differences from the single-`:spawn` vocabulary, both enforced at registrati
 
 - **`:on-done` IS honoured on a child spec.** It is the same `(fn [{:keys [data result]}] new-data)` fold a single `:spawn` declares, run against the **parent's** `:data` at that child's finality, **before** the join fold. It is what lets a fan-out land each child's result under its own key without a staging slot:
 
-  ```clojure
-  {:id :cfg :machine-id :load-config
-   :on-done (fn [{:keys [data result]}] (assoc-in data [:loaded :cfg] result))}
-  ```
+    ```clojure
+    {:id :cfg :machine-id :load-config
+     :on-done (fn [{:keys [data result]}] (assoc-in data [:loaded :cfg] result))}
+    ```
 
 - **`:on-error` is NOT.** A join child has no per-child error transition: failure control flow under a join is the block's own `:on-any-failed`, which decides for the whole fan-out. Declaring `:on-error` on a child spec is rejected at registration with `:rf.error/machine-unknown-spawn-key` rather than silently ignored.
 

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -3051,13 +3051,13 @@ With the five other wire mechanisms catalogued in [Tool-Pair.md](Tool-Pair.md), 
 
 - **× `:sensitive?` (privacy).** Sensitive drops **before** size elides. A value matching both predicates produces a `:sensitive? true` trace event with the value already redacted; no `:rf.size/large-elided` marker is emitted (the marker itself would leak `:path` / `:bytes` / `:digest`). The walker's predicate cascade is:
 
-  ```clojure
-  (cond
-    (and sensitive? large?)  ::drop                  ; no marker; emit :sensitive? true
-    sensitive?               ::redact-or-drop        ; today's :rf/redacted sentinel
-    large?                   ::elide-with-marker     ; :rf.size/large-elided
-    :else                    ::pass-through)
-  ```
+    ```clojure
+    (cond
+      (and sensitive? large?)  ::drop                  ; no marker; emit :sensitive? true
+      sensitive?               ::redact-or-drop        ; today's :rf/redacted sentinel
+      large?                   ::elide-with-marker     ; :rf.size/large-elided
+      :else                    ::pass-through)
+    ```
 
 - **× `:rf.mcp/diff-from` (epoch diff-encoding).** When a diff patch points at a large value, the walker substitutes the marker inside the patch's `:assoc` slot. The patch itself stays small (path + marker). The `:handle` carries `:as-of-epoch <epoch-id>` when the marker rides a past-epoch payload — `get-path` resolves against the existing epoch-record's `:db-after` snapshot so the agent sees that-epoch's value, not now's.
 - **× `:rf.mcp/dedup-table`.** Marker shapes are small (~150 bytes) — a 5 MB blob referenced from N epoch records produces N markers (~150N bytes) rather than one dedup-table entry plus N references. The marker IS the dedup for large values; no extra dedup work needed. If the agent opts in (`:rf.egress/include-large? true`), the underlying values ride the wire and the dedup table picks them up at the slice boundary — the two mechanisms compose cleanly because they operate at different pipeline points.

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -1097,12 +1097,12 @@ When a route is loading and the user navigates away before the load completes, t
 
 2. **Capture.** An `:on-match`-reached handler declares the framework-supplied `:rf.route/nav-token` cofx via `{:rf.cofx/requires [:rf.route/nav-token]}`; the value-returning supplier delivers the current token (read from `[:rf.runtime/routing :current :nav-token]`) flat under `:rf.route/nav-token` in the handler's coeffects, so the handler captures the epoch live at scheduling time. A loader SHOULD also declare the companion `:rf.route/route-id` cofx (the live route id, read from `[:rf.runtime/routing :current :route-id]`) so it captures **both** facts the route-loader [work id](Managed-Effects.md#work-id-correlation) `[:rf.work/route route-id nav-token loader-id]` needs together — the documented path then cannot thread a nil route id into the work-id tuple (the route id is a *carried* fact of the attempt, captured at scheduling time, never read from the live slice at stale-arrival where a cross-route completion's slice id would be the superseding route's):
 
-   ```clojure
-   (rf/reg-event :cart/load-items
-     {:rf.cofx/requires [:rf.route/nav-token :rf.route/route-id]}    ;; <-- declare BOTH cofx
-     (fn [{:keys [db] :rf.route/keys [nav-token route-id]} _]        ;; <-- "nav-42" + :route/cart, live at scheduling time
-       ...))
-   ```
+    ```clojure
+    (rf/reg-event :cart/load-items
+      {:rf.cofx/requires [:rf.route/nav-token :rf.route/route-id]}    ;; <-- declare BOTH cofx
+      (fn [{:keys [db] :rf.route/keys [nav-token route-id]} _]        ;; <-- "nav-42" + :route/cart, live at scheduling time
+        ...))
+    ```
 
 3. **Threading.** Async completions either (a) carry the captured facts in their follow-up event payload, or (b) use the framework-supplied `:rf.route/with-nav-token` fx wrapper, which names the continuation by the canonical `:rf/reply-to` reply target (the [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) lowering — on match the route loader's `:status :ok` reply map is appended to the target via the shared `re-frame.reply/complete`; on mismatch the completion is suppressed and the app target is never dispatched — a stale completion never app-delivers) and threads the captured token + route id for the gate and the work-id:
 

--- a/spec/Pattern-NineStates.md
+++ b/spec/Pattern-NineStates.md
@@ -349,10 +349,10 @@ When the page issues a fresh `:counter/load` while a previous one is still in fl
 
 1. **`:request-id` supersession.** Using a stable `:request-id` (e.g. `:counter/load` above), the second `:rf.http/managed` with the same id supersedes the first — the older request is superseded with `:reason :request-id-superseded` (per [014 §`:request-id` (internal)](014-HTTPRequests.md#request-id-internal)). A superseded request's app reply is **suppressed** (trace-only) — it never reaches the handler. A *manual* abort or an actor-destroy cancel, by contrast, delivers a live `:status :cancelled` reply carrying the `:rf.http/aborted` map under `:error`; branch on the `:cancelled` status (a separate branch from `:error`) so a cancellation never lands as a user-visible failure:
 
-   ```clojure
-   :cancelled
-   {:db db}                       ;; a cancel is expected; don't broadcast :fetch-failed
-   ```
+    ```clojure
+    :cancelled
+    {:db db}                       ;; a cancel is expected; don't broadcast :fetch-failed
+    ```
 
 2. **Connection-epoch on the dispatched reply.** For request shapes where `:request-id` isn't enough (e.g. the same id is reused after the user has navigated away and back, and an outstanding earlier reply may still be in flight), the page-level container carries an epoch and the reply suppresses on mismatch. The epoch advances on every life event of the container (a reset, a route re-enter); the dispatched success/failure event carries the epoch it was issued under; the handler compares on receipt. This is the canonical staleness idiom; see [Pattern-StaleDetection](Pattern-StaleDetection.md).
 


### PR DESCRIPTION
Repairs **rf2-tdlg**: an under-indented fence ENDS its list, so the markers after it open a fresh list that restarts at 1.

python-markdown wants a list item's child block at `owner_indent + 4`. At 1, 2 or 3 columns the fence is not a child: the list CLOSES, the following markers open a NEW list, and neither `<ol>` carries a `start` attribute. In `spec/012-Routing.md` a reader saw "1. Allocation, 2. Capture, 1. Threading, 2. Validation" where the author wrote four numbered steps. In the `<ul>` cases there is no visible renumbering, but the code block is stranded *between* two lists instead of belonging to its bullet.

Both renderings are valid markup, which is what makes the class silent.

## What changed

Whitespace only. `git diff -w` against trunk is **empty** for the whole branch. One commit per file, ten commits, 12 sites.

| file | `<ol>`+`<ul>` | sites | kind |
| --- | --- | --- | --- |
| `docs/EP/EP-0004-subscription-inputs.md` | 18 → 16 | 2 | ordered |
| `docs/core/flows.md` | 9 → 7 | 2 | unordered |
| `spec/005-StateMachines.md` | 155 → 154 | 1 | unordered |
| `spec/009-Instrumentation.md` | 74 → 73 | 1 | unordered |
| `spec/012-Routing.md` | 63 → 62 | 1 | ordered |
| `spec/Pattern-NineStates.md` | 19 → 18 | 1 | ordered |
| `skills/re-frame-migration/references/guided-handlers-state.md` | 14 → 13 | 1 | ordered |
| `skills/re-frame2/references/fundamentals/frames.md` | 7 → 6 | 1 | unordered |
| `skills/reagent-migration/references/catalog-judgment.md` | 9 → 8 | 1 | unordered |
| `docs/design/freehand/decisions/D004-state-identity-and-addressing.md` | 12 → 11 | 1 | ordered |

Every before/after figure reproduces the bead's measurement exactly.

**594 candidate sites exist across 51 files and only these 12 are defects.** The other 582 are left exactly as written: in those pages the under-indented fence is the LAST block of its item, so there is no following marker for the closed list to strand. Three such non-splitting candidates sit inside two of the files touched here and were deliberately not swept in.

## The fence CONTENT moves with the fence

Worth flagging for anyone repairing this class again. `pymdownx.superfences` dedents a fenced block by the **fence's** indent, and in every one of these sites the content sits at the same indent as the fence. Shifting the two fence lines alone — the obvious minimal repair — merges the list correctly but **changes the rendered code block**: measured on `skills/re-frame2/references/fundamentals/frames.md`, the code text went from `[rf/frame-provider {:frame :stories} [my-story-shell]]` to `clojure\n  [rf/frame-provider …]`, i.e. the info string leaked into the block body. The list count still dropped by the right amount, so a count-only check passes over it. The repair here shifts the opening fence, the closing fence and every enclosed line by the same delta, preserving relative indent.

## Verification — NO AUTOMATED GATE COVERS THIS CLASS

`mkdocs build --strict` has no warning to promote (both renderings are valid markup), neither link gate looks at list structure, and `check_flattened_lists.py` grades consecutive *item pairs* — a split removes the pair rather than failing it, so it reads 0 on this class both before and after. Its green below is a no-regression signal, not evidence the repair worked.

Verified by hand, by **render**, through mkdocs' own config loader (`_load_renderer()` in `scripts/check_flattened_lists.py` — imported, not modified; eleven extensions, not `extensions=['extra']`), with `md.reset()` between documents. Per file, all ten:

- `<ol>`+`<ul>` count drops by exactly the amount above — **and** the post-repair count equals the bead's stated "after" figure;
- `<li>` count UNCHANGED (e.g. 576 → 576 in `spec/005`);
- `<li>` text multiset UNCHANGED once code-block text is excluded — the only li-text change anywhere is the item *gaining* the code block it should always have owned, a strict append;
- code-block text multiset UNCHANGED, and `<pre>` count UNCHANGED — this is the check that catches over-indentation turning a fence into a literal code block;
- every changed line identical after `lstrip()`, line count unchanged, and CRLF byte counts unchanged per file.

Re-run after the repair: **0 splitting sites remain across the ten files**, with the 3 non-splitting candidates still present and still non-splitting.

Gates, all run locally, all green:

| gate | result |
| --- | --- |
| `python scripts/check_doc_slugs.py` | exit 0, silent |
| `python scripts/check_readme_links.py --ci` | exit 0, silent |
| `python -m mkdocs build --strict` | exit 0, 0 WARNING/ERROR lines, 43s |
| `python scripts/check_flattened_lists.py` | exit 0 — 291 files, 0 flattened, 0 unmeasurable |

Nothing here validates prose, tables or nav; anchors and table column counts in the touched pages were unchanged by this diff, since every changed line differs only in leading whitespace.

## The excluded-tree site, called out rather than swept in

The last commit repairs `docs/design/freehand/decisions/D004-…`, the one site of the twelve no reader can see: `design/freehand/` is in `mkdocs.yml`'s `exclude_docs`, so it never renders on the published site, and Freehand is a retired, removed subsystem. Repaired deliberately — the repo already sweeps mechanical tree-wide changes into this tree (`8b17cc53d5`, the product-name sweep, on current trunk), the page is still read on GitHub, and leaving one live instance makes the next census of this class read "1 remaining" and re-litigate the exclusion. It is the **last commit on the branch and touches nothing else**, so it can be dropped on its own if that call goes the other way.

Whether the class earns a permanent gate is rf2-jzv2's open half and is not decided here.
