### PR TITLE
fix(xray): sweep metadata React keys into attrs maps across 13 files (rf2-a38l)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/chart/timing_waterfall.cljc
@@ -167,8 +167,8 @@
                           bar-x     (+ label-width bar-padding)
                           bar-w-px  (max 1 (Math/round (* (:width-pct row) bar-area-w)))
                           fill      (bar-fill (:phase row) slow?)]]
-                ^{:key (str (:phase row) "-" i)}
-                [:g {:data-testid (str "rf-xray-waterfall-row-" (phase-label row))
+                [:g {:key         (str (:phase row) "-" i)
+                     :data-testid (str "rf-xray-waterfall-row-" (phase-label row))
                      :data-phase  (phase-label row)
                      :data-slow   (str slow?)}
                  ;; left label

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -322,9 +322,17 @@
                  :align-items "center"
                  :gap         "6px"
                  :flex-wrap   "wrap"}}
+   ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader meta. The
+   ;; meta reaches React under Reagent and NOWHERE under Fresco, whose
+   ;; codec reads a literal `:key` from an attribute map and Clojure
+   ;; metadata not at all. `pill` takes `dispatch` positionally, so there
+   ;; is no props map at index 1 to write the key into and inserting one
+   ;; would shift its arguments — `[:<> {:key …} …]` carries the key on a
+   ;; head BOTH substrates honour and leaves the call untouched (the same
+   ;; shape `views/edn_inspector` uses under rf2-k97c.3).
    (for [[idx p] (map-indexed vector (:in filters))]
-     ^{:key (str "in-" idx)}
-     [pill dispatch {:mode :in :pill p :idx idx}])
+     [:<> {:key (str "in-" idx)}
+      [pill dispatch {:mode :in :pill p :idx idx}]])
    (for [[idx p] (map-indexed vector (:out filters))]
-     ^{:key (str "out-" idx)}
-     [pill dispatch {:mode :out :pill p :idx idx}])])
+     [:<> {:key (str "out-" idx)}
+      [pill dispatch {:mode :out :pill p :idx idx}]])])

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -426,8 +426,8 @@
       ;; value has a matching option even when the pinned frame has no
       ;; events (rf2-v8bule).
       (for [f option-frames]
-        ^{:key (str f)}
-        [:option {:value (str f)}
+        [:option {:key   (str f)
+                  :value (str f)}
          (str (if (= f active) "✓ " "  ") f)])]]))
 
 ;; ---- install -------------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -220,8 +220,8 @@
           (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                 (concat
                   (for [row shown]
-                    ^{:key (:slug row)}
-                    [:li {:data-testid (str "rf-xray-" panel-id "-boundary-" (:slug row))
+                    [:li {:key         (:slug row)
+                          :data-testid (str "rf-xray-" panel-id "-boundary-" (:slug row))
                           :style       row-style}
                      [:div
                       ;; The VIEW leads when the producer names it — that is
@@ -261,8 +261,8 @@
          (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                (concat
                  (for [row shown]
-                   ^{:key (:slug row)}
-                   [:li {:data-testid (str "rf-xray-" panel-id "-edge-" (:slug row))
+                   [:li {:key         (:slug row)
+                         :data-testid (str "rf-xray-" panel-id "-edge-" (:slug row))
                          :style       row-style}
                     ;; The PROJECTED QUERY, not the bare sub-id. `[:row 1]`
                     ;; and `[:row 2]` are one registration and two cells, and
@@ -302,8 +302,8 @@
          (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
                (concat
                  (for [[i row] (map-indexed vector shown)]
-                   ^{:key i}
-                   [:li {:data-testid (str "rf-xray-" panel-id "-intent-" (:slug row))
+                   [:li {:key         i
+                         :data-testid (str "rf-xray-" panel-id "-intent-" (:slug row))
                          :style       row-style}
                     [:div [:span {:style {:font-family mono-stack}}
                            (hh/format-id (:event-id row))]
@@ -339,8 +339,8 @@
          (into [:ul {:style {:list-style "none" :margin 0 :padding 0}}]
                (concat
                  (for [row shown]
-                   ^{:key (:slug row)}
-                   [:li {:data-testid (str "rf-xray-" panel-id "-explain-" (:slug row))
+                   [:li {:key         (:slug row)
+                         :data-testid (str "rf-xray-" panel-id "-explain-" (:slug row))
                          :style       row-style}
                     ;; The frame rides beside the label. Frames are isolated
                     ;; contexts, so one query read in two of them is two facts
@@ -454,14 +454,14 @@
          [:div (:says r)]
          (into [:ul {:style {:margin "4px 0 0 16px" :padding 0}}]
                (for [n (:next r)]
-                 ^{:key (str (:class n))}
-                 [:li {:data-testid (str stem "-refusal-" (name (:class n)))}
+                 [:li {:key         (str (:class n))
+                       :data-testid (str stem "-refusal-" (name (:class n)))}
                   (str (:label n) " — " (:authority n))]))])
       (into [:ol {:data-testid (str stem "-loop")
                   :style {:margin "6px 0 0 16px" :padding 0
                           :color (:text-tertiary tokens)}}]
             (for [[i s] (map-indexed vector (:working-loop advice))]
-              ^{:key i} [:li s]))]]))
+              [:li {:key i} s]))]]))
 
 (defn- advisor-view
   [{:keys [advice envelope]}]
@@ -470,7 +470,12 @@
     [:div {:data-testid (str "rf-xray-" panel-id "-advisor")}
      (or (presence-note (hh/presence envelope (empty? rows)) :advisor)
          (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
-               (concat (for [row shown] ^{:key (:slug row)} [advice-row row])
+               ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader
+               ;; meta (Reagent honours it, Fresco's codec reads it
+               ;; nowhere). `advice-row` takes its row positionally, so
+               ;; there is no props map at index 1 to hold the key.
+               (concat (for [row shown]
+                         [:<> {:key (:slug row)} [advice-row row]])
                        [(overflow/overflow-row {:panel-id     (str panel-id "-advisor")
                                                 :over-cap?    over?
                                                 :hidden-count hidden})])))
@@ -483,8 +488,8 @@
       [:div "Three of the five pressure classes are not measured here:"]
       (into [:ul {:style {:margin "4px 0 0 16px" :padding 0}}]
             (for [c (:unmeasured advice)]
-              ^{:key (str (:class c))}
-              [:li {:data-testid (str "rf-xray-" panel-id "-advisor-unmeasured-"
+              [:li {:key         (str (:class c))
+                    :data-testid (str "rf-xray-" panel-id "-advisor-unmeasured-"
                                       (name (:class c)))}
                [:strong (:label c)] " — " (:authority c) ". " (:why c)]))]]))
 
@@ -522,8 +527,12 @@
    (if (nil? slice)
      (presence-note :idle :causal)
      (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
+           ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader meta
+           ;; (Reagent honours it, Fresco's codec reads it nowhere).
+           ;; `causal-link` takes its link positionally, so there is no
+           ;; props map at index 1 to hold the key.
            (for [link (:links slice)]
-             ^{:key (name (:id link))} [causal-link link])))])
+             [:<> {:key (name (:id link))} [causal-link link]])))])
 
 ;; ---- the sub-strip and the panel -----------------------------------------
 
@@ -539,8 +548,8 @@
                :role        "tablist"
                :style       strip-style}]
         (for [{:keys [id label asks]} hh/sub-modes]
-          ^{:key id}
-          [:button {:data-testid   (str "rf-xray-" panel-id "-sub-" (name id))
+          [:button {:key           id
+                    :data-testid   (str "rf-xray-" panel-id "-sub-" (name id))
                     :role          "tab"
                     :aria-selected (= id selected)
                     :title         asks

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -543,8 +543,16 @@
        ;; ordinary re-render, so the per-epoch repaint needs no remount.
        ;; Re-fitting on navigation rides the orthogonal `:fit-signal`
        ;; nonce (rf2-6tw7t). See `h/focused-event-section-key`.
-       (with-meta (focused-event-section cascade record)
-         {:key (h/focused-event-section-key target-frame record)})])))
+       ;; rf2-a38l — KEYED FRAGMENT rather than `with-meta` on the vector
+       ;; the call returns. Reagent's `get-react-key` reads that metadata,
+       ;; but Fresco's codec takes a literal `:key` from an ATTRIBUTE MAP
+       ;; and reads Clojure metadata nowhere — so under a boundary this
+       ;; section would keep one identity across epochs and the remount
+       ;; this key exists to force would silently stop happening.
+       ;; `focused-event-section` answers hiccup whose own attribute map
+       ;; is not ours to write into, so the key rides the fragment.
+       [:<> {:key (h/focused-event-section-key target-frame record)}
+        (focused-event-section cascade record)]])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -356,8 +356,8 @@
            :style       (field-style)}
      [:span {:style (label-style)} "Click-to-source links open in"]
      (for [{:keys [id value label]} editor-override-options]
-       ^{:key id}
-       [:label {:style {:display "flex" :align-items "center" :gap "8px"
+       [:label {:key   id
+                :style {:display "flex" :align-items "center" :gap "8px"
                         :cursor "pointer"
                         :font-size (:body type-scale)
                         :color (:text-primary tokens)}}
@@ -478,8 +478,8 @@
       ;; `(xray/popout!)` API, not via this panel-position radio.
       (for [[pos label] [[:right-rail "Right rail (inline)"]
                          [:fullscreen "Fullscreen overlay"]]]
-        ^{:key pos}
-        [:label {:style {:display "flex" :align-items "center" :gap "8px"
+        [:label {:key   pos
+                 :style {:display "flex" :align-items "center" :gap "8px"
                          :cursor  "pointer"
                          :font-size (:body type-scale)
                          :color   (:text-primary tokens)}}
@@ -869,8 +869,8 @@
            (apply concat
                   (for [{:keys [group rows]} keybinding-rows]
                     (concat
-                      [^{:key (str "g-" group)}
-                       [:div {:style {:padding     "8px 10px"
+                      [[:div {:key   (str "g-" group)
+                              :style {:padding     "8px 10px"
                                       :background  (:bg-1 tokens)
                                       :color       (:text-tertiary tokens)
                                       :font-size   (:caption type-scale)
@@ -882,8 +882,8 @@
                         group]]
                       (map-indexed
                         (fn [idx [chord action]]
-                          ^{:key (str group "-" idx)}
-                          [:div {:style (keybinding-table-row-style (odd? idx))}
+                          [:div {:key   (str group "-" idx)
+                                 :style (keybinding-table-row-style (odd? idx))}
                            [:span {:style {:font-family mono-stack
                                            :color       (:text-primary tokens)
                                            :font-size   (:body type-scale)}}

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2151,15 +2151,26 @@
         ;; the header dividers + every row's out-of-render dispatches
         ;; (body-click focus, context menu, col resize) so they land on
         ;; the surrounding instance frame.
+        ;; rf2-a38l — these three sibling keys ride an ATTRIBUTE MAP, never
+        ;; `^{:key …}` reader meta. Meta on a vector literal reaches React
+        ;; under Reagent and reaches it NOWHERE under Fresco, whose codec
+        ;; reads a literal `:key` from the attribute map and Clojure
+        ;; metadata not at all — so the meta spelling works today and would
+        ;; drop every key here, silently, the day this list renders under a
+        ;; boundary. `l2-column-header` takes both arguments positionally,
+        ;; so its key rides a KEYED FRAGMENT (the rf2-k97c.3 shape) rather
+        ;; than a props map that would shift them; `event-row` already
+        ;; takes one opts map, so its key rides that, which is where a
+        ;; boundary head reads `:key` from and where the body never sees it.
         (list
-         ^{:key "header"} [l2-column-header col-widths dispatch]
-         (into ^{:key "rows"}
-               [:ul {:style {:list-style "none" :margin 0 :padding 0
-                            :display "flex" :flex-direction "column"
-                            :gap "2px"}}]
+         [:<> {:key "header"} [l2-column-header col-widths dispatch]]
+         (into [:ul {:key "rows"
+                     :style {:list-style "none" :margin 0 :padding 0
+                             :display "flex" :flex-direction "column"
+                             :gap "2px"}}]
               (for [event-bundle event-bundles]
-                ^{:key (str (:dispatch-id event-bundle))}
-                [event-row {:event-bundle     event-bundle
+                [event-row {:key              (str (:dispatch-id event-bundle))
+                            :event-bundle     event-bundle
                             :focused-id  focused-id
                             :auto-track? auto-track?
                             :now-ms      now-ms
@@ -2328,11 +2339,16 @@
       "selected"]
      ;; rf2-2moh1 — iterate `dynamic-tabs` (registry-derived) rather
      ;; than a literal vector. Tab order follows each entry's `:order`.
+     ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader meta, which
+     ;; Reagent honours and Fresco's codec reads nowhere. `tab-button`'s one
+     ;; argument is the tab map itself, so the key does NOT go there: it is
+     ;; registry-derived domain data the body destructures, and `:key` is
+     ;; React's. The fragment keeps the two apart.
      (for [{:keys [id] :as tab} (dynamic-tabs)]
-       ^{:key id}
-       ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
-       ;; tab click's select-tab write lands on the instance frame.
-       [tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch)])
+       [:<> {:key id}
+        ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
+        ;; tab click's select-tab write lands on the instance frame.
+        [tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch)]])
      ;; rf2-hga49 — `margin-left:auto` spacer pushes the Reset cluster to
      ;; the FAR RIGHT of the ribbon, past the tab buttons.
      [:span {:data-testid "rf-xray-tab-bar-spacer"
@@ -2440,13 +2456,18 @@
                    :background  (:bg-2 tokens)
                    :color       (:text-primary tokens)}}
      ;; rf2-5kfxe.3 — re-mount on selected-tab change so the fade-in
-     ;; keyframes auto-play. The `^{:key selected}` reader-meta is on a
-     ;; *vector literal* (the wrapper `[:div ...]`), so Reagent's
-     ;; `get-react-key` picks it up via the vector's meta (no
-     ;; `with-meta` needed here — different from the function-call
-     ;; case in `render-sections`).
-     ^{:key selected}
-     [:div {:data-testid (str "rf-xray-detail-panel-fade-"
+     ;; keyframes auto-play.
+     ;;
+     ;; rf2-a38l — the remount key rides the ATTRIBUTE MAP below. It used
+     ;; to be `^{:key selected}` reader meta on that vector literal, which
+     ;; Reagent's `get-react-key` does read — but Fresco's codec takes a
+     ;; literal `:key` from the attribute map and reads Clojure metadata
+     ;; nowhere, so under a boundary the wrapper would keep ONE identity
+     ;; across every tab change and the fade would simply stop playing:
+     ;; no error, no warning, just an animation that never re-triggers.
+     ;; The attribute map is honoured by both substrates.
+     [:div {:key         selected
+            :data-testid (str "rf-xray-detail-panel-fade-"
                               (name selected))
             :style {:height     "100%"
                     ;; Keyframes named in `global-styles/motion-css`.

--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -444,8 +444,12 @@
                       :gap "4px"
                       :overflow-y "auto"
                       :max-height "44vh"}}]
+        ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader meta,
+        ;; which Reagent honours and Fresco's codec reads nowhere. Both
+        ;; of `mute-row`'s arguments are positional, so there is no props
+        ;; map to hold the key and inserting one would shift them.
         (for [id (sort-by str muted-ids)]
-          ^{:key (str id)} [mute-row dispatch id])))
+          [:<> {:key (str id)} [mute-row dispatch id]])))
 
 (defn- clear-all-button
   [dispatch]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -353,8 +353,8 @@
                      :font-size "12px"}}]
      [:datalist {:id datalist-id}
       (for [ev suggestions]
-        ^{:key (str ev)}
-        [:option {:value (str ev)}])]]))
+        [:option {:key   (str ev)
+                  :value (str ev)}])]]))
 
 (defn- pending-data-input
   [dispatch machine-id pending-data]
@@ -527,15 +527,18 @@
                  :style {:list-style "none" :padding 0 :margin 0}}]
            ;; `^{:key …}` reader meta on the `(available-transition-row
            ;; …)` call below would be attached to the source list and
-           ;; lost when the call returns its fresh vector — Reagent's
-           ;; `get-react-key` only reads `:key` meta from vectors (see
-           ;; reagent2.impl.template). `available-transition-row`
-           ;; always returns a `[:li …]` vector, so apply the key
-           ;; directly via `with-meta`.
+           ;; lost when the call returns its fresh vector.
+           ;;
+           ;; rf2-a38l — and `with-meta` on that returned vector, which
+           ;; this used to do, is only half a fix: Reagent's
+           ;; `get-react-key` does read vector meta, but Fresco's codec
+           ;; takes a literal `:key` from an ATTRIBUTE MAP and reads
+           ;; Clojure metadata nowhere, so the key vanished silently
+           ;; under a boundary. A KEYED FRAGMENT carries it on a head
+           ;; both substrates honour without touching the call.
            (for [t transitions]
-             (with-meta
-               (available-transition-row dispatch machine-id pending-event t)
-               {:key (str (:event t))}))))])
+             [:<> {:key (str (:event t))}
+              (available-transition-row dispatch machine-id pending-event t)])))])
 
 (defn- error-toast
   [{:keys [event reason]}]
@@ -595,13 +598,14 @@
                  :style {:list-style "none" :padding 0 :margin 0}}]
            ;; `^{:key …}` reader meta on the `(audit-trail-row …)` call
            ;; below would be attached to the source list and lost when
-           ;; the call returns its fresh vector — Reagent's
-           ;; `get-react-key` only reads `:key` meta from vectors (see
-           ;; reagent2.impl.template). `audit-trail-row` always returns
-           ;; a `[:li …]` vector, so apply the key directly via
-           ;; `with-meta`.
+           ;; the call returns its fresh vector.
+           ;;
+           ;; rf2-a38l — and `with-meta` on that returned vector, which
+           ;; this used to do, dies at a Fresco boundary for the reason
+           ;; given at `available-transitions` above. A KEYED FRAGMENT
+           ;; carries the key on a head both substrates honour.
            (for [[idx row] (map-indexed vector trail)]
-             (with-meta (audit-trail-row idx row) {:key idx}))))])
+             [:<> {:key idx} (audit-trail-row idx row)])))])
 
 (defn SimRail
   "The Sim sub-mode's content rail — banner + current state + event

--- a/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
@@ -109,7 +109,7 @@
                             :cursor        "pointer"
                             :flex-shrink   0}}
      (for [{:keys [mode label]} modes]
-       ^{:key mode}
-       [:option {:data-testid (str "rf-xray-mode-pill-" (name mode))
+       [:option {:key         mode
+                 :data-testid (str "rf-xray-mode-pill-" (name mode))
                  :value       (name mode)}
         label])]))

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/browse_list.cljs
@@ -195,12 +195,17 @@
                                  :display        "flex"
                                  :flex-direction "column"
                                  :gap            "1px"}}]
