### PR TITLE
feat(xray): the Static shell becomes four Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2546,18 +2546,30 @@
   ## rf2-uu3lp — DOM-rooted via `display: contents`
 
   Returning the inner component head directly (`[dynamic-chrome]` /
-  `[static-shell/surface]`) would skip the source-coord DOM
+  `[static-shell/surface-bridge]`) would skip the source-coord DOM
   annotation (Spec 006 §Documented exemption: component head) and
   emit a one-shot warning. A `display: contents` wrapper lets
   `data-rf2-source-coord` land on a real DOM node while keeping the
   inner surface as the effective layout child of `shell-view`'s flex
-  column."
+  column.
+
+  ## rf2-k97c.3 — the Static arm is a Fresco boundary behind a bridge
+
+  `static-shell/surface` is now an `rf.fresco/defview`, so this
+  `reg-view` body mounts `static-shell/surface-bridge` — the
+  `as-component` crossing Fresco documents for exactly this direction.
+  The Static chrome therefore renders under THIS shell's enclosing
+  `rf/frame-provider`, taking `:rf/xray` from React context rather than
+  from a second root, and a hiccup walk of this composer now STOPS at
+  the bridge's `[:>]` interop head: what the composer owes is that the
+  Static arm mounts the bridge, and the Static surface's own first
+  paint is `static/shell_fresco_boundary_dom_cljs_test`'s subject."
   []
   (let [mode @(rf/subscribe [:rf.xray/mode])]
     [:div {:data-rf-xray-surface-composer ""
            :style {:display "contents"}}
      (case mode
-       :static  [static-shell/surface]
+       :static  [static-shell/surface-bridge]
        [dynamic-chrome])]))
 
 ;; ---- shell view ----------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -80,10 +80,47 @@
 
   Same discipline as the Dynamic shell. The Static shell is wrapped
   in `[rf/frame-provider {:frame :rf/xray}]`; every subscribe +
-  dispatch inside the shell resolves to `:rf/xray`. Every subscribing
-  region is `reg-view`-registered so its rendered component carries
-  `:contextType frame-context` (Spec 000 §Plain Reagent fns do not
-  pick up the surrounding frame).
+  dispatch inside the shell resolves to `:rf/xray`.
+
+  ## Substrate (rf2-k97c.3)
+
+  The four regions below — [[ribbon]], [[tab-bar]], [[detail-panel]]
+  and [[surface]] — are `rf.fresco/defview` BOUNDARIES, not
+  `rf/reg-view`s. They read through `rf.fresco/sub` and dispatch
+  through `(:dispatch (rf/capture-frame))`, and they resolve their
+  frame from REACT CONTEXT — the same context `rf/frame-provider` and
+  `rf.fresco/frame-provider` both write — so the chrome renders
+  identically under today's Reagent-rendered mount and under the
+  Fresco root Xray will eventually own. Nothing here consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  Boundary count tracks READS and head-position use, not file size.
+  [[ribbon]] and [[surface]] read nothing and are boundaries anyway:
+  [[surface]] because it is what the Dynamic composer mounts (so it is
+  where the crossing sits — one bridge for the whole surface) and
+  because a boundary is the only legal hiccup head for the three
+  regions under it; [[ribbon]] because it carries a dispatcher and
+  hosts the two Reagent islands below.
+
+  TWO REAGENT ISLANDS REMAIN, both reached through an `as-child`
+  seam — `identity` for a hiccup caller and the node lane,
+  `reagent.core/as-element` for a boundary:
+
+    * the L1 ribbon's `frame-switcher/frame-switcher-view` and
+      `mode-pill/mode-pill`, both still `rf/reg-view`s and both ALSO
+      headed by the Dynamic `shell.cljs` ribbon, which is still a
+      `reg-view` tree. Migrating them would move a fenced Dynamic
+      head; islanding them does not.
+    * [[detail-panel]]'s `[(:panel tab)]`, because
+      `panel-registry/reg-l4-tab!` stores a CALLABLE and four of the
+      five Static panels register an `as-component` bridge while
+      `static.routes.panel/Panel` is still an `rf/reg-view`.
+
+  Both are MIGRATION SCAFFOLDING WITH A DEFINED END: the ribbon seam
+  goes when those two widgets are boundaries, and the L4 seam goes
+  when all five Static panels are boundaries and the registry stores
+  them directly — the deletion each panel's own bridge comment
+  already promises.
 
   ## Mode-signal mechanism (4 stacked signals)
 
@@ -114,6 +151,8 @@
     - Flows        — registry browse
     - Interceptors — lens"
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
+            [reagent.core :as r]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
@@ -215,7 +254,7 @@
   reaching back into the Dynamic ns.
 
   `dispatch` is the frame-aware dispatcher captured by the
-  `ribbon` reg-view body so the settings / close clicks land on the
+  [[ribbon]] boundary's body so the settings / close clicks land on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal."
   [dispatch]
   (let [icon-style {:background     "transparent"
@@ -239,26 +278,27 @@
                :style       icon-style}
       "✕"]]))
 
-(rf/reg-view ribbon
-  "L1 ribbon — 56px chrome, Static-flavoured. Per the parent-epic
-  mode-signal mechanism the ribbon paints a 2-px left-edge stripe in
-  the single `:accent` (GitHub blue), same in both modes. Mode pill
-  sits at ribbon-left; the L1 frame-switcher sits between mode-pill and
-  the right-icons cluster; right-icons (Settings · Close) sit at
-  ribbon-right.
+(defn ribbon-tree
+  "The Static L1 ribbon's WHOLE chrome, as a pure function of the
+  frame-bound `dispatch` and the `as-child` spelling for the two
+  REAGENT ISLANDS (see the ns docstring).
 
-  The frame picker is MODE-INDEPENDENT — Static is also frame-scoped
-  (registrations — events · subs · machines · routes · schemas · flows
-  · interceptors — live in a particular frame, so the user must be
-  able to pick which frame they are browsing). Reaching through
-  `frame_switcher.cljs` (the canonical contract surface) keeps Static
-  on the same picker as Dynamic; mode toggles preserve the selection.
-  Dynamic's nav cluster (`[◀ ▶ ⏭]`) and filter pills remain HIDDEN in
-  Static — those clusters are spine-coupled and have no meaning in an
-  event-independent surface.
+  SPLIT OUT OF [[ribbon]] BY rf2-k97c.3, and the split is `defview`'s
+  own documented extract-a-helper spelling rather than an invention: a
+  boundary's body may only run inside a React render window, so
+  `(ribbon)` is no longer a callable that answers hiccup — while the
+  chrome itself is ordinary data → data and is worth walking in the fast
+  node lane.
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
-  [_props]
+  `as-child` is `identity` for a hiccup caller (the node lane, and any
+  Reagent caller), which leaves each island a fn-headed hiccup vector
+  exactly as it has always been; the boundary passes
+  `reagent.core/as-element`, which answers a React element — a legal
+  child anywhere per Fresco's component ABI.
+
+  PURE: `ribbon-right-icons` is CALLED rather than headed, and answers
+  keyword hiccup all the way down."
+  [dispatch as-child]
   [:div {:data-testid "rf-xray-static-ribbon"
          :style {:display          "flex"
                  :align-items      "center"
@@ -281,10 +321,45 @@
    ;; (Dynamic) and event-independent (Static) lenses.
    [:div {:data-testid "rf-xray-static-ribbon-selectors"
           :style {:display "flex" :align-items "center" :gap "8px"}}
-    [frame-switcher/frame-switcher-view]
-    [mode-pill/mode-pill]]
+    ;; rf2-k97c.3 — the two REAGENT ISLANDS. Both are still
+    ;; `rf/reg-view`s, which grade `:invalid` as a Fresco head down the
+    ;; same arm a plain `defn` does, and both are ALSO headed by the
+    ;; Dynamic `shell.cljs` ribbon. See the ns docstring.
+    (as-child [frame-switcher/frame-switcher-view])
+    (as-child [mode-pill/mode-pill])]
    [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-    [ribbon-right-icons dispatch]]])
+    (ribbon-right-icons dispatch)]])
+
+(rf.fresco/defview ribbon
+  "L1 ribbon — 56px chrome, Static-flavoured, and a FRESCO BOUNDARY
+  (rf2-k97c.3) rather than an `rf/reg-view`. Per the parent-epic
+  mode-signal mechanism the ribbon paints a 2-px left-edge stripe in
+  the single `:accent` (GitHub blue), same in both modes. Mode pill
+  sits at ribbon-left; the L1 frame-switcher sits between mode-pill and
+  the right-icons cluster; right-icons (Settings · Close) sit at
+  ribbon-right.
+
+  The frame picker is MODE-INDEPENDENT — Static is also frame-scoped
+  (registrations — events · subs · machines · routes · schemas · flows
+  · interceptors — live in a particular frame, so the user must be
+  able to pick which frame they are browsing). Reaching through
+  `frame_switcher.cljs` (the canonical contract surface) keeps Static
+  on the same picker as Dynamic; mode toggles preserve the selection.
+  Dynamic's nav cluster (`[◀ ▶ ⏭]`) and filter pills remain HIDDEN in
+  Static — those clusters are spine-coupled and have no meaning in an
+  event-independent surface.
+
+  IT READS NOTHING. It is a boundary because it carries the DISPATCHER
+  the settings / close icons need — `(:dispatch (rf/capture-frame))`,
+  core's own door, which answers the boundary's DECLARED frame inside a
+  body and replaces the `dispatch` the `reg-view` body used to inject
+  lexically. Same guarantee, one call, and it is the spelling every
+  migrated view now uses.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface]] mounts it with none, so it is destructured away."
+  [_props]
+  (ribbon-tree (:dispatch (rf/capture-frame)) r/as-element))
 
 ;; ---- L3 tab bar (Static) ------------------------------------------------
 
