### PR TITLE
ci(gate): wire the escaped-continuation gate into verify-readme-links (rf2-jzv2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1001,6 +1001,42 @@ jobs:
       - name: Verify no nested markdown list renders flat
         run: python scripts/check_flattened_lists.py
 
+      # Escaped continuation blocks (rf2-jzv2).  The SIBLING GATE ABOVE CANNOT
+      # SEE THIS CLASS, and that false coverage claim is why this exists: it
+      # matches list MARKERS and grades consecutive ITEM pairs, so a
+      # continuation PARAGRAPH under a bullet — under-indented, and therefore
+      # rendered OUTSIDE every `li` — is invisible to it.  Measured on the
+      # landed tree: a file whose two-space continuation renders outside its
+      # item exits 0 under the gate above while the real render puts the
+      # paragraph in a sibling `<p>`.  Same shape as its sibling's own
+      # argument: valid markup, no broken target, no anchor, nothing for
+      # `mkdocs build --strict` to promote — 542 escaped LINES corpus-wide
+      # stood before rf2-6ml6 and rf2-2brt cleared them, and nothing on screen
+      # said so.  (The unit matters and has already confused three readers of
+      # this corpus: rf2-6ml6 counts that same surface as 438 BLOCKS.  The tool
+      # prints lines, blocks and tables separately and never one headline
+      # number.)  A zero is only kept at zero by something that checks.
+      #
+      # WHY THIS JOB.  Identical reasoning to the two gates above, and NOT a new
+      # one: it imports the sibling's renderer, so it needs python-markdown and
+      # mkdocs' config loader and cannot sit beside the stdlib checkers in
+      # `Repo invariant checks`.  Unguarded like its neighbours, because no
+      # classifier surface arms for `scripts/**` — all 29 read false — so there
+      # is nothing to scope it to.  Cost measured over the same 291-file corpus:
+      # 19-24 s, the CHEAPER of this pair, against this job's 0.5 min and a
+      # 15.2 min longest job.
+      #
+      # Self-test first, then the live scan — the self-test is what makes the
+      # green mean anything, and it pins BOTH disjuncts of the union rule in
+      # opposite directions (depth-only and outside-`li`-only each miss a case
+      # the other catches), plus the deliberate non-detection of an escaped
+      # FENCE, which is a different instrument's job (rf2-tdlg).
+      - name: Self-test the escaped-continuation gate
+        run: python scripts/check_escaped_continuations.py --self-test
+
+      - name: Verify no continuation block renders outside its list item
+        run: python scripts/check_escaped_continuations.py
+
       # SKILL.md description-budget gate (rf2-w9p2; armed under rf2-bn5f). Guards
       # the SKILL.md description limits: the portable 1,024 and the Claude 1,536.
       # It hard-fails a description over the 1,024-char Agent Skills packaging cap

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -325,6 +325,11 @@ is_doc_surface_path() {
     mkdocs.yml|mkdocs_hooks.py|requirements.txt) return 0 ;;
     scripts/check_readme_links.py|scripts/check_doc_slugs.py) return 0 ;;
     scripts/check_flattened_lists.py) return 0 ;;
