### PR TITLE
feat(xray): retire the resizable-table hover Ratom, add its Fresco head (rf2-fcy5)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -861,6 +861,30 @@
     "    transparent\n"
     "  ) !important;\n"
     "}\n"
+    ;; rf2-fcy5 — shared resizable-table header-gutter hover affordance.
+    ;; The 4px track between adjacent header columns IS the drag handle
+    ;; (`views/resizable_table.cljs` §Header gutter): `cursor: col-resize`
+    ;; on the element is the always-visible signal, the accent fill is the
+    ;; hover one.
+    ;;
+    ;; It lives here rather than in a component-local hover flag because a
+    ;; Fresco boundary is a React function component with no form-2 outer
+    ;; body to hold one, and `rf.fresco/reg-state` CONSUMES an instance key
+    ;; without minting one — so keeping the hover as STATE would force a
+    ;; stable instance key onto every `resizable-table` call site. Pure CSS
+    ;; needs none, and the gutter already stamps a stable `data-testid`, so
+    ;; this selector matched with no markup change at all.
+    ;;
+    ;; `!important` because the gutter carries `background: transparent`
+    ;; INLINE and an inline declaration beats a stylesheet rule without it
+    ;; — the same reason the column-divider rule above carries one. The
+    ;; fill is the WHOLE 4px track rather than that rule's 1px stripe
+    ;; because that is what the retired Ratom painted: this is a faithful
+    ;; port of the widget's existing look, not a redesign. The 0.15s
+    ;; cross-fade stays inline on the element, where it already was.
+    "[data-testid^=\"rf-xray-resizable-gutter-\"]:hover {\n"
+    "  background: var(--rf-xray-accent) !important;\n"
+    "}\n"
     ;; rf2-t2dsh — L2/L3 seam handle hover treatment. The seam ships
     ;; with an always-visible 1px accent hairline at 33% alpha (inline
     ;; `box-shadow` in `resize_handle.cljs` §seam-handle-style). On

--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -36,6 +36,17 @@
   See `subscriptions-table` in `panels/epoch/view.cljs` for the
   canonical consumer.
 
+  ## TWO HEADS, one renderer (rf2-fcy5)
+
+  `resizable-table` is the Reagent `reg-view` head; `resizable-table-view`
+  is the Fresco boundary. Same props, same output — both delegate to
+  `render-table` and differ only in how they resolve the column-widths
+  read and the frame-bound dispatcher. **Mount the one your parent is**: a
+  Fresco boundary in a Reagent head position fails as loudly as the
+  reverse, so a panel adopts `resizable-table-view` when its own mount
+  becomes a boundary and not before. Every call site in the tree is still
+  on `resizable-table`.
+
   ## localStorage persistence (rf2-xzg1y)
 
   Column-widths are durable per browser profile. The slot
@@ -51,8 +62,11 @@
   carrying them across sessions is the desired behaviour."
   (:require [clojure.string :as string]
             [cljs.reader :as reader]
-            [reagent.core :as r]
             [re-frame.core :as rf]
+            ;; rf2-fcy5 — `resizable-table-view` below is the Fresco
+            ;; boundary; `resizable-table` stays the Reagent `reg-view`
+            ;; head its call sites mount. Both delegate to `render-table`.
+            [re-frame.fresco :as rf.fresco]
             [re-frame.frame :as rf.frame]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.local-storage :as ls]))
@@ -362,8 +376,10 @@
   never calls it except through the `header-gutter` `:on-pointer-down`.
 
   `dispatch-fn` (rf2-r0o63) is the frame-bound `dispatch` the
-  surrounding `resizable-table` `reg-view` body injects (the macro
-  expands it over a `capture-frame` capturing the render frame). The
+  surrounding head supplies — the `reg-view` head's injected `dispatch`
+  (the macro expands it over a `capture-frame` capturing the render
+  frame), or `(:dispatch (rf/capture-frame))` in the Fresco boundary,
+  which is the same door written by hand. The
   pointer-move/up/cancel handlers run OUTSIDE the React tree (via raw
   `window.addEventListener`), so the dynamic frame
   context has unwound by the time they fire — but the injected
@@ -464,7 +480,25 @@
 ;; gutter fills with accent (the drag affordance signal); the border-left
 ;; disappears under the fill which is fine — the operator is grabbing the
 ;; handle, not reading the boundary.