@@ -297,11 +372,20 @@
   `aria-selected` so assistive tech reads it as a tab, not a generic
   button."
   [dispatch {:keys [id label mnem active?]}]
-  ;; `dispatch` is the frame-bound `dispatch` injected by
-  ;; the `tab-bar` reg-view body and threaded in here (a plain fn
-  ;; invoked as a Reagent component renders in its OWN cycle, so
-  ;; `current-frame-id` would fall through to :rf/default — threading the
-  ;; injected `dispatch` is the reliable path).
+  ;; `dispatch` is the frame-bound dispatcher [[tab-bar]]'s boundary body
+  ;; captures and threads in here. A plain fn invoked as a Reagent
+  ;; component would render in its OWN cycle, so `current-frame-id` would
+  ;; fall through to `:rf/default`; threading the captured `dispatch` is
+  ;; the reliable path, and under a Fresco boundary it is the only one —
+  ;; an AMBIENT dispatch inside a boundary body is a loud refusal.
+  ;;
+  ;; rf2-k97c.3 (RULING 2) — the React `:key` rides in this button's own
+  ;; ATTRIBUTE MAP. It used to be `^{:key id}` reader metadata on the
+  ;; call site's vector literal, which Reagent reads and Fresco's codec
+  ;; reads NOWHERE, so it would have reached React as no key at all once
+  ;; the tab bar rendered through a boundary. The key EXPRESSION is
+  ;; unchanged; the button is the seq element, so the key belongs on it
+  ;; and no extra node is needed to carry one.
   (let [glyph    (if active? "◉" "○")
         color    (if active? (:text-primary tokens) (:text-secondary tokens))
         ;; Mirror the Dynamic tab-button pattern: stable
@@ -309,7 +393,8 @@
         ;; `aria-labelledby` resolves.
         tab-id   (str "rf-xray-static-tab-button-" (name id))
         panel-id (str "rf-xray-static-tabpanel-" (name id))]
-    [:button {:data-testid   (str "rf-xray-static-tab-" (name id))
+    [:button {:key           id
+              :data-testid   (str "rf-xray-static-tab-" (name id))
               :id            tab-id
               :role          "tab"
               :aria-selected (if active? "true" "false")
@@ -339,30 +424,58 @@
       glyph]
      label]))
 
-(rf/reg-view tab-bar
-  "L3 tab bar — five Static tabs. Same height (40px), same row anatomy,
+(defn tab-bar-tree
+  "The Static L3 tab bar's WHOLE chrome, as a pure function of the
+  frame-bound `dispatch` and the selected tab id.
+
+  SPLIT OUT OF [[tab-bar]] BY rf2-k97c.3, for the reason every migrated
+  view splits: a boundary's body may only run inside a React render
+  window, so `(tab-bar)` is no longer a callable that answers hiccup.
+
+  PURE: `tab-button` is CALLED rather than headed, and answers keyword
+  hiccup. The tab INVENTORY still comes from `(tabs)` — the registry
+  read this bar has always made, and process-global rather than
+  frame-scoped."
+  [dispatch selected]
+  [:div {:data-testid "rf-xray-static-tab-bar"
+         :role        "tablist"
+         :aria-label  "Xray Static-mode panel tabs"
+         :style {:display       "flex"
+                 :align-items   "center"
+                 :gap           "4px"
+                 :height        "40px"
+                 :padding       "0 8px"
+                 :background    (:bg-1 tokens)
+                 :border-top    (str "1px solid " (:border-subtle tokens))
+                 :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   ;; iterate the registry's static-mode entries. The `:key` rides in
+   ;; each button's attribute map — see `tab-button` (rf2-k97c.3).
+   (for [{:keys [id] :as tab} (tabs)]
+     (tab-button dispatch (assoc tab :active? (= id selected))))])
+
+(rf.fresco/defview tab-bar
+  "L3 tab bar — five Static tabs, and a FRESCO BOUNDARY (rf2-k97c.3)
+  rather than an `rf/reg-view`. Same height (40px), same row anatomy,
   same ARIA pattern as the Dynamic tab-bar. The selected-tab slot is
   Static-scoped (`:rf.xray.static/selected-tab`) so flipping modes
   doesn't clobber the Dynamic tab choice and vice-versa.
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
-  []
-  (let [selected @(rf/subscribe [:rf.xray.static/selected-tab])]
-    [:div {:data-testid "rf-xray-static-tab-bar"
-           :role        "tablist"
-           :aria-label  "Xray Static-mode panel tabs"
-           :style {:display       "flex"
-                   :align-items   "center"
-                   :gap           "4px"
-                   :height        "40px"
-                   :padding       "0 8px"
-                   :background    (:bg-1 tokens)
-                   :border-top    (str "1px solid " (:border-subtle tokens))
-                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     ;; iterate the registry's static-mode entries.
-     (for [{:keys [id] :as tab} (tabs)]
-       ^{:key id}
-       [tab-button dispatch (assoc tab :active? (= id selected))])]))
+  The READ is `rf.fresco/sub`, a plain call the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. That is the third of the epic's three
+  couplings, and the one a first-paint smoke test cannot see.
+
+  It is its OWN boundary rather than folded into [[surface]] because
+  the two read different things at different rates: hoisting this read
+  up would re-render the whole Static surface — L4 panel included — on
+  every tab click. Boundary count tracks reads.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface]] mounts it with none, so it is destructured away."
+  [_props]
+  (tab-bar-tree (:dispatch (rf/capture-frame))
+                (rf.fresco/sub [:rf.xray.static/selected-tab])))
 
 ;; ---- L4 detail panel ----------------------------------------------------
 ;;
@@ -370,25 +483,31 @@
 ;; mounts the selected tab's `:panel` view; an unknown `:selected-tab`
 ;; falls through to the unknown-tab stub.
 
-(rf/reg-view detail-panel
-  "L4 detail panel — registry-driven mount.
+(defn detail-panel-tree
+  "The Static L4 detail panel's WHOLE chrome, as a pure function of the
+  selected tab id, that tab's registry entry (or `nil`) and the
+  `as-child` spelling for the L4 REAGENT ISLAND.
 
-  Each Static panel's `install!` registers its tab entry via
-  `panel-registry/reg-l4-tab!` with `:modes #{:static}` + a `:panel`
-  view fn. The Static-mode L4 tabs are:
+  SPLIT OUT OF [[detail-panel]] BY rf2-k97c.3, for the reason every
+  migrated view splits: a boundary's body may only run inside a React
+  render window.
 
-    :machines     → `static.machines.panel/panel`
-    :routes       → `static.routes.panel/Panel`
-    :schemas      → `static.schemas.panel/Panel`
-    :flows        → `static.flows.panel/Panel`
-    :interceptors → `static.interceptors.panel/Panel`
+  THE MOUNT IS AN ISLAND, and deliberately. `reg-l4-tab!`'s `:pre`
+  requires `:panel` to be CALLABLE, so four of the five Static panels
+  register an `as-component` BRIDGE — a plain fn answering
+  `[:> Component {}]` — while `static.routes.panel/Panel` is still an
+  `rf/reg-view`. Both grade `:invalid` as a Fresco head, down the same
+  arm. `as-child` is `identity` for a hiccup caller and the node lane,
+  which leaves `[(:panel tab)]` exactly the vector it has always been,
+  and `reagent.core/as-element` for the boundary, which answers a React
+  element — a legal child anywhere per Fresco's component ABI, and the
+  crossing every Static panel's own bridge comment already describes.
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
-  []
-  (let [selected (or @(rf/subscribe [:rf.xray.static/selected-tab])
-                     default-tab)
-        tab      (panel-registry/tab-by-id :static selected)]
-    [:div {:data-testid (str "rf-xray-static-detail-panel-" (name selected))
+  MIGRATION SCAFFOLDING WITH A DEFINED END: when all five Static panels
+  are boundaries the registry takes them directly, the `[:>]` bridges
+  go, and this seam goes with them."
+  [selected tab as-child]
+  [:div {:data-testid (str "rf-xray-static-detail-panel-" (name selected))
            ;; Static L4 closes the tab/tabpanel loop.
            ;; Pairs with the per-tab `id` set by `tab-button` so
            ;; assistive tech reads the panel as "labelled by <tab
@@ -402,24 +521,53 @@
                    :background  (:bg-2 tokens)
                    :color       (:text-primary tokens)}}
      (if tab
-       [(:panel tab)]
+       (as-child [(:panel tab)])
        [:div {:data-testid "rf-xray-static-tab-unknown"
               :style {:padding     "16px"
                       :color       (:text-secondary tokens)
                       :font-family sans-stack}}
-        "Unknown Static tab: " [:code (pr-str selected)]])]))
+        "Unknown Static tab: " [:code (pr-str selected)]])])
+
+(rf.fresco/defview detail-panel
+  "L4 detail panel — registry-driven mount, and a FRESCO BOUNDARY
+  (rf2-k97c.3) rather than an `rf/reg-view`.
+
+  Each Static panel's `install!` registers its tab entry via
+  `panel-registry/reg-l4-tab!` with `:modes #{:static}` + a `:panel`
+  view fn. The Static-mode L4 tabs are:
+
+    :machines     → `static.machines.panel/panel`
+    :routes       → `static.routes.panel/Panel`
+    :schemas      → `static.schemas.panel/Panel`
+    :flows        → `static.flows.panel/Panel`
+    :interceptors → `static.interceptors.panel/Panel`
+
+  The READ is `rf.fresco/sub`. It is its OWN boundary rather than
+  folded into [[surface]] for the reason [[tab-bar]] is: the L4 mount
+  is the most expensive subtree in the surface, and hoisting the tab
+  read above it would re-render the ribbon and the tab bar with it.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface]] mounts it with none, so it is destructured away."
+  [_props]
+  (let [selected (or (rf.fresco/sub [:rf.xray.static/selected-tab])
+                     default-tab)]
+    (detail-panel-tree selected
+                       (panel-registry/tab-by-id :static selected)
+                       r/as-element)))
 
 ;; ---- Static surface ------------------------------------------------------
 