+             ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader
+             ;; meta, which Reagent honours and Fresco's codec reads
+             ;; nowhere. `route-row` takes `dispatch` and `row`
+             ;; positionally ahead of its opts map, so there is no props
+             ;; map at index 1 to write the key into.
              (for [row routes]
-               ^{:key (str (:route-id row))}
-               [route-row dispatch row
-                {:expanded?  (contains? expanded (:route-id row))
-                 :sim-open?  (contains? sim-open (:route-id row))
-                 :routes-map routes-map
-                 :on-toggle  (fn [_]
-                               (dispatch [:rf.xray.static.routes/toggle-row
-                                          (:route-id row)]))}])))]))
+               [:<> {:key (str (:route-id row))}
+                [route-row dispatch row
+                 {:expanded?  (contains? expanded (:route-id row))
+                  :sim-open?  (contains? sim-open (:route-id row))
+                  :routes-map routes-map
+                  :on-toggle  (fn [_]
+                                (dispatch [:rf.xray.static.routes/toggle-row
+                                           (:route-id row)]))}]])))]))

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_url.cljs
@@ -159,6 +159,10 @@
                             :display        "flex"
                             :flex-direction "column"
                             :gap            "1px"}}]
+              ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader
+              ;; meta, which Reagent honours and Fresco's codec reads
+              ;; nowhere. `candidate-row` takes its candidate
+              ;; positionally, so there is no props map to hold the key.
               (for [c candidates]
-                ^{:key (str (:route-id c))}
-                [candidate-row c]))]))])
+                [:<> {:key (str (:route-id c))}
+                 [candidate-row c]]))]))])

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -541,12 +541,20 @@
             (map-indexed
               (fn [idx mount-id]
                 (let [{:keys [value opts]} (get entries mount-id)]
-                  (with-meta
-                    (popup-chrome
-                      {:mount-id    mount-id
-                       :value       value
-                       :opts        opts
-                       :positioning positioning
-                       :stack-pos   idx})
-                    {:key mount-id})))
+                  ;; rf2-a38l — KEYED FRAGMENT rather than `with-meta` on
+                  ;; the vector `popup-chrome` returns. Reagent reads that
+                  ;; metadata; Fresco's codec takes a literal `:key` from
+                  ;; an ATTRIBUTE MAP and reads Clojure metadata nowhere,
+                  ;; so under a boundary every popup in the stack would
+                  ;; lose its identity and React would reconcile them by
+                  ;; position. The key does NOT go in the opts map — that
+                  ;; is `popup-chrome`'s domain data, and `:key` is
+                  ;; React's.
+                  [:<> {:key mount-id}
+                   (popup-chrome
+                     {:mount-id    mount-id
+                      :value       value
+                      :opts        opts
+                      :positioning positioning
+                      :stack-pos   idx})]))
               stack)))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -16,7 +16,12 @@
   hiccup tree by `data-testid` rather than mounting to the DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
