### PR TITLE
feat(xray): migrate the managed-fx list mount to a Fresco boundary (rf2-fcy5)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
@@ -58,9 +58,17 @@
     :mount  string  — the public `mount-<panel>!` fn name in
                       `day8.re-frame2-xray.panels` (the facade var the
                       guard reconciles).
-    :view   string  — the `reg-view` rendered by the mount fn, as a
+    :view   string  — the VIEW rendered by the mount fn, as a
                       `<ns-tail>/<View>` reference (documentation /
                       cross-check axis; not load-bearing for the guard).
+                      It names the view by its NATURAL name and says
+                      nothing about which substrate authored it: several
+                      entries here are `rf.fresco/defview` boundaries
+                      mounted through a `*-bridge`, and the bridge is
+                      deliberately NOT what this axis records — it is
+                      migration scaffolding with a defined end, while the
+                      natural name is the stable identity the spec tables
+                      and the api-manifest rows also carry.
     :tier   keyword — the 007-UX-IA §Mountable surface inventory tier:
                       :l3-tab        — Tier 1, an L3 detail-panel tab.
                       :overlay       — Tier 2, a modal-light popup.

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -170,6 +170,7 @@
   `tools/xray/spec/008-Embedding-Contract.md` for the full
   embedding contract."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.substrate.adapter :as rf.substrate.adapter]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
@@ -447,39 +448,103 @@
   ([mount-point]      (mount-cancellation-cascade-popover! mount-point nil))
   ([mount-point opts] (render-panel! cancellation-cascade/Popover mount-point opts)))
 
-(rf/reg-view ManagedFxList
-  "The managed-fx wire-boundary diff template's mountable wrapper —
-  reads `:rf.xray/managed-fx-for-focused-event` and renders the
-  records list. `managed-fx-template/records-list` is a pure fn over
-  a records vector; this reg-view ties it to the focused event-bundle's
-  managed-fx sub so consumers get the per-event-bundle managed-fx content
-  inline.
+(defn managed-fx-list-tree
+  "The managed-fx list's WHOLE body, as a pure function of the two values
+  [[ManagedFxList]] reads and the frame-bound dispatcher it captures.
 
-  Exposing this as a reg-view (rather than a plain fn) follows the
-  Conventions.md panel-facade contract — every mount target
-  is a `reg-view` so the React-context tier resolves to the wrapping
-  frame-provider per Spec 006 §706."
+  SPLIT OUT OF [[ManagedFxList]] BY rf2-fcy5, and the split is `defview`'s
+  own documented extract-a-helper spelling rather than an invention: a
+  boundary's body may only run inside a React render window, so
+  `(ManagedFxList)` is no longer a callable that answers hiccup, while
+  this fn is ordinary values → hiccup and stays worth driving from the
+  fast node lane.
+
+  It is also where the ONE composition this panel performs lives, and
+  keeping it in ONE place is the point. `:rf.xray/managed-fx-for-focused-event`
+  answers `{:dispatch-id … :frame … :records […]}` while
+  `managed-fx-template/records-list` takes the RECORDS VECTOR. Handing it
+  the whole map made `(for [rec records] …)` walk MAP ENTRIES, so
+  `(name (:status rec))` got nil and threw before the panel could paint
+  (rf2-90kv) — the rf2-qhoj \"panel that never appears\" shape, since no
+  error boundary sits above this render path. `managed_fx_subs_cljs_test`
+  grades exactly this fn against a seeded two-record cascade; before the
+  migration it drove the `reg-view` body through `((rf/view id))`, which a
+  boundary has no analogue for.
+
+  `expanded` is the per-section disclosure override map, threaded down as
+  plain data: `records-list` / `record-panel` are plain fns, and per Spec
+  006 §Plain-fn footgun an ambient `subscribe` inside one cannot resolve
+  the surrounding frame, so the read belongs at the boundary and the value
+  travels as an argument (the same shape `views/edn-inspector` uses for
+  its own expansion slot).
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [focused expanded dispatch]
+  (managed-fx/records-list dispatch expanded (:records focused)))
+
+(rf.fresco/defview ManagedFxList
+  "The managed-fx wire-boundary diff template's mountable wrapper — a
+  FRESCO BOUNDARY (rf2-fcy5), not an `rf/reg-view`. Reads the focused
+  event-bundle's managed-fx composite plus the per-section disclosure
+  slot and hands their values, with a frame-bound dispatcher, to
+  [[managed-fx-list-tree]].
+
+  WHY IT MOVED. `managed_fx_template` is a pure hiccup folder whose only
+  non-native heads are the vectors `edn-widget/inspect` returns —
+  `[ei/edn-inspector …]`, a `reg-view` head, which Fresco's codec grades
+  `:invalid` exactly as it grades a plain `defn`. The replacement head
+  `edn/inspect-view` emits the `edn-inspector-view` boundary instead, and
+  it could not be adopted while this mount was a `reg-view`, because a
+  Fresco boundary in a Reagent head position is the mirror failure. So the
+  order was forced and is the whole content of this change: migrate the
+  mount, then adopt the head.
+
+  The READS are `rf.fresco/sub`, plain calls the shipped collector records
+  an edge for — no deref, no reaction owned by the installed adapter, and
+  a re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the name `reg-view` used to inject lexically: `defview` binds NO name
+  inside your body, so the bare `dispatch` this body used to close over
+  would be a LOUD compile error, which is the good failure. It still lands
+  the panel's context-menu / focus / disclosure affordances on the
+  surrounding instance frame rather than on a `{:frame :rf/xray}` literal.
+
+  The argument is the ordinary one-props-map vector every `defview` takes.
+  This panel reads nothing from props — `mount-managed-fx!` passes none —
+  so it is destructured away."
+  [_props]
+  (managed-fx-list-tree (rf.fresco/sub [:rf.xray/managed-fx-for-focused-event])
+                        (rf.fresco/sub [:rf.xray/managed-fx-expanded-sections])
+                        (:dispatch (rf/capture-frame))))
+
+(def ^:private ManagedFxList-component
+  "The React component `ManagedFxList` presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the panel on each
+  parent render."
+  (rf.fresco/as-component ManagedFxList))
+
+(defn ManagedFxList-bridge
+  "The callable a Reagent parent mounts this panel through. Returns
+  Reagent-shaped hiccup interoping to the React component above; the
+  enclosing `rf/frame-provider` [[render-panel!]] writes is what puts the
+  frame in React context for it.
+
+  PUBLIC, unlike `static.routes.panel`'s equivalent, and the difference is
+  a real one rather than a slip: this panel carries a standalone
+  `mount-managed-fx!` facade, and [[render-panel!]] takes the view to
+  mount as an ARGUMENT, so the embedding contract needs a name it can
+  pass. `panels/resources`'s bridge is public for the same reason.
+
+  THIS IS SCAFFOLDING WITH A DEFINED END. When `render-panel!` itself
+  builds a Fresco tree, it takes `ManagedFxList` directly, `[:>]` goes,
+  and both defs here are deleted with every other `*-bridge`."
   []
-  (let [focused  @(rf/subscribe [:rf.xray/managed-fx-for-focused-event])
-        ;; The panel's per-section disclosure state. Read HERE because
-        ;; `records-list` / `record-panel` are plain fns, and per Spec 006
-        ;; §Plain-fn footgun an ambient `subscribe` inside one raises
-        ;; `:rf.error/no-frame-context` — it carries no `:contextType`
-        ;; wiring and so cannot resolve the surrounding frame. A `reg-view`
-        ;; can, so the read happens at this boundary and the map is threaded
-        ;; down as plain data (the same shape `views/edn-inspector` uses for
-        ;; its own expansion slot).
-        expanded @(rf/subscribe [:rf.xray/managed-fx-expanded-sections])]
-    ;; Thread the reg-view-injected frame-aware dispatch so the panel's
-    ;; context-menu / focus / disclosure affordances land on the surrounding
-    ;; instance frame, not a `{:frame :rf/xray}` literal.
-    ;;
-    ;; `:records` — the composite sub answers
-    ;; `{:dispatch-id … :frame … :records […]}`, and `records-list` takes the
-    ;; RECORDS VECTOR. Handing it the whole map made `(for [rec records] …)`
-    ;; walk map entries, so `(name (:status rec))` got nil and threw before
-    ;; the panel could paint (rf2-90kv).
-    (managed-fx/records-list dispatch expanded (:records focused))))
+  [:> ManagedFxList-component {}])
 
 (defn mount-managed-fx!
   "Mount the managed-fx wire-boundary diff list in isolation at
@@ -487,7 +552,11 @@
   inside the focused event-bundle's managed-fx records. Empty when the
   focused event-bundle had no managed-fx records."
   ([mount-point]      (mount-managed-fx! mount-point nil))
-  ([mount-point opts] (render-panel! ManagedFxList mount-point opts)))
+  ;; rf2-fcy5 — `ManagedFxList-bridge`, not `ManagedFxList`, for the reason
+  ;; `mount-resources!` records above: the view is now a Fresco boundary
+  ;; and `render-panel!` builds a Reagent tree, which `defview`'s contract
+  ;; forbids mounting a boundary into. `render-panel!` itself is untouched.
+  ([mount-point opts] (render-panel! ManagedFxList-bridge mount-point opts)))
 
 ;; ---- full-shell mount ---------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -32,12 +32,16 @@
   in the helpers ns (`panels/managed_fx_helpers`); this ns is purely a
   hiccup folder over the record shape.
 
