### PR TITLE
fix(xray): move the Epoch panel's six metadata React keys into attrs maps (rf2-h100)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2486,8 +2486,8 @@
    ;; (redact-by-default). The leaf id rides verbatim (owner-qualified
    ;; vocabulary, not PII); only the VALUE is summarized.
    (for [[idx {:keys [key value generated?]}] (map-indexed vector inputs)]
-     ^{:key (str "recordable-cofx-" idx)}
-     [:div {:data-testid (str "rf-xray-epoch-recordable-cofx-row-" (name key))
+     [:div {:key (str "recordable-cofx-" idx)
+            :data-testid (str "rf-xray-epoch-recordable-cofx-row-" (name key))
             :data-recordable-cofx-key (name key)
             :data-recordable-cofx-generated (str (boolean generated?))
             :style recordable-cofx-row-style}
@@ -3234,16 +3234,16 @@
            :style structured-cascade-history-banner-style}
      (map-indexed
        (fn [i rec]
-         ^{:key (str "restored-" i)}
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-restored-" i)
+         [:div {:key (str "restored-" i)
+                :data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-restored-" i)
                 :style structured-cascade-history-line-style}
           [:span {:aria-hidden true :style structured-cascade-history-glyph-style} "⟲"]
           [:span (fmt/history-restored-headline rec)]])
        history-restored)
      (map-indexed
        (fn [i rec]
-         ^{:key (str "recorded-" i)}
-         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-recorded-" i)
+         [:div {:key (str "recorded-" i)
+                :data-testid (str "rf-xray-epoch-machine-cascade-history-" step "-recorded-" i)
                 :style structured-cascade-history-line-style}
           [:span {:aria-hidden true :style structured-cascade-history-glyph-style} "✎"]
           [:span (fmt/history-recorded-headline rec)]])
@@ -3430,8 +3430,8 @@
           [:span {:style cascade-detail-label-style} "fx"]
           (for [[j entry] (map-indexed vector fx)
                 :let [[fx-id _args] (if (vector? entry) entry [entry nil])]]
-            ^{:key (str "cascade-fx-" (:step row) "-" j)}
-            [:span {:data-testid (str "rf-xray-epoch-machine-cascade-fx-"
+            [:span {:key (str "cascade-fx-" (:step row) "-" j)
+                    :data-testid (str "rf-xray-epoch-machine-cascade-fx-"
                                       (:step row) "-" j)
                     :style cascade-detail-fx-chip-style}
              (fmt/ns-keyword fx-id)])])])))
@@ -4514,8 +4514,8 @@
           :style subs-filter-bar-style}
    (for [m [:all :changed :unchanged]
          :let [active? (= mode m)]]
-     ^{:key (name m)}
-     [:button {:data-testid (str "rf-xray-epoch-subscriptions-filter-" (name m))
+     [:button {:key (name m)
+               :data-testid (str "rf-xray-epoch-subscriptions-filter-" (name m))
                :aria-pressed (str active?)
                :on-click (fn [e]
                            (.stopPropagation e)
@@ -5750,8 +5750,8 @@
      ;; §Lazy-seq deref tracking.
      (doall
        (for [[i step] (map-indexed vector steps)]
-         ^{:key (str "step-" (:step step) "-" i)}
-         [:div {:data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
+         [:div {:key (str "step-" (:step step) "-" i)
+                :data-testid (str "rf-xray-epoch-pipeline-step-" (:step-number step))
                 :data-step (when (:step step) (name (:step step)))
                 :data-rolled-back (str (boolean (:rolled-back? step)))
                 ;; rf2-xgeag — when an `:app-db` violation rolled back

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -9,6 +9,7 @@
             [clojure.string :as string]
             [reagent.core :as r]
             [re-frame.core :as rf]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
@@ -1451,6 +1452,172 @@
       (is (= ["cascade-row-1" "cascade-row-2" "cascade-row-3"] ks)
           "the key React receives is the one `cascade-row-view` stamps into
            its own attribute map, off the projection's 1..N `:step`"))))
+
+;; ---- rf2-h100 — the moved keys reach React on BOTH substrates -----------
+;;
+;; SIX `for` / `map-indexed` loops in this panel wrote their React key as
+;; `^{:key …}` reader metadata on a hiccup vector LITERAL. Reagent honours
+;; that spelling (`reagent.impl.template` reads meta first, the props map
+;; second), so those keys worked and moving them into the attribute map is a
+;; NO-OP on today's substrate. They stop working, silently, the moment this
+;; panel renders under a Fresco boundary: `re-frame.fresco.impl.codec` takes a
+;; literal `:key` from the ATTRIBUTE MAP for every head kind it accepts and
+;; reads Clojure metadata nowhere, so every row would lose its key with no
+;; error and no warning and React would reconcile by position.
+;;
+;; That is the OTHER half of the family from `machine-cascade-rows-…` above:
+;; there the meta rode a CALL form and reached React on no substrate; here it
+;; rode a vector literal and reached React on exactly one.
+;;
+;; Graded through BOTH doors, because only one of them can see the defect:
+;;
+;;   - `react-key` (above) — today's substrate. Reagent reads meta AND props,
+;;     so it returns the same key either way. It is the half that pins the
+;;     carrier move as a no-op.
+;;   - `fresco-key` — the codec's own hiccup→element door. It is the half
+;;     that goes RED on a revert to `^{:key …}`.
+;;
+;; Rows are taken from the RAW tree for the reason `raw-children` states: a
+;; rebuilt vector has its reader metadata stripped, so a reverted site would
+;; read nil at BOTH doors and this gate would go red for the wrong reason
+;; instead of showing the Reagent/Fresco SPLIT that names the actual fault.
+;;
+;; Same shape as `views/resizable-table-key-cljs-test`, this tree's pattern
+;; for the question.
+
+;; The Fresco door is asked about the node with its CHILDREN DROPPED
+;; (`subvec … 0 2` — head plus attribute map), the same idiom as
+;; `machine-inspector-view-cljs-test`. It does not weaken the question:
+;; `:key` is read off the node's OWN attribute map, so dropping the
+;; subtree changes nothing about the answer. It is necessary because the
+;; codec lowers children EAGERLY and these subtrees still contain plain
+;; functions in head position, which it refuses outright as HD-016
+;; `:rf.error/fresco-bad-head`. That refusal is the Fresco MIGRATION's
+;; business — those heads become views when the panel crosses — and
+;; letting it throw here would hide the key answer behind it.
+;;
+;; `react-key` is deliberately NOT subvec'd: Reagent lowers children
+;; lazily, so the whole node is safe there, and reading it whole is what
+;; keeps the DIAGNOSTIC SPLIT. On a revert to `^{:key …}` Reagent still
+;; reports the key (it honours meta on a vector literal) while Fresco
+;; reports nil, and that disagreement names the fault exactly. Subvec'ing
+;; both doors would drop the metadata before Reagent saw it, leaving two
+;; nils — still red, but red without saying why.
+
+(defn- fresco-key
+  "The key a Fresco boundary would commit, read off the node's own
+  attribute map. nil for a meta-only key, which is the whole point."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element (subvec node 0 2))))
+
+(defn- raw-nodes-where-testid
+  "Every node under `tree` whose `:data-testid` satisfies `pred`, walked
+  WITHOUT rebuilding so a re-introduced reader key stays visible."
+  [tree pred]
+  (vec (filter (fn [node]
+                 (and (vector? node)
+                      (map? (second node))
+                      (let [testid (:data-testid (second node))]
+                        (and (string? testid) (pred testid)))))
+               (tree-seq (some-fn vector? seq?) raw-children tree))))
+
+(defn- expect-keys-on-both-substrates
+  "Assert that every sibling in `rows` hands React the same non-nil key at
+  both doors, and that the siblings differ from one another."
+  [rows expected what]
+  ;; Precondition — a vacuous pass is the failure mode here, so the row count
+  ;; is asserted before the keys are.
+  (is (= expected (count rows))
+      (str what ": the fixture's " expected " keyed siblings render"))
+  (let [fresco  (mapv fresco-key rows)
+        reagent (mapv react-key rows)]
+    (is (every? some? fresco)
+        (str what ": every key reaches a FRESCO boundary — a meta-spelled key "
+             "reads nil here. Got " (pr-str fresco)))
+    (is (= reagent fresco)
+        (str what ": both substrates receive the SAME key — only the carrier "
+             "moved. Reagent " (pr-str reagent) " vs Fresco " (pr-str fresco)))
+    (is (= (count rows) (count (distinct fresco)))
+        (str what ": sibling keys are distinct. Got " (pr-str fresco)))))
+
+(deftest moved-keys-reach-react-on-both-substrates-test
+  (testing "rf2-h100 — RECORDABLE COEFFECTS leaf rows"
+    (let [tree (view/render-recordable-cofx-step
+                 {:step :recordable-cofx :badge :RECORDABLE-COFX :step-number 2
+                  :inputs [{:key :counter/delta :value (rh/summarize 1)}
+                           {:key :prefs/theme   :value (rh/summarize 2)}
+                           {:key :todo/filter   :value (rh/summarize 3)}]})]
+      (expect-keys-on-both-substrates
+        (raw-nodes-where-testid
+          tree #(string/starts-with? % "rf-xray-epoch-recordable-cofx-row-"))
+        3 "recordable-cofx leaf rows")))
+
+  (testing "rf2-h100 — per-action FX attribution chips"
+    (let [tree (view/machine-cascade-mini-pipeline
+                 [{:kind :action :step 2 :action-id :open-socket :phase :entry
+                   :fx [[:http/get {:url "/u"}] [:db/write {}] [:log/info {}]]}]
+                 :ws/start)]
+      (expect-keys-on-both-substrates
+        (raw-nodes-where-testid
+          tree #(string/starts-with? % "rf-xray-epoch-machine-cascade-fx-2-"))
+        3 "cascade fx chips")))
+
+  (testing "rf2-h100 — machine-cascade HISTORY restore/record lines"
+    (let [tree (view/machine-cascade-mini-pipeline
+                 [{:kind :transition :step 2 :machine-id :ws/conn
+                   :from-state [:idle] :to-state [:connected] :microsteps 1
+                   :history-restored
+                   [{:compound-path [:player] :kind :deep :source :recorded
+                     :restored-config [:player :paused]
+                     :resolved-leaf   [:player :paused]}
+                    {:compound-path [:media] :kind :shallow :source :default
+                     :fallback :default-target
+                     :resolved-leaf [:media :idle]}]
+                   :history-recorded
+                   [{:compound-path [:player] :recorded-config [:player :paused]}
+                    {:compound-path [:media]  :recorded-config [:media :idle]
+                     :prev-config [:media :playing]}]}]
+                 :ws/start)]
+      ;; restored and recorded lines are siblings under ONE banner div, so
+      ;; all four are graded together — their keys must not collide.
+      (expect-keys-on-both-substrates
+        (raw-nodes-where-testid
+          tree #(string/starts-with? % "rf-xray-epoch-machine-cascade-history-2-"))
+        4 "cascade history lines")))
+
+  (testing "rf2-h100 — pipeline step bodies"
+    (let [tree (view/pipeline-view
+                 [{:step :dispatch :badge :DISPATCH :step-number 1
+                   :event [:counter/inc] :source :ui :coord nil}
+                  {:step :handler :badge :HANDLER :step-number 2
+                   :flavour :db-only :event-id :counter/inc
+                   :fx [] :machine nil}
+                  {:step :recordable-cofx :badge :RECORDABLE-COFX :step-number 3
+                   :time-ms 1781078400123}])]
+      (expect-keys-on-both-substrates
+        (raw-nodes-where-testid
+          tree #(re-matches #"rf-xray-epoch-pipeline-step-\d+" %))
+        3 "pipeline step bodies"))))
+
+(deftest subscriptions-filter-buttons-reach-react-on-both-substrates-test
+  (testing "rf2-h100 — the SUBSCRIPTIONS `[all][changed][unchanged]` bar.
+            Its own frame setup, so it is its own row rather than a
+            fifth `testing` block above."
+    (epoch-orchestrator/install!)
+    (rf/make-frame {:id :rf/xray})
+    (rf/with-frame :rf/xray
+      (let [tree (view/render-subscriptions-step
+                   {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                    :rows [{:sub-id :a :sub-vec [:a] :changed? true :before 1 :after 2}
+                           {:sub-id :b :sub-vec [:b] :changed? false}
+                           {:sub-id :c :sub-vec [:c] :changed? false}]
+                    :changed 1 :unchanged 2})]
+        (expect-keys-on-both-substrates
+          (raw-nodes-where-testid
+            tree #(re-matches
+                    #"rf-xray-epoch-subscriptions-filter-(all|changed|unchanged)" %))
+          3 "subscriptions filter buttons")))))
+
 
 (deftest machine-handler-renders-cascade-view-test
   (testing "rf2-u69j7 — machine handler renders the time-ordered


### PR DESCRIPTION
Six `for` / `map-indexed` loops in `panels/epoch/view.cljs` wrote their React key as `^{:key …}` reader metadata on a hiccup vector LITERAL. Reagent honours that spelling — `reagent.impl.template` reads meta first and the props map second — so the keys worked and this is a no-op on today's substrate. They stop working, silently, the moment the panel renders under a Fresco boundary: `re-frame.fresco.impl.codec` takes a literal `:key` from the attribute map for every head kind it accepts and reads Clojure metadata nowhere, so every row would lose its key with no error and no warning and React would reconcile by position.

This is rf2-h100's Epoch-panel slice. The bead's other two sites (`panels/managed_fx_template.cljs`, `panels/trace.cljs`) are held by a live peer and ride with rf2-fcy5's panel migration per rf2-k97c.3.

## The census

Re-measured rather than taken from the bead: **6 sites**, found with a three-pass scan (line-oriented; whole-file flattened; comment-markers stripped then flattened) plus a brace-walking site scanner that tolerates an arbitrary gap — including comment lines — between the `^{:key …}` and the vector it decorates. That gap tolerance is the point: the site the previous sweep missed had a comment line in between, and a naive "metadata then vector on the next line" pattern reads **6 where the instrument reads 7** on a control fixture built by planting exactly that shape. `with-meta` reads **0** here, controlled against a fixture carrying two (the instrument counts them).

All six are **shape 1** — a hiccup vector with a keyword head and a literal attrs map already at index 1 — so each key moves into the map it was sitting on top of. **Shape 2 count: 0.** No component vector is involved, so the keyed-fragment form `[:<> {:key …} [child …]]` is not needed here; inserting a map at index 1 of a component vector would have shifted the callee's arguments.

The `{` does not move, so every continuation line keeps its column and nothing was reindented.

## The no-op proof

Only the CARRIER moves. Every React-key expression in the file was extracted before and after — carrier-agnostically, so a key in metadata and the same key in an attrs map are indistinguishable to the instrument — and compared as a MULTISET, which catches a reordering, a duplication and a silent substitution alike. Taken against trunk's own copy of the file rather than a local snapshot:

```
TOTAL :key sites: 13   distinct expressions: 13   (identical both sides, diff exit 0)
```

**0 of 1 file changed a key expression**, matching rf2-a38l's 0 of 13.

## Graded at the renderer, through both doors

`(.-key (r/as-element node))` is hollow for this question — Reagent reads metadata AND props and returns the same key either way, so it passes on the unfixed code. The new rows in `view_cljs_test.cljs` therefore read both doors:

- **`react-key`** (Reagent, already in this file) — the half that pins the move as a no-op today.
- **`fresco-key`** (`rf.fresco.impl.codec/as-element`) — the half that can see the defect.

The Fresco door is asked about head+attrs only (`subvec … 0 2`), the same idiom as `machine_inspector_view_cljs_test`: the codec lowers children eagerly and these subtrees still hold plain functions in head position, which it refuses as HD-016 `:rf.error/fresco-bad-head`. That refusal is the Fresco migration's business, not this change's, and letting it throw would hide the key answer behind it. `react-key` is deliberately NOT subvec'd — Reagent lowers children lazily, and reading the node whole is what keeps the diagnostic split.

Rows are taken from the RAW tree, never `expand-tree`, which rebuilds vectors with `mapv` and strips reader metadata — a reverted site would otherwise read nil at both doors and the gate would go red for the wrong reason.

Five surfaces are covered, one per `for`: recordable-cofx leaf rows, cascade fx chips, cascade history restore/record lines, pipeline step bodies, and the subscriptions filter bar.

### The sabotage run

With ONE site reverted to `^{:key …}` (plant matched exactly 1 line before the run; restore verified by blob hash against the committed object, and independently by `git diff --quiet`):

```
recordable-cofx leaf rows: both substrates receive the SAME key — only the carrier moved.
  Reagent ["recordable-cofx-0" "recordable-cofx-1" "recordable-cofx-2"] vs Fresco [nil nil nil]
```

Exit 1, three failing assertions, test and assertion totals identical to the green run (11644 / 58386) — so these rows are a gate rather than a suite that merely got smaller.

## Quality gates

Run on the final rebased base (`615f19f717`), each phase's own exit code captured on one command line and quoted:

| Gate | Exit | Result |
| --- | --- | --- |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | 1945 files, 254 compiled, **0 warnings** |
| `node out/node-test.js` (the run half of `npm run test:cljs`) | 0 | **Ran 11652 tests containing 58425 assertions — 0 failures, 0 errors** |
| `python scripts/check_require_alias_dialect.py --verbose` | 0 | 2847 files, 11210 re-frame require edges, **0 non-canonical**, every surface at or under its floor |

`npm run test:cljs` is the gate that covers `tools/xray`'s CLJS tests — `implementation/shadow-cljs.edn`'s `:node-test` build lists `../tools/xray/src` and `../tools/xray/test`. It was split into its two phases rather than run as the chained npm script, so the run half could be gated on the compile half's *captured* exit rather than on a pipeline's status.

The alias gate was run because this change adds one require, `[re-frame.fresco.impl.codec :as rf.fresco.impl.codec]` — the canonical spelling, which `c1db1a8e1a` names explicitly while fixing its sibling.

**`npm run test:xray-feature-gate` was not run, deliberately.** This change moves no mount and no chrome — it moves where a key is carried, and the src diff is exactly 12 lines across the six sites. The bead scopes the full feature gate to a change that touches a panel's mount or chrome.

The gate was confirmed to have read this worktree by both available routes: the compile log names this worktree's own `shadow-cljs.edn` path, and the planted fault came back red naming what was planted — a run that had wandered into a sibling checkout would have come back green.