+            [reagent.core :as r]
             [re-frame.core :as rf]
+            ;; rf2-a38l — the codec's own hiccup→element door, so the
+            ;; focused-event section's key is graded where a Fresco
+            ;; boundary would actually read it rather than at `(meta …)`.
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.frame :as rf.frame]
             ;; Boot the optional machines artefact's late-bind hooks so
             ;; `reg-machine*` resolves rather than throwing
@@ -1252,10 +1257,41 @@
                          (.startsWith prefix))))
           (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
 
-(deftest focused-event-sections-carry-key-meta
-  (testing "focused-event-section per-record for-loop ships per-section
-            children carrying :key meta on the returned [:section …]
-            vector (rf2-ppzid)"
+;; rf2-a38l — graded AT THE RENDERER, not at `(meta …)`. `(:key (meta
+;; node))` is hollow in both directions: it passes on metadata React
+;; never sees and fails on a key that reaches React perfectly well. The
+;; section's key rides a KEYED FRAGMENT, which Reagent and Fresco's
+;; codec both honour; the codec door is the half that can see a revert
+;; to `with-meta`, since it reads Clojure metadata nowhere.
+
+;; Both doors are asked about the keyed node with its CHILDREN DROPPED
+;; (`subvec … 0 2` — head plus attribute map). That is deliberate and it
+;; does not weaken the question: `:key` is read off the node's own
+;; attribute map by both renderers, so dropping the subtree changes
+;; nothing about the answer. It is necessary because the codec lowers
+;; children EAGERLY, and this section's subtree still contains a plain
+;; function in head position — `[machine-canvas/Chart …]` and friends —
+;; which the codec refuses outright as HD-016 `:rf.error/fresco-bad-head`.
+;; That refusal is the Fresco MIGRATION's business (those heads become
+;; views when the panel crosses); it is a different defect from this one,
+;; and letting it throw here would hide the key answer behind it.
+
+(defn- reagent-key
+  "The key Reagent hands React — meta OR props, so it cannot see the
+  defect alone; it pins the sweep as a no-op today."
+  [node]
+  (.-key (r/as-element (subvec node 0 2))))
+
+(defn- fresco-key
+  "The key a Fresco boundary would commit, read off the node's own
+  attribute map. nil for a meta-only key, which is the whole point."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element (subvec node 0 2))))
+
+(deftest focused-event-sections-reach-react-with-a-key
+  (testing "focused-event-section ships a per-section child whose key
+            reaches React on BOTH substrates (rf2-ppzid; regraded at the
+            renderer under rf2-a38l)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login :checkout/flow])
@@ -1277,13 +1313,22 @@
       (focus-epoch! 1)
       (let [tree     (machine-inspector/Panel)
             sections (raw-find-all-by-testid-prefix
-                       tree "rf-xray-machine-focused-event-section-")]
+                       tree "rf-xray-machine-focused-event-section-")
+            ;; The keyed sibling is the fragment the host <div> holds,
+            ;; not the [:section …] the call answers.
+            host     (first (raw-find-all-by-testid-prefix
+                              tree "rf-xray-machine-focused-event"))
+            keyed    (remove nil? (drop 2 host))]
         (when (seq sections)
           (doseq [section sections]
-            (is (vector? section) "focused-event-section is a hiccup vector")
-            (is (some? (some-> (meta section) :key))
-                (str "focused-event-section carries :key meta — got "
-                     (pr-str (meta section))))))))))
+            (is (vector? section) "focused-event-section is a hiccup vector"))
+          (is (= 1 (count keyed)) "exactly one keyed section child")
+          (doseq [node keyed]
+            (is (some? (fresco-key node))
+                (str "focused-event-section key reaches a Fresco boundary — got "
+                     (pr-str (fresco-key node))))
+            (is (= (reagent-key node) (fresco-key node))
+                "the same key reaches React on both substrates")))))))
 
 ;; ---- (6) rf2-3d987 layout fixes -----------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -34,7 +34,9 @@
 
     9. **Frame isolation** — sim state stays on `:rf/xray`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
             [re-frame.core :as rf]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.machines :as rf.machines]
             [re-frame.frame :as rf.frame]
             [re-frame.registrar :as rf.registrar]