-  ## Pure hiccup (rf2-tijr)
+  ## Pure hiccup (rf2-tijr), rendered inside a Fresco boundary (rf2-fcy5)
 
   Same contract as every other Xray panel — pure hiccup, no Reagent /
-  UIx references. Frame isolation is provided by the enclosing
-  `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`. Every
-  `subscribe` / `dispatch` here resolves to the `:rf/xray` frame.
+  UIx references. Nothing here reads or dispatches ambiently: the reads
+  happen at the mount, `panels/ManagedFxList`, which since rf2-fcy5 is an
+  `rf.fresco/defview` BOUNDARY, and the frame-aware `dispatch` it captures
+  is threaded down as an ordinary argument. That is what makes this ns
+  substrate-neutral — every head in the tree it folds is either a native
+  tag or the `edn-inspector-view` boundary, both of which Fresco's codec
+  accepts and Reagent renders unchanged.
 
   ## Cross-link
 
@@ -225,21 +229,39 @@
 ;;
 ;; The four sites below were this tree's ONLY head-position users of
 ;; `inspect`; the other six caller files already call it. Calling it is
-;; correct on BOTH substrates — the value rendered is the vector `inspect`
-;; RETURNS — so this is the shape that survives the migration, and the
-;; facade keeps its one-renderer-many-call-sites property because
-;; `inspect`'s own shape is untouched.
+;; correct on BOTH substrates — the value rendered is the vector the facade
+;; RETURNS — so the call shape survived the migration, and the facade keeps
+;; its one-renderer-many-call-sites property because the facade's own shape
+;; is untouched.
 ;;
-;; NOT THE SAME THING AS BEING FRESCO-READY. `inspect` returns
-;; `[ei/edn-inspector …]`, a `reg-view` head, which Fresco's codec also
-;; refuses — `views/edn_inspector.cljs`'s own ns docstring puts it plainly:
-;; "Only `edn-inspector-view` is a head in a Fresco body." The day
-;; `panels/ManagedFxList` becomes a boundary, these four calls become
-;; `edn/inspect-view`, which exists for precisely that and takes the same
-;; `node-key`. Until then the Reagent head is the correct one.
+;; rf2-fcy5 — AND THE HEAD INSIDE THAT RETURNED VECTOR HAS NOW MOVED TOO,
+;; which is the second of the two blocking classes rf2-twil could only name.
+;; `inspect` returns `[ei/edn-inspector …]`, a `reg-view` head, which
+;; Fresco's codec refuses for the same reason it refuses a plain `defn` —
+;; `views/edn_inspector.cljs`'s own ns docstring puts it plainly: "Only
+;; `edn-inspector-view` is a head in a Fresco body." Now that
+;; `panels/ManagedFxList` IS a boundary, the four calls below are
+;; `edn/inspect-view`, the facade's Fresco head: same value, same opts,
+;; same renderer, differing only in that it emits `[ei/edn-inspector-view
+;; …]`. The order was forced — adopting it before the mount migrated would
+;; have put a Fresco boundary in a Reagent head position, the mirror
+;; failure.
+;;
+;; THE NODE-KEY IS NOW PER-RECORD, and that is load-bearing rather than
+;; cosmetic. `inspect-view` hands the node-key straight to the boundary as
+;; its `:mount-id`, and `edn-inspector/container-ref-for` MEMOISES the ref
+;; callback on it, so two mounts sharing a node-key share one
+;; ResizeObserver entry and one measured-width slot — detaching either
+;; releases the survivor's (the defect `static/flows/panel.cljs` records
+;; against its own rows). The old keys were built from the fx-id alone,
+;; and an event-bundle routinely carries several invocations of the SAME
+;; fx-id; the HANDLER key was the bare constant `"managed-fx/handler"`, so
+;; every record in every list shared one. `record-key` is this file's own
+;; per-record identity — already the React `:key` and the expansion key —
+;; so deriving all three from it is what stops them drifting apart.
 
 (defn- request-section
-  [{:keys [req surface fx-id]}]
+  [{:keys [req surface] :as record}]
   (cond
     (and (nil? req) (= surface :flow))
     [:span {:style {:color (:text-tertiary tokens)}} "(flow input — see registration)"]
@@ -248,7 +270,7 @@
     [:span {:style {:color (:text-tertiary tokens)}} "(no request payload)"]
 
     :else
-    (edn/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req"))))
+    (edn/inspect-view req (str "managed-fx/" (h/record-key record) "/req"))))
 
 (defn- wire-section
   "Wire timing section. When the surface emits per-phase wire data we
@@ -266,7 +288,7 @@
      "n/a — this surface does not emit per-phase wire timing today."]))
 
 (defn- response-section
-  [{:keys [res surface fx-id failure]}]
+  [{:keys [res surface failure] :as record}]
   (cond
     failure
     [:div
@@ -274,8 +296,8 @@
                     :font-weight 600
                     :margin-bottom "4px"}}
       (str "✗ " (or (some-> failure :kind name) "FAILURE"))]