+    # Same rule as its sibling above — a gate whose own script changed has to
+    # run.  CI's classifier does not list it (no surface arms for `scripts/**`),
+    # so this is the `check_retired_image_keys.py` case below rather than the
+    # mirroring one: over-arming a ~20 s check on a diff that edits it.
+    scripts/check_escaped_continuations.py) return 0 ;;
     scripts/check_provenance_pins.py) return 0 ;;
     scripts/check_ep_status_sync.py|scripts/check_runtime_subsystem_grading.py) return 0 ;;
     scripts/_test_fixtures/check_readme_links/*|scripts/_test_fixtures/check_doc_slugs/*) return 0 ;;
@@ -1376,6 +1381,19 @@ if [ "$run_docs" = true ]; then
 
   run "flattened-list gate" "python scripts/check_flattened_lists.py" \
     python "$spine_root/scripts/check_flattened_lists.py"
+
+  # Escaped continuation blocks (rf2-jzv2).  The gate above cannot see this
+  # class either: it grades consecutive list ITEMS, so a continuation
+  # PARAGRAPH that renders outside every `li` is invisible to it — which is
+  # how 542 escaped lines accumulated corpus-wide under a gate reporting zero.
+  # Same schedule as its sibling: ALWAYS-ON in CI's verify-readme-links,
+  # classifier-gated here, so cite CI and not a green spine for a diff the
+  # classifier did not call documentation.
+  run "escaped-continuation gate self-test" "python scripts/check_escaped_continuations.py --self-test" \
+    python "$spine_root/scripts/check_escaped_continuations.py" --self-test
+
+  run "escaped-continuation gate" "python scripts/check_escaped_continuations.py" \
+    python "$spine_root/scripts/check_escaped_continuations.py"
 
   # Provenance pins (rf2-kqac1).  This repo rebase-merges, so a Fresco page
   # that pins a measurement to its own authored SHA is stranded the moment its


### PR DESCRIPTION
Wires `scripts/check_escaped_continuations.py` — merged in #9641 with the corpus at zero — into CI, so the zero is kept at zero by something that checks. Implements the half-2 disposition on rf2-jzv2.

## What changed

Two steps in `.github/workflows/test.yml`'s `verify-readme-links` job, immediately after the sibling flattened-list gate, self-test first and then the live scan; and the same pair in `scripts/test-fast-pr.sh`'s documentation tier beside the sibling's two `run` lines. Nothing else. The detector itself is untouched.

## Why this job, and why unguarded

The detector imports the sibling's renderer, so it needs python-markdown and mkdocs' config loader and cannot sit beside the stdlib checkers in `Repo invariant checks`. `verify-readme-links` already installs `requirements.txt` for the slugifier and already runs the sibling gate, and it carries no changed-files guard.

It cannot be given one, and that was measured rather than assumed: all **29** classifier surfaces read `false` for the detector's own path, against a control of `implementation/core/src/re_frame/core.cljc`, which arms **16** of those same 29. So the gate simply always runs.

## Why the sibling gate is not enough

`check_flattened_lists.py` matches list MARKERS and grades consecutive ITEM pairs, so a continuation PARAGRAPH that renders outside every `li` is invisible to it — valid markup, no broken target, no anchor, nothing for `mkdocs build --strict` to promote. 542 escaped LINES stood corpus-wide before rf2-6ml6 and rf2-2brt cleared them, and nothing on screen said so. (Unit noted deliberately: rf2-6ml6 counts that same surface as 438 BLOCKS, and this corpus has already confused three readers on lines-vs-blocks.)

## No new job — the check band does not move

These are STEPS inside an existing job. Added job keys against the merge base read **0** and removed job keys **0**; `check_workflow_job_timeouts.py` reads 71/71 jobs in `test.yml` both before and after.

## Cost

Measured over the full 291-file corpus on one machine:

| | live scan | self-test |
|---|---|---|
| `check_escaped_continuations.py` (new) | 19.4 s | 0.6 s |
| `check_flattened_lists.py` (sibling) | 26.0 s | — |

The new gate is the cheaper of the pair. The job's own budget note cites 0.5 min against a 15.2 min longest job, so this stays off the critical path.

## Also armed: the spine's own doc surface

`is_doc_surface_path` now names the detector, the rule its neighbours already follow — a gate whose own script changed has to run. Without it, a PR editing only that detector would get a green local spine that never ran it. CI's classifier lists no `scripts/**` surface, so this is the `check_retired_image_keys.py` case rather than the CI-mirroring one.

## Verification

| check | result |
|---|---|
| `check_escaped_continuations.py --self-test` | exit 0, 27/27 |
| `check_escaped_continuations.py` (live) | exit 0 — 291 scanned, 0 escaped lines in 0 blocks across 0 files, 0 unmeasurable, 17 not markable |
| `check_flattened_lists.py` (live) | exit 0 — 291 scanned, 0 flattened, 0 unmeasurable |
| fast-PR docs-gate self-test | 44/44 |
| `check_workflow_yaml.py` | PASS, 11 files |
| `check_workflow_job_timeouts.py` | PASS, 118 jobs / 11 files |
| `check_ci_reproduce_commands.py` | clean, 47 checker steps in sync |
| `bash -n` / `sh -n` on the spine | exit 0 |

The live count matches the figure verified at trunk on rf2-jzv2 exactly.