@@ -778,12 +780,46 @@
 ;; rf2-r4nao rehost source; see ns docstring in `static/machines/sim.cljs`).
 ;;
 ;; Two `for` loops in the Sim rail wrap function-call list forms — the
-;; available-transition rows and audit-trail rows. Reagent's
-;; `get-react-key` only reads `:key` from vector meta, so the keys must
-;; land on the returned `[:li …]` vectors via `with-meta` rather than
-;; reader-meta on the source list. This test asserts the meta is
-;; preserved across the rehost.
+;; available-transition rows and audit-trail rows. Reader meta on the
+;; source list would be lost when the call returns its fresh vector, so
+;; each row's key has to be applied to the value the call ANSWERS.
+;;
+;; rf2-a38l — it is applied as a KEYED FRAGMENT, and these tests grade it
+;; AT THE RENDERER rather than at `(meta …)`. `(:key (meta row))` is a
+;; hollow instrument in both directions: it passes on metadata React
+;; never sees, and fails on a key that reaches React perfectly well. The
+;; two doors below are the real question, and only the second can see
+;; this defect:
+;;
+;;   - `reagent-key` — today's substrate. Reagent reads meta AND props,
+;;     so it returns the same key either way; it is the half that pins
+;;     the sweep as a NO-OP today.
+;;   - `fresco-key` — `re-frame.fresco.impl.codec/as-element`, the
+;;     codec's own hiccup→element door, which takes a literal `:key`
+;;     from an attribute map and reads Clojure metadata NOWHERE. This
+;;     is the half that goes red on a revert to `with-meta`.
+;;
+;; Same shape as `views/resizable_table_key_cljs_test`, which is this
+;; tree's pattern for the question.
 ;; ---------------------------------------------------------------------------