-(rf/reg-view surface
-  "The full Static surface — 3 stacked layers (ribbon · tab bar ·
-  detail panel). The Static surface plugs into the Dynamic shell's
-  outer envelope (`shell.cljs/shell-view`) which owns the
-  frame-provider + global-styles install + modal mounts; this surface
-  just renders the chrome that swaps in when Static mode is active.
+(defn surface-tree
+  "The Static surface's outer envelope, as a pure function of its three
+  already-composed layers. Genuinely shared between the two lanes
+  rather than reproduced for them: [[surface]] passes the three
+  BOUNDARY-headed vectors and `test-helpers.static-shell-tree` passes
+  the three layers' already-expanded plain hiccup, so a node-lane row
+  that walks this envelope walks the real thing.
 
-  `reg-view`-registered for parity with every other shell region."
-  []
+  SPLIT OUT OF [[surface]] BY rf2-k97c.3."
+  [ribbon* tab-bar* detail-panel*]
   [:div {:data-testid "rf-xray-static-surface"
          :data-rf-xray-mode "static"
          :style {:display          "flex"
@@ -430,6 +578,68 @@
                  :color            (:text-primary tokens)
                  :font-family      sans-stack
                  :font-size        (:body type-scale)}}
-   [ribbon {}]
-   [tab-bar]
-   [detail-panel]])
+   ribbon*
+   tab-bar*
+   detail-panel*])
+
+(rf.fresco/defview surface
+  "The full Static surface — 3 stacked layers (ribbon · tab bar ·
+  detail panel), and a FRESCO BOUNDARY (rf2-k97c.3) rather than an
+  `rf/reg-view`. The Static surface plugs into the Dynamic shell's
+  outer envelope (`shell.cljs/shell-view`) which owns the
+  frame-provider + global-styles install + modal mounts; this surface
+  just renders the chrome that swaps in when Static mode is active.
+
+  IT READS NOTHING, and it is still a boundary for the two reasons the
+  ns docstring gives: it is what the Dynamic composer mounts, so it is
+  where the Reagent→Fresco crossing sits — one bridge for the whole
+  surface — and a boundary is the only legal hiccup head for the three
+  region boundaries below it.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface-bridge]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (surface-tree [ribbon {}] [tab-bar] [detail-panel]))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's DYNAMIC shell is still a `reg-view` tree rendered by the
+;; installed adapter, and `shell.cljs`'s `surface-composer` mounts this
+;; surface as the hiccup head `[static-shell/surface]` — which a React
+;; component is not.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI.
+;;
+;; THE BRIDGE IS PUBLIC, unlike the Static panels' private ones, and
+;; that is measured rather than defaulted: `surface-composer` mounts it
+;; BY NAME from another namespace, so a name has to cross. `surface`
+;; itself keeps the natural name — the #9581 spelling the mayor's
+;; RULING 1 fixed as the surviving one — and neither
+;; `spec/api-manifest.edn` nor its curated sidecar rows anything in this
+;; namespace, so no hot-zone file moves.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When `shell.cljs` is itself a
+;; Fresco tree, `surface-composer` heads `surface` directly, `[:>]` goes,
+;; and both defs below are deleted.
+
+(def ^:private surface-component
+  "The React component [[surface]] presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the whole
+  Static surface on each parent render."
+  (rf.fresco/as-component surface))
+
+(defn surface-bridge
+  "The callable `shell.cljs`'s `surface-composer` mounts for Static
+  mode. Returns Reagent-shaped hiccup interoping to the React component
+  above; the shell's enclosing `rf/frame-provider` is what puts
+  `:rf/xray` in React context for it."
+  []
+  [:> surface-component {}])

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -37,7 +37,8 @@
             [day8.re-frame2-xray.settings.view :as settings-view]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