-(def ^:private gutter-base-style
+;;
+;; THE HOVER FILL IS CSS, AND THAT IS WHAT MAKES THE WIDGET PORTABLE
+;; (rf2-fcy5). `background: transparent` is the only state this map
+;; carries; `theme/global_styles.cljs` §motion-css paints the accent under
+;; `[data-testid^="rf-xray-resizable-gutter-"]:hover`, with `!important`
+;; because this inline declaration would otherwise win. Same shape the
+;; sibling `rf-xray-event-list-col-divider-` handle already uses.
+;;
+;; It used to be a Form-2 Reagent component holding a `r/atom` hover flag.
+;; That flag was this file's ONLY component-local state and its only
+;; `reagent.core` use, and it was the one thing standing between the
+;; widget and a Fresco boundary: a React function component has no form-2
+;; outer body to allocate per-instance state in, and `rf.fresco/reg-state`
+;; consumes an instance key rather than minting one — so keeping the hover
+;; as STATE would have forced a stable instance key onto every call site.
+;; With the flag gone the gutter is a pure function CALLED like
+;; `body-spacer`, so it is no longer a head at all and the codec has
+;; nothing to grade `:invalid`.
+(def ^:private gutter-style
   {:cursor      "col-resize"
    :background  "transparent"
    :border-left "1px solid var(--rf-xray-text-tertiary)"
@@ -472,31 +506,23 @@
    :user-select "none"
    :align-self  "stretch"})
 
-(def ^:private gutter-hover-style
-  (assoc gutter-base-style :background "var(--rf-xray-accent)"))
-
 (defn- header-gutter
-  "Render one interactive drag-handle between adjacent header
-  columns. Local Reagent atom tracks hover (paint the 4px column
-  with the accent colour on hover); pointer-down on the cell
-  starts the drag flow.
+  "Render one interactive drag-handle between adjacent header columns.
+  Pointer-down on the cell starts the drag flow; the hover paint is the
+  CSS rule named above, so this holds no state and is CALLED rather than
+  mounted.
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the surrounding `resizable-table` `reg-view` body; threaded into the
-  raw-window-listener drag flow so resize ticks land on the instance
-  frame."
-  [_props]
-  (let [hover? (r/atom false)]
-    (fn [{:keys [table-id left-id right-id dispatch-fn]}]
-      [:div
-       {:data-testid (str "rf-xray-resizable-gutter-"
-                          (name table-id) "-" (name left-id))
-        :data-rf-xray-resizable-gutter (name left-id)
-        :style       (if @hover? gutter-hover-style gutter-base-style)
-        :on-pointer-enter #(reset! hover? true)
-        :on-pointer-leave #(reset! hover? false)
-        :on-pointer-down  (fn [ev]
-                            (on-pointer-down dispatch-fn table-id left-id right-id ev))}])))
+  the surrounding head's body; threaded into the raw-window-listener drag
+  flow so resize ticks land on the instance frame."
+  [{:keys [table-id left-id right-id dispatch-fn]}]
+  [:div
+   {:data-testid (str "rf-xray-resizable-gutter-"
+                      (name table-id) "-" (name left-id))
+    :data-rf-xray-resizable-gutter (name left-id)
+    :style       gutter-style
+    :on-pointer-down (fn [ev]
+                       (on-pointer-down dispatch-fn table-id left-id right-id ev))}])
 
 ;; ---- Body row spacer (non-interactive) ----------------------------------
 
@@ -578,16 +604,19 @@
                (let [col-id (:id (nth columns i))]
                  (if (< i (dec n))
                    [(keyed cell (str "h-" (name col-id)))
-                    ;; The gutter's key rides the PROPS map of the
-                    ;; component call form. `header-gutter` destructures
-                    ;; named opts and never spreads them, so the extra
-                    ;; entry is inert for its body — the same shape
-                    ;; rf2-hxfy used for `flat-row-list`.
-                    (keyed [header-gutter
-                            {:table-id    table-id
-                             :left-id     col-id
-                             :right-id    (:id (nth columns (inc i)))
-                             :dispatch-fn dispatch-fn}]
+                    ;; CALLED, not mounted (rf2-fcy5) — `header-gutter` is
+                    ;; a pure fn since its hover flag became a CSS rule, so
+                    ;; what lands here is the gutter's own `[:div …]` and
+                    ;; its key rides that div's ATTRS MAP like every other
+                    ;; woven node. Before, it was a component call form
+                    ;; `[header-gutter {…}]` whose key rode the props map —
+                    ;; a plain `defn` in head position, which the Fresco
+                    ;; codec grades `:invalid` and refuses.
+                    (keyed (header-gutter
+                             {:table-id    table-id
+                              :left-id     col-id
+                              :right-id    (:id (nth columns (inc i)))
+                              :dispatch-fn dispatch-fn})
                            (str "g-" (name col-id)))]
                    [(keyed cell (str "h-" (name col-id)))])))
              header-cells))))
@@ -607,7 +636,7 @@
                    [(keyed cell (str "c-" (name col-id)))])))
              row-cells))))
 
-;; ---- Top-level view ------------------------------------------------------
+;; ---- Header cell ---------------------------------------------------------
 
 (defn- header-cell
   "Wrap a header label so the wrapper carries the
@@ -620,21 +649,22 @@
                        header-cell-style)}
    label])
 
-(rf/reg-view resizable-table
-  "See the ns docstring for the consumer API.
+;; ---- The renderer, shared by both heads -----------------------------------
 
-  ## Frame-aware via `reg-view` (rf2-r0o63)
+(defn- render-table
+  "The widget's ENTIRE rendering, given the consumer's props, the resolved
+  column-width `overrides` for this table, and the frame-bound
+  `dispatch-fn` the drag flow runs on.
 
-  `resizable-table` is `reg-view`-registered so its rendered component
-  carries `:contextType frame-context`: the injected `subscribe` /
-  `dispatch` resolve to the SURROUNDING instance frame (the shell's
-  `frame-id`) through React-context. The column-widths slot is read via
-  the injected `subscribe` and the raw-window-listener drag flow
-  dispatches via the injected frame-bound `dispatch` — so N shells keep
-  independent column widths. (Pre rf2-r0o63 this was a plain `defn`
-  that escaped to a hardcoded `:rf/xray` frame via `rf/with-frame`,
-  which entrenched the singleton; the `reg-view` registration is the
-  same shape every other Xray panel uses.)
+  Substrate-pure: each head below resolves those two values its own way
+  and hands them here, so there is one renderer and nothing can drift
+  between the Reagent head and the Fresco boundary. Same split
+  `views/edn_inspector.cljs` uses for its own pair (§`render-inspector`).
+
+  `overrides` may be nil — an unregistered sub, which is what a pure-render
+  test that never ran `registry/register-xray-handlers!` sees. Both heads
+  pass that nil straight through: `template-track` reads the map with
+  `get`, so nil means 'no overrides' and the default flex tracks apply.
 
   ## Optional `:row-extras` (rf2-jnxfj)
 
@@ -662,23 +692,10 @@
   per-table-id slot and applied to body rows."
   [{:keys [table-id columns rows row-key row-attrs row-cells row-extras
            header-attrs container-attrs header-cell-style header?]
-    :or   {header? true}}]
-  ;; rf2-r0o63 — the injected `subscribe` resolves to the surrounding
-  ;; instance frame via React-context (the column-widths slot lives on
-  ;; THIS shell's frame), and `dispatch-fn` is the injected frame-bound
-  ;; `dispatch` for the raw-window-listener drag flow (which fires after
-  ;; render unwinds).
-  ;;
-  ;; Defensive: `subscribe` returns nil when the sub isn't registered
-  ;; (e.g. in pure-render tests that exercise a view directly without
-  ;; running `registry/register-xray-handlers!`). A nil reaction would
-  ;; throw on deref; treat it as "no overrides" so the test render path
-  ;; sees default widths and a downstream install-before-mount in
-  ;; production stays the canonical path.
-  (let [dispatch-fn dispatch
-        reaction   (subscribe [:rf.xray.column-widths/for-table table-id])
-        overrides  (some-> reaction deref)
-        template   (build-template columns overrides)
+    :or   {header? true}}
+   overrides
+   dispatch-fn]
+  (let [template   (build-template columns overrides)
         grid-style {:display "grid"
                     :grid-template-columns template
                     :align-items "stretch"}
@@ -701,7 +718,9 @@
                   dispatch-fn)))]
     (into [:div (merge {:data-rf-xray-resizable-table (name table-id)}
                        container-attrs)
-           ;; Header hiccup is nil-tolerated by React/Reagent.
+           ;; Header hiccup is nil-tolerated by BOTH substrates — Reagent
+           ;; skips it, and the Fresco codec's `:nothing` arm renders nil
+           ;; and false as nothing (HD-016).
            header-hiccup]
           ;; Body rows — eager `map-indexed` (per rf2-9ec65 / spec/006
           ;; §Lazy-seq deref tracking, rf2-atqkg): a substrate widget
@@ -734,3 +753,92 @@
                      woven])
                   (row-key row i))))
             rows))))