+
+(defn- reagent-key
+  "The key Reagent hands React. Honours meta AND props, so this alone
+  cannot see the defect."
+  [node]
+  (.-key (r/as-element node)))
+
+(defn- fresco-key
+  "The key a Fresco boundary would commit. Reads nil for a meta-only
+  key, which is the whole point."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element node)))
+
+(defn- keyed-children
+  "The children of hiccup container `node` — the forms after its
+  attribute map, each of which should be a keyed sibling."
+  [node]
+  (remove nil? (drop 2 node)))
 
 (defn- meta-preserving-children [node]
   (cond
@@ -808,9 +844,10 @@
                          (.startsWith prefix))))
           (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
 
-(deftest sim-available-transitions-carry-key-meta
+(deftest sim-available-transitions-reach-react-with-distinct-keys
   (testing "available-transition-row for-loop ships per-transition <li>
-            children with :key meta on the returned vector (rf2-ppzid)"
+            children whose keys reach React on BOTH substrates
+            (rf2-ppzid; regraded at the renderer under rf2-a38l)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login])
@@ -828,17 +865,34 @@
                         (fn [n]
                           (= "rf-xray-static-machines-sim-available-list"
                              (:data-testid (second n))))
-                        available)]
+                        available)
+            list-node (first
+                        (filter
+                          (fn [n]
+                            (= "rf-xray-static-machines-sim-available-list"
+                               (:data-testid (second n))))
+                          available))
+            siblings  (keyed-children list-node)]
         (is (>= (count li-rows) 1) "at least one available-transition row")