-            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
@@ -125,7 +126,7 @@
   (testing "rf2-plajx — Static L4 panel mirrors the Dynamic pattern."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree        (static-shell/surface)
+      (let [tree        (static-shell-tree/surface-tree)
             active-tab  :machines ;; the default Static tab
             tab-button  (rf.test-helpers/find-by-testid tree (str "rf-xray-static-tab-" (name active-tab)))
             tab-attrs   (props tab-button)

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_machines_panel_e2e_cljs_test.cljs
@@ -61,7 +61,8 @@
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
-            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.test-helpers.e2e-multi-frame :as e2e]
             [day8.re-frame2-xray.test-helpers.host-fixtures.deep-machine
              :as deep-machine]
@@ -79,13 +80,17 @@
   `static-shell/detail-panel` case-switch on the right axis. Returns
   the expanded hiccup tree.
 
-  The view-fn `static-shell/surface` is `reg-view`-registered so its
-  subscribes resolve to `:rf/xray` when invoked inside a
-  `with-frame :rf/xray` body."
+  RE-POINTED BY rf2-k97c.3. `static-shell/surface` is now an
+  `rf.fresco/defview`, so it is no longer a callable that answers
+  hiccup and `[static-shell/surface]` is no longer a hiccup head the
+  node-lane walker can expand. `test-helpers.static-shell-tree`
+  reproduces the four boundaries' reads and composes the shell through
+  its own exported `*-tree` fns, so what this walk sees is the shipped
+  chrome; the subject of the suite is unchanged."
   []
   (rf/dispatch-sync [:rf.xray/set-mode :static] {:frame :rf/xray})
   (rf/with-frame :rf/xray
-    (rf.test-helpers/expand-tree [static-shell/surface])))
+    (rf.test-helpers/expand-tree (static-shell-tree/surface-tree))))
 
 (defn- render-machines-panel
   "Render the Machines sub-tab's own tree under `:rf/xray`, off the LIVE

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -37,7 +37,8 @@
             [day8.re-frame2-xray.static.machines.instances-jump :as jump]
             [day8.re-frame2-xray.static.machines.persistence :as ls]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
-            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.test-helpers.static-machines-tree
              :as machines-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
@@ -113,7 +114,7 @@
     (xray-setup!)
     (seed-machines! [:m/a :m/b])
     (rf/with-frame :rf/xray
-      (let [tree  (static-shell/surface)
+      (let [tree  (static-shell-tree/surface-tree)
             slot  (rf.test-helpers/find-by-testid
                     tree "rf-xray-static-detail-panel-machines")
             tab   (panel-registry/tab-by-id :static :machines)

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -39,6 +39,8 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.routes.panel :as panel]
             [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -341,7 +343,7 @@
       (rf/dispatch-sync [:rf.xray.static/select-tab :routes] {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree (static-shell/surface)]
+      (let [tree (static-shell-tree/surface-tree)]
         ;; When the :routes tab is selected the Static shell mounts the
         ;; Static Routes panel (not the placeholder card).
         (is (some? (find-by-testid tree "rf-xray-static-routes"))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -44,6 +44,8 @@
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.persistence :as static-persistence]
             [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -172,7 +174,7 @@
             (NO L2 event list — Static is event-INDEPENDENT)"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (static-shell/surface)]
+      (let [tree (static-shell-tree/surface-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-surface"))
             "Static surface envelope present")
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-ribbon"))
@@ -195,7 +197,7 @@
             has no spine)."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (static-shell/surface)]
+      (let [tree (static-shell-tree/surface-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-mode-pill"))
             "mode pill present at ribbon-left")
         ;; L1 frame picker mounts in Static (the picker collapses to a
@@ -232,7 +234,7 @@
             (Machines / Routes / Schemas / Flows / Interceptors)"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (static-shell/surface)]
+      (let [tree (static-shell-tree/surface-tree)]
         (doseq [tab-id expected-static-tab-ids]
           (is (some? (rf.test-helpers/find-by-testid tree (str "rf-xray-static-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))
@@ -243,14 +245,14 @@
             button, aria-selected matching the active state)"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree    (static-shell/surface)
+      (let [tree    (static-shell-tree/surface-tree)
             tab-bar (rf.test-helpers/find-by-testid tree "rf-xray-static-tab-bar")
             attrs   (second tab-bar)]
         (is (= "tablist" (:role attrs))
             "container carries role='tablist'")
         (is (string? (:aria-label attrs))
             "container has an accessible name"))
-      (let [tree (static-shell/surface)]
+      (let [tree (static-shell-tree/surface-tree)]
         (doseq [tab-id expected-static-tab-ids]
           (let [btn   (rf.test-helpers/find-by-testid tree (str "rf-xray-static-tab-" (name tab-id)))
                 attrs (second btn)]
@@ -284,7 +286,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (frame-dispatch [:rf.xray.static/select-tab :machines])
-      (let [tree  (static-shell/surface)
+      (let [tree  (static-shell-tree/surface-tree)
             slot  (rf.test-helpers/find-by-testid
                     tree "rf-xray-static-detail-panel-machines")
             mount ((:panel (panel-registry/tab-by-id :static :machines)))]
@@ -396,13 +398,28 @@
 
 (deftest surface-composer-renders-static-when-mode-static
   (testing "with mode :static, the composer renders the Static surface
-            (per rf2-8l3uk — Static mode is unconditionally available)"
+            (per rf2-8l3uk — Static mode is unconditionally available).
+
+            RE-AUTHORED ONE LEVEL UP BY rf2-k97c.3, the same repair the
+            mayor ruled correct for `static-machines-mounts-live-panel`.
+            `static-shell/surface` is now an `rf.fresco/defview` behind
+            an `as-component` bridge, so this hiccup walk reaches the
+            bridge's `[:>]` interop head and STOPS —
+            `rf-xray-static-surface` is committed by React, not present
+            in the tree. Asserting that testid here would from now on be
+            asserting the walker's reach rather than the mount, which is
+            the hollow-gate shape. What the COMPOSER owes is that the
+            Static arm mounts exactly `surface-bridge` and that no
+            Dynamic region mounts beside it; the Static surface's own
+            first paint is W1 in
+            `static/shell_fresco_boundary_dom_cljs_test`."
     (xray-setup!)
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
       (let [tree (shell/surface-composer)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-surface"))
-            "Static surface mounts")
+        (is (= [static-shell/surface-bridge] (last tree))
+            (str "the Static arm mounts exactly `surface-bridge`. "
+                 "Got: " (pr-str (last tree))))
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon"))
             "Dynamic ribbon does NOT mount")
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-list"))
@@ -459,11 +476,18 @@
             Static tabs project a per-frame surface (machines snapshots,
             current-route slice, app-db schemas, flows), so the picker
             is mode-INDEPENDENT and persists across mode toggles even
-            though the registrar itself is process-global"
+            though the registrar itself is process-global.
+
+            rf2-k97c.3 — driven through the Static shell's own tree
+            composer rather than through `shell/surface-composer`, whose
+            walk now stops at the Fresco bridge. The claim is unchanged
+            and the ribbon under test is the shipped one; only the door
+            onto it moved. `surface-composer-renders-static-when-mode-
+            static` above is what still pins the composer's Static arm."
     (xray-setup!)
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
-      (let [tree (shell/surface-composer)]
+      (let [tree (static-shell-tree/surface-tree)]
         (is (or (some? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker"))
                 (some? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame")))
             "L1 frame picker (or single-frame label) present in Static")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,656 @@
+(ns day8.re-frame2-xray.static.shell-fresco-boundary-dom-cljs-test
+  "Xray's Static SHELL re-authored in the re-frame-native view layer, read
+  off a real React commit (rf2-k97c.3).
+
+  `static.shell`'s four regions — `ribbon`, `tab-bar`, `detail-panel` and
+  `surface` — are now `rf.fresco/defview` BOUNDARIES rather than
+  `rf/reg-view`s. Every earlier increment of this epic migrated a PANEL;
+  this is the first to migrate a piece of Xray's own CHROME, and the
+  chrome is what the mount path paints. This file is the behavioural
+  evidence for that swap.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1, and here that means the whole
+                                    3-layer chrome, because the node lane
+                                    can no longer walk past the bridge
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes
+                                    the update mean liveness)
+    3 XRAY'S OWN INTERACTIONS     — W2's phase 3 fires the shell's OWN
+                                    affordance, a tab click, through the
+                                    committed DOM
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                    — W3, SCOPED — see below
+    6 CLEAN TEARDOWN              — W4
+
+  W5 is not one of the six: it witnesses that the tab-button React key
+  the migration moved out of `^{:key …}` reader metadata and into the
+  button's own ATTRIBUTE MAP is the key React actually reconciles on.
+  A lost key does not fail — it degrades into index-based
+  reconciliation, which paints identically and corrupts identity only
+  once the list changes SHAPE — so no amount of \"the tabs are on
+  screen\" can see it. The key expression is the tab `id`, a keyword,
+  which is DOMAIN-shaped rather than positional, so a head-removal
+  identity row can see it (the positional-key case two earlier
+  increments hit has nothing for such a row to witness).
+
+  ## W3'S ZERO IS SCOPED, AND THE SCOPE IS THE POINT
+
+  A Fresco boundary emits no `:rf.view/*` op — that is the structural
+  claim, and W3 makes it. But the Static shell's rendered SUB-TREE is
+  not trace-silent, and cannot be in this increment: the L1 ribbon
+  reaches `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`
+  through an `as-child` REAGENT ISLAND, and both are still `rf/reg-view`s
+  that emit view trace wherever they render.
+
+  So W3 asserts on the view-op ids rather than on a bare count: NO op
+  names a view in `day8.re-frame2-xray.static.shell`, and the ids that
+  DO fire are exactly the two documented islands. That second half is
+  what stops the row degrading into \"some ops fired, fine\" — a future
+  change that islands a third widget reddens here and has to say so.
+  The remaining emissions go when those two widgets are boundaries, in
+  the same commit that deletes the ribbon's `as-child` seam.
+
+  ## The mount is the SHELL'S mount
+
+  `shell.cljs`'s `surface-composer` mounts the Static arm as the hiccup
+  head `[static-shell/surface-bridge]` inside `shell-view`'s
+  `[rf/frame-provider {:frame …}]`. [[mount-shell!]] does exactly that.
+
+  Nothing below ever calls a view a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed
+  on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the chrome is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing: the fixture's default ambient
+  scope is still in effect during a synchronous `flushSync`, and tier 1
+  of the frame resolver is the dynamic var, so an ambient frame would
+  SHADOW the React-context tier W1's frame-targeting row is about and
+  that row would pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing
+  silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. Two rows need
+  one that is not `:rf/xray`: W1 reads it as the negative half of the
+  frame-targeting claim, and W3 mounts INSIDE it so the evidence claim
+  cannot be carried by `:rf/xray`'s trace-disabled gate."
+  ::app)
+
+(def ^:private selected-tab-q
+  "The shell's one read, made by TWO of its boundaries (`tab-bar` and
+  `detail-panel`, deliberately kept apart so a tab click does not
+  re-render the ribbon). Named once because three rows key off it — the
+  sub-cache is keyed by the query vector itself, so this value IS the
+  cache key."
+  [:rf.xray.static/selected-tab])
+
+(def ^:private shell-ns
+  "The namespace whose views W3 asserts emit nothing. Compared against
+  the `view-id` half of a `:rf.view/render-key`, which is a namespaced
+  keyword naming the registered `reg-view`."
+  "day8.re-frame2-xray.static.shell")
+
+(def ^:private expected-island-views
+  "The view-ids W3 EXPECTS to fire, and the whole of them: the L1
+  ribbon's two `as-child` Reagent islands. Stated positively so that
+  islanding a third widget cannot slip past a row that only counted
+  zeros in one direction.
+
+  W3 PINS THE L4 SLOT TO :flows FOR THIS SET TO BE WELL-DEFINED, and
+  the reason is measured rather than tidy. Written against the DEFAULT
+  :machines tab the row failed with a third id,
+  `panels.machine-canvas/Chart` — the Static Machines panel's own
+  Topology island, which `definition-detail` reaches through its
+  `as-child` seam once a machine is selected. Whether one IS selected
+  is a property of the PAGE rather than of this row: the registrar is
+  process-GLOBAL, the `:browser-test` build runs every `-dom-cljs-test`
+  namespace in one page, and a neighbouring suite's `rf/reg-machine`
+  is enough. So :machines would make this set depend on load order in
+  BOTH directions. The Flows tab is fully migrated with no island at
+  all, which makes the set a statement about THIS shell."
+  #{:day8.re-frame2-xray.frame-switcher/frame-switcher-view
+    :day8.re-frame2-xray.static.mode-pill/mode-pill})
+
+(def ^:private island-free-tab
+  "The Static tab W3 mounts. See [[expected-island-views]]."
+  :flows)
+
+;; ---- probes ---------------------------------------------------------------
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W3, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame,
+  in the same commit shape as the shell — so the only variable between
+  it and the shell's chrome is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+(defn- probe-panel
+  "W2's deaf lever mounts a real L4 tab, so it needs a real `:panel`
+  callable. Plain hiccup: the tab under test is the BUTTON in the L3
+  bar, never this body."
+  []
+  [:div {:data-testid "rf-xray-static-probe-panel"}])
+
+(def ^:private probe-tab-id :probe/deaf)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W4's release row read a residue that is not
+                      ;; this shell's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than an
+;; omission. A Fresco boundary is NOT in Reagent's render queue — its update is
+;; scheduled by the collector through React — so draining Reagent's queue
+;; commits nothing of these boundaries', and a row written that way reads a DOM
+;; that has not moved and reports a live shell as dead. Mount is committed with
+;; `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the Static tab
+  slot's sub / event family AND every Static panel's `:static` L4 tab
+  entry, so the L3 bar and the L4 mount both read the real registry —
+  and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- mount-shell!
+  "Mount the Static shell the way `shell.cljs`'s `surface-composer`
+  mounts it: `static-shell/surface-bridge` as a hiccup head, inside a
+  `frame-provider` scoping `frame`. Committed synchronously — React 19's
+  `root.render` is otherwise async and phase 1 would assert against an
+  empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [static-shell/surface-bridge]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid [container id]
+  (q container (str "[data-testid=\"" id "\"]")))
+
+(defn- tab-node
+  "The committed `<button>` for one Static tab id, or nil."
+  [container tab-id]
+  (testid container (str "rf-xray-static-tab-" (name tab-id))))
+
+(defn- tab-nodes [container]
+  (vec (.from js/Array
+              (.querySelectorAll
+                container
+                "[data-testid^=\"rf-xray-static-tab-\"][role=\"tab\"]"))))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display of the WHOLE chrome, and the read lands in the frame
+;;      the tree named
+;; ===========================================================================
+
+(deftest w1-shell-paints-three-layers-and-its-read-lands-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Static shell commits its whole
+            3-layer chrome through the bridge `surface-composer` mounts,
+            and its `rf.fresco/sub` read resolves against the frame the
+            enclosing `frame-provider` named rather than the ambient one.
+            Epic criteria 1 and 4.
+
+            THIS ROW CARRIES MORE THAN A PANEL'S W1 DOES, and by
+            necessity: the node lane's chrome rows now stop at the
+            bridge's `[:>]` interop head, so the assertion that all three
+            layers actually paint has nowhere else to live."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            {:keys [container root]} (mount-shell! :rf/xray)]
+        (try
+          (is (some? (testid container "rf-xray-static-surface"))
+              "the Static surface committed a real DOM root under React — a
+               Fresco boundary mounted through Reagent's `:>` from the bridge
+               `surface-composer` names")
+          (is (some? (testid container "rf-xray-static-ribbon"))
+              "L1 ribbon painted")
+          (is (some? (testid container "rf-xray-static-tab-bar"))
+              "L3 tab bar painted")
+          (is (some? (testid container "rf-xray-static-detail-panel-machines"))
+              "L4 detail panel painted on the default :machines tab")
+          (is (= 5 (count (tab-nodes container)))
+              (str "all five Static tabs painted, so the L3 bar really ran "
+                   "through `tab-bar-tree` rather than painting an empty "
+                   "container. Got: " (count (tab-nodes container))))
+          (is (nil? (testid container "rf-xray-event-list"))
+              "and NO L2 event list — Static is event-INDEPENDENT, which is
+               the one structural claim that distinguishes this surface from
+               the Dynamic one")
+          ;; The two Reagent islands crossed. `as-child` handing back
+          ;; something React drops would leave the chrome above intact and
+          ;; only these missing, which is why they are asserted separately.
+          (is (some? (testid container "rf-xray-mode-pill"))
+              "the mode-pill ISLAND crossed the `as-child` seam and
+               committed — a `reg-view` reached through
+               `reagent.core/as-element` from inside a Fresco body")
+          (is (some? (testid container "rf-xray-static-ribbon-icons"))
+              "and the right-icons cluster, which is CALLED rather than
+               headed, painted beside it")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray selected-tab-q))
+              (str "the shell's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame selected-tab-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-shell-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted shell re-renders and commits new DOM
+            when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control
+            that makes the update mean liveness rather than a commit that
+            simply had not happened yet; and epic criterion 3, because the
+            lever in phase 3 is the shell's OWN affordance — a tab button
+            clicked in the committed DOM — rather than a dispatch aimed at
+            the slot from outside.
+
+            THE DEAF LEVER IS THE L4 TAB REGISTRY, which is a
+            process-GLOBAL atom that `tab-bar-tree` reads through `(tabs)`
+            and that no subscription watches. Registering a tab therefore
+            changes what the bar WOULD compute while invalidating nothing
+            it holds — which is exactly the shape a deaf control needs."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-shell! :rf/xray)
+              surface (testid container "rf-xray-static-surface")
+              probe?  (fn [] (some? (tab-node container probe-tab-id)))
+              flows?  (fn [] (some? (testid container
+                                            "rf-xray-static-detail-panel-flows")))]
+          (is (some? surface)
+              "PRECONDITION: the shell is on screen at all")
+          (is (some? (testid container "rf-xray-static-detail-panel-machines"))
+              "PRECONDITION: the L4 slot starts on the default :machines tab")
+          (is (not (probe?))
+              "NON-VACUITY: the tab this row drives in is NOT on screen
+               before it is registered")
+
+          ;; ---- phase 2: the world moves, and the shell is deaf ------------
+          (panel-registry/reg-l4-tab!
+            {:id    probe-tab-id
+             :label "Deaf"
+             :mnem  "z"
+             :modes #{:static}
+             :order 99
+             :panel probe-panel})
+          (is (some? (panel-registry/tab-by-id :static probe-tab-id))
+              "PRECONDITION: the read's UNDERLYING data now carries the new
+               tab — so a missing button below is the bar failing to
+               re-render, and not the tab failing to exist")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (probe?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the new tab button. A bar that
+                       re-rendered here would make phase 3 pass for a reason
+                       that is not liveness")
+                  ;; ---- phase 3: the shell's OWN affordance, in the DOM ----
+                  (.click (tab-node container :flows))
+                  (rf.test-support/poll-until flows?
+                    {:label "the shell committed the :flows L4 slot"})))
+              (.then
+                (fn [_]
+                  (is (flows?)
+                      "clicking the shell's own :flows tab button re-rendered
+                       the L4 boundary on a real invalidation of its read and
+                       committed the new slot — criteria 2 and 3 together")
+                  (is (nil? (testid container
+                                    "rf-xray-static-detail-panel-machines"))
+                      "and the old slot is gone, so this is a swap rather than
+                       an accretion")
+                  (is (probe?)
+                      "the L3 bar re-rendered in the same turn and NOW carries
+                       the tab it was deaf to — which is what makes the
+                       control above an absence of liveness rather than an
+                       absence of data")
+                  (is (identical? surface (testid container
+                                                  "rf-xray-static-surface"))
+                      "and it is the SAME surface node: React reconciled the
+                       live tree in place, so the swap did not arrive by the
+                       shell being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (panel-registry/unreg-l4-tab! probe-tab-id)
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — the tool's own chrome is not application view evidence
+;; ===========================================================================
+
+(defn- view-ids-of
+  "The `view-id` half of every `:rf.view/*` op in `traces` — a
+  `:rf.view/render-key` is `[view-id instance-token]`."
+  [traces]
+  (into #{}
+        (comp (filter #(and (keyword? (:operation %))
+                            (= "rf.view" (namespace (:operation %)))))
+              (map #(first (:rf.view/render-key (:tags %))))
+              (remove nil?))
+        traces))
+
+(deftest w3-the-shell-boundaries-emit-no-view-trace
+  (testing "rf2-k97c.3 / rf2-tqlmq — rendering the migrated Static chrome
+            contributes NOTHING to the substrate's view-trace stream under
+            any of its own view names, even when it is mounted INSIDE an
+            application frame. Epic criterion 5, proven structurally
+            rather than by the `:rf/xray` frame gate: a Fresco boundary is
+            not a substrate view render, so there is no event to gate.
+
+            THE ZERO IS SCOPED, AND THE SCOPE IS ASSERTED. The rendered
+            sub-tree is not silent — the ribbon's two `as-child` Reagent
+            islands are still `reg-view`s and emit wherever they render —
+            so this row states BOTH halves: no id names the shell's own
+            namespace, and the ids that fire are exactly those two
+            islands. A future change that islands a third widget reddens
+            here rather than sliding under a bare count.
+
+            The control is an ordinary `reg-view` in the same root, the
+            same frame and the same commit shape."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_      (setup!)
+            traces (atom [])]
+        ;; The L4 slot is pinned to an island-free tab BEFORE the listener is
+        ;; armed, and in the frame the shell will read from — React context,
+        ;; not the ambient scope. See `expected-island-views`.
+        (rf/dispatch-sync [:rf.xray.static/select-tab island-free-tab]
+                          {:frame app-frame})
+        (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+        (try
+          ;; ---- the subject: the shell, mounted in an APPLICATION frame ----
+          (let [{:keys [container root]} (mount-shell! app-frame)
+                ids (view-ids-of @traces)]
+            (try
+              (is (some? (testid container "rf-xray-static-surface"))
+                  "precondition: the chrome really did render in this commit —
+                   an empty container would make the zero below vacuous")
+              (is (some? (testid container
+                                 (str "rf-xray-static-detail-panel-"
+                                      (name island-free-tab))))
+                  (str "precondition: the L4 boundary really did mount the "
+                       "island-free tab, so the id set below is scoped by a "
+                       "tree that IS there rather than by one that is absent "
+                       "for some other reason"))
+              (is (empty? (filterv #(= shell-ns (namespace %)) ids))
+                  (str "no :rf.view/* op names a view in " shell-ns
+                       " — the four chrome regions are boundaries, not "
+                       "substrate view renders. Ids seen: " (pr-str ids)))
+              (is (= expected-island-views ids)
+                  (str "and the ids that DO fire are exactly the two "
+                       "documented Reagent islands, so the scope of the zero "
+                       "above is pinned rather than assumed. Expected: "
+                       (pr-str expected-island-views)
+                       " Got: " (pr-str ids)))
+              (finally (teardown! root container))))
+
+          ;; ---- the control: a reg-view, same root shape, same frame -------
+          (reset! traces [])
+          (let [container (.createElement js/document "div")
+                root      (rdc/create-root container)]
+            (.appendChild (.-body js/document) container)
+            (try
+              (react-dom/flushSync
+                (fn []
+                  (rdc/render root [rf/frame-provider {:frame app-frame}
+                                    [ProbeRegView]])))
+              (let [ids (view-ids-of @traces)]
+                (is (some? (testid container "rf-xray-probe-reg-view"))
+                    "precondition: the control really did render")
+                (is (pos? (count ids))
+                    (str "CONTROL FIRES: an ordinary reg-view rendered the same "
+                         "way DOES put an id in the stream, so the shell's "
+                         "absence from it is a property of the boundary and "
+                         "not of a dead instrument. Ids seen: " (pr-str ids))))
+              (finally (teardown! root container))))
+          (finally
+            (rf/unregister-listener! :trace ::collect)))))))
+
+;; ===========================================================================
+;; W4 — clean teardown: the read is released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released? []
+  (zero? (ref-count-of :rf/xray selected-tab-q)))
+
+(deftest w4-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-k97c.3 — unmounting the Static shell releases its
+            subscription reference completely, and mounting it again
+            returns to the SAME count rather than a higher one. Epic
+            criterion 6, and the number the spike caught the rejected
+            design on: with a four-call interop binding the `:rf/xray`
+            ref-count climbed across renders and never fell on unmount.
+
+            TWO boundaries read this one query, deliberately, so the
+            count is what it is; what the row is about is that the count
+            RETURNS, not what it equals.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls
+            rather than reading once: the collector gives a cell whose
+            last reader unmounts one macrotask of grace, so that a keyed
+            reorder which unmounts and remounts within a single turn
+            reuses the reaction instead of rebuilding it. A synchronous
+            assertion would report a LEAK against a collector behaving
+            exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-shell! :rf/xray)
+                      mounted (ref-count-of :rf/xray selected-tab-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released the read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-shell! :rf/xray)
+                                remounted (ref-count-of :rf/xray selected-tab-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W5 — the tab keys REACH REACT: the survivor of a head removal is the same
+;;      DOM node
+;; ===========================================================================
+
+(deftest w5-tab-identity-survives-a-head-removal
+  (testing "rf2-k97c.3 (RULING 2) — the tab-button React key the migration
+            moved out of `^{:key …}` reader metadata and into the button's
+            own ATTRIBUTE MAP is the key React actually reconciles on.
+            Removing the HEAD of the tab list leaves the survivor as the
+            SAME DOM node; under index-based reconciliation — which is
+            what a lost key silently degrades to — React would reuse the
+            head's node for the survivor and destroy the one this row is
+            holding.
+
+            The head position is ASSERTED rather than assumed: a removal
+            from the TAIL leaves the survivor untouched under either
+            spelling and would make this row vacuous.
+
+            The removal alone invalidates nothing (the L4 registry is a
+            plain atom no sub watches — that is exactly what makes it W2's
+            deaf lever), so the re-render is driven by a real tab
+            selection, which is also what makes the survivor's props
+            change and the identity claim non-trivial."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [head-entry (panel-registry/tab-by-id :static :machines)
+              {:keys [container root]} (mount-shell! :rf/xray)
+              head       (tab-node container :machines)
+              survivor   (tab-node container :routes)]
+          (is (some? head-entry)
+              "PRECONDITION: the head tab is registered, so restoring it in
+               the finally below is real")
+          (is (some? head)     "PRECONDITION: the head tab is on screen")
+          (is (some? survivor) "PRECONDITION: the survivor tab is on screen")
+          (is (= 5 (count (tab-nodes container)))
+              "PRECONDITION: exactly the five Static tabs are on screen")
+          (when (and (some? head) (some? survivor))
+            ;; DOCUMENT_POSITION_FOLLOWING = 4. A removal from the tail is
+            ;; invisible to this row's claim, so prove we are removing the head.
+            (is (pos? (bit-and (.compareDocumentPosition head survivor) 4))
+                "NON-VACUITY: the tab being removed really does PRECEDE the
+                 survivor in document order, so this is a reorder and not a
+                 tail truncation"))
+          (panel-registry/unreg-l4-tab! :machines)
+          (.click survivor)
+          (-> (rf.test-support/poll-until
+                (fn [] (= 4 (count (tab-nodes container))))
+                {:label "the head tab left the committed DOM"})
+              (.then
+                (fn [_]
+                  (is (nil? (tab-node container :machines))
+                      "the removed tab is gone from the committed DOM")
+                  (is (identical? survivor (tab-node container :routes))
+                      "and the survivor is the IDENTICAL DOM node React
+                       already had — which is only true if the key reached
+                       React. With the key left in metadata the codec cannot
+                       read, React reconciles by index and hands the survivor
+                       the HEAD's node instead")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (panel-registry/reg-l4-tab! head-entry)
+                       (teardown! root container)
+                       (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
@@ -251,6 +251,26 @@
                 container
                 "[data-testid^=\"rf-xray-static-tab-\"][role=\"tab\"]"))))
 
+(defn- click!
+  "Click a committed node, or FAIL THIS ROW rather than aborting the lane.
+
+  MEASURED, and it is why this helper exists rather than a bare
+  `.click`. Two rows below drive the shell through its own affordances,
+  so both hold a node that a regression can make nil. A raw `.click` on
+  nil throws a `TypeError` out of the async block, and
+  `cljs.test/run-block` has no try/catch — under a sabotage plant that
+  emptied the chrome it took the WHOLE browser lane down with NO
+  cljs.test summary at all, and every namespace scheduled after this one
+  never executed. A row whose subject has vanished should redden; it
+  must not silence its neighbours. The subsequent `poll-until` then
+  times out and reddens on its own message, which is the honest report."
+  [node label]
+  (if (some? node)
+    (do (.click node) true)
+    (do (is false (str "cannot click " label ": it is not in the committed "
+                       "DOM, so this row's subject is already gone"))
+        false)))
+
 (defn- cache-of
   "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
   the frame is not live, which is a defect in the row's own setup and
@@ -392,7 +412,8 @@
                        re-rendered here would make phase 3 pass for a reason
                        that is not liveness")
                   ;; ---- phase 3: the shell's OWN affordance, in the DOM ----
-                  (.click (tab-node container :flows))
+                  (click! (tab-node container :flows)
+                          "the shell's own :flows tab button")
                   (rf.test-support/poll-until flows?
                     {:label "the shell committed the :flows L4 slot"})))
               (.then
@@ -632,7 +653,7 @@
                  survivor in document order, so this is a reorder and not a
                  tail truncation"))
           (panel-registry/unreg-l4-tab! :machines)
-          (.click survivor)
+          (click! survivor "the survivor tab button")
           (-> (rf.test-support/poll-until
                 (fn [] (= 4 (count (tab-nodes container))))
                 {:label "the head tab left the committed DOM"})
@@ -651,6 +672,7 @@
                                        " — DOM: " (.-textContent container)))
                         nil))
               (.then (fn [_]
-                       (panel-registry/reg-l4-tab! head-entry)
+                       (when head-entry
+                         (panel-registry/reg-l4-tab! head-entry))
                        (teardown! root container)
                        (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/static_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/static_shell_tree.cljs
@@ -1,0 +1,105 @@
+(ns day8.re-frame2-xray.test-helpers.static-shell-tree
+  "The node lane's door onto Xray's Static SHELL (rf2-k97c.3).
+
+  ## Why this exists
+
+  The Static shell's four regions are now Fresco boundaries —
+  `static.shell/ribbon`, `/tab-bar`, `/detail-panel` and `/surface` are
+  `rf.fresco/defview`s, i.e. real React function components. A
+  boundary's body may only run inside a React render window, so
+  `(static-shell/surface)` is no longer a callable that answers hiccup,
+  and the node-lane rows across five suites that walked its return value
+  could not survive unchanged.
+
+  The repair is `defview`'s own documented extract-a-helper spelling,
+  the one every migrated panel in this epic already uses: the shell
+  exports PURE `*-tree` fns of its reads' values, each boundary is the
+  thin thing that reads and calls one, and the node lane drives the tree
+  fns. This ns is the composer that does that driving.
+
+  ## It REPRODUCES THE BOUNDARIES' READS — same subs, same shape
+
+  That is what makes a node-lane row evidence about the shipped shell
+  rather than about a parallel fixture. Each fn below mirrors the
+  boundary beside it, with `rf.fresco/sub` swapped for `rf/subscribe`
+  (the node lane has no React render window and no collector extent)
+  and nothing else changed:
+
+    * [[tab-bar-tree]] passes the RAW `:rf.xray.static/selected-tab`
+      value, `nil` included — the tab bar highlights nothing when the
+      slot is unset, and `default-tab` is deliberately NOT applied
+      there;
+    * [[detail-panel-tree]] applies `(or … default-tab)` exactly as the
+      boundary does, and looks the entry up through
+      `panel-registry/tab-by-id`, so what a row walks is what the shell
+      actually mounts;
+    * both pass `identity` as `as-child`, so the ribbon's two Reagent
+      islands and the L4 `[(:panel tab)]` mount stay fn-headed hiccup
+      vectors that `rf.test-helpers/expand-tree` walks precisely as it
+      always has. The boundaries pass `reagent.core/as-element` there;
+      that crossing's evidence is the browser lane's, not this one's.
+
+  SINGLE-SOURCED ON PURPOSE. Five suites need this composition
+  (`static/shell_cljs_test`, `p3_polish_aria_cljs_test`,
+  `static/machines/panel_cljs_test`, `static/routes/panel_cljs_test`
+  and the Static Machines multi-frame e2e). Five private copies of a
+  read reproduction is five things to keep in step with four
+  boundaries, and the failure mode when one drifts is a row that stays
+  green while measuring a tree the shell does not render.
+
+  ## Call these INSIDE a frame scope
+
+  Every fn here subscribes ambiently, so each call belongs inside
+  `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
+  bodies had, and the same one every existing caller already satisfies."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.shell :as static-shell]))
+
+(defn ribbon-tree
+  "The L1 ribbon's hiccup, composed the way `static-shell/ribbon`
+  composes it. `dispatch` defaults to `(:dispatch (rf/capture-frame))`
+  — the SAME door the boundary uses, so a handler this lane pulls off
+  the tree and fires later carries the frame exactly as the shipped one
+  does. The ribbon reads nothing."
+  ([] (ribbon-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (static-shell/ribbon-tree dispatch identity)))
+
+(defn tab-bar-tree
+  "The L3 tab bar's hiccup, read the way `static-shell/tab-bar` reads
+  it — the raw `:rf.xray.static/selected-tab` value, with no
+  `default-tab` fallback, because the boundary applies none here."
+  ([] (tab-bar-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (static-shell/tab-bar-tree
+     dispatch
+     @(rf/subscribe [:rf.xray.static/selected-tab]))))
+
+(defn detail-panel-tree
+  "The L4 detail panel's hiccup, read the way
+  `static-shell/detail-panel` reads it — the same
+  `(or … default-tab)` fallback and the same
+  `panel-registry/tab-by-id` lookup."
+  []
+  (let [selected (or @(rf/subscribe [:rf.xray.static/selected-tab])
+                     static-shell/default-tab)]
+    (static-shell/detail-panel-tree
+      selected
+      (panel-registry/tab-by-id :static selected)
+      identity)))
+
+(defn surface-tree
+  "The WHOLE Static surface as plain hiccup — the node lane's
+  replacement for the old `(static-shell/surface)` call.
+
+  Composes the three region trees above through the shell's own
+  `surface-tree` envelope, so the testids, the flex column and the
+  `data-rf-xray-mode` attribute are the shipped definitions rather than
+  a copy of them."
+  ([] (surface-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (static-shell/surface-tree
+     (ribbon-tree dispatch)
+     (tab-bar-tree dispatch)
+     (detail-panel-tree))))


### PR DESCRIPTION
Step-2 slice of rf2-k97c.3 (Design B). **The bead stays open** — this is one increment of N, and it is not the slice the dispatch asked for. Why, measured, is the first section.

## THE DISPATCH'S COUPLING CLAIM DOES NOT HOLD, AND THE REAL COUPLING IS BIGGER

The brief said the shells and `mount.cljs`'s paint site "move together, or neither does", on the reasoning that a Fresco boundary handed to a Reagent head position is the mirror of HD-016. That is not so, and eight merged increments of this epic already depend on it not being so: `rf.fresco/as-component` is Fresco's documented OUTWARD door, and a React parent — Reagent included — mounts the result under the frame it is already in. A boundary behind a bridge in a `reg-view` tree is the migration's normal shape, not a failure.

What genuinely blocks the paint flip is one level up. Re-derived at the branch point, `shell.cljs`'s `shell-view` chain carries **44 component-shaped hiccup heads**, and their closure reaches **12 more `reg-view`s in 10 other files** (`filters/Modal`, `palette/Modal`, `resize-handle/Handle` + `/SeamHandle`, `settings-popup/Modal`, `editor-hint/Toast`, `spine-filters/Modal` + `/RowContextMenu`, `app-db-segment-inspector/Popup`, `edn-inspector-popup/…`, `frame-switcher/…`, `mode-pill/…`) plus the whole Dynamic L4 registry, whose `[(:panel tab)]` mount cannot head a boundary while `reg-l4-tab!` stores a callable. `mount.cljs:396` cannot flip until every one of those is Fresco-legal, so the Dynamic shell is several slices rather than one, and `mount.cljs` is untouched here.

The **Static** shell is the half that does move cleanly, and it is what this PR delivers.

## WHAT LANDED

`static/shell.cljs`'s four regions — `ribbon`, `tab-bar`, `detail-panel`, `surface` — are now `rf.fresco/defview` boundaries. This is the first increment of the epic to migrate Xray's own CHROME rather than a panel.

FOUR BOUNDARIES, NOT ONE, and the count is reactive granularity, not file layout. `tab-bar` and `detail-panel` read the same slot but stay apart: hoisting that read into `surface` would re-render the L4 panel on every tab click and the ribbon with it. `ribbon` and `surface` read nothing and are still boundaries — `surface` because it is what the Dynamic composer mounts (so it is where the crossing sits) and because a boundary is the only legal head for the three regions under it; `ribbon` because it carries the dispatcher and hosts two islands.

TWO REAGENT ISLANDS, both through an `:as-child` seam (`identity` for the node lane, `reagent.core/as-element` for a boundary), both scaffolding with a stated end:

* the ribbon's `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` — still `reg-view`s, and both ALSO headed by the Dynamic shell at `shell.cljs:1309`/`:1314`. Migrating them would move a Dynamic head this slice is not touching; islanding them does not.
* `detail-panel`'s `[(:panel tab)]` — `reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE, so four Static panels register an `as-component` bridge and `static.routes.panel/Panel` is still a `reg-view`. Both grade `:invalid` as a Fresco head.

**The bridges deliberately stay, and that is a finding rather than laziness.** Every migrated Static panel's own comment promises `reg-l4-tab!` will take `Panel` directly "when the Static shell is itself a Fresco tree". Cashing that in needs `static/routes/panel.cljs` migrated first AND breaks four merged panels' boundary DOM suites, every one of which mounts `[(:panel tab)]` from a Reagent root. That is its own slice, and this one unblocks it.

`shell.cljs` moves ONE line: the composer's Static arm mounts `static-shell/surface-bridge`.

## RULING 2 — THE KEY SWEEP

`static/shell.cljs` carried exactly one `^{:key id}` site, reader metadata on the call site's vector literal. Repaired into the tab button's own attribute map; the key EXPRESSION is unchanged. Metadata is read by Reagent and by Fresco's codec nowhere, so it would have reached React as no key at all once the bar rendered through a boundary.

Stripped census (string literals and `;` comments removed) over `tools/xray/src`, live control **35 `^{:key` / 13 files, 16 `with-meta` / 7 files** — so the instrument bites. In the changed source file: **ZERO of both**. Four sites found OUTSIDE this slice, in files with no migration in flight (`static/machines/sim.cljs`, `static/mode_pill.cljs`, `static/routes/browse_list.cljs`, `static/routes/simulate_url.cljs`) — reported, not swept.

## HD-016 CENSUS

Whole-file scan (never line-oriented — that defect cost an earlier increment a browser run), restricted to namespaced heads and heads naming a def somewhere under `tools/xray/src`. Live control: `topology.cljs` **4**, `static/routes/panel.cljs` **2**, reproducing the figures the bead records.

`static/shell.cljs` reads **6**, every one accounted for: `ribbon` / `tab-bar` / `detail-panel` (all three inside `surface`'s body, all three boundaries — a boundary heads a boundary cleanly); `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` (both inside `(as-child …)`, so they reach React as elements and never as Fresco heads); `icon-style` (a `let` binding, instrument noise). The instrument cannot see `[(:panel tab)]` — the head is a list, not a symbol — and that site is inside `(as-child …)` too.

## EVIDENCE

New browser suite `static/shell_fresco_boundary_dom_cljs_test`, five rows off a real React commit, mounted exactly as `surface-composer` mounts it:

* **W1** first display of ALL THREE layers plus the five tab buttons and both islands — this row carries more than a panel's W1 by necessity, because the node lane's chrome rows now stop at the bridge — and the read landing in the frame the tree NAMED, with a live entry in the other frame proving the reader is not blind.
* **W2** liveness with a DEAF CONTROL. The lever is the L4 tab registry: a process-global atom `tab-bar-tree` reads and no subscription watches, so registering a tab changes what the bar WOULD compute while invalidating nothing. Then the shell's OWN affordance — a tab button clicked in the committed DOM — moves it (criterion 3 in the same row). Node identity asserted, so the swap cannot have arrived by a remount.
* **W3** the boundaries emit no `:rf.view/*` op while mounted INSIDE an application frame, against a `reg-view` control in the same frame that FIRES. **The zero is SCOPED and the scope is asserted**: the row states both that no id names `day8.re-frame2-xray.static.shell` AND that the ids which do fire are exactly the two documented islands, so islanding a third widget reddens here.
* **W4** unmount releases the read completely and reopening returns to the SAME count. Polled — the collector's one-macrotask grace makes a synchronous read report a leak against a collector behaving as documented.
* **W5** tab identity survives a head removal, which is what proves the moved key reaches React. The key expression is the tab id, a keyword — DOMAIN-shaped, not positional, so this row can exist at all.

**W3 was written against the default `:machines` tab and went RED with a third id, `panels.machine-canvas/Chart`** — the Static Machines panel's own Topology island, reached once a machine is selected. Whether one is selected is a property of the PAGE, not of the row: the registrar is process-global and the `:browser-test` build runs every `-dom-cljs-test` namespace in one page. The row now pins the L4 slot to `:flows`, which is island-free, and asserts that slot committed so the scope is a tree that IS there.

Node lane: six `(static-shell/surface)` call sites across five suites re-pointed at ONE shared composer (`test_helpers/static_shell_tree`) that reproduces the boundaries' reads with `identity` as `as-child`. Three rows that walked hiccup for a testid only React now commits are re-authored one level up rather than pointed deeper, which would assert the walker's reach instead of the mount.

## FOUR SABOTAGE PLANTS — REAL WORK COMMITTED FIRST, EVERY GREEN MADE TO BITE

| plant | lane | result | totals |
|---|---|---|---|
| 1 — `:key` deleted from the tab button's attrs, button and seq kept | browser | EXIT 1, **exactly 1 failure**, W5's identity assertion; every precondition still passed | **925 / 5107 — IDENTICAL to green** |
| 2 — `r/as-element` → `identity` in the `ribbon` boundary (one token) | browser | EXIT 1, **21 failures** across W1 (8) W2 (4) W3 (3) W4 (1) W5 (5) | test count **925 UNCHANGED**; assertions 5104 vs 5107 |
| 3 — the composer heads `surface` instead of `surface-bridge` | node | EXIT 1, 1 failure + 3 errors, all in the composer rows | **11634 / 58285 — IDENTICAL to green** |
| 4 — the L3 tab-bar testid renamed inside `tab-bar-tree` | node | EXIT 1, **exactly 3 failures**, 0 errors, in two node rows | **11634 / 58285 — IDENTICAL to green** |

Plant 4 is the hollow-gate check on the node-lane composer: it proves those rows walk the SHIPPED `tab-bar-tree` rather than a parallel fixture. Plant 2's blast radius is HD-016 measured directly — the throw takes the whole Xray root down, so no row survived, unlike an earlier increment where rows pinning an empty fixture stayed green.

**PLANT 2 FOUND A REAL DEFECT IN MY OWN ROWS, AND ITS FIX IS THE SECOND COMMIT.** On its first run the browser lane ABORTED with no cljs.test summary at all: a bare `.click` on a nil node throws a `TypeError` out of the async block, `cljs.test/run-block` has no try/catch, and every namespace scheduled after this one never executed. Both click sites now go through a guard that reddens the row and lets the following poll time out on its own message. The re-run is the 21-failure row above — the rows still bite; they no longer silence their neighbours.

Restores verified BY GIT BLOB HASH each time (`i/lf` on the changed file, so the DEFAULT filtered form is the one that matches), with `git diff --quiet HEAD -- <path>` exit 0 as a second independent instrument.

## GATES — every number read from that run's own exit file, never a pipeline, never the harness. All re-run on the final base after the rebase.

```
npm run test:cljs (node)                    EXIT 0   11635 tests / 58288 assertions, 0 fail
npm run test:browser                        EXIT 0     925 tests /  5107 assertions, 0 fail
clojure -M:test in tools/xray               EXIT 0    1276 tests /  6118 assertions, 0 fail
npm run test:xray-feature-gate              EXIT 0    16 scenarios, 0 failures, 13 matrix rows
lint_kondo.py (CI's pinned binary + flags)  EXIT 0    errors 0; no NEW finding on any changed file
clojure -M:splint --fail-on-errors (CI args) EXIT 0   2605 files, 0 parsing errors
check_require_alias_dialect.py --verbose    EXIT 0    2845 files, 11198 edges, 0 non-canonical
check_flattened_lists.py                    EXIT 0    291 files, 0 flattened lists
api-manifest gen --check                    EXIT 0    in sync, 471 public vars, no file rewritten
api-manifest xray-spec-check                EXIT 0    in sync, 38 references
check-commit-attribution.sh                 EXIT 0    both commits clean
check-beads-pr-boundary.sh                  EXIT 0    no beads-database paths
```

The kondo row reads "no NEW finding" deliberately. Five changed files DO carry warnings; every one verified pre-existing against `origin/main` at source (`rf.frame/` reads 0 in BOTH the old and new text of four test files; `find-by-role` is defined-never-called in `origin/main` too; `shell.cljs`'s two `Redundant nested call: str` sit at lines 1592/1609 while this diff touches only 2549-2572). Probed per file with `grep -F` plus a live control (`gallery_diff_mode_3.cljs` reads 1), which is the guard an earlier increment recorded after a Windows-path regex gave it a false zero. **Three findings WERE new and are fixed**: dropping the last `static-shell/` use from three test files left their require dead; the requires are removed, and the whole-tree warning count fell 1908 → 1905.

The alias gate's counts moved with the edits (2843/11192 → 2845/11198), and the browser compile named this worktree's own `implementation/shadow-cljs.edn` on line 5 of its log — two witnesses that the gates read THIS tree rather than a cached surface.

## FENCES HELD

`mount.cljs` (not one line — the paint sites at :396 and :1688 are untouched, and `refuse-unsupported-substrate!` still reads 4 occurrences, as rf2-k97c.4 requires), `panels.cljs` and `panels/epoch/view.cljs` (held by another worker; the rebase over their landed slice was clean and touches none of my files), `panel_enum.cljc`, `panel_registry.cljc`, every existing `*-bridge`, and all five Static panel sources — untouched. No hot-zone file: `spec/API.md` and both `spec/api-manifest*.edn` unchanged, and the manifest still reads 471 public vars, so the new public `surface-bridge` is correctly outside the rostered surface. No `.beads` path on the branch. Nothing under `implementation/` requires anything under `tools/`. The worktree carries a real `npm ci` install rather than a junction — 103 immediate entries, 27 in `.bin`, counted with `find -mindepth 1 -maxdepth 1` — so no link had to be removed and no recursive delete could reach the mayor's tree.

No AI-attribution trailers in either commit or in this body, per CLAUDE.md's Git Conventions over the session-level instruction that says the opposite; both arms of the guard exit 0 locally.

## WHAT THIS LEAVES

Re-derived at the branch point with a stripped census: **34 `reg-view` registrations across 21 files** against 16 `defview` before this slice. This removes 4, all of them chrome. Step 3's named jobs on this surface: delete the ribbon's `as-child` seam when `frame_switcher` and `mode_pill` are boundaries (and expect W3's scoping note to become unnecessary in that commit); delete the L4 seam and all five Static bridges when `static/routes/panel.cljs` is a boundary and `reg-l4-tab!` takes them directly; and `surface-bridge` itself goes when `shell.cljs` is a Fresco tree.