-     (edn/inspect (or (:tags failure) failure)
-                  (str "managed-fx/" (h/format-fx-id fx-id) "/failure"))]
+     (edn/inspect-view (or (:tags failure) failure)
+                       (str "managed-fx/" (h/record-key record) "/failure"))]
 
     (and (nil? res) (= surface :flow))
     [:span {:style {:color (:text-tertiary tokens)}}
@@ -286,20 +308,20 @@
      "(no response payload yet)"]
 
     :else
-    (edn/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res"))))
+    (edn/inspect-view res (str "managed-fx/" (h/record-key record) "/res"))))
 
 (defn- handler-section
   "Renders the dispatched handler event vector + a click-to-focus
   affordance that pivots the spine to that child event-bundle. Anchors the
   F.3 'failed response handler' diagnostic."
-  [dispatch {:keys [handler frame dispatch-id]}]
+  [dispatch {:keys [handler frame dispatch-id] :as record}]
   (if (and (vector? handler) (seq handler))
     [:div {:style {:display "flex"
                    :align-items "center"
                    :gap "12px"
                    :flex-wrap "wrap"}}
      [:div {:style {:flex 1 :min-width 0}}
-      (edn/inspect handler "managed-fx/handler")]
+      (edn/inspect-view handler (str "managed-fx/" (h/record-key record) "/handler"))]
      [:button {:data-testid "rf-xray-managed-fx-focus-handler"
                :on-click    #(dispatch [:rf.xray/focus-event dispatch-id frame])
                :style       {:background  "transparent"
@@ -342,9 +364,17 @@
     [:ul {:style {:list-style "none"
                   :margin     0
                   :padding    0}}
+     ;; rf2-fcy5 (rf2-k97c.3 RULING 2) — the key rides the ATTRIBUTE MAP,
+     ;; not `^{:key …}` reader meta. Reagent reads meta THEN props, so both
+     ;; spellings worked while this panel mounted under `reg-view`; Fresco's
+     ;; codec reads a literal `:key` from a native tag's attrs and reads
+     ;; Clojure metadata NOWHERE, so on the migration the meta form becomes
+     ;; a silent nil — every row in the list loses its key with nothing on
+     ;; screen to say so. The attribute map satisfies both substrates and
+     ;; the key EXPRESSION is unchanged.
      (for [[i path] (map-indexed vector paths-touched)]
-       ^{:key i}
-       [:li {:style {:padding "2px 0"
+       [:li {:key   i
+             :style {:padding "2px 0"
                      :font-family mono-stack
                      :font-size "12px"
                      :color (:text-primary tokens)}}

--- a/tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panel_enum_guard_cljs_test.cljs
@@ -73,8 +73,9 @@
   "PROJECTION A — the live public `mount-<panel>!` vars of
   `day8.re-frame2-xray.panels`, captured at compile time. Filtered to
   the `mount-*!` shape (the ns has other publics — `render-panel!` is
-  private; `ManagedFxList` is a reg-view; the mount fns are the panel
-  facade)."
+  private; `ManagedFxList` is an `rf.fresco/defview` boundary since
+  rf2-fcy5, with `ManagedFxList-bridge` and `managed-fx-list-tree` beside
+  it; the mount fns are the panel facade)."
   (into #{}
         (comp (map first)
               (filter #(re-matches #"mount-[a-z][a-z0-9-]*!" %)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_dom_cljs_test.cljs
@@ -230,34 +230,47 @@
 ;; ===========================================================================
 
 (deftest each-record-owns-its-inspector-mount-ids
-  (testing "rf2-fcy5 — with REQUEST, RESPONSE and HANDLER open, the payload
-            bodies are in the committed tree, so the four `edn/inspect-view`
+  (testing "rf2-fcy5 — with the payload sections open, the `edn/inspect-view`
             heads really rendered rather than raising
-            `:rf.error/fresco-bad-head`. Their `:mount-id`s are derived from
-            `record-key`, so two records carrying the SAME fx-id still own
-            disjoint sets — the pre-rf2-fcy5 keys were composed from the
-            fx-id alone and the HANDLER key was a bare constant, so every
-            record in the list shared one."
+            `:rf.error/fresco-bad-head`, which is what a committed
+            `data-rf-mount-id` says. A seeded `:rf.fx/handled` carries a
+            request and an on-success handler but no response yet, so the
+            widgets that commit are REQUEST and HANDLER per record; the row
+            counts what is there rather than a fixed number.
+
+            Their `:mount-id`s are derived from `record-key`, so two records
+            carrying the SAME fx-id still own disjoint sets — the pre-rf2-fcy5
+            keys were composed from the fx-id alone and the HANDLER key was
+            the bare constant `\"managed-fx/handler\"`, so every record in
+            every list shared one."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (let [_ (setup!)
             m (mount!)]
         (try
-          (let [ids   (mount-ids (:container m))
-                per-a (filterv #(string/includes? % "-1-") ids)
-                per-b (filterv #(string/includes? % "-2-") ids)]
-            ;; Control: widgets committed at all. An empty set would make
-            ;; every distinctness assertion below vacuously true.
+          ;; The expected groups are DERIVED from `record-key` rather than
+          ;; spelled out: that is the composer `edn-widget/inspect-view`'s
+          ;; node-key is built from, so this row states the claim in the
+          ;; renderer's own terms and cannot drift from the seeded trace ids.
+          (let [rec-keys (mapv h/record-key (records))
+                ids      (mount-ids (:container m))
+                groups   (mapv (fn [rk] (filterv #(string/includes? % rk) ids))
+                               rec-keys)]
+            ;; Controls, taken from the target: widgets committed at all, and
+            ;; the two records really do carry different keys. An empty set or
+            ;; two equal keys would make the disjointness below vacuous.
             (is (seq ids)
-                "control: at least one edn-inspector widget committed, so the
-                 inspector heads are boundaries the codec accepted")
+                (str "control: at least one edn-inspector widget committed, so "
+                     "the inspector heads are boundaries the codec accepted"))
+            (is (= 2 (count (distinct rec-keys)))
+                (str "control: the two records carry distinct record-keys — "
+                     (pr-str rec-keys)))
             (is (= (count ids) (count (distinct ids)))
                 (str "no two committed widgets share a mount-id — " (pr-str ids)))
-            ;; `record-key` is "<surface>-<origin-event-id>-<fx-id>", and the
-            ;; two fx events were seeded at trace ids 3 and 4, so each
-            ;; record's ids carry its own origin id and no other's.
-            (is (seq per-a) (str "the first record's widgets are present — " (pr-str ids)))
-            (is (seq per-b) (str "the second record's widgets are present — " (pr-str ids)))
-            (is (= (count ids) (+ (count per-a) (count per-b)))
-                "every committed widget belongs to exactly one record"))
+            (is (every? seq groups)
+                (str "each record owns at least one widget — keys "
+                     (pr-str rec-keys) " ids " (pr-str ids)))
+            (is (= (count ids) (reduce + (map count groups)))
+                (str "every committed widget belongs to exactly one record — "
+                     (pr-str ids))))
           (finally (unmount! m)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_dom_cljs_test.cljs
@@ -1,0 +1,263 @@
+(ns day8.re-frame2-xray.panels.managed-fx-mount-dom-cljs-test
+  "`mount-managed-fx!` COMMITS THE PANEL TO A REAL DOM (rf2-fcy5).
+
+  ## Why this needs a DOM, and why nothing else could stand in
+
+  rf2-fcy5 migrated `panels/ManagedFxList` from `rf/reg-view` to an
+  `rf.fresco/defview` boundary, mounted through the public facade behind
+  `panels/ManagedFxList-bridge`. Three things moved at once and NONE of
+  them is observable from a hiccup assertion:
+
+    1. The bridge — `rf.fresco/as-component` interoped into the Reagent
+       tree `panels/render-panel!` builds. The node lane cannot see it:
+       every `panels_mount_cljs_test` row stubs
+       `rf.substrate.adapter/render`, so the captured tree is READ and
+       never rendered, and the view's body never runs at all.
+    2. The boundary's own reads. `rf.fresco/sub` resolves its frame from
+       React context, which exists only inside a real render window.
+    3. The four `edn/inspect-view` heads inside the template. A plain fn
+       or a `reg-view` head in a Fresco body raises
+       `:rf.error/fresco-bad-head`, and on this render path there is no
+       error boundary above it — React unmounts the whole root, which
+       presents as A PANEL THAT NEVER APPEARS rather than as an error.
+       That is the rf2-qhoj shape, and rf2-90kv is this very panel
+       throwing before painting with no red row anywhere in the tree.
+
+  So the claim under test is the plain one every tier so far has had to
+  assume: mounting this panel puts its records on the screen.
+
+  ## And the Xray feature-matrix gate is NOT this row's substitute
+
+  Measured at this slice's base: `rf-xray-managed-fx` appears in no
+  testbed, example or scenario file in the repository — `mount-managed-fx!`
+  has zero call sites outside `tools/xray` — so no browser scenario mounts
+  this panel and none can go red on it. `016-Auxiliary-Panels.md` says as
+  much in its own row: \"standalone mount — no current panel embeds it\".
+  This file is the browser-lane coverage for the surface, not a second
+  opinion about it.
+
+  ## The two observables are the two things that moved
+
+  `data-testid=\"rf-xray-managed-fx-record-…\"` — one per record, written
+  by `record-panel`, so its presence says the boundary rendered and the
+  composite's `:records` vector reached the renderer.
+
+  `data-rf-mount-id` — stamped by the edn-inspector widget itself on every
+  committed container. Its presence says the `edn-inspector-view`
+  BOUNDARIES rendered rather than raising, and its DISTINCTNESS across the
+  two records is the per-record node-key claim measured rather than
+  argued: `edn-widget/inspect-view` hands the node-key straight to the
+  boundary as `:mount-id`, and `edn-inspector/container-ref-for` memoises
+  the ref callback on it, so two records sharing one would share one
+  ResizeObserver entry and one width slot.
+
+  ## Substrate and fixture
+
+  The installed adapter renders, and nothing here builds a tree of its
+  own — the thing under test is the public mount fn. The fixture is the
+  one `app_db_diff_mount_instance_id_dom_cljs_test` uses, for the same
+  reason: `:ambient-frame nil` leaves the Xray reset in sole charge of the
+  frame, and Fresco's collector tables are process-global `defonce`s the
+  core fixture knows nothing about.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`. The `:node-test` build's `cljs-test$`
+  regex also matches, so it LOADS under Node — where every row
+  short-circuits through [[browser?]] and reports the skip rather than
+  passing silently."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.panels :as panels]
+            [day8.re-frame2-xray.panels.managed-fx-helpers :as h]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about, and
+                      ;; `ManagedFxList` is a Fresco boundary — a neighbour's
+                      ;; entry left in the cache would make these rows read a
+                      ;; residue that is not this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the seeded cascade --------------------------------------------------
+
+(def ^:private dispatch-id 600)
+
+(defn- cascade-evs
+  "One cascade carrying TWO `:rf.http/managed` invocations.
+
+  Two is what makes the distinctness assertions discriminating, and both
+  carry the SAME fx-id deliberately: that is the case the pre-rf2-fcy5
+  node-keys could not tell apart, since they were composed from the fx-id
+  alone. `record-key` separates them on `:origin-event-id`, which is the
+  trace-event id of the fx event and so differs per record."
+  []
+  [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
+    :tags {:rf.trace/dispatch-id dispatch-id :rf.event/v [:user/load]}}
+   {:id 2 :op-type :rf.fx :operation :rf.fx/do-fx
+    :tags {:rf.trace/dispatch-id dispatch-id}}
+   {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/1"}
+                        :request-id :req-a
+                        :on-success [:user/loaded]}}}
+   {:id 4 :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/2"}
+                        :request-id :req-b
+                        :on-success [:user/loaded]}}}])
+
+(defn- records
+  "The composite sub's records vector, read the way the boundary reads it."
+  []
+  (rf/with-frame :rf/xray
+    (:records @(rf/subscribe [:rf.xray/managed-fx-for-focused-event]))))
+
+(defn- setup!
+  "Seed the trace buffer, focus the cascade, and open every section.
+
+  The sections are opened BEFORE the mount, deliberately: the boundary
+  reads the disclosure slot on its FIRST render, so the payload-bearing
+  sections are in the very first commit and no row below depends on
+  driving a React update from a dispatch."
+  []
+  (registry/register-xray-handlers!)
+  (mount/ensure-xray-frame! :rf/xray)
+  (doseq [ev (cascade-evs)]
+    (trace-collector/seed-trace-for-test! ev))
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/focus-event dispatch-id :rf/default])
+    (doseq [rec  (records)
+            sect [:request :response :handler]]
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section
+                         (h/record-key rec) sect])))
+  nil)
+
+;; ---- mounting, and reading the DOM back ----------------------------------
+
+(defn- mount!
+  "Mount the managed-fx list through the PUBLIC facade, committed
+  synchronously.
+
+  `react-dom/flushSync` rather than a Reagent queue drain: the panel's
+  view is a Fresco boundary, which is not in Reagent's render queue at
+  all, so draining that queue commits nothing of this panel's and a row
+  written that way reads a container that never moved."
+  []
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    (let [unmount (react-dom/flushSync
+                    (fn [] (panels/mount-managed-fx! container)))]
+      {:container container :unmount unmount})))
+
+(defn- unmount!
+  [{:keys [container unmount]}]
+  (react-dom/flushSync (fn [] (unmount)))
+  (.remove container))
+
+(defn- query-all
+  "Every element matching `sel` in `container`'s committed DOM, in document
+  order. Reads the DOM React wrote — nothing here reproduces the panel."
+  [container sel]
+  (->> (.querySelectorAll container sel)
+       (js/Array.from)
+       (array-seq)))
+
+(defn- record-testids [container]
+  (mapv #(.getAttribute % "data-testid")
+        (query-all container "[data-testid^='rf-xray-managed-fx-record-']")))
+
+(defn- mount-ids [container]
+  (mapv #(.getAttribute % "data-rf-mount-id")
+        (query-all container "[data-rf-mount-id]")))
+
+;; ===========================================================================
+;; W1 — the boundary paints, through the bridge, into a real container
+;; ===========================================================================
+
+(deftest mounting-commits-one-record-panel-per-record
+  (testing "rf2-fcy5 — `mount-managed-fx!` wraps `ManagedFxList-bridge` in a
+            frame-provider and hands it to the adapter; the bridge interops
+            to the `as-component` React component; the boundary resolves
+            `:rf/xray` from React context and renders. If ANY link in that
+            chain is wrong the container is empty rather than wrong, which
+            is why this row reads the committed DOM and not a tree."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)]
+        ;; CONTROL FIRST, taken from the target: the composite really answers
+        ;; two records, so an empty container below is the mount's answer and
+        ;; not the seeding's. Without it the two readings are identical.
+        (is (= 2 (count (records)))
+            "control: the composite answers two records before anything mounts")
+        (let [m (mount!)]
+          (try
+            (let [ids (record-testids (:container m))]
+              (is (= 2 (count ids))
+                  (str "one record panel per record reached the DOM — "
+                       (pr-str ids)))
+              (is (= 2 (count (distinct ids)))
+                  "and the two are distinct, so this is not one record twice"))
+            (finally (unmount! m))))))))
+
+;; ===========================================================================
+;; W2 — the edn-inspector BOUNDARIES render, and each record owns its own
+;; ===========================================================================
+
+(deftest each-record-owns-its-inspector-mount-ids
+  (testing "rf2-fcy5 — with REQUEST, RESPONSE and HANDLER open, the payload
+            bodies are in the committed tree, so the four `edn/inspect-view`
+            heads really rendered rather than raising
+            `:rf.error/fresco-bad-head`. Their `:mount-id`s are derived from
+            `record-key`, so two records carrying the SAME fx-id still own
+            disjoint sets — the pre-rf2-fcy5 keys were composed from the
+            fx-id alone and the HANDLER key was a bare constant, so every
+            record in the list shared one."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            m (mount!)]
+        (try
+          (let [ids   (mount-ids (:container m))
+                per-a (filterv #(string/includes? % "-1-") ids)
+                per-b (filterv #(string/includes? % "-2-") ids)]
+            ;; Control: widgets committed at all. An empty set would make
+            ;; every distinctness assertion below vacuously true.
+            (is (seq ids)
+                "control: at least one edn-inspector widget committed, so the
+                 inspector heads are boundaries the codec accepted")
+            (is (= (count ids) (count (distinct ids)))
+                (str "no two committed widgets share a mount-id — " (pr-str ids)))
+            ;; `record-key` is "<surface>-<origin-event-id>-<fx-id>", and the
+            ;; two fx events were seeded at trace ids 3 and 4, so each
+            ;; record's ids carry its own origin id and no other's.
+            (is (seq per-a) (str "the first record's widgets are present — " (pr-str ids)))
+            (is (seq per-b) (str "the second record's widgets are present — " (pr-str ids)))
+            (is (= (count ids) (+ (count per-a) (count per-b)))
+                "every committed widget belongs to exactly one record"))
+          (finally (unmount! m)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_subs_cljs_test.cljs
@@ -11,9 +11,12 @@
             [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
-            ;; rf2-90kv — the reg-view that composes the sub with the renderer
-            ;; is itself the defect surface, so it is the instrument.
-            [day8.re-frame2-xray.panels]
+            ;; rf2-90kv — the mount that composes the sub with the renderer
+            ;; is itself the defect surface, so it is the instrument. rf2-fcy5
+            ;; moved that composition into `panels/managed-fx-list-tree`, which
+            ;; the row below calls by name, so the alias is now load-bearing at
+            ;; runtime rather than only forcing the ns to load.
+            [day8.re-frame2-xray.panels :as panels]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -146,11 +149,22 @@
   "Every node in a hiccup tree, payload values included. Walked structurally
   rather than through `rf.test-helpers/expand-tree`, which rebuilds nested
   vectors with `mapv` and would substitute its own vectors for the ones under
-  test (it strips reader metadata besides)."
+  test (it strips reader metadata besides).
+
+  rf2-fcy5 — IT DESCENDS INTO MAP VALUES, and that is what keeps \"payload
+  values included\" true. A Reagent component took its value as a POSITIONAL
+  argument (`[ei/edn-inspector v opts]`), so a vectors-and-seqs walk reached
+  it; a Fresco boundary takes ONE PROPS MAP (`[ei/edn-inspector-view
+  {:value v …}]`), so the payload now sits behind a map key. Without this
+  arm the walk still returns the props map itself and simply never looks
+  inside it — an absence that reads exactly like a payload the panel failed
+  to render, which is the direction that matters here, since every caller
+  below asserts PRESENCE."
   [node]
   (cond
     (vector? node) (cons node (mapcat tree-nodes node))
     (seq? node)    (cons node (mapcat tree-nodes node))
+    (map? node)    (cons node (mapcat tree-nodes (vals node)))
     :else          [node]))
 
 (deftest expanded-sections-slot-starts-empty
@@ -226,7 +240,7 @@
         (is (true? (shown?))
             "one toggle later the request payload is in the rendered tree")))))
 
-;; ---- the reg-view's own composition (rf2-90kv) ----------------------------
+;; ---- the mount's own composition (rf2-90kv) -------------------------------
 ;;
 ;; `panels/ManagedFxList` is the ONLY caller of `records-list`, and it is where
 ;; the composite sub's value meets the renderer. Nothing graded that seam:
@@ -236,6 +250,17 @@
 ;; already in hand. Both tiers were blind to the one line that composes them,
 ;; which is how the panel came to throw before painting without a red row
 ;; anywhere.
+;;
+;; rf2-fcy5 — THE INSTRUMENT MOVED, AND THE SEAM DID NOT. `ManagedFxList` is
+;; now an `rf.fresco/defview` boundary, a real React function component whose
+;; body may only run inside a React render window, so `((rf/view id))` — what
+;; this row used to drive — has no analogue. The composition it graded was
+;; therefore EXTRACTED rather than duplicated here: `panels/managed-fx-list-tree`
+;; is `defview`'s own documented extract-a-helper split, holding the
+;; `(:records focused)` line and nothing else, and the boundary is a
+;; three-argument pass-through into it. Reproducing the reads in this file
+;; instead would have made the row assert against its OWN copy of the
+;; composition, which is precisely the blindness rf2-90kv was filed about.
 
 (defn- cascade-evs-two-managed-fx
   "One cascade carrying TWO managed-fx invocations.
@@ -295,9 +320,13 @@
             is red either way and is why the count assertion is stated over a
             tree that has to have been built at all.
 
-            The view's body is invoked headlessly through `((rf/view id))`,
-            which runs the real reg-view render path under the plain-atom
-            substrate the Xray suite installs."
+            rf2-fcy5 — the body is now driven through
+            `panels/managed-fx-list-tree`, which IS the composition: the
+            boundary reads the two slots and passes them straight in, so
+            this row still grades the one line that meets the renderer.
+            The WHOLE composite map is handed over, exactly as the
+            boundary hands it, so the `(:records …)` extraction is inside
+            the thing under test rather than performed by the test."
     (seed-buffer! (cascade-evs-two-managed-fx 600 0))
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 600 :rf/default])
@@ -308,7 +337,10 @@
       (is (= 2 (count (:records @(rf/subscribe
                                    [:rf.xray/managed-fx-for-focused-event]))))
           "control: the composite really answers two records")
-      (let [tree    ((rf/view :day8.re-frame2-xray.panels/ManagedFxList))
+      (let [tree    (panels/managed-fx-list-tree
+                      @(rf/subscribe [:rf.xray/managed-fx-for-focused-event])
+                      @(rf/subscribe [:rf.xray/managed-fx-expanded-sections])
+                      (:dispatch (rf/capture-frame)))
             testids (record-panel-testids tree)]
         (is (= 2 (count testids))
             "one record panel per RECORD, not one per entry of the composite map")

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -217,16 +217,17 @@
 ;; assertion of ours, so the zero below is the renderer's answer and not
 ;; a claim about what we think the renderer would say.
 ;;
-;; WHY THIS IS NOT A FRESCO DOM ROW. A DOM row would mount the panel
-;; through the codec, which is not reachable for this file today: the
-;; value `inspect` returns is `[ei/edn-inspector …]`, a `reg-view` head,
-;; which the codec also refuses — `views/edn_inspector.cljs` says it
-;; outright, "Only `edn-inspector-view` is a head in a Fresco body" — and
-;; the panel's own mount, `panels/ManagedFxList`, is still a `reg-view`.
-;; So the repair removes ONE of two blocking classes; the other is the
-;; migration's, and the day it happens these four calls become
-;; `edn/inspect-view`. Asserting only what is actually true here is the
-;; point: a row claiming Fresco-readiness would be the hollow one.
+;; BOTH BLOCKING CLASSES ARE NOW CLEARED (rf2-fcy5). rf2-twil removed the
+;; first — `inspect` is CALLED, never headed. The second was the head inside
+;; the value it returns: `[ei/edn-inspector …]` is a `reg-view` head, which
+;; the codec refuses for the same reason it refuses a plain `defn` —
+;; `views/edn_inspector.cljs` says it outright, "Only `edn-inspector-view`
+;; is a head in a Fresco body". That one could not be repaired until the
+;; panel's own mount was a boundary, because a Fresco head in a Reagent
+;; position is the mirror failure; `panels/ManagedFxList` is an
+;; `rf.fresco/defview` now, so the four sites call `edn/inspect-view` and
+;; the tree this file folds is codec-clean all the way down. The
+;; every-section-open row below states that in the codec's own words.
 ;;
 ;; WHAT THIS ROW CANNOT DO, STATED PLAINLY BECAUSE THE FIRST DRAFT OF IT
 ;; LIED. It walks the DEFAULT tree, where three of the five sections are
@@ -397,11 +398,24 @@
   "Every node in a hiccup tree, payload values included. Walked structurally
   rather than through `rf.test-helpers/expand-tree`, which rebuilds nested
   vectors with `mapv` — that would substitute its own vectors for the ones
-  under test, and strips reader metadata besides."
+  under test, and strips reader metadata besides.
+
+  rf2-fcy5 — IT DESCENDS INTO MAP VALUES, and that is what keeps \"payload
+  values included\" true. A Reagent component took its value as a POSITIONAL
+  argument (`[ei/edn-inspector v opts]`), so a vectors-and-seqs walk reached
+  it; a Fresco boundary takes ONE PROPS MAP (`[ei/edn-inspector-view
+  {:value v …}]`), so the payload now sits behind a map key. Without this
+  arm the walk still returns the props map itself and simply never looks
+  inside it — an absence that reads exactly like a payload the panel failed
+  to render, which is the direction that matters here, since every caller
+  below asserts PRESENCE. `body-shown?` and `testids` are unaffected: they
+  are a different walker that reads the attribute map by position and never
+  descends into one."
   [node]
   (cond
     (vector? node) (cons node (mapcat tree-nodes node))
     (seq? node)    (cons node (mapcat tree-nodes node))
+    (map? node)    (cons node (mapcat tree-nodes (vals node)))
     :else          [node]))
 
 (defn- open-all
@@ -603,25 +617,90 @@
           "Fresco's own classifier grades the plain fn an invalid head")
       (is (< 30 (count heads))
           "the walker reached a populated tree, so a zero below means absence")
-      ;; `(empty? (filter fn? heads))` — the shape the DEFAULT-tree row above
-      ;; can use — would be WRONG here, and measuring it is how that was
-      ;; found: it reads three `cljs.core.MetaFn`s, which are the three
-      ;; `edn/inspect` returns now in the tree. `inspect` answers
-      ;; `[ei/edn-inspector …]`, a REG-VIEW head, and a reg-view head IS a fn
-      ;; value on CLJS — `build-frame-aware-view` returns `(with-meta (fn …)
-      ;; {:contextType …})`. That head is the CORRECT one while this panel
-      ;; mounts under `reg-view`; `head-kind` cannot separate the two, since
-      ;; Fresco's codec grades a reg-view head `:invalid` as well.
+      ;; rf2-fcy5 — THE DISCRIMINATOR IS THE CODEC, and it is the only
+      ;; instrument that survives BOTH sides of this migration.
       ;;
-      ;; The discriminator is the metadata: a registered frame-aware view
-      ;; head carries some, a bare `defn` carries none.
-      (let [fn-heads (filter fn? heads)]
-        (is (pos? (count fn-heads))
-            "the inspector heads are in the tree, so `every?` below is not vacuous")
+      ;; Neither of the two obvious shapes does. `(empty? (filter fn? heads))`
+      ;; — what the DEFAULT-tree row above can use, because the default tree
+      ;; carries no inspector at all — is wrong here in the permissive
+      ;; direction AND the strict one: a reg-view head IS a fn value on CLJS
+      ;; (`build-frame-aware-view` returns `(with-meta (fn …) {:contextType …})`,
+      ;; a `cljs.core.MetaFn`), and so is a Fresco boundary, by
+      ;; `codec/boundary-head?`'s own definition. And `(some? (meta head))` —
+      ;; what this row asserted while the heads were reg-views — reads NIL on
+      ;; the correct code now: a boundary is a plain React function component
+      ;; carrying a JS own-property and no Clojure metadata at all.
+      ;;
+      ;; `head-kind` answers both eras without a branch, because it is the
+      ;; renderer's own question: a plain `defn` and a reg-view head both grade
+      ;; `:invalid`, a boundary grades `:boundary`, a native tag `:tag`. A
+      ;; revert of any of the four call sites from `edn/inspect-view` to
+      ;; `edn/inspect` puts an `:invalid` head back in this tree and reds the
+      ;; row — which is the whole point, since that revert is silent under
+      ;; Reagent and unmounts the Xray root under Fresco.
+      (is (= :invalid (rf.fresco.impl.codec/head-kind
+                        (first (edn-widget/inspect {:probe 1} "probe"))))
+          "the Reagent head these sites used to carry grades :invalid")
+      (is (= :boundary (rf.fresco.impl.codec/head-kind
+                         (first (edn-widget/inspect-view {:probe 1} "probe"))))
+          "the Fresco head they carry now grades :boundary")
+      (let [kinds (frequencies (map rf.fresco.impl.codec/head-kind heads))]
+        (is (pos? (get kinds :boundary 0))
+            "the inspector heads are in the tree, so the absence below is not vacuous")
         (is (not-any? #(identical? edn-widget/inspect %) heads)
             "`edn/inspect` is a plain defn and is never itself a hiccup head")
-        (is (every? #(some? (meta %)) fn-heads)
-            "every fn in head position is a registered view head, not a plain fn")))))
+        (is (zero? (get kinds :invalid 0))
+            (str "every head in the rendered panel is one Fresco accepts — " kinds))))))
+
+;; ---- RULING 2: the app-db path rows key through the ATTRIBUTE MAP ---------
+;;
+;; rf2-fcy5 — `app-db-slice-section` wrote its per-path keys as `^{:key i}`
+;; reader META on the `[:li …]` vector. Reagent reads meta THEN props and so
+;; returned the same key either way, which is why that spelling survived this
+;; long; Fresco's codec reads a literal `:key` from a native tag's attrs and
+;; reads Clojure metadata NOWHERE, so on the migration every row in the list
+;; would have lost its key, with nothing on screen to say so.
+;;
+;; THE OBVIOUS INSTRUMENT IS HOLLOW HERE, which is the whole reason this row
+;; exists beside `records-list-keys-reach-react` rather than inside it. That
+;; row reads `(.-key (r/as-element node))` — exactly right for ITS defect
+;; (meta on a CALL form, dead on every substrate) and BLIND to this one,
+;; because Reagent reads meta AND props and answers the same key before and
+;; after. Measured under rf2-k97c.3 on `views/resizable_table.cljs`: on
+;; reverted source the Reagent assertion PASSED while the Fresco assertion on
+;; the very next line read `[nil nil nil]`. The door that can tell meta from
+;; attrs is the codec's own.
+
+(defn- emitted-key
+  "The React key the FRESCO codec commits for one hiccup node — the
+  hiccup→element door a boundary's children actually cross, rather than
+  whatever the authoring vector happens to be carrying."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element node)))
+
+(deftest app-db-path-rows-key-through-the-fresco-codec
+  (testing "rf2-fcy5 / RULING 2 — the one `^{:key …}` metadata site in this
+            file writes its key into the `[:li]` ATTRIBUTE MAP now, which is
+            the only spelling Fresco reads. Reverting it to reader meta makes
+            `:key` absent from the attrs and the codec's key nil, and both
+            halves below go red."
+    (let [r   (record {:surface :http :fx-id :rf.http/managed
+                       :status :ok :http-status 200
+                       :paths [[:users 42] [:users 43] [:session :token]]})
+          lis (->> (tree-nodes (template/record-panel r))
+                   (filter #(and (vector? %) (= :li (first %))))
+                   vec)]
+      ;; Control: the walker really reached the rows, so a nil key below is
+      ;; the codec's answer about a key rather than an empty selection.
+      (is (= 3 (count lis)) "one :li per touched path")
+      (let [ks (mapv emitted-key lis)]
+        (is (every? some? ks) "every path row reaches React with a key")
+        (is (= 3 (count (distinct ks))) "sibling keys are distinct"))
+      ;; And the contract surface stays observable in the hiccup itself.
+      (is (every? #(contains? (second %) :key) lis)
+          "the key rides the attribute map")
+      (is (every? #(nil? (meta %)) lis)
+          "no `^{:key …}` reader meta survives on these rows"))))
 
 (deftest user-facing-text-carries-no-internal-refs
   (let [recs [(record {:surface :http :fx-id :rf.http/managed

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -674,9 +674,34 @@
 (defn- emitted-key
   "The React key the FRESCO codec commits for one hiccup node — the
   hiccup→element door a boundary's children actually cross, rather than
-  whatever the authoring vector happens to be carrying."
+  whatever the authoring vector happens to be carrying.
+
+  HEAD + ATTRS ONLY, which is this tree's idiom for the Fresco door (see
+  `panels/machine_inspector_view_cljs_test`'s `fresco-key`). The key is
+  read off the attribute map by both renderers, so dropping the subtree
+  cannot change the answer; what it buys is that the codec lowers children
+  EAGERLY, so a whole-node call raises HD-016
+  `:rf.error/fresco-bad-head` the moment anything below the node is still
+  a plain fn in head position. That is unmigrated tree rather than a key
+  defect, and letting it throw here would hide the key answer behind it.
+
+  MEASURED on this file rather than assumed, because it is file-dependent:
+  at the time of writing the whole-node form ANSWERS on these rows — the
+  `[:li]` subtree is one `[:span]` — and reads `[nil nil nil]` under a
+  revert to `^{:key …}` rather than raising. The subvec is taken anyway,
+  so a future child with a fn head cannot turn this row's answer into an
+  exception about something else.
+
+  `subvec` DROPS VECTOR METADATA, which would matter if the metadata-vs-attrs
+  discrimination lived in a Reagent/Fresco PAIR — subvec both doors and the
+  meta is gone before Reagent sees it, so both read nil and the pair stops
+  saying which fault it is. It does not matter here: `r/as-element` is
+  HOLLOW for this sub-case (Reagent reads meta AND props and answers the
+  same key either way), so this row carries no Reagent door at all and the
+  discrimination is carried by the two structural assertions below — the
+  key is IN the attrs map, and NO reader meta survives on the row."
   [node]
-  (.-key (rf.fresco.impl.codec/as-element node)))
+  (.-key (rf.fresco.impl.codec/as-element (subvec node 0 2))))
 
 (deftest app-db-path-rows-key-through-the-fresco-codec
   (testing "rf2-fcy5 / RULING 2 — the one `^{:key …}` metadata site in this

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -188,10 +188,14 @@
 ;; ---- inline content surface (managed-fx) -------------------------------
 
 (deftest mount-managed-fx-wraps-ManagedFxList
+  ;; rf2-fcy5 — the expected view is `ManagedFxList-bridge`, for the reason
+  ;; `mount-reactive-panel-…` records above: `ManagedFxList` is now a Fresco
+  ;; boundary and `render-panel!` builds a REAGENT tree. The shape this row
+  ;; pins — frame-provider :rf/xray wrapping the view — is unchanged.
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-managed-fx! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) panels/ManagedFxList)))))
+      (is (frame-provider-wrap? (captured-tree capture) panels/ManagedFxList-bridge)))))
 
 ;; ---- full-shell mount --------------------------------------------------
 


### PR DESCRIPTION
rf2-fcy5's managed-fx half — the second of that bead's three sequenced pieces.
Slice 1 (`resizable-table`) and slice 1b are merged; `panels/trace.cljs` is the
third slice and is not touched here.

## What moved

`panels/ManagedFxList` was an `rf/reg-view`; it is now an `rf.fresco/defview`
behind a **public** `as-component` bridge, the shape `app-db-diff`,
`reactive-panel`, `resources` and the five Static sub-tabs already carry. The
bridge is public rather than private because this panel has a standalone
`mount-managed-fx!` facade and `render-panel!` takes the view to mount as an
argument — RULING 1's spelling, with the boundary keeping the natural name.

The body splits into `managed-fx-list-tree`, `defview`'s own documented
extract-a-helper spelling. That split is load-bearing here rather than cosmetic:
it is where the `(:records focused)` composition lives — the exact line rf2-90kv
was filed about — and keeping it in ONE place is what lets the node lane keep
grading it. `managed_fx_subs_cljs_test` drove the old `reg-view` body through
`((rf/view id))`, which a boundary has no analogue for; reproducing the reads
inside the test would have made that row assert against its own copy of the
composition, which is precisely the blindness that bead records.

**The four `edn/inspect` sites become `edn/inspect-view`**, which is the whole
reason the mount had to move first. `inspect` returns `[ei/edn-inspector …]`, a
`reg-view` head, which Fresco's codec grades `:invalid` exactly as it grades a
plain `defn`; `inspect-view` emits the `edn-inspector-view` boundary. Adopting
it before the mount migrated would have put a Fresco head in a Reagent position
— the mirror failure. Scope held to those four: `edn-inspector` has eighteen
head use sites across the tree, and the other fourteen stay on the `reg-view`
spelling until their own slices run.

**The node-keys are now per-record, and that is a defect repaired rather than a
rename.** `inspect-view` hands the node-key to the boundary as its `:mount-id`,
and `edn-inspector/container-ref-for` MEMOISES the ref callback on it, so two
mounts sharing one share a ResizeObserver entry and a measured-width slot — the
defect `static/flows/panel.cljs` records against its own rows. The old keys were
composed from the fx-id alone, and an event-bundle routinely carries several
invocations of the same fx-id; the HANDLER key was the bare constant
`"managed-fx/handler"`, so every record in every list shared one. All four now
derive from `record-key`, the file's existing per-record identity, which is
already the React `:key` and the expansion key.

## RULING 2 key sweep, including the zeros

`managed_fx_template.cljs` carried **one** `^{:key …}` metadata site
(`app-db-slice-section`'s path rows), now in the `[:li]` attribute map. **Zero**
`with-meta` sites and **zero** metadata on a call form — rf2-hxfy had already
moved the one that existed into `record-panel`'s `:section` attrs. `panels.cljs`
carried **zero** of either. Live control over `tools/xray/src` at this base: 41
`^{:key` hits across 23 files, 18 `with-meta` hits.

The new row grades the key at `(.-key (codec/as-element (subvec node 0 2)))`.
`r/as-element` is hollow for this sub-case — Reagent reads meta AND props and
answers the same key either way — and the head+attrs form is taken because the
codec lowers children eagerly, so a whole-node call raises HD-016 the moment
anything below is still a plain fn head. Measured on this file rather than
assumed: the whole-node form answers here today and reads `[nil nil nil]` under
a revert, so the subvec is robustness rather than a repair. `subvec` drops
vector metadata, which would matter if the discrimination lived in a
Reagent/Fresco pair; it does not here, because the row carries no Reagent door
and the discrimination is two structural assertions instead.

## The head instrument had to be re-authored, and neither obvious shape works

`no-plain-fn-in-head-position-with-every-section-open` is now on
`codec/head-kind`. A boundary IS a fn, so the `fn?` filter is wrong in the
permissive direction; a boundary carries no Clojure metadata, so the
`(some? (meta head))` discriminator is wrong in the strict one. The codec
answers both eras without a branch, and the row grades the pair explicitly:
`:invalid` for what `inspect` returns, `:boundary` for what `inspect-view`
returns.

Both `tree-nodes` walkers gain a map-value arm. A Reagent component took its
payload as a positional argument; a boundary takes one props map, so "payload
values included" is only true of a walk that looks inside one. Without it, seven
presence rows read absence.

## A new DOM suite, and why the feature gate is not its substitute

`managed_fx_mount_dom_cljs_test` mounts through the public facade into a real
container and reads the committed DOM: one record panel per record, and disjoint
`data-rf-mount-id` sets per record.

It exists because nothing else can see this surface. **Measured:**
`rf-xray-managed-fx` appears in no testbed, example or scenario file in the
repository, and `mount-managed-fx!` has zero call sites outside `tools/xray`, so
no Xray feature-matrix scenario mounts this panel and none can go red on it —
`016-Auxiliary-Panels.md` says as much in its own row. The node lane cannot
stand in either: every `panels_mount_cljs_test` row stubs
`rf.substrate.adapter/render`, so the bridge is read and never rendered and the
view's body never runs at all.

## What needed no change

`panel_enum.cljc`'s `:view` row and both spec tables name the view by its
NATURAL name, which the migration keeps — exactly as `app-db-diff/Panel` and
`reactive-panel/Panel` kept theirs. So `tools/xray/spec/007-UX-IA.md` and
`016-Auxiliary-Panels.md` are untouched. Only `panel_enum.cljc`'s docstring
moved: it called that axis a `reg-view`, which had been false for four panels
already.

## Quality gates

Every exit code below is the runner's own, captured with `echo $?` on the
runner's command line — not a harness report. The two disagreed on every red run
here.

| Gate | Result | Captured exit |
|---|---|---|
| `npm run test:cljs` (final base) | 11655 tests / 58434 assertions / 0 failures / 0 errors | **0** |
| `npm run test:browser` (final base) | 927 tests / 5115 assertions / 0 failures / 0 errors | **0** |
| `npm run test:xray-feature-gate` (full, not smoke) | 16 scenarios, 0 failures, 13 matrix rows covered | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | 2848 files, 11215 edges, 0 non-canonical | **0** |
| `python scripts/check_require_alias_dialect.py --self-test` | 79 passed, 0 failed | **0** |
| `python scripts/check_retired_spellings.py` | clean | **0** |
| `check_view_lifetime_residue`, `check_ambient_durable_reads`, `check_thrown_error_messages`, `check_retired_composition_vocab` | clean | **0** each |

`test:browser` is the gate for the new DOM suite and is a separate lane from
`test:cljs`: `shadow-cljs.edn`'s `:browser-test` build selects on
`.*-dom-cljs-test$`, so under `test:cljs` that namespace merely loads and every
row short-circuits on `(browser?)` — green having executed nothing.

The retired-spellings ratchet was exercised against a fault it should flag
rather than trusted on its silence: a planted occurrence reds it at exit 1
naming file and line, and the restore returns it to exit 0.

Skipped, with reasons: `check_doc_slugs.py`, `check_readme_links.py --ci` and
`mkdocs build --strict` — no markdown changed.

### Sabotage runs — three, all red, each naming what was planted

* **HD-016 head revert** (`edn/inspect-view` back to `edn/inspect` in
  `request-section`), node lane: captured exit **1**, 5 failures. The head row
  read `{:tag 49, :invalid 1, :boundary 2}` — one `:invalid` head back, the two
  untouched sites still `:boundary`.
* **The same revert, browser lane**: captured exit **1**, 4 failures. Both DOM
  rows red, with `one record panel per record reached the DOM — []`. The
  container is EMPTY, which is the HD-016 throw unmounting the root: a panel that
  never appears rather than an error. That is the rf2-qhoj shape, and it is the
  class this slice exists to prevent.
* **Key revert** (`:key i` in attrs back to `^{:key i}` meta): captured exit
  **1**, 4 failures, the codec door reading `[nil nil nil]` — the same signature
  slice 1 measured on `resizable_table.cljs`.

Every restore was verified by blob hash against the committed object, plus
`git diff --quiet HEAD -- <path>` at exit 0, before the next run.

### One red that was informative rather than wasted

The DOM row's first run failed on its OWN arithmetic: it grouped mount-ids by
the substrings `-1-` and `-2-`, which are not the records' origin-event-ids —
those are the trace ids of the seeded fx events, 3 and 4. Its failure message
printed the four committed mount-ids, which is the migration's claim measured:

```
rf-xray-inspect-managed-fx/:http-3-:rf.http/managed/req
rf-xray-inspect-managed-fx/:http-3-:rf.http/managed/handler
rf-xray-inspect-managed-fx/:http-4-:rf.http/managed/req
rf-xray-inspect-managed-fx/:http-4-:rf.http/managed/handler
```

The boundary mounted through the bridge, the `edn-inspector-view` heads
committed rather than raising, and two records sharing one fx-id own disjoint
sets. The groups are derived from `record-key` now rather than spelled out, so
the row cannot drift from the fixture again.