+        (is (= (count li-rows) (count siblings))
+            "one keyed sibling per rendered row")
         (doseq [row li-rows]
-          (is (vector? row) "available-transition row is a hiccup vector")
-          (is (some? (some-> (meta row) :key))
-              (str "available-transition row carries :key meta — got "
-                   (pr-str (meta row)))))))))
+          (is (vector? row) "available-transition row is a hiccup vector"))
+        (doseq [sib siblings]
+          (is (some? (fresco-key sib))
+              (str "available-transition key reaches a Fresco boundary — got "
+                   (pr-str (fresco-key sib))))
+          (is (= (reagent-key sib) (fresco-key sib))
+              "the same key reaches React on both substrates"))
+        ;; Counted rather than `apply distinct?`, which throws on an
+        ;; empty seq — the count above is an `is`, not a short-circuit.
+        (is (= (count siblings) (count (distinct (map fresco-key siblings))))
+            "sibling keys are distinct")))))
 
-(deftest sim-audit-trail-rows-carry-key-meta
-  (testing "audit-trail-row for-loop ships per-step <li> children with
-            :key meta on the returned vector (rf2-ppzid)"
+(deftest sim-audit-trail-rows-reach-react-with-distinct-keys
+  (testing "audit-trail-row for-loop ships per-step <li> children whose
+            keys reach React on BOTH substrates (rf2-ppzid; regraded at
+            the renderer under rf2-a38l)"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login])
@@ -862,10 +916,24 @@
                                (:data-testid (second n)))
                             (= "rf-xray-static-machines-sim-audit-empty"
                                (:data-testid (second n)))))
-                      rows)]
+                      rows)
+            list-node (first
+                        (filter
+                          (fn [n]
+                            (= "rf-xray-static-machines-sim-audit-list"
+                               (:data-testid (second n))))
+                          rows))
+            siblings  (keyed-children list-node)]
         (is (>= (count li-rows) 2) "two audit rows after two steps")