+
+;; ---- The two heads -------------------------------------------------------
+;;
+;; BOTH SHIP, and that is the sequencing rather than an indecision
+;; (rf2-fcy5). A Fresco boundary in a Reagent head position fails exactly
+;; as loudly as the reverse, so the boundary cannot be ADOPTED until each
+;; consumer's own mount is one: `panels/trace.cljs` and
+;; `panels/epoch/view.cljs` migrate on their own beads, and until they do
+;; every call site keeps mounting `resizable-table`. Same pair, same
+;; reason, as `views/edn_inspector.cljs`'s `edn-inspector` /
+;; `edn-inspector-view`.
+;;
+;; Neither head has any state to hold, so neither needs an instance key:
+;; the widget's one piece of component-local state was the gutter's hover
+;; flag, and §Header gutter is where that went.
+
+(rf/reg-view resizable-table
+  "THE REAGENT HEAD. See the ns docstring for the consumer API and
+  `render-table` for the option inventory.
+
+  ## Frame-aware via `reg-view` (rf2-r0o63)
+
+  `resizable-table` is `reg-view`-registered so its rendered component
+  carries `:contextType frame-context`: the injected `subscribe` /
+  `dispatch` resolve to the SURROUNDING instance frame (the shell's
+  `frame-id`) through React-context. The column-widths slot is read via
+  the injected `subscribe` and the raw-window-listener drag flow
+  dispatches via the injected frame-bound `dispatch` — so N shells keep
+  independent column widths. (Pre rf2-r0o63 this was a plain `defn`
+  that escaped to a hardcoded `:rf/xray` frame via `rf/with-frame`,
+  which entrenched the singleton; the `reg-view` registration is the
+  same shape every other Xray panel uses.)
+
+  Defensive nil: `subscribe` returns nil when the sub isn't registered
+  (a pure-render test that never ran `registry/register-xray-handlers!`).
+  A nil reaction would throw on deref, so `some->` keeps it nil and
+  `render-table` reads that as 'no overrides'."
+  [props]
+  (render-table props
+                (some-> (subscribe [:rf.xray.column-widths/for-table
+                                    (:table-id props)])
+                        deref)
+                dispatch))
+
+(rf.fresco/defview resizable-table-view
+  "THE FRESCO BOUNDARY — a real React function component, mounted the same
+  way as the Reagent head:
+
+      [resizable-table-view {:table-id :rf.xray.epoch/subscriptions …}]
+
+  Identical props, identical rendering: both heads hand the same map to
+  `render-table` and differ only in HOW they resolve the two things the
+  renderer cannot resolve for itself.
+
+  ## The read
+
+  `rf.fresco/sub` in place of `@(subscribe …)`. It returns the VALUE, not
+  a reaction, and the edge is recorded by Fresco's own collector where the
+  read happens — which is the coupling this migration exists to sever: a
+  `reg-view` body's reads are tracked only by whichever reaction machinery
+  the installed adapter happens to ship. No `some->` guard is needed here
+  and its absence is not an oversight: an unregistered query is
+  `cold-read!`'s recovery path, which answers nil (emitting
+  `:rf.error/no-such-sub` once per run) rather than handing back a
+  reaction to deref.
+
+  ## The dispatcher
+
+  `(:dispatch (rf/capture-frame))` — core's own door, answering the frame
+  THIS boundary renders under. `:dispatch` rather than a bare `rf/dispatch`
+  because the drag flow's ticks fire from raw `window` listeners, long
+  after the render extent has unwound (see `on-pointer-down`): the
+  dynamic frame context is gone by then, so the dispatcher has to have
+  been bound during render. That is the case `capture-frame` documents
+  itself for, and it is what keeps N shells' column widths independent.
+
+  ## NO instance key, and that is the whole of why this head is cheap
+
+  `edn-inspector-view` hard-throws without a caller-supplied `:mount-id`
+  because a React function component has no form-2 outer body to allocate
+  per-mount identity in. This widget needs none: its state lives in app-db
+  keyed by the consumer's own `:table-id`, its drag bookkeeping is a
+  module-level `defonce`, and the gutter's hover flag — the one piece of
+  genuinely component-local state it ever had — is now a CSS rule."
+  [props]
+  (render-table props
+                (rf.fresco/sub [:rf.xray.column-widths/for-table
+                                (:table-id props)])
+                (:dispatch (rf/capture-frame))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
@@ -1,0 +1,239 @@
+(ns day8.re-frame2-xray.views.resizable-table-fresco-head-cljs-test
+  "rf2-fcy5 slice 1b — the shared resizable-table's FRESCO SIBLING.
+
+  `views/resizable_table.cljs` now ships two heads over one renderer:
+  `resizable-table`, the Reagent `reg-view`, and `resizable-table-view`,
+  the `rf.fresco/defview` boundary. Same props, same output; they differ
+  only in how they resolve the column-widths read and the frame-bound
+  dispatcher the drag flow runs on.
+
+  ## Why the codec is the instrument, not a pattern match
+
+  `head-kind` is the renderer's OWN answer to 'what kind of head is
+  this?', and it is one call. A census that pattern-matches the authoring
+  shape gets this wrong in both directions: a `reg-view` head is a `def`
+  and LOOKS like a component while grading `:invalid`, and a `defview`
+  product is also a `def` and grades `:boundary`. `heads-are-what-the-
+  codec-says-they-are` asks the codec instead, in both directions and
+  against a `:tag` control.
+
+  ## The kit runs the BODY, which is the half a `def` cannot pin
+
+  `re-frame.fresco.test/tree` runs a boundary body on the runtime's own
+  body-run path — the real ambient-read extent, the real read-set
+  accounting — and answers a Spec 004B tree. No React, no DOM, so it runs
+  in `:node-test` beside everything else.
+
+  That matters here for one specific reason: `rf.fresco/sub` REFUSES
+  outside a render extent, so a boundary whose read is misspelled cannot
+  be caught by looking at the var. The kit's `:subs` roster is what turns
+  the read into a gate — a body that reads a key no fixture answers is
+  refused by name (`:rf.error/fresco-test-missing-read-fixture`) rather
+  than resolving to nil, so the fixture below IS the assertion that the
+  boundary reads `[:rf.xray.column-widths/for-table <table-id>]` and
+  nothing else.
+
+  ## THE FIXTURE IS THE CORE ONE, WITH `:ambient-frame nil`, AND THAT IS
+  LOAD-BEARING
+
+  The suite's usual `make-xray-runtime-fixture` cannot be used here, and
+  the failure is loud rather than subtle, so it is worth naming for
+  whoever writes the next boundary test.
+
+  `make-reset-runtime-fixture` binds `re-frame.frame/*current-frame*` to
+  `:rf/default` by default, and the Xray wrapper deliberately does not
+  thread the option that turns it off. `ht/tree` runs the body under a
+  probe frame of its own, and `(rf/capture-frame)` inside a boundary body
+  refuses when it finds a CARRIED stamp naming a different frame from the
+  extent's — `:rf.error/ambient-frame-refused`, on the reasoning that two
+  frames in one body is exactly what frame isolation forbids. The refusal
+  is correct; an ambient `:rf/default` left standing by a test fixture is
+  the artefact. So this namespace opts out, as
+  `make-xray-runtime-fixture`'s own docstring says to
+  (\"reach for the core fixture directly if you do\"), and drives its own
+  frames explicitly.
+
+  Production is unaffected: a boundary renders inside a React tree with
+  no dynamic frame scope in force, and an Xray shell that does scope one
+  scopes the SAME frame the boundary renders under, which is a match
+  rather than a conflict.
+
+  ## What is deliberately NOT here
+
+  Nothing adopts `resizable-table-view`. The two consumer panels
+  (`panels/trace.cljs`, `panels/epoch/view.cljs`) migrate on their own
+  beads, and until their own mounts are boundaries they must keep
+  mounting the Reagent head — a Fresco boundary in a Reagent head
+  position is the mirror of the failure `reagent-head-is-invalid-to-the-
+  codec` pins below."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
+            [re-frame.fresco.test :as ht]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.substrate.plain-atom/adapter
+     ;; See the ns docstring — an ambient `:rf/default` collides with the
+     ;; kit's probe frame inside a boundary body.
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      (rt/clear!)
+                      (rt/set-storage-key! nil))}))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def ^:private table-id :rf.xray.test/fresco)
+
+(def ^:private columns
+  [{:id :a :label "a" :default-flex "1fr"}
+   {:id :b :label "b" :default-flex "1fr"}
+   {:id :c :label "c" :default-flex "1fr"}])
+
+(def ^:private overrides
+  "A width override per column pair, so `build-template` has something to
+  say that the default flex tracks do not — otherwise a read that never
+  happened would produce the same template as one that did."
+  {:a 120 :b 90})
+
+(defn- opts []
+  {:table-id  table-id
+   :columns   columns
+   :rows      [{:v 1} {:v 2}]
+   :row-key   (fn [_row i] (str "row-" i))
+   :row-attrs (fn [_row i] {:data-testid (str "r-" i)})
+   :row-cells (fn [row _i]
+                (for [col columns]
+                  [:div {:data-col (name (:id col))} (str (:v row))]))})
+
+(def ^:private widths-query
+  [:rf.xray.column-widths/for-table table-id])
+
+;; ---- (1) the codec's own answer ----------------------------------------
+
+(deftest heads-are-what-the-codec-says-they-are
+  (testing "rf2-fcy5 slice 1b — `head-kind` is the renderer's own answer,
+            asked in both directions. Both heads are `def`s and neither
+            spelling can be told from the other by looking; only the codec
+            knows."
+    (is (= :boundary (rf.fresco.impl.codec/head-kind rt/resizable-table-view))
+        "the Fresco sibling is a minted boundary")
+    (is (true? (rf.fresco.impl.codec/boundary-head? rt/resizable-table-view))
+        "…and carries the boundary marker the codec reads")
+    (is (= :invalid (rf.fresco.impl.codec/head-kind rt/resizable-table))
+        "the Reagent `reg-view` head is NOT a boundary — a plain fn to the
+         codec, which is the whole reason this sibling exists")
+    (is (= :tag (rf.fresco.impl.codec/head-kind :div))
+        "control — the instrument distinguishes, so `:invalid` above is an
+         answer rather than a default")))
+
+(deftest reagent-head-is-invalid-to-the-codec
+  (testing "rf2-fcy5 slice 1b — the refusal a consumer panel would meet if
+            it kept `[rt/resizable-table …]` after its own mount became a
+            boundary. It is LOUD, which is why both heads can ship at once
+            and why the panels can migrate one at a time."
+    (let [thrown (try
+                   (rf.fresco.impl.codec/as-element [rt/resizable-table (opts)])
+                   nil
+                   (catch :default e e))]
+      (is (some? thrown) "a `reg-view` head in a Fresco position throws")
+      (is (= :rf.error/fresco-bad-head (:rf.error/id (ex-data thrown)))
+          "…under the codec's own bad-head id"))
+    (is (some? (rf.fresco.impl.codec/as-element
+                 [rt/resizable-table-view (opts)]))
+        "…while the boundary is accepted in the same position")))
+
+;; ---- (2) the body actually runs, and reads the slot it claims to -------
+
+(defn- fresco-tree []
+  (ht/tree [rt/resizable-table-view (opts)]
+           {:subs {widths-query overrides}}))
+
+(defn- style-of [node]
+  (:style (ht/attrs node)))
+
+(defn- testid-of [node]
+  (:data-testid (ht/attrs node)))
+
+(deftest fresco-head-runs-and-reads-the-column-widths-slot
+  (testing "rf2-fcy5 slice 1b — the boundary body runs on the runtime's own
+            body-run path under exactly ONE read fixture. A body reading a
+            key no fixture answers is refused by name, so a green run here
+            IS the assertion that the read is
+            `[:rf.xray.column-widths/for-table <table-id>]`."
+    (let [tree (fresco-tree)]
+      (is (= :div (:tag tree)) "the container is a div")
+      (is (= "fresco" (:data-rf-xray-resizable-table (ht/attrs tree)))
+          "…and it is this widget's container")
+      (is (= (rt/build-template columns overrides)
+             (:grid-template-columns (style-of (ht/find tree #(= "grid" (:display (style-of %)))))))
+          "THE READ ROW — the header's grid template is built from the
+           fixture's overrides, so the value the boundary read reached
+           `build-template`. Compared against the widget's own pure
+           builder rather than a hand-typed string, so the row grades the
+           read and not the track syntax."))))
+
+(deftest fresco-head-emits-the-gutters-as-native-nodes
+  (testing "rf2-fcy5 slice 1b — the gutters are the half that USED to be
+            impossible under a boundary: `header-gutter` held a Form-2
+            Reagent Ratom for its hover flag, so it sat in head position
+            as a plain `defn` and the codec refused it. With the hover
+            moved to CSS it is a pure fn the weaver CALLS, so what the
+            Fresco tree carries here is N-1 ordinary divs."
+    (let [tree    (fresco-tree)
+          gutters (ht/find-all tree #(some-> (testid-of %)
+                                             (.startsWith "rf-xray-resizable-gutter-")))]
+      (is (= 2 (count gutters)) "N-1 gutters for N columns")
+      (is (= ["rf-xray-resizable-gutter-fresco-a"
+              "rf-xray-resizable-gutter-fresco-b"]
+             (mapv testid-of gutters))
+          "the stable testids the CSS hover rule selects on")
+      (is (= ["g-a" "g-b"] (mapv :key gutters))
+          "keyed in the attrs map, which is where the codec reads a key")
+      (is (every? #(= "transparent" (:background (style-of %))) gutters)
+          "no hover state to render — the accent is the global CSS rule's")
+      (is (every? #(contains? (:events %) :on-pointer-down) gutters)
+          "the drag affordance survives the migration"))))
+
+(deftest fresco-head-emits-every-row-with-the-consumers-key
+  (testing "rf2-fcy5 slice 1b — the row weaver's output under the boundary.
+            Slice 1 moved these keys out of metadata and into the attrs
+            map precisely so this would hold; this is that fix observed
+            through a real Fresco body run rather than through the codec's
+            element door alone."
+    (let [tree (fresco-tree)
+          rows (ht/find-all tree #(some-> (testid-of %) (.startsWith "r-")))]
+      (is (= 2 (count rows)) "one node per row")
+      (is (= ["row-0" "row-1"] (mapv :key rows))
+          "the consumer's `:row-key`, reaching the substrate"))))
+
+;; ---- (3) the two heads agree ------------------------------------------
+
+(deftest both-heads-resolve-the-same-widths
+  (testing "rf2-fcy5 slice 1b — one renderer, two reads. The Reagent head
+            resolves the slot through its `reg-view`-injected `subscribe`
+            and the boundary through `rf.fresco/sub`; with the SAME
+            overrides in play both must produce the same grid template.
+            This is the row that would go red if a future edit taught one
+            head a different query vector or a different renderer."
+    (registry/register-xray-handlers!)
+    (rf/make-frame {:id :rf/xray})
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray.column-widths/hydrate {table-id overrides}]))
+    (let [reagent-tree (rf/with-frame :rf/xray (rt/resizable-table (opts)))
+          reagent-header (nth reagent-tree 2)
+          reagent-template (get-in reagent-header [1 :style :grid-template-columns])
+          fresco-template (:grid-template-columns
+                            (style-of (ht/find (fresco-tree)
+                                               #(= "grid" (:display (style-of %))))))]
+      (is (= (rt/build-template columns overrides) reagent-template)
+          "the Reagent head read the hydrated slot")
+      (is (= reagent-template fresco-template)
+          "…and the boundary resolved the same widths through
+           `rf.fresco/sub`"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
@@ -42,7 +42,7 @@
 
   `make-reset-runtime-fixture` binds `re-frame.frame/*current-frame*` to
   `:rf/default` by default, and the Xray wrapper deliberately does not
-  thread the option that turns it off. `ht/tree` runs the body under a
+  thread the option that turns it off. `rf.fresco.test/tree` runs the body under a
   probe frame of its own, and `(rf/capture-frame)` inside a boundary body
   refuses when it finds a CARRIED stamp naming a different frame from the
   extent's — `:rf.error/ambient-frame-refused`, on the reasoning that two
@@ -71,7 +71,7 @@
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.test-support :as rf.test-support]
             [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
-            [re-frame.fresco.test :as ht]
+            [re-frame.fresco.test :as rf.fresco.test]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
@@ -152,14 +152,14 @@
 ;; ---- (2) the body actually runs, and reads the slot it claims to -------
 
 (defn- fresco-tree []
-  (ht/tree [rt/resizable-table-view (opts)]
+  (rf.fresco.test/tree [rt/resizable-table-view (opts)]
            {:subs {widths-query overrides}}))
 
 (defn- style-of [node]
-  (:style (ht/attrs node)))
+  (:style (rf.fresco.test/attrs node)))
 
 (defn- testid-of [node]
-  (:data-testid (ht/attrs node)))
+  (:data-testid (rf.fresco.test/attrs node)))
 
 (deftest fresco-head-runs-and-reads-the-column-widths-slot
   (testing "rf2-fcy5 slice 1b — the boundary body runs on the runtime's own
@@ -169,10 +169,10 @@
             `[:rf.xray.column-widths/for-table <table-id>]`."
     (let [tree (fresco-tree)]
       (is (= :div (:tag tree)) "the container is a div")
-      (is (= "fresco" (:data-rf-xray-resizable-table (ht/attrs tree)))
+      (is (= "fresco" (:data-rf-xray-resizable-table (rf.fresco.test/attrs tree)))
           "…and it is this widget's container")
       (is (= (rt/build-template columns overrides)
-             (:grid-template-columns (style-of (ht/find tree #(= "grid" (:display (style-of %)))))))
+             (:grid-template-columns (style-of (rf.fresco.test/find tree #(= "grid" (:display (style-of %)))))))
           "THE READ ROW — the header's grid template is built from the
            fixture's overrides, so the value the boundary read reached
            `build-template`. Compared against the widget's own pure
@@ -187,7 +187,7 @@
             moved to CSS it is a pure fn the weaver CALLS, so what the
             Fresco tree carries here is N-1 ordinary divs."
     (let [tree    (fresco-tree)
-          gutters (ht/find-all tree #(some-> (testid-of %)
+          gutters (rf.fresco.test/find-all tree #(some-> (testid-of %)
                                              (.startsWith "rf-xray-resizable-gutter-")))]
       (is (= 2 (count gutters)) "N-1 gutters for N columns")
       (is (= ["rf-xray-resizable-gutter-fresco-a"
@@ -208,7 +208,7 @@
             through a real Fresco body run rather than through the codec's
             element door alone."
     (let [tree (fresco-tree)
-          rows (ht/find-all tree #(some-> (testid-of %) (.startsWith "r-")))]
+          rows (rf.fresco.test/find-all tree #(some-> (testid-of %) (.startsWith "r-")))]
       (is (= 2 (count rows)) "one node per row")
       (is (= ["row-0" "row-1"] (mapv :key rows))
           "the consumer's `:row-key`, reaching the substrate"))))
@@ -230,7 +230,7 @@
           reagent-header (nth reagent-tree 2)
           reagent-template (get-in reagent-header [1 :style :grid-template-columns])
           fresco-template (:grid-template-columns
-                            (style-of (ht/find (fresco-tree)
+                            (style-of (rf.fresco.test/find (fresco-tree)
                                                #(= "grid" (:display (style-of %))))))]
       (is (= (rt/build-template columns overrides) reagent-template)
           "the Reagent head read the hydrated slot")

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_key_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_key_cljs_test.cljs
@@ -43,13 +43,17 @@
   attrs-map key that works perfectly. `meta-is-not-where-the-key-lives`
   states that as an executable claim instead of a comment.
 
-  ## The gutter is deliberately not graded by the codec
+  ## The gutter IS graded by the codec now (rf2-fcy5 slice 1b)
 
-  `[header-gutter {…}]` is a plain `defn` in head position, which the
-  codec grades `:invalid` and refuses outright — that refusal is
-  rf2-fcy5's REMAINING work (the Fresco sibling), not this change's.
-  Its key is graded at the Reagent door and in the props map, which is
-  where a boundary would later read it from.
+  It was not, at slice 1: `[header-gutter {…}]` was a plain `defn` in
+  head position, which the codec grades `:invalid` and refuses outright,
+  so its key could only be read at the Reagent door and out of the props
+  map. Slice 1b retired the Form-2 hover Ratom that made it a component
+  at all — the hover paint is a CSS rule keyed on the gutter's own
+  `data-testid` — so `header-gutter` is now a pure fn CALLED like
+  `body-spacer`, there is no head to refuse, and the gutter's key rides
+  the emitted div's attrs map like every other woven node. It is graded
+  at BOTH doors below.
 
   ## The helper's three cases
 
@@ -60,11 +64,16 @@
   five shapes through `:row-cells` and asserts both that the key reaches
   React and that the cell's own children SURVIVE."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; rf2-fcy5 slice 1b — the gutter's hover paint is a global CSS
+            ;; rule now, so its selector is part of this widget's contract
+            ;; and is pinned here beside the markup it selects on.
+            [day8.re-frame2-xray.theme.global-styles :as gs]
             [day8.re-frame2-xray.views.resizable-table :as rt]))
 
 ;; ---- fixture ------------------------------------------------------------
@@ -183,25 +192,79 @@
       (is (= 3 (count (distinct (mapv fresco-key cells))))
           "sibling keys are distinct"))))
 
-;; ---- (2) gutters: Reagent + props map only ------------------------------
+;; ---- (2) gutters: a CALLED pure fn, graded at BOTH doors ----------------
 
-(deftest header-gutters-carry-their-key-in-the-props-map
-  (testing "rf2-fcy5 — the gutter is a component call form, so its key
-            rides the PROPS map `header-gutter` receives (it destructures
-            named opts and never spreads them, so the entry is inert for
-            its body — the shape rf2-hxfy used for `flat-row-list`).
-            NOT graded at the Fresco door: a plain `defn` in head
-            position is `:invalid` to the codec and is refused, which is
-            this bead's remaining work, not this change's."
+(deftest header-gutters-reach-both-renderers-with-keys
+  (testing "rf2-fcy5 slice 1b — the gutter is no longer a head. Retiring
+            its Form-2 hover Ratom made `header-gutter` a pure fn, so
+            `weave-header` CALLS it and what lands in the woven seq is the
+            gutter's own `[:div …]`, keyed in its attrs map and gradeable
+            at the Fresco door like every other node. At slice 1 this row
+            could only read the Reagent door and the props map."
     (xray-setup!)
     (let [woven   (header-woven (render (three-column-opts {})))
           gutters (vec (take-nth 2 (rest woven)))]
       (is (= 2 (count gutters)) "N-1 gutters for N columns")
-      (is (= ["g-a" "g-b"] (mapv reagent-key gutters)))
-      (is (= ["g-a" "g-b"] (mapv #(:key (nth % 1)) gutters))
-          "the key is in the props map, where a boundary would read it")
-      (is (every? #(contains? (nth % 1) :dispatch-fn) gutters)
-          "the gutter's own props survive the key injection"))))
+      (is (every? #(= :div (nth % 0)) gutters)
+          "a CALLED pure fn — the node is a native div, not a component
+           call form the codec would grade `:invalid`")
+      (is (= ["g-a" "g-b"] (mapv reagent-key gutters)) "REAGENT")
+      (is (= ["g-a" "g-b"] (mapv fresco-key gutters))  "FRESCO")
+      (is (= ["rf-xray-resizable-gutter-keys-a"
+              "rf-xray-resizable-gutter-keys-b"]
+             (mapv #(:data-testid (nth % 1)) gutters))
+          "the stable testid survives — it is what the CSS hover rule
+           selects on, so the widget's affordance rides on this string")
+      (is (every? #(fn? (:on-pointer-down (nth % 1))) gutters)
+          "the drag affordance survives the key injection")
+      (is (every? #(and (not (contains? (nth % 1) :on-pointer-enter))
+                        (not (contains? (nth % 1) :on-pointer-leave)))
+                  gutters)
+          "THE RETIREMENT ROW — the hover handlers the Ratom needed are
+           gone; the paint is CSS now"))))
+
+;; ---- (2b) the hover paint is stateless, and the CSS is its other half ---
+
+(deftest gutter-carries-no-hover-state
+  (testing "rf2-fcy5 slice 1b — the gutter renders ONE style regardless of
+            pointer state, because there is no state left to render from.
+            Two independent renders of the same table produce byte-equal
+            gutter nodes bar their handler identities; the style map is
+            the transparent base, never an accent fill."
+    (xray-setup!)
+    (let [style-of (fn [] (mapv #(:style (nth % 1))
+                                (take-nth 2 (rest (header-woven
+                                                    (render (three-column-opts {})))))))
+          a (style-of)
+          b (style-of)]
+      (is (= a b) "the same style on every render — nothing to toggle")
+      (is (every? #(= "transparent" (:background %)) a)
+          "the base state is transparent; the accent is the CSS rule's")
+      (is (every? #(= "col-resize" (:cursor %)) a)
+          "the always-visible affordance signal stays inline"))))
+
+(deftest global-styles-paints-the-gutter-hover
+  (testing "rf2-fcy5 slice 1b — the OTHER half of the retirement. The
+            hover affordance is now a global CSS rule keyed on the
+            gutter's `data-testid` prefix, so this row pins the selector,
+            the accent token, and the `!important` WITHOUT which the
+            gutter's inline `background: transparent` would win and the
+            handle would never light up. Nothing else in the tree can see
+            a broken CSS rule — no gate renders CSS."
+    (let [css @#'gs/motion-css]
+      (is (string? css))
+      (is (str/includes? css "[data-testid^=\"rf-xray-resizable-gutter-\"]:hover")
+          "the selector matches the prefix `header-gutter` stamps")
+      (is (str/includes? css
+                         (str "[data-testid^=\"rf-xray-resizable-gutter-\"]:hover {\n"
+                              "  background: var(--rf-xray-accent) !important;\n"
+                              "}\n"))
+          "accent token + !important — the inline `background: transparent`
+           beats a stylesheet rule without it")
+      (is (str/includes? css "[data-testid^=\"rf-xray-event-list-col-divider-\"]:hover")
+          "the sibling rule this one was modelled on is still there — a
+           control, so a broken read of `motion-css` cannot pass this
+           test vacuously"))))
 
 ;; ---- (3) body cells + spacers reach BOTH renderers with keys ------------
 


### PR DESCRIPTION
Slice 1b of **rf2-fcy5**, following slice 1 (#9642). Two halves, and the first is what makes the second cheap rather than a ruling.

## 1. Retiring the Form-2 Ratom

`header-gutter` held a boolean hover flag in a Form-2 Reagent Ratom, purely to paint the 4px drag track with the accent colour on hover. That flag was `views/resizable_table.cljs`'s only component-local state and its only `reagent.core` use, and it was the one thing standing between the shared widget and a Fresco boundary: a React function component has no form-2 outer body to allocate per-instance state in, and `rf.fresco/reg-state` **consumes** an instance key rather than minting one — `edn-inspector-view` hard-throws without a caller-supplied `:mount-id` for exactly this reason. Keeping the hover as state would have forced a stable instance key onto all five call sites, across two panels.

The hover does not need state. `theme/global_styles.cljs` already carries the same treatment for the sibling event-list column-divider handle, keyed on its `data-testid` prefix and marked `!important` because the element's inline `background: transparent` would otherwise win. The gutter already stamped a stable `data-testid`, so the new rule matched **with no markup change at all**, and the port is faithful rather than a redesign — the same accent fill over the same 4px track, with the same 0.15s cross-fade, which stays inline where it already was.

That removes the **component**, not just the state. `header-gutter` is now a pure fn the weaver CALLS like its neighbour `body-spacer`, so it is no longer a hiccup head — which deletes the widget's only codec-`:invalid` head and lets its key ride the emitted div's attrs map like every other woven node.

## 2. The Fresco sibling

`resizable-table-view` is a `rf.fresco/defview` over the same renderer, on the `edn-inspector` / `edn-inspector-view` pattern: one private `render-table` holding the whole rendering, and two heads that differ only in how they resolve the two things it cannot resolve for itself. The boundary reads with `rf.fresco/sub` in place of the `reg-view`-injected `@(subscribe …)`, and takes its dispatcher from `(:dispatch (rf/capture-frame))` — the drag flow's ticks fire from raw `window` listeners long after the render extent has unwound, which is the case `capture-frame` documents itself for.

Nothing else resisted: the `:contextType` injection is replaced by the boundary, `on-pointer-down` already takes `dispatch-fn` as an explicit parameter (rf2-r0o63), and `install!` / `hydrate!` mention neither the view nor its registration id, so their call sites in `registry.cljs` and `mount.cljs` are untouched.

It needs **no instance key**, which is the whole of why this head is cheap: the widths live in app-db under the consumer's own `:table-id`, the drag bookkeeping is a module-level `defonce`, and the hover flag is gone.

## Both heads ship, and nothing adopts the new one

A Fresco boundary in a Reagent head position fails as loudly as the reverse, so `panels/trace.cljs` and `panels/epoch/view.cljs` keep mounting `resizable-table` until their own mounts are boundaries. Those are slices 2 and 3; the bead's own sequencing is shared widget first.

## Tests

`resizable_table_key_cljs_test`'s gutter row could previously read only the Reagent door and the props map, because a plain `defn` in head position is refused by the codec. It now grades the gutter at **both** doors, and asserts the two hover handlers are gone. Two new rows pin the stateless half: that the gutter renders one style regardless of pointer state, and that `motion-css` carries the selector, the accent token and the `!important` — with the sibling column-divider rule beside it as a control, so a broken read of the CSS cannot pass vacuously.

`resizable_table_fresco_head_cljs_test` is new. It asks the **codec** what each head is rather than pattern-matching the authoring shape (both are `def`s and neither spelling can be told from the other by looking), and pins the loud refusal a premature adoption would meet. It then runs the boundary **body** through `re-frame.fresco.test/tree`, the L0–L2 kit, under a single read fixture: `rf.fresco/sub` refuses outside a render extent, so a misspelled read cannot be caught by looking at the var, and the kit refuses a read no fixture answers *by name* — which is what makes the subscription wiring a gate rather than a description. A last row renders both heads over the same widths and requires the same grid template.

One fixture note for whoever writes the next boundary test: the suite's `make-xray-runtime-fixture` binds an ambient `:rf/default`, and `(rf/capture-frame)` inside a boundary body refuses a carried stamp that names a different frame from the extent's (`:rf.error/ambient-frame-refused`). That namespace therefore uses the core fixture with `:ambient-frame nil`, as `make-xray-runtime-fixture`'s own docstring says to. Production is unaffected — a boundary renders with no dynamic frame scope in force, and a shell that scopes one scopes the same frame the boundary renders under.

## Quality gates

- `npm run test:cljs` — the covering gate for a `tools/xray` CLJS change (`implementation/shadow-cljs.edn`'s `:node-test` build lists `../tools/xray/src` and `../tools/xray/test`). Counts in the thread.
- `cd tools/xray && clojure -M:test` — run as a **secondary** check only, because it text-scans `views/resizable_table.cljs` in `frame_singleton_guard_test.clj`. It is a JVM run and cannot load a `.cljs` test, so it is not the covering gate here.
- **No gate renders CSS.** Verified by hand: `!important` on an author declaration beats an inline `style` attribute (author-normal), so the accent wins on hover and `transparent` stands off it — byte-equivalent to the retired `gutter-hover-style`, which was the same map with `:background` swapped. `--rf-xray-accent` is defined for both themes (`#0969da` / `#539bf5`) via `token-key->css-var`; `motion-css` is injected by `install-into!` into the host document and the pop-out document alike, the same block the existing column-divider rule ships in. The selector prefix matches the only producer of that `data-testid` in the tree, and the inline `transition: background 0.15s ease` is unchanged, so the cross-fade still fires — a CSS transition runs on a computed-value change regardless of which declaration won.
