### PR TITLE
feat(xray): migrate the Static Routes panel to a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -52,12 +52,34 @@
   is no per-route routing-scope filter on the lens (the lens IS the
   focused event's slice of routing concerns).
 
-  ## Pure hiccup
+  ## Public surface
 
-  Same contract as every Xray view — pure hiccup, no Reagent / UIx
-  references. Frame isolation comes from the enclosing
-  `[rf/frame-provider {:frame :rf/xray}]` in `static/shell.cljs`."
+  - `Panel`      — the tab's root. Since rf2-k97c.3 an
+                   `rf.fresco/defview` BOUNDARY — a real React function
+                   component, not an `rf/reg-view`. The LAST of the five
+                   Static sub-tabs to migrate.
+  - `panel-tree` — the whole body, as a pure fn of the values [[Panel]]
+                   reads, a frame-bound dispatcher and the `as-child`
+                   spelling for the browse-list REAGENT ISLAND.
+  - `install!`   — idempotent install for the subs, events and the L4
+                   tab registration.
+
+  ## Frame isolation
+
+  The FRAME comes from React context, which the enclosing frame boundary
+  writes — `rf/frame-provider` (today's Reagent-rendered Static shell)
+  and `rf.fresco/frame-provider` write the SAME context, so the reads
+  resolve `:rf/xray` under either root. Nothing here consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  ## Pure hiccup, and the ONE Reagent reference
+
+  The markup is still pure hiccup. `reagent.core/as-element` appears in
+  exactly one place — [[Panel]]'s `as-child` argument — and is the
+  migration seam [[panel-tree]] documents, not a view-layer dependency."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
+            [reagent.core :as r]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.routing-helpers :as h]
             [day8.re-frame2-xray.static.routes.browse-list :as browse-list]
@@ -73,39 +95,178 @@
   [:div {:data-testid "rf-xray-static-routes-header"
          :style       {:padding "4px 16px"}}])
 
+;; ---- the body, as a pure fn of the reads' values --------------------------
+
+(defn panel-tree
+  "The Static Routes tab's WHOLE body, as a pure function of the four
+  values [[Panel]] reads, the frame-bound `dispatch` the list and the
+  Simulate-URL box need, and the `as-child` spelling for the browse-list
+  REAGENT ISLAND.
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention: a
+  boundary's body may only run inside a React render window, so
+  `(Panel)` is no longer a callable that answers hiccup, while this fn
+  is ordinary values → hiccup and stays worth driving from the fast node
+  lane.
+
+  `ui` is the map [[browse-list/render]] already takes —
+  `{:expanded :sim-open :routes-map}` — threaded through unchanged.
+
+  ## WHY THE ISLAND, MEASURED RATHER THAN ASSUMED
+
+  The migration's standard repair for a plain fn in hiccup head position
+  is to CALL the helper instead of heading with it. It works only when
+  the helper answers hiccup AND that hiccup is head-free ALL THE WAY
+  DOWN — the second limit `static/machines` recorded. It is not met
+  here. Census of every symbol-headed hiccup vector in this tab's render
+  subtree, taken at the base of this slice (line numbers drift — they
+  are here to make the census re-runnable, not to be cited):
+
+      panel.cljs        [browse-list/render …]        ×2   (this file)
+      browse_list.cljs  [route-row …]                      (:200)
+      browse_list.cljs  [row-expand/render …]              (:164)
+      simulate_url.cljs [candidate-row …]                  (:164)
+      row_expand.cljs   [sim-nav-toggle …]                 (:192)
+      row_expand.cljs   [jump-button …]                    (:193)
+      row_expand.cljs   [sim-nav/preview …]                (:237)
+      simulate_nav.cljs none
+
+  Calling this file's two would move the HD-016 site one level down into
+  `browse_list.cljs`, and repairing THAT reaches `row_expand.cljs`, and
+  so on — FOUR files for one panel, none of them coupled to this file's
+  reads. `codec/head-kind` grades a plain fn `:invalid` and
+  `vec->element` raises `:rf.error/fresco-bad-head`, so every one of
+  those five out-of-file sites would throw at first paint.
+
+  So the door is the same one `static/shell.cljs` and
+  `static/machines/definition_detail.cljs` already use: Fresco's own ABI
+  says a React ELEMENT is a legal child anywhere, reached through an
+  `as-child` seam. `identity` for a hiccup caller and the node lane,
+  which leaves the browse list exactly the fn-headed vector it has
+  always been; `reagent.core/as-element` for the boundary, which answers
+  a React element Fresco splices in as a child.
+
+  THE SIMULATE-URL HEADER IS CALLED, NOT HEADED — it always was — and it
+  STILL needs the seam, because the hiccup it answers contains
+  `[candidate-row c]`. That is the same limit stated from the other
+  side, and it is why the call form alone is not evidence of safety.
+
+  SCAFFOLDING WITH A DEFINED END: when `browse_list`, `row_expand`,
+  `simulate_url` and `simulate_nav` are themselves head-free (each one a
+  mechanical call-repair, and none of them coupled to this file's
+  reads), `as-child` goes and the two islands become ordinary children.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [sim-url sim-result silent?] :as data} ui dispatch as-child]
+  [:section {:data-testid "rf-xray-static-routes"
+             :style       {:height         "100%"
+                           :display        "flex"
+                           :flex-direction "column"
+                           :background     (:bg-2 tokens)
+                           :color          (:text-primary tokens)
+                           :font-family    sans-stack
+                           :font-size      (:body type-scale)}}
+   (header)
+   (if silent?
+     (as-child [browse-list/render dispatch data ui])
+     [:<>
+      (as-child (simulate-url/header dispatch sim-url sim-result))
+      [:div {:style {:flex 1 :overflow "auto"}}
+       (as-child [browse-list/render dispatch data ui])]])])
+
 ;; ---- root view -----------------------------------------------------------
 