+        (is (= (count li-rows) (count siblings))
+            "one keyed sibling per rendered row")
         (doseq [row li-rows]
-          (is (vector? row) "audit row is a hiccup vector")
-          (is (some? (some-> (meta row) :key))
-              (str "audit row carries :key meta — got "
-                   (pr-str (meta row)))))))))
+          (is (vector? row) "audit row is a hiccup vector"))
+        (doseq [sib siblings]
+          (is (some? (fresco-key sib))
+              (str "audit row key reaches a Fresco boundary — got "
+                   (pr-str (fresco-key sib))))
+          (is (= (reagent-key sib) (fresco-key sib))
+              "the same key reaches React on both substrates"))
+        (is (= (count siblings) (count (distinct (map fresco-key siblings))))
+            "sibling keys are distinct")))))


### PR DESCRIPTION
Sweeps React keys carried as Clojure METADATA into the place both substrates read, across 13 files under `tools/xray/src`.

A key in metadata reaches React under Reagent — `reagent.impl.template` reads meta first, props second — and reaches it NOWHERE under Fresco: `re-frame.fresco.impl.codec` takes a literal `:key` from the ATTRIBUTE MAP for every head kind it accepts, and reads Clojure metadata not at all. So every site here is correct today and loses its key silently the moment its file renders under a boundary: no error, no warning, React reconciling by position.

## What changed

**32 sites across 13 files**, each repaired according to what the decorated vector actually is:

| shape | sites | fix |
|---|---:|---|
| native tag with an attrs map | 17 | `:key` into that map |
| native tag with no attrs map | 1 | attrs map inserted at index 1 |
| component vector with a leading opts map | 1 | `:key` into that map |
| component vector with positional args | 9 | keyed fragment `[:<> {:key …} …]` |
| `with-meta` on a returned vector | 4 | keyed fragment |

The keyed fragment is this tree's existing answer for "there is no one attribute map to write the key into" — `views/edn_inspector`'s `render-block-child` under rf2-k97c.3. It matters that it is used rather than the bead's blanket "insert one": **inserting an attrs map at index 1 of `[mute-row dispatch id]` would shift the callee's arguments**, and for `[tab-button (assoc tab …)]` folding `:key` into the tab map would mix React's key into registry-derived domain data.

## Corrections to the bead's census

Re-counted at the bead's own trunk with an instrument that falls through to the following line and skips comment lines by position.

- **35 sites, not 34.** `shell.cljs` carries **5**, not 4. The extra one is the tab bar: its `^{:key id}` is separated from the vector by a *comment line*, so a probe that reads only the next line misses it. The bead predicted 6 unclassifiable prose hits "all prose"; five were, the sixth was this real site.
- The 29/34 next-line split is **confirmed** for the 34 the bead found, as is the 5-site same-line count.
- The `with-meta` count is **confirmed exactly**: 5 sites across 4 files. Three of those four files are not among the bead's 13, so the editable surface is 13 + 3.
- **"ZERO SITES ARE ON A CALL FORM" is confirmed** for the vector class.

## Three files deliberately NOT touched

The bead scopes `panels/epoch/view.cljs`, `panels/managed_fx_template.cljs` and `panels/trace.cljs` on the stated ground that "none of the three is in flight right now". That premise does not hold: all three are held by peer branches carrying committed, unmerged work on exactly those files. Per the repository's own rule — two beads touching the same file are sequenced, the second waiting for the first's PR to merge — they are left for a follow-up.

**8 sites remain**: 6 in `panels/epoch/view.cljs`, 1 in `panels/managed_fx_template.cljs`, 1 `with-meta` in `panels/trace.cljs`. All 8 are the vector-literal/`with-meta` class; the peer branches cleared only the disjoint CALL-FORM class, and all 8 target lines survive untouched on every peer tip, so the follow-up is mechanical once those merge.

## Verification

Graded at the RENDERER, never at `(meta …)` — which is hollow in both directions, passing on metadata React never sees and failing on an attrs-map key that works perfectly. Two existing tests asserted exactly that and are regraded through both doors: `(.-key (r/as-element node))` and `(.-key (codec/as-element node))`, following `views/resizable_table_key_cljs_test`.

**Hollow-gate check.** With one fix reverted and the fault kept, the Reagent door read `":start"` while the Fresco door read `nil` — the Reagent assertion passing on the defect is precisely why it cannot grade this alone. Suite totals were **identical either side** (11642 tests / 58365 assertions), so the new rows are a gate rather than a suite that got smaller.

**No-op proof.** Every React-key EXPRESSION was extracted from each touched file before and after and compared as a multiset: **0 of 13 files** show a changed key expression. Not one rendered key moves.

## Quality gates

`npm run test:cljs` — **11642 tests, 58365 assertions, 0 failures, 0 errors** (exit 0).

`scripts/check-commit-attribution.sh origin/main` — clean across the 9 commits.

One note for the reviewer: neither this change's files nor `mkdocs`/link gates are implicated, and `cd tools/xray && clojure -M:test` is NOT the gate here — it is a JVM run that cannot load a `.cljs` test and goes green having inspected nothing.