-(rf/reg-view Panel
-  "Static Routes panel root view. Subscribes to the static-routes
-  composite + UI-state slots and composes the header + Simulate-URL
-  surface + browse list.
+(rf.fresco/defview Panel
+  "The Static Routes tab's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Reads the static-routes composite plus the three
+  UI-state slots and hands their values, a frame-bound dispatcher and
+  the island spelling to [[panel-tree]].
 
-  `reg-view`-registered so subscribes resolve to `:rf/xray`."
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. That is the third of the epic's three
+  couplings, and the one a first-paint smoke test cannot see. The four
+  reads keep the `reg-view` body's ORDER, which is the order the node
+  lane reproduces.
+
+  ONE READ SITE, ONE BOUNDARY. Boundary count tracks reads and
+  head-position use, not file size (the #9581 sizing note): the four
+  slots are read together and rendered together, so splitting them would
+  buy nothing and cost a component type.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which Fresco's authoring surface deliberately does not duplicate, and
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the name `reg-view` used to inject lexically: `defview` binds NO name
+  inside your body, so the bare `dispatch` this body used to close over
+  would be a LOUD compile error, which is the good failure.
+
+  `r/as-element` is the `as-child` spelling for the browse-list island —
+  [[panel-tree]] records the census that makes it necessary.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (let [data       (rf.fresco/sub [:rf.xray.static.routes/tab-data])
+        expanded   (rf.fresco/sub [:rf.xray.static.routes/expanded])
+        sim-open   (rf.fresco/sub [:rf.xray.static.routes/sim-nav-open])
+        routes-map (rf.fresco/sub [:rf.xray/registered-routes])]
+    (panel-tree data
+                {:expanded   expanded
+                 :sim-open   sim-open
+                 :routes-map routes-map}
+                (:dispatch (rf/capture-frame))
+                r/as-element)))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's Static shell mounts the active tab as the hiccup head
+;; `[(:panel tab)]` (`static/shell.cljs`'s `detail-panel-tree`), and
+;; `panel-registry/reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE —
+;; neither of which a React component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; BOTH DEFS ARE PRIVATE, and that is measured rather than defaulted:
+;; `Panel` is named outside this file only in `static/shell.cljs`'s PROSE
+;; (a docstring listing the L4 tabs), in `tools/xray/spec/API.md`, and in
+;; the two `spec/api-manifest*.edn` rows — never mounted or called by name.
+;; The L4 registry is the only consumer, and `install!` below is the only
+;; thing that passes the bridge. A panel carrying a standalone `mount-*!`
+;; facade would need a PUBLIC bridge instead, because `panels/render-panel!`
+;; takes the view to mount as an argument and needs a name to pass; this
+;; panel has none — `panels.cljs` names no Static sub-tab, so no caller
+;; line changes.
+;;
+;; `Panel` KEEPS THE NATURAL NAME — RULING 1's surviving #9581 spelling —
+;; which is also what keeps the two hot-zone `api-manifest` rows for
+;; `static.routes.panel/Panel` valid without touching either file.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the Static shell is itself
+;; a Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and
+;; both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the Static shell's enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it."
   []
-  (let [data       @(rf/subscribe [:rf.xray.static.routes/tab-data])
-        expanded   @(rf/subscribe [:rf.xray.static.routes/expanded])
-        sim-open   @(rf/subscribe [:rf.xray.static.routes/sim-nav-open])
-        routes-map @(rf/subscribe [:rf.xray/registered-routes])
-        {:keys [sim-url sim-result silent?]} data]
-    [:section {:data-testid "rf-xray-static-routes"
-               :style       {:height         "100%"
-                             :display        "flex"
-                             :flex-direction "column"
-                             :background     (:bg-2 tokens)
-                             :color          (:text-primary tokens)
-                             :font-family    sans-stack
-                             :font-size      (:body type-scale)}}
-     (header)
-     (if silent?
-       [browse-list/render dispatch data {:expanded   expanded
-                                          :sim-open   sim-open
-                                          :routes-map routes-map}]
-       [:<>
-        (simulate-url/header dispatch sim-url sim-result)
-        [:div {:style {:flex 1 :overflow "auto"}}
-         [browse-list/render dispatch data {:expanded   expanded
-                                            :sim-open   sim-open
-                                            :routes-map routes-map}]]])]))
+  [:> Panel-component {}])
 
 ;; ---- registrations -------------------------------------------------------
 
@@ -205,6 +366,10 @@
      :mnem  "r"
      :modes #{:static}
      :order 1
-     :panel Panel})
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the Static shell mounts `:panel`
+     ;; as a Reagent hiccup head; the bridge is the one line between them
+     ;; and goes when the shell is a Fresco tree.
+     :panel Panel-bridge})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -119,9 +119,10 @@
   is to CALL the helper instead of heading with it. It works only when
   the helper answers hiccup AND that hiccup is head-free ALL THE WAY
   DOWN — the second limit `static/machines` recorded. It is not met
-  here. Census of every symbol-headed hiccup vector in this tab's render
-  subtree, taken at the base of this slice (line numbers drift — they
-  are here to make the census re-runnable, not to be cited):
+  here. Census of every symbol-headed hiccup vector WRITTEN IN the four
+  `static/routes/*.cljs` files, taken at the base of this slice (line
+  numbers drift — they are here to make the census re-runnable, not to
+  be cited):
 
       panel.cljs        [browse-list/render …]        ×2   (this file)
       browse_list.cljs  [route-row …]                      (:200)
@@ -132,12 +133,34 @@
       row_expand.cljs   [sim-nav/preview …]                (:237)
       simulate_nav.cljs none
 
+  AND A NINTH THAT NO SYNTACTIC CENSUS OF THOSE FILES CAN SEE, because a
+  CALL into a fifth file RETURNS it: `row_expand.cljs:66` calls
+  `edn/inspect`, and `views/edn_widget.cljs`'s `inspect` answers
+  `[ei/edn-inspector …]` — a REAGENT component, hence a plain fn head.
+  That widget namespace already anticipates the migration with a second
+  head, `inspect-view`, emitting the Fresco boundary
+  `[ei/edn-inspector-view …]`; under the island `inspect` stays correct,
+  because the island IS Reagent. So read the census as a LOWER BOUND on
+  a subtree-wide claim, and note the shape: a call site is not evidence
+  of a head-free subtree — only reading what the callee returns is.
+
   Calling this file's two would move the HD-016 site one level down into
   `browse_list.cljs`, and repairing THAT reaches `row_expand.cljs`, and
-  so on — FOUR files for one panel, none of them coupled to this file's
-  reads. `codec/head-kind` grades a plain fn `:invalid` and
-  `vec->element` raises `:rf.error/fresco-bad-head`, so every one of
-  those five out-of-file sites would throw at first paint.
+  so on — FOUR files for one panel plus the widget facade, none of them
+  coupled to this file's reads. `codec/head-kind` grades a plain fn
+  `:invalid` and `vec->element` raises `:rf.error/fresco-bad-head`, so
+  every one of those out-of-file sites would throw at first paint.
+
+  MEASURED, NOT ARGUED, and the measurement is worth more than the
+  census. Planting exactly the naive migration — `rf.fresco/sub` for the
+  reads, `(:dispatch (rf/capture-frame))` for the dispatcher, and the
+  hiccup left as it stood with NO `as-child` — the Static Routes tab
+  never paints at all: the browser gate fails with `expected Static
+  sub-tab :routes real panel root rf-xray-static-routes mounted …
+  (last=null)`. On that same tree `npm run test:cljs` is GREEN, at
+  IDENTICAL totals, because the node lane's `as-child` is `identity` and
+  so the seam is invisible to it BY CONSTRUCTION. A node-lane green is
+  not evidence about this seam; only the browser lane is.
 
   So the door is the same one `static/shell.cljs` and
   `static/machines/definition_detail.cljs` already use: Fresco's own ABI

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -36,6 +36,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.registrar :as rf.registrar]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.static.routes.panel :as panel]
             [day8.re-frame2-xray.static.shell :as static-shell]
@@ -99,6 +100,44 @@
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
 
+;; ---- the node lane's door onto the panel --------------------------------
+
+(defn- panel-tree
+  "The hiccup the view rows below walk.
+
+  rf2-k97c.3 — `panel/Panel` is now an `rf.fresco/defview` boundary, a
+  real React function component whose body may only run inside a React
+  render window, so calling `panel/Panel` no longer answers hiccup.
+  This helper REPRODUCES THE BOUNDARY'S READS EXACTLY — the same
+  four queries in the same ORDER — and hands their values to
+  `panel/panel-tree`, so every row below asserts on the same hiccup it
+  asserted on before.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))`, the SAME door the
+  boundary uses, so a handler a row pulls off the tree and fires later
+  (`routes-row-enter-key-activates-toggle` does exactly that) carries the
+  frame the shipped one does.
+
+  `identity` is the `as-child` spelling for the node lane, so the browse
+  list and the Simulate-URL header stay fn-headed hiccup the walker above
+  expands precisely as it always has. The boundary passes
+  `reagent.core/as-element` there; that crossing's evidence is the
+  browser lane's, not this one's.
+
+  Call it inside `(rf/with-frame :rf/xray …)` — it subscribes ambiently,
+  the same requirement the `reg-view` body had."
+  []
+  (let [data       @(rf/subscribe [:rf.xray.static.routes/tab-data])
+        expanded   @(rf/subscribe [:rf.xray.static.routes/expanded])
+        sim-open   @(rf/subscribe [:rf.xray.static.routes/sim-nav-open])
+        routes-map @(rf/subscribe [:rf.xray/registered-routes])]
+    (panel/panel-tree data
+                      {:expanded   expanded
+                       :sim-open   sim-open
+                       :routes-map routes-map}
+                      (:dispatch (rf/capture-frame))
+                      identity)))
+
 ;; ---- fixture data -------------------------------------------------------
 
 (def cart-routes
@@ -143,7 +182,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test {}]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes"))
             "panel root present")
         (is (some? (find-by-testid tree "rf-xray-static-routes-header"))
@@ -165,7 +204,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-list"))
             "flat list rendered")
         (is (some? (find-by-testid tree "rf-xray-static-routes-search"))
@@ -188,7 +227,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-query "checkout"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)
+      (let [tree (panel-tree)
             rows (find-all-by-testid-prefix tree "rf-xray-static-routes-row-")]
         (is (= #{"rf-xray-static-routes-row-route/checkout"
                  "rf-xray-static-routes-row-route/payment"
@@ -203,7 +242,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-query "zzz-not-found"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-empty-filtered"))
             "empty-filtered surface rendered when the query matches no rows")))))
 
@@ -217,7 +256,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/cart"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-result"))
             "simulator result rendered")
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-candidate-route/cart"))
@@ -230,7 +269,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/nope-not-here"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-result"))
             "simulator result rendered even on no-match")))))
 
@@ -243,12 +282,12 @@
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
       ;; Initial render — expand absent.
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (nil? (find-by-testid tree "rf-xray-static-routes-expand-route/cart"))
             "expand surface absent before toggle"))
       (rf/dispatch-sync [:rf.xray.static.routes/toggle-row :route/cart]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-expand-route/cart"))
             "expand surface rendered after toggle")
         ;; Inline expand carries the meta + jump button + sim-nav toggle.
@@ -260,7 +299,7 @@
             "Simulate-navigation toggle rendered"))
       (rf/dispatch-sync [:rf.xray.static.routes/toggle-row :route/cart]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (nil? (find-by-testid tree "rf-xray-static-routes-expand-route/cart"))
             "expand surface hidden after second toggle")))))
 
@@ -279,7 +318,7 @@
                           {:frame :rf/xray})
         (rf/dispatch-sync [:rf.xray.static.routes/toggle-row :route/article]
                           {:frame :rf/xray})
-        (let [tree (panel/Panel)]
+        (let [tree (panel-tree)]
           (is (some? (find-by-testid tree "rf-xray-static-routes-params-schema-route/article"))
               ":params schema block rendered")
           (is (some? (find-by-testid tree "rf-xray-static-routes-query-schema-route/article"))
@@ -302,7 +341,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/toggle-sim-nav :route/confirm]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-nav-route/confirm"))
             "preview surface rendered")
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-nav-on-match"))
@@ -335,7 +374,20 @@
 ;; ---- (9) Static tab inventory exposes :routes --------------------------
 
 (deftest static-shell-routes-tab-is-in-inventory
-  (testing ":routes is in the Static tab inventory + the shell can render it"
+  (testing ":routes is in the Static tab inventory + the shell mounts it.
+
+            RE-AUTHORED ONE LEVEL UP BY rf2-k97c.3, exactly as
+            `static/shell_cljs_test`'s `static-machines-mounts-live-panel`
+            already was and for the same reason. `static.routes.panel/
+            Panel` is now an `rf.fresco/defview` behind an `as-component`
+            bridge, so this hiccup walk reaches the bridge's `[:>]`
+            interop head and stops — `rf-xray-static-routes` is committed
+            by React, not present in the tree. Asserting that testid here
+            would from now on be asserting the WALKER'S REACH rather than
+            the mount, which is the hollow-gate shape. What the shell owes
+            is that the `:routes` slot mounts the REGISTRY's `:panel` and
+            that no placeholder renders; the boundary's own first paint is
+            the browser lane's subject, and its body is every row above."
     (is (contains? (set (map :id (static-shell/tabs))) :routes)
         ":routes is in the Static tab inventory")
     (setup-xray-frame!)
@@ -343,11 +395,13 @@
       (rf/dispatch-sync [:rf.xray.static/select-tab :routes] {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree (static-shell-tree/surface-tree)]
-        ;; When the :routes tab is selected the Static shell mounts the
-        ;; Static Routes panel (not the placeholder card).
-        (is (some? (find-by-testid tree "rf-xray-static-routes"))
-            "Static Routes panel mounted via the shell's :routes branch")
+      (let [tree  (static-shell-tree/surface-tree)
+            slot  (find-by-testid tree "rf-xray-static-detail-panel-routes")
+            mount ((:panel (panel-registry/tab-by-id :static :routes)))]
+        (is (some? slot) "the :routes L4 slot renders")
+        (is (= (last slot) mount)
+            (str "the slot mounts exactly the registry's :panel value. "
+                 "Got: " (pr-str (last slot))))
         (is (nil? (find-by-testid tree "rf-xray-static-placeholder-routes"))
             "the :routes placeholder card is no longer rendered")))))
 
@@ -376,7 +430,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree      (panel/Panel)
+      (let [tree      (panel-tree)
             list-node (find-by-testid tree "rf-xray-static-routes-list")
             listitems (find-all-by-role tree "listitem")
             buttons   (find-all-by-role tree "button")]
@@ -400,7 +454,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree     (panel/Panel)
+      (let [tree     (panel-tree)
             ;; the cart row's clickable body is the role=button whose
             ;; aria-label mentions the cart route.
             row-body (some (fn [node]
@@ -443,7 +497,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/toggle-row :route/cart]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)
+      (let [tree (panel-tree)
             widget (find-all-by-testid-prefix
                      tree "rf-xray-edn-inspector-")]
         (is (some? (find-by-testid tree "rf-xray-static-routes-meta-route/cart"))

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/simulate_url_cljs_test.cljs
@@ -13,8 +13,10 @@
     - result block renders one candidate row per match, with the
       winner highlighted.
 
-  Drives the view via the `panel/Panel` root so the dispatch round-
-  trip lands through the registered subs/events."
+  Drives the view through [[panel-tree]] below — the node lane's
+  reproduction of `panel/Panel`'s reads (rf2-k97c.3 made that root an
+  `rf.fresco/defview` boundary) — so the dispatch round-trip still lands
+  through the registered subs/events."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
@@ -70,6 +72,39 @@
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
 
+;; ---- the node lane's door onto the panel --------------------------------
+
+(defn- panel-tree
+  "The hiccup the rows below walk.
+
+  rf2-k97c.3 — `panel/Panel` is now an `rf.fresco/defview` boundary, a
+  real React function component whose body may only run inside a React
+  render window, so calling `panel/Panel` no longer answers hiccup.
+  This helper REPRODUCES THE BOUNDARY'S READS EXACTLY — the same
+  four queries in the same ORDER — and hands their values to
+  `panel/panel-tree`, so every row below asserts on the same hiccup it
+  asserted on before, and the dispatch round-trip still lands through the
+  registered subs / events as this file's ns docstring promises.
+
+  KEPT IN STEP WITH `static/routes/panel_cljs_test`'s private twin, which
+  is the same reproduction. Two copies is the established repair at two
+  files (#9578); the shared-composer form
+  (`test_helpers/static_machines_tree`) is what a THIRD consumer would
+  earn.
+
+  Call it inside `(rf/with-frame :rf/xray …)` — it subscribes ambiently."
+  []
+  (let [data       @(rf/subscribe [:rf.xray.static.routes/tab-data])
+        expanded   @(rf/subscribe [:rf.xray.static.routes/expanded])
+        sim-open   @(rf/subscribe [:rf.xray.static.routes/sim-nav-open])
+        routes-map @(rf/subscribe [:rf.xray/registered-routes])]
+    (panel/panel-tree data
+                      {:expanded   expanded
+                       :sim-open   sim-open
+                       :routes-map routes-map}
+                      (:dispatch (rf/capture-frame))
+                      identity)))
+
 (def cart-routes
   {:route/cart      {:path "/cart"      :doc "cart"}
    :route/checkout  {:path "/checkout"  :doc "checkout"}
@@ -83,7 +118,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim"))
             "Simulate-URL section present")
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-input"))
@@ -99,7 +134,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/cart"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-clear"))
             "clear button surfaces when input is non-blank")))))
 
@@ -113,7 +148,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/cart"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)
+      (let [tree (panel-tree)
             winner (find-by-testid tree "rf-xray-static-routes-sim-candidate-route/cart")]
         (is (some? winner) "winner candidate row rendered")
         (is (= "true" (:data-winner (second winner)))
@@ -127,7 +162,7 @@
                         {:frame :rf/xray})
       (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/no-such-path"]
                         {:frame :rf/xray})
-      (let [tree (panel/Panel)
+      (let [tree (panel-tree)
             candidates (find-all-by-testid-prefix
                          tree "rf-xray-static-routes-sim-candidate-")]
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-result"))
@@ -142,7 +177,7 @@
       (rf/dispatch-sync [:rf.xray/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/xray})
       ;; Default — no sim-url set.
-      (let [tree (panel/Panel)]
+      (let [tree (panel-tree)]
         (is (nil? (find-by-testid tree "rf-xray-static-routes-sim-result"))
             "no result block when input is blank")))))
 


### PR DESCRIPTION
Migrates `day8.re-frame2-xray.static.routes.panel/Panel` from `rf/reg-view` to
`rf.fresco/defview` behind an `as-component` bridge. It was the **last `reg-view` among
the five Static sub-tabs** — flows, interceptors, machines and schemas were already
boundaries — so the set is now complete and `static/shell.cljs`'s L4 `as-child` seam has
its stated precondition ("when all five Static panels are boundaries") satisfied for
whoever takes the shell next.

Owner: **rf2-k97c.3**. The bead is NOT claimed and NOT closed by this PR — this is one
increment of many.

## The subtree is a Reagent island, and that is measured rather than preferred

The straightforward reading of this migration is a three-line swap: `@(rf/subscribe …)`
becomes `rf.fresco/sub`, the lexically injected `dispatch` becomes
`(:dispatch (rf/capture-frame))`, done. **That is necessary but not sufficient here, and
the failure is total rather than partial.**

Every symbol-headed hiccup vector written in the four `static/routes/*.cljs` files:

| file | head |
|---|---|
| `panel.cljs` | `[browse-list/render …]` ×2 |
| `browse_list.cljs` | `[route-row …]`, `[row-expand/render …]` |
| `simulate_url.cljs` | `[candidate-row …]` |
| `row_expand.cljs` | `[sim-nav-toggle …]`, `[jump-button …]`, `[sim-nav/preview …]` |
| `simulate_nav.cljs` | none |

…plus a ninth that no syntactic census of those files can see, because a **call** into a
fifth file returns it: `row_expand.cljs:66` calls `edn/inspect`, and
`views/edn_widget.cljs`'s `inspect` answers `[ei/edn-inspector …]` — a Reagent component,
hence a plain fn head. **A call site is not evidence of a head-free subtree.**

`codec/head-kind` grades a plain fn `:invalid` and `vec->element` raises
`:rf.error/fresco-bad-head` (HD-016), so the standard call-repair would only move the
failure one level down — four files plus the widget facade, for one panel, none of them
coupled to this file's reads.

The door is the one `static/shell.cljs` and `static/machines/definition_detail.cljs`
already use: a React element is a legal child anywhere per Fresco's ABI, reached through
an `as-child` seam — `identity` for a hiccup caller and the node lane,
`reagent.core/as-element` for the boundary.

**This island is purely presentational.** The four helper files carry zero `rf/subscribe`,
zero `rf/dispatch` and zero `rf/reg-view` between them (form-anchored count: 0 in all
five files; the 5 textual `reg-view` hits are docstring prose). So it adds no reads, no
frame coupling of its own, and — unlike the Static Machines Topology island — **no view
trace**, because there is no `reg-view` inside it to emit any.

## The naive migration ships a blank tab, and the briefed gates are green on it

Planted exactly the naive form (boundary reads and dispatcher migrated, hiccup left as it
stood, no `as-child`) and ran both lanes on that one tree:

| gate | result |
|---|---|
| `npm run test:cljs` | **exit 0, GREEN**, 11642 tests / 58357 assertions — identical totals |
| `npm run test:xray-feature-gate` (full) | **exit 1** — `FAIL static mode chrome and chord: waitForValue: expected Static sub-tab :routes real panel root rf-xray-static-routes mounted (placeholder absent) within 5000ms (last=null)` |
| `npm run test:xray-feature-gate:smoke` | would also be green — see below |

The node lane cannot see this seam **by construction**: its `as-child` is `identity`, so
wrapping and not wrapping are literally the same value. A node-lane green is not evidence
about the crossing; only the browser lane is.

## The PR-smoke feature gate does not reach this panel

The `:routes` first-paint witness lives in the `static mode chrome and chord` scenario,
which carries **no `smoke: true`** — it is nightly-only (`--smoke` selects 5 scenarios;
the full sweep runs 16). The `routes-epochs routing ladder` scenario is likewise not
smoke-tagged and covers the **Dynamic** Routing panel (`panels: ['routing']`), not this
one. So on this PR the browser row that would have caught the failure above does not run;
the full sweep was run locally instead and is reported below.

## Scope: three files

* `tools/xray/src/.../static/routes/panel.cljs` — the migration.
* `tools/xray/test/.../static/routes/panel_cljs_test.cljs` — 14 `(panel/Panel)` sites move
  to a private read-reproducing helper; `static-shell-routes-tab-is-in-inventory` is
  re-authored one level up, exactly as `static/shell_cljs_test`'s
  `static-machines-mounts-live-panel` already was (asserting the panel's own testid
  through the shell walk would from now on assert the walker's reach, not the mount).
* `tools/xray/test/.../static/routes/simulate_url_cljs_test.cljs` — **forced.** It drove
  `(panel/Panel)` at 5 sites and walked the returned hiccup; no migration of this panel
  leaves it green. It gets the same private helper. Two consumers is the established
  two-file repair; a third would earn the shared-composer form
  (`test_helpers/static_machines_tree`).

Nothing else is touched. No `:as-child` bridge is deleted, `static/shell.cljs` and
`shell.cljs` are untouched, and no sibling panel or sibling DOM suite changes — verified:
none of the four merged `panel_fresco_boundary_dom_cljs_test.cljs` suites mounts
`:routes`, and `static/shell_fresco_boundary_dom_cljs_test`'s W3 pins the island-free
`:flows` tab.

`Panel` keeps its natural name (RULING 1's surviving #9581 spelling), so both hot-zone
`spec/api-manifest*.edn` rows for `static.routes.panel/Panel` stay valid with neither file
moved. Both bridge defs are private.

## RULING 2 key sweep

`static/routes/panel.cljs`: **ZERO** `^{:key` sites and **ZERO** `with-meta` sites,
against a live control over `tools/xray/src` taken with the same instrument — 61 hits /
27 files for `^{:key`, 21 / 14 for `with-meta` — so the zero reads as absence rather than
a broken instrument. (`browse_list.cljs` does carry a metadata key; it is another
branch's file, and under the island Reagent still reads it, so the two changes are
orthogonal.)

## Quality gates

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` | 0 | 11642 tests / 58357 assertions, 0 failures |
| `npm run test:xray-feature-gate` (full) | 0 | 16 scenarios, 0 failures, 13 matrix rows |
| `npm run test:xray-feature-gate:smoke` | 0 | 5 scenarios, 0 failures, 10 matrix rows |

All re-run on the final rebased base.

### Hollow-gate check

A second plant, this one aimed at what the changed node rows actually cover: the
Simulate-URL header dropped from `panel-tree`'s non-silent branch.

* **red**: exit 1, **10 failures across BOTH changed suites** — 3 in `panel_cljs_test`
  (`panel-renders-flat-list-when-routes-present`,
  `panel-simulates-url-and-surfaces-candidates` ×2), 7 in `simulate_url_cljs_test`.
* **totals IDENTICAL either side**: 11642 tests / 58357 assertions, green and red. The
  suite did not merely get smaller.

Both plants restored and verified two ways: `git hash-object` in the default filtered form
matching `git rev-parse HEAD:<path>` (the file is `i/lf w/crlf`, so that is the right
form), and `git diff --quiet HEAD -- <path>` exit 0.

## Known gap, deliberately not filled here

Each of the four migrated siblings ships a `panel_fresco_boundary_dom_cljs_test.cljs`
(548–764 lines, W1–W5: first paint, liveness, trace silence, teardown, row identity).
This slice adds none — it was outside the dispatched fence. The boundary's own behaviour
is therefore witnessed here only by the full feature gate's first-paint row (proven
non-vacuous above) and, incidentally, by
`static/shell_fresco_boundary_dom_cljs_test`'s W5, which clicks the `:routes` tab in a
real browser. Liveness, teardown and evidence isolation for this boundary are unwitnessed
and want a follow-up.

Prose left stale on purpose, because it is stale for all five panels and its files are
outside this fence: `docs/xray/api/reference.md` and `tools/xray/spec/API.md` §Static-mode
Panel reg-views still describe all five as reg-views (they already did for the four
migrated ones), and `static/shell.cljs:117`/`:498` still say
`static.routes.panel/Panel` "is still an `rf/reg-view`".
