### PR TITLE
feat(xray): migrate the Fresco panel onto a Fresco boundary, and stop the tab reporting itself (rf2-k97c.3)

### DIFF
--- a/tools/xray/spec/027-Fresco-Evidence.md
+++ b/tools/xray/spec/027-Fresco-Evidence.md
@@ -35,11 +35,15 @@ cannot ship carrying a sixth view's sentence.
 
 The sub-view is panel-local app-db state (`:rf.xray.fresco/set-view` /
 `:rf.xray.fresco/view`), normalised on write so a stale or hand-dispatched
-id lands on a view that exists. The strip dispatches through the
-`reg-view`-injected frame-bound `dispatch`, threaded down from the `Panel`
-body: the click fires after render unwinds, when the ambient frame is gone,
-so a bare global `rf/dispatch` would leak to `:rf/default` and switch some
-other shell's sub-view (rf2-1w07r; `frame_singleton_guard_test` holds it).
+id lands on a view that exists. The strip dispatches through a frame-bound
+`dispatch` threaded down from the `Panel` body: the click fires after render
+unwinds, when the ambient frame is gone, so a bare global `rf/dispatch` would
+leak to `:rf/default` and switch some other shell's sub-view (rf2-1w07r;
+`frame_singleton_guard_test` holds it, and the browser row below drives the
+click end to end). Under rf2-k97c.3's migration that dispatcher is built from
+`rf/current-frame-id` rather than injected by `reg-view`, which binds no name
+inside a `defview` body — the same target and the same behaviour, taken from
+a different door.
 All four envelopes are taken in ONE turn by
 `:rf.xray.fresco/data` — the rosters are projections of a single runtime
 state, and reading them across two turns would let a mount land between the
@@ -90,15 +94,58 @@ of which takes an argument — no audience, no profile, no verbosity — so the
 AI pair calling `read-mounted-boundaries` on a running application receives
 the identical value Xray does. Xray's read seam (`fresco-reads.cljs`) passes
 each envelope through UNCHANGED, and `fresco_cljs_test/the-seam-reshapes-nothing`
-asserts the whole Xray chain — seam and the subscription the view derefs —
-is `pr-str` identical to the producer's answer. Row shaping happens one layer
-further out, in the pure helpers, against an envelope a reader can still see
-whole.
+asserts it is `pr-str` identical to the producer's answer, along with the
+subscription the view derefs for every boundary the APPLICATION owns. Row
+shaping happens one layer further out, in the pure helpers, against an
+envelope a reader can still see whole.
+
+**The one place the subscription is not the door's bytes** is the
+self-exclusion below: it drops Xray's OWN boundaries, and only from the six
+views. `the-subscription-drops-XRAYs-own-boundaries-and-the-DOOR-does-not`
+pins both halves at once — the door still carries the `:rf/xray` row and what
+the views see does not — which is also what keeps the byte claim above from
+holding merely because a fixture happens to mount no Xray boundary.
 
 The producer's rosters are sorted through one total order, so two calls over
 one runtime state print identically; that determinism is the precondition the
 byte claim rests on and it has its own witness
 (`tool_reads_cljs_test/every-read-is-deterministic`).
+
+### The tab does not show XRAY's own boundaries (rf2-k97c.3)
+
+Since this panel became a Fresco boundary, it is itself in Fresco's tables.
+The census walks the collector's process-global entry table with no frame
+filter, so the tab listed ITSELF: with one application boundary mounted, the
+Mounted view committed two rows, the second naming `…panels.fresco/Panel` in
+frame `:rf/xray`. Tool activity must never present as application evidence,
+so `fresco-helpers/without-own-frame` drops every row seated in `:rf/xray`
+before any view sees it.
+
+This is the rule `self-noise` already applies to the trace surface, and it
+keeps that namespace's posture: the drop is unconditional, with no "show
+internals" toggle — introspecting Xray's own machinery is a separate feature,
+not an opt-out on a user-facing feed.
+
+**It is a PANEL filter, not a door filter, and the distinction is the whole
+of the byte claim above.** `fresco-reads` still passes the producer's
+envelope through unchanged, and the AI pair calling the same four reads still
+receives every boundary including Xray's. Only the six views are filtered.
+
+Three things it does not do. `:unknown` is not Xray's frame, so a row whose
+frame the producer could not resolve stays on screen with its chip — silently
+dropping a stated absence is the failure this tab exists to prevent. An
+intent is dropped only when EVERY frame it touched is `:rf/xray`, so a
+dispatch that reached an application frame survives whatever else it also
+touched. And an absent or schema-mismatched envelope passes through whole, so
+a mismatch still renders as a mismatch rather than as a clean empty roster.
+
+The filter runs ONCE, in `:rf.xray.fresco/data`, upstream of everything —
+because the Advisor and the Causal slice read the ENVELOPES, not the rows. A
+row-level filter would have left the Advisor ranking Xray's own panel, and
+the slice, which is drawn for whichever boundary the advisor ranked first,
+narrating the tool's own render as the application's. Filtering all four
+together is the same one-turn reasoning: a partial filter shows an edge whose
+boundary is missing from the census.
 
 ### The schema pin is consumer-owned
 
@@ -547,10 +594,10 @@ Adding it moved six governance pins, each of which fails the build on drift:
 | `re-frame.fresco.evidence-schema-cljs-test` | node | the envelope door stamps a coherent read and refuses a foreign read, a foreign or unsized loss and a loss beside a completeness claim, each refusal asserting the problem it named, with a positive control |
 | `re-frame.fresco.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; a declared view is named on the mounted row, the attribution reader and the explanation with the coordinate `defview` captured, two declared views over one edge set are one row naming both, an unnamed body states `:unknown`, and a name minted outside the macro carries no source; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
 | `re-frame.fresco.erasure-sentinels-cljs-test` | node | the live half of the erasure proof — a dev render mints the `frescoViews` slot the release scan requires absent, and only the commit names a view in it |
-| `…panels.fresco-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the per-view empties, counted against the LIVE `sub-modes` list (six today) rather than a literal, so a seventh view cannot be added carrying a sixth view's sentence; labels and testids are built from the projected key; a named row leads with its view and an unnamed one carries the `unknown` chip; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v2 stamp is refused rather than mis-parsed; the schema pin; row projections |
+| `…panels.fresco-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the per-view empties, counted against the LIVE `sub-modes` list (six today) rather than a literal, so a seventh view cannot be added carrying a sixth view's sentence; labels and testids are built from the projected key; a named row leads with its view and an unnamed one carries the `unknown` chip; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v2 stamp is refused rather than mis-parsed; the schema pin; row projections; and the self-exclusion drop over all four rosters at once — the application row survives and Xray's own does not, an intent is dropped only when EVERY frame it touched is `:rf/xray`, and neither an `:unknown` frame nor an unparseable envelope is eaten by it |
 | `…panels.fresco-cljs-test` | node (reactive substrate) | the four EVIDENCE views answer on a running app (Advisor and Causal are the derived pair, and have their own suites per [`028-Fresco-Advisor.md`](028-Fresco-Advisor.md)); a declared view is named on the Mounted, Reads and Why pages with a `…-views` testid, and a harness body renders the `unknown` chip instead; `:rf.xray.fresco/data` INVALIDATES and RECOMPUTES on a real `:rf.xray/trace-buffer` tick with no cache clear, against a held reaction proved stale first — the SUBSCRIPTION's half of liveness, the panel's half being the browser row below; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
-| `…panels.fresco-live-panel-dom-cljs-test` | browser (real React DOM) | the RUNNING panel is live: one `Panel` mounted into a real `reagent.dom.client` root, inside the shell's own `[frame-provider {:frame :rf/xray}]`, picks up a newly-mounted boundary on a trace tick and commits the row to the DOM. Nothing calls `Panel` a second time; a drained render queue proves the panel stale across the mount first; the `<section>` node afterwards is the one it started with, so the roster arrived by reconciliation and not by a remount |
-| `frame_singleton_guard_test` | JVM (source text) | the sub-strip dispatches through the `reg-view`-injected frame-bound `dispatch`, never a bare global one |
+| `…panels.fresco-live-panel-dom-cljs-test` | browser (real React DOM) | THIS PANEL'S BOUNDARY WITNESS (rf2-k97c.3), under its older name. The panel is mounted once through the L4 registry's own `:panel` value — the bridge the shell mounts — inside `[frame-provider {:frame :rf/xray}]`, and nothing calls it again. W0: it picks up a newly-mounted boundary on a trace tick and commits the row, against a settled deaf control proving the panel stale across the mount first, and the `<section>` afterwards is the node it started with, so the roster arrived by reconciliation and not a remount. It is ALSO the self-exclusion witness — exactly ONE row, so the panel's own `:rf/xray` boundary is absent from its own census. W1: first paint, and BOTH reads hold references in `:rf/xray`'s sub-cache and none in the application frame's, against a live probe in that frame. W2: the sub-strip CLICK switches the view through the boundary's own frame, with the `<section>` identity held across it. W3: unmount releases both reads within the collector's grace macrotask, and reopening returns to the same counts rather than higher ones |
+| `frame_singleton_guard_test` | JVM (source text) | the sub-strip dispatches through a captured frame-bound `dispatch`, never a bare global one |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |
 
 ### The populated arms in the browser: one liveness row, and no deck

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -53,13 +53,38 @@
      identity the runtime actually keys on. A body minted without a name
      renders the `unknown` chip in that position rather than a blank.
 
-  ## Pure hiccup + helpers
+  ## A Fresco boundary over pure hiccup (rf2-k97c.3)
 
-  Same contract as every Xray panel — `rf/reg-view` and pure hiccup, no
-  Reagent or UIx reference, no component-local state. The data → data
-  projection lives in `fresco_helpers.cljc` so the algebra runs under the
-  JVM unit-test target; the live read seam is `fresco_reads.cljs`, which
-  passes the producer's envelopes through unchanged.
+  [[Panel]] is an `rf.fresco/defview` — a real React function component
+  minted by Fresco — rather than the `rf/reg-view` it was. Everything
+  below it stays what it was: pure hiccup, no Reagent or UIx reference,
+  no component-local state. The data → data projection lives in
+  `fresco_helpers.cljc` so the algebra runs under the JVM unit-test
+  target; the live read seam is `fresco_reads.cljs`, which passes the
+  producer's envelopes through unchanged.
+
+  ONE boundary for six views, because boundary count tracks READS and
+  HEAD-POSITION use rather than view count: the two reads are on two
+  lines inside [[Panel]], and every one of the fourteen helpers below is
+  CALLED. That last part is not incidental — under Fresco a plain
+  function in hiccup head position is a loud `:rf.error/fresco-bad-head`
+  (HD-016), so the six view fns and the two row fns that WERE heads are
+  now calls. See [[panel-tree]] for the split that keeps the algebra in
+  the node lane.
+
+  The READ is `rf.fresco/sub`, a plain call the collector records an
+  edge for — no deref, no reaction owned by the installed adapter, and a
+  re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and
+  the one a first-paint smoke test cannot see.
+
+  The FRAME the reads resolve against comes from React context, which
+  the enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context (core's
+  `re-frame.adapter.context/frame-context`) — so this boundary resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
 
   Normative owner: `tools/xray/spec/027-Fresco-Evidence.md`."
   (:require [clojure.string :as string]
@@ -73,7 +98,8 @@
             [day8.re-frame2-xray.theme.section :as section]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack with-alpha]]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]))
 
 (def ^:private panel-id "fresco")
 
@@ -418,10 +444,15 @@
                 (str "fan-out " (:total fan-out))]))
 
 (defn- advice-row
+  "One ranked boundary. CALLED, never a hiccup head (HD-016), and it
+  carries its OWN `:key` in the `:li` attrs — the list identity Fresco's
+  codec reads, which is `(:key props)` and nothing else."
   [row]
   (let [{:keys [class advice]} row
         stem (str "rf-xray-" panel-id "-advice-" (:slug row))]
-    [:li {:data-testid stem :style row-style}
+    [:li {:key         (:slug row)
+          :data-testid stem
+          :style       row-style}
      [:div
       [:span {:style {:font-family mono-stack}} (str "#" (:rank row) "  ")]
       (view-name (str stem "-views") row)
@@ -470,12 +501,16 @@
     [:div {:data-testid (str "rf-xray-" panel-id "-advisor")}
      (or (presence-note (hh/presence envelope (empty? rows)) :advisor)
          (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
-               ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader
-               ;; meta (Reagent honours it, Fresco's codec reads it
-               ;; nowhere). `advice-row` takes its row positionally, so
-               ;; there is no props map at index 1 to hold the key.
+               ;; rf2-a38l put the key on a WRAPPING FRAGMENT because
+               ;; `[advice-row row]` was a hiccup vector whose index 1 was
+               ;; the argument, leaving nowhere for a key. rf2-k97c.3 made
+               ;; it a CALL (HD-016), so the row's own `:li` props map is
+               ;; back and holds the key directly; the wrapper is gone with
+               ;; the reason for it. The hazard rf2-a38l fixed is unchanged
+               ;; — Fresco's codec reads `(:key props)` and never vector
+               ;; metadata.
                (concat (for [row shown]
-                         [:<> {:key (:slug row)} [advice-row row]])
+                         (advice-row row))
                        [(overflow/overflow-row {:panel-id     (str panel-id "-advisor")
                                                 :over-cap?    over?
                                                 :hidden-count hidden})])))
@@ -496,9 +531,13 @@
 ;; ---- view 6 — the causal slice --------------------------------------------
 
 (defn- causal-link
+  "One link of §10's chain. CALLED, never a hiccup head (HD-016), and it
+  carries its own `:key` for the reason [[advice-row]] does."
   [link]
   (let [stem (str "rf-xray-" panel-id "-causal-link-" (name (:id link)))]
-    [:li {:data-testid stem :style row-style}
+    [:li {:key         (name (:id link))
+          :data-testid stem
+          :style       row-style}
      [:div
       [:span {:style {:font-family mono-stack}}
        (str (:ordinal link) ". " (:label link))]
@@ -527,21 +566,26 @@
    (if (nil? slice)
      (presence-note :idle :causal)
      (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
-           ;; rf2-a38l — KEYED FRAGMENT rather than `^{:key …}` reader meta
-           ;; (Reagent honours it, Fresco's codec reads it nowhere).
-           ;; `causal-link` takes its link positionally, so there is no
-           ;; props map at index 1 to hold the key.
+           ;; Keys live in each link's own `:li` props — see [[advice-row]]
+           ;; for why rf2-a38l's wrapping fragment went with the head.
            (for [link (:links slice)]
-             [:<> {:key (name (:id link))} [causal-link link]])))])
+             (causal-link link))))])
 
 ;; ---- the sub-strip and the panel -----------------------------------------
 
-;; `dispatch` (rf2-1w07r) is the reg-view-injected frame-bound dispatcher
-;; threaded down from the `Panel` body, so the deferred `:on-click` lands on
-;; the surrounding Xray instance's frame. A bare global `rf/dispatch` would
-;; fire after render unwinds, when the ambient frame is gone, and leak to
-;; `:rf/default` — the click would silently switch some other shell's
-;; sub-view, or none. This is the tab's only dispatch: the six views read.
+;; `dispatch` (rf2-1w07r) is a frame-bound dispatcher threaded down from
+;; [[panel-tree]], so the deferred `:on-click` lands on the surrounding Xray
+;; instance's frame. A bare global `rf/dispatch` would fire after render
+;; unwinds, when the ambient frame is gone, and leak to `:rf/default` — the
+;; click would silently switch some other shell's sub-view, or none. This is
+;; the tab's only dispatch: the six views read.
+;;
+;; rf2-k97c.3 — it USED to be `reg-view`'s lexically injected `dispatch`.
+;; `defview` binds no name inside a body, so [[Panel]] now builds the same
+;; dispatcher from the frame it carries. The target is unchanged: the
+;; surrounding instance frame (rf2-nesy9), never a `{:frame :rf/xray}`
+;; literal. A plain fn at an `on-*` prop crosses Fresco's codec untouched,
+;; so the click itself is the same click.
 (defn- sub-strip
   [dispatch selected]
   (into [:div {:data-testid (str "rf-xray-" panel-id "-sub-strip")
@@ -557,18 +601,36 @@
                     :style         (pill-style (= id selected))}
            label])))
 
-(rf/reg-view Panel
-  "The Fresco tab: a sub-strip over six views of one evidence surface.
+(defn panel-tree
+  "Everything [[Panel]] renders, as a pure function of the two values it
+  read and the frame it is seated in.
 
-  Every view derefs `:rf.xray.fresco/data`, which takes all four
-  envelopes in one turn — the four rosters are projections of ONE runtime
-  state, and reading them across two turns would let a mount land between
-  the census and the edges. Six views over four envelopes because Advisor
-  and Causal are derivations over the same take rather than reads of their
-  own: the four are the rosters, the six are the projections of them."
-  []
-  (let [selected (hh/normalise-sub-mode @(rf/subscribe [:rf.xray.fresco/view]))
-        {:keys [envelopes] :as data} @(rf/subscribe [:rf.xray.fresco/data])
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup — but this panel's
+  projection is ordinary data → data and is worth driving in the fast
+  node lane rather than behind a real React commit. `fresco_cljs_test`
+  and `fresco_causal_cljs_test` drive THIS fn with the values they take
+  from the two subs directly; the boundary's own behaviour — first paint,
+  liveness, frame targeting, the sub-strip click, evidence isolation and
+  teardown — is `fresco_live_panel_dom_cljs_test`'s subject. That file
+  is this panel's `*_fresco_boundary_dom_cljs_test` under an older and
+  better name: it already mounted this panel into a real React root
+  before the migration, so rf2-k97c.3 EXTENDED it rather than standing a
+  near-duplicate fixture up beside it.
+
+  It also keeps the reads on TWO lines inside the boundary, where it is
+  easy to see that the panel takes exactly two and that nothing below it
+  touches the substrate at all.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [{:keys [selected data frame]}]
+  (let [selected (hh/normalise-sub-mode selected)
+        {:keys [envelopes]} data
+        ;; rf2-k97c.3 — the dispatcher `reg-view` used to inject. See
+        ;; [[sub-strip]] for why it must carry the frame.
+        dispatch (fn [event-v] (rf/dispatch event-v {:frame frame}))
         envelope (get envelopes (case selected
                                   :mounted     :mounted-boundaries
                                   :attribution :read-attribution
@@ -599,13 +661,86 @@
         {:label  (string/upper-case (:label (first (filter #(= selected (:id %))
                                                            hh/sub-modes))))
          :testid (str "rf-xray-" panel-id "-section")}
+        ;; CALLED, not hiccup heads. Under Fresco a plain function in head
+        ;; position is `:rf.error/fresco-bad-head` (HD-016), and none of
+        ;; these six wants a boundary of its own: they read nothing, so a
+        ;; boundary each would buy six React components and no edges.
         (case selected
-          :mounted     [mounted-view     {:envelope envelope :rows (:mounted data)}]
-          :attribution [attribution-view {:envelope envelope :rows (:attribution data)}]
-          :intents     [intents-view     {:envelope envelope :rows (:intents data)}]
-          :explain     [explain-view     {:envelope envelope :rows (:explain data)}]
-          :advisor     [advisor-view     {:envelope envelope :advice (:advice data)}]
-          :causal      [causal-view      {:slice (:slice data)}]))]]))
+          :mounted     (mounted-view     {:envelope envelope :rows (:mounted data)})
+          :attribution (attribution-view {:envelope envelope :rows (:attribution data)})
+          :intents     (intents-view     {:envelope envelope :rows (:intents data)})
+          :explain     (explain-view     {:envelope envelope :rows (:explain data)})
+          :advisor     (advisor-view     {:envelope envelope :advice (:advice data)})
+          :causal      (causal-view      {:slice (:slice data)})))]]))
+
+;; ---- the boundary --------------------------------------------------------
+
+(rf.fresco/defview Panel
+  "The Fresco tab: a sub-strip over six views of one evidence surface.
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. See the ns
+  docstring for what that changes; [[panel-tree]] is everything below it.
+
+  Both reads are `rf.fresco/sub`. `:rf.xray.fresco/data` takes all four
+  envelopes in one turn — the four rosters are projections of ONE runtime
+  state, and reading them across two turns would let a mount land between
+  the census and the edges. Six views over four envelopes because Advisor
+  and Causal are derivations over the same take rather than reads of their
+  own: the four are the rosters, the six are the projections of them.
+
+  `rf/current-frame-id` is one of core's PURE frame doors, which
+  `impl.intent/with-frame` answers with the boundary's DECLARED frame
+  precisely because it neither reads nor dispatches — so the sub-strip's
+  click still lands on the surrounding instance frame (rf2-nesy9) and is
+  still not a `:rf/xray` literal.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — the L4 registry mounts it
+  with none — so it is destructured away."
+  [_props]
+  (panel-tree
+    {:selected (rf.fresco/sub [:rf.xray.fresco/view])
+     :data     (rf.fresco/sub [:rf.xray.fresco/data])
+     :frame    (rf/current-frame-id)}))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell/detail-panel` mounts the active tab as the hiccup head
+;; `[(:panel tab)]`, and `panel-registry/reg-l4-tab!`'s `:pre` requires
+;; `:panel` to be CALLABLE — neither of which a React component is.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (UIx, Reagent or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and both
+;; defs below are deleted. Nothing else in the tree references them.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn ^:private Panel-bridge
+  "The callable the L4 tab registry stores. Returns Reagent-shaped hiccup
+  interoping to the React component above; the enclosing shell's
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it.
+
+  PRIVATE, like the merged `module_view.cljs` template's equivalent and
+  unlike `resources.cljs`'s public one. The difference is the one
+  `resources.cljs` documents: this tab is L4-ONLY — a `reg-l4-tab!`
+  surface with no standalone `mount-*!` facade and no `panel-enum` entry —
+  so the bridge has exactly one consumer, in [[install!]] below, and no
+  embedding contract needs a name it can pass."
+  []
+  [:> Panel-component {}])
 
 ;; ---- installation --------------------------------------------------------
 
@@ -664,6 +799,8 @@
      :mnem  "h"
      :modes #{:dynamic}
      :order 10
-     :panel Panel})
+     ;; The BRIDGE, not the boundary: `:pre` wants a callable and `Panel`
+     ;; is a React component now (rf2-k97c.3).
+     :panel Panel-bridge})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -509,8 +509,7 @@
                ;; the reason for it. The hazard rf2-a38l fixed is unchanged
                ;; — Fresco's codec reads `(:key props)` and never vector
                ;; metadata.
-               (concat (for [row shown]
-                         (advice-row row))
+               (concat (map advice-row shown)
                        [(overflow/overflow-row {:panel-id     (str panel-id "-advisor")
                                                 :over-cap?    over?
                                                 :hidden-count hidden})])))
@@ -568,8 +567,7 @@
      (into [:ol {:style {:list-style "none" :margin 0 :padding 0}}]
            ;; Keys live in each link's own `:li` props — see [[advice-row]]
            ;; for why rf2-a38l's wrapping fragment went with the head.
-           (for [link (:links slice)]
-             (causal-link link))))])
+           (map causal-link (:links slice))))])
 
 ;; ---- the sub-strip and the panel -----------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -770,7 +770,17 @@
   (rf/reg-sub :rf.xray.fresco/data
     {:inputs [[:rf.xray/trace-buffer]]}
     (fn [[_tick] _query]
-      (let [envelopes (reads/evidence)
+      ;; rf2-k97c.3 — `hh/without-own-frame` drops Xray's OWN boundaries
+      ;; before anything downstream sees them. Xray's panels are Fresco
+      ;; boundaries now and Fresco's census has no frame filter, so this
+      ;; tab listed ITSELF among the inspected application's boundaries
+      ;; until this landed. It sits HERE rather than inside `reads/`
+      ;; because that seam answers the producer's envelope VERBATIM — a
+      ;; byte-for-byte contract with the AI pair, pinned by a witness —
+      ;; and HERE rather than in the row projections because the advisor
+      ;; and the causal slice read the envelopes directly. See
+      ;; `fresco-helpers/without-own-frame`.
+      (let [envelopes (hh/without-own-frame (reads/evidence))
             ;; The window is taken in the SAME turn as the four envelopes,
             ;; for the reason the four are taken together: the advisor
             ;; joins the ring's recompute counts to the census's read

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
@@ -617,6 +617,99 @@
   [m]
   (if (contains? sub-mode-ids m) m default-sub-mode))
 
+;; ---- Xray's own machinery is not application evidence --------------------
+;;
+;; rf2-k97c.3. Xray's panels are Fresco boundaries now, and Fresco's census
+;; walks the collector's process-global entry table with NO frame filter —
+;; so the Fresco tab, which is itself a boundary reading two `:rf/xray`
+;; subs, listed ITSELF among the inspected application's boundaries. It was
+;; measured: with one application boundary mounted, the Mounted view
+;; committed two rows, the second reading
+;; `day8.re-frame2-xray.panels.fresco/Panel · frame :rf/xray · 2 reads`.
+;; That is epic criterion 5 — tool activity must never masquerade as
+;; application evidence — and the migration is what made it reachable: a
+;; `reg-view` contributed nothing to Fresco's tables at all.
+;;
+;; THE RULE IS NOT NEW AND IS NOT BEING INVENTED HERE. `self-noise` already
+;; drops any trace event whose frame resolves to `:rf/xray`, for this exact
+;; reason and with the same posture it states in terms: the drop is
+;; unconditional, with no "show internals" toggle, because introspecting
+;; Xray's own machinery is a separate feature and not an opt-out on a
+;; user-facing feed. This applies that rule to the evidence rosters.
+;;
+;; IT LIVES HERE, ONE LAYER ABOVE THE SEAM, AND THAT PLACEMENT IS FORCED.
+;; `fresco-reads` passes the producer's envelope through VERBATIM — a
+;; byte-for-byte contract with the AI pair, pinned by a witness asserting
+;; the seam's answer is `identical?` to the door's — so a filter there
+;; would break a contract to fix a presentation defect. Row projection is
+;; where shaping belongs, and `fresco-reads`' own docstring says so.
+;;
+;; The four rosters are filtered TOGETHER, for the reason they are read in
+;; one turn: dropping a boundary from the census while leaving its edges in
+;; the attribution roster would show an edge whose boundary is not in the
+;; census, which is the inconsistency the one-turn read exists to prevent.
+
+(def ^:private xray-frame
+  "Xray's own frame. A row seated here is the tool, not the application."
+  :rf/xray)
+
+(defn- own-frame?
+  "True when `frame` IS Xray's own. Deliberately `=` against a resolved
+  frame id and nothing cleverer: [[unknown]] is not Xray's frame, and a
+  row whose frame the producer could not resolve must stay on screen
+  carrying its chip rather than be silently dropped as self-noise."
+  [frame]
+  (= xray-frame frame))
+
+(defn- own-intent?
+  "True when every frame an intent touched is Xray's own.
+
+  EVERY, not any: a dispatch that reached an application frame is the
+  user's, whatever else it also touched, and dropping it would hide real
+  evidence. An intent carrying no frames at all is kept for the same
+  reason — an empty set is an absence, not a claim about Xray."
+  [frames]
+  (and (seq frames) (every? own-frame? frames)))
+
+(defn- without
+  "`envelope` with `k`'s collection filtered by `keep?`. A non-envelope
+  (nil, or a schema this build cannot parse) passes through untouched —
+  degrading is [[presence]]'s job, and a filter must not be able to turn
+  a mismatch into an empty roster."
+  [envelope k keep?]
+  (if-not (supported? envelope)
+    envelope
+    (update envelope k #(vec (filter keep? %)))))
+
+(defn without-own-frame
+  "The four-envelope map with every row seated in Xray's OWN frame
+  removed. Pure; the caller hands it exactly what `fresco-reads/evidence`
+  answered.
+
+  APPLIED ONCE, HERE, AND NOT AT ROW PROJECTION — because the rows are
+  not the only consumer. `fresco-advisor/advise` and
+  `fresco-causal/slice` take the ENVELOPES, not the rows, so a filter
+  living in [[mounted-rows]] and its three siblings would leave the
+  Advisor ranking Xray's own panel and the Causal slice explaining it —
+  the slice is drawn for whichever boundary the advisor ranked FIRST,
+  so the tool would have narrated its own render as the application's.
+  One filter upstream of all six views cannot develop that gap.
+
+  It is also why the four are filtered TOGETHER rather than one at a
+  time: they are read in ONE turn precisely so a reader cannot see an
+  edge whose boundary is missing from the census, and a partial filter
+  would manufacture exactly that."
+  [envelopes]
+  (-> envelopes
+      (update :mounted-boundaries without :boundaries
+              (comp not own-frame? :frame))
+      (update :read-attribution   without :edges
+              (comp not own-frame? :frame-id))
+      (update :intents            without :intents
+              (comp not own-intent? :frames))
+      (update :explain-render     without :explanations
+              (comp not own-frame? :frame))))
+
 (defn mounted-rows
   "The Mounted view's rows: one per distinct edge set, carrying the
   instance count and the per-row absences already turned into chips.

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
@@ -679,7 +679,7 @@
   [envelope k keep?]
   (if-not (supported? envelope)
     envelope
-    (update envelope k #(vec (filter keep? %)))))
+    (update envelope k #(filterv keep? %))))
 
 (defn without-own-frame
   "The four-envelope map with every row seated in Xray's OWN frame

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_causal_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_causal_cljs_test.cljs
@@ -40,8 +40,13 @@
             [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
+            ;; rf2-k97c.3 / rf2-a38l — the codec's own hiccup→element door,
+            ;; so a key is graded at the renderer that actually ships it
+            ;; rather than at the hiccup a reader hopes it means.
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
-            [re-frame.trace.tooling :as rf.trace.tooling]))
+            [re-frame.trace.tooling :as rf.trace.tooling]
+            [reagent.core :as r]))
 
 (def ^:private app-frame ::causal-app)
 
@@ -454,3 +459,62 @@
     (is (= (:key (:boundary top)) (get-in data [:slice :scope :boundary]))
         "the slice is about the boundary the advisor ranked first")
     (release)))
+
+;; ---------------------------------------------------------------------------
+;; THE KEYS REACH REACT (rf2-k97c.3 RULING 2, regraded at the renderer)
+;; ---------------------------------------------------------------------------
+;;
+;; The key sweep found ZERO `^{:key …}` / `with-meta` sites in this panel —
+;; rf2-a38l had already converted both to KEYED FRAGMENTS, and rf2-k97c.3
+;; moved them one step further: the two row fns are CALLS now, not hiccup
+;; heads (a plain fn in head position is HD-016 `:rf.error/fresco-bad-head`),
+;; so each returned `:li` has its own props map and carries its own key.
+;;
+;; That move is exactly the kind a hiccup-level assertion cannot grade, so
+;; these rows read the key off a real ELEMENT from BOTH doors.
+;;
+;; HEAD + ATTRS, NOT THE WHOLE NODE. The codec lowers children EAGERLY, so
+;; calling it on a whole `:li` walks a subtree this file has no business
+;; grading. `(subvec node 0 2)` is the tree's existing idiom for this
+;; (`machine_inspector_view_cljs_test`), and both doors read a key from
+;; exactly the same place — the attribute map at index 1 — so dropping the
+;; children changes nothing about the answer. Both sides are subvec'd here
+;; because there is no metadata in play: with a meta-vs-attrs key the
+;; Reagent door would have to see the WHOLE node, since `subvec` drops
+;; vector metadata and both sides would read nil for different reasons.
+
+(defn- reagent-key [node] (.-key (r/as-element (subvec node 0 2))))
+(defn- fresco-key  [node] (.-key (rf.fresco.impl.codec/as-element (subvec node 0 2))))
+
+(defn- li-nodes
+  "Every `:li` in the rendered tree, in order."
+  [tree]
+  (into [] (filter #(and (vector? %) (= :li (first %)))) (hiccup-seq tree)))
+
+(deftest advisor-and-causal-rows-reach-react-with-a-key-on-both-doors
+  (testing "rf2-k97c.3 — every ranked-boundary row and every causal link
+            commits a non-nil React key through FRESCO's codec as well as
+            through Reagent. Fresco's codec reads `(:key props)` and vector
+            metadata NOWHERE, so a key that regressed to reader meta would
+            read nil on the Fresco door here while Reagent — which honours
+            both — went on answering, which is precisely why the pair is
+            graded rather than one side."
+    (setup!)
+    (let [release (mount! (fn [_] (rf.fresco/sub [:hcaus/left]) nil))
+          _       (interact!)]
+      (doseq [[view label] [[:advisor "advisor"] [:causal "causal"]]]
+        (testing label
+          (let [rows (li-nodes (show! view))]
+            (is (seq rows)
+                (str "NON-VACUITY: the " label " view rendered at least one "
+                     "<li>, so the key assertions below are about real rows "
+                     "rather than an empty roster"))
+            (doseq [node rows]
+              (is (some? (fresco-key node))
+                  (str label " row reached React with a key through FRESCO's "
+                       "codec. node head+attrs: " (pr-str (subvec node 0 2))))
+              (is (= (reagent-key node) (fresco-key node))
+                  (str "and BOTH doors agree on it — an attrs-map key is read "
+                       "identically by each, which a metadata key is not. node "
+                       "head+attrs: " (pr-str (subvec node 0 2))))))))
+      (release))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_causal_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_causal_cljs_test.cljs
@@ -137,11 +137,18 @@
   (first (filter #(= id (:id %)) (:links s))))
 
 (defn- show!
+  "rf2-k97c.3 — `Panel` is an `rf.fresco/defview` now, so it is a React
+  component rather than a callable answering hiccup. `panel-tree` is the
+  projection the boundary calls; these rows drive it with the values
+  taken from the two subs the boundary reads."
   [view]
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray.fresco/set-view view])
     (rf/clear-sub-cache! :rf/xray)
-    (fresco/Panel)))
+    (fresco/panel-tree
+      {:selected @(rf/subscribe [:rf.xray.fresco/view])
+       :data     @(rf/subscribe [:rf.xray.fresco/data])
+       :frame    (rf/current-frame-id)})))
 
 ;; ---------------------------------------------------------------------------
 ;; The positive control — the whole chain, on a real interaction

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
@@ -161,13 +161,30 @@
   []
   (rf/clear-sub-cache! :rf/xray))
 
+(defn- panel!
+  "The panel's tree, as the boundary builds it.
+
+  rf2-k97c.3 — `Panel` is an `rf.fresco/defview` now, so it is a React
+  component and `(fresco/Panel)` is no longer a callable that answers
+  hiccup. `fresco/panel-tree` is the projection the boundary calls, and
+  these rows drive it with the values taken from the two subs the
+  boundary reads — the same two queries, resolved through `:rf/xray` by
+  the surrounding `with-frame`. What is NOT witnessed here is the seam
+  itself: the mount, the commit and the release are
+  `fresco_live_panel_dom_cljs_test`'s subject, under a real React root."
+  []
+  (fresco/panel-tree
+    {:selected @(rf/subscribe [:rf.xray.fresco/view])
+     :data     @(rf/subscribe [:rf.xray.fresco/data])
+     :frame    (rf/current-frame-id)}))
+
 (defn- show!
   "Select `view`, refresh, and render the panel."
   [view]
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray.fresco/set-view view])
     (refresh!)
-    (fresco/Panel)))
+    (panel!)))
 
 (defn- render-now
   "Render the panel the way the RUNNING shell renders it — no `refresh!`.
@@ -178,7 +195,7 @@
   reaction currently answers, which is the only way to ask whether the tab
   is a live projection or a screenshot of one."
   []
-  (rf/with-frame :rf/xray (fresco/Panel)))
+  (rf/with-frame :rf/xray (panel!)))
 
 (defn- tick-trace!
   "One trace-buffer tick, delivered the way the collector delivers it.

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
@@ -144,10 +144,15 @@
   nil)
 
 (defn- mount!
-  "A real boundary, rendered and committed. Answers React's cleanup."
-  [body-fn]
-  (rf.fresco.impl.collector/render-body app-frame body-fn {})
-  (rf.fresco.impl.collector/commit-boundary! (rf.fresco.impl.collector/last-reads) (fn [])))
+  "A real boundary, rendered and committed. Answers React's cleanup.
+
+  The frame arity exists for the self-exclusion rows: a boundary seated in
+  `:rf/xray` is what Xray's OWN panels are, and it is the thing the tab
+  must not report as application evidence."
+  ([body-fn] (mount! app-frame body-fn))
+  ([frame body-fn]
+   (rf.fresco.impl.collector/render-body frame body-fn {})
+   (rf.fresco.impl.collector/commit-boundary! (rf.fresco.impl.collector/last-reads) (fn []))))
 
 (defn- refresh!
   "Drop Xray's sub cache so `:rf.xray.fresco/data` recomputes against the
@@ -591,7 +596,8 @@
                            [rf.fresco.tool/explain-render          reads/explain-render]]]
         (is (= (pr-str (door)) (pr-str (seam)))
             "a seam that reshaped could not be byte-identical to its door")))
-    (testing "and so does the subscription the VIEW derefs — the whole chain"
+    (testing "and so does the subscription the VIEW derefs, for every
+              boundary the APPLICATION owns"
       (refresh!)
       (let [held (rf/with-frame :rf/xray
                    (:envelopes @(rf/subscribe [:rf.xray.fresco/data])))]
@@ -600,6 +606,44 @@
         (is (= (pr-str (rf.fresco.tool/read-read-attribution))
                (pr-str (:read-attribution held))))))
     (release)))
+
+(deftest the-subscription-drops-XRAYs-own-boundaries-and-the-DOOR-does-not
+  (testing "rf2-k97c.3 — the byte-for-byte claim above is about the DOOR and
+            the SEAM, and it is unchanged. The SUBSCRIPTION additionally
+            applies the self-exclusion, and this row is the one that tells the
+            two apart.
+
+            IT ALSO KEEPS THE ROW ABOVE HONEST. Once Xray's own panels became
+            Fresco boundaries, `the-seam-reshapes-nothing`'s second half holds
+            only while no `:rf/xray` boundary is mounted — which is true of
+            that fixture and false of a running Xray. Without this row its
+            pass would be a property of the harness rather than of the chain."
+    (setup!)
+    (let [app-side  (mount! (fn [_] (rf.fresco/sub [:htab/left]) nil))
+          xray-side (mount! :rf/xray (fn [_] (rf.fresco/sub [:htab/right]) nil))
+          door      (rf.fresco.tool/read-mounted-boundaries)
+          held      (rf/with-frame :rf/xray
+                      (refresh!)
+                      (:envelopes @(rf/subscribe [:rf.xray.fresco/data])))
+          frames-of #(mapv :frame (:boundaries %))]
+      (is (some #{:rf/xray} (frames-of door))
+          (str "THE DOOR STILL CARRIES IT — the producer's own answer is "
+               "untouched, so the AI pair reading the same four functions "
+               "sees every boundary including Xray's. Door frames: "
+               (pr-str (frames-of door))))
+      (is (some #{app-frame} (frames-of door))
+          "NON-VACUITY: and the application's boundary is in the door's
+           answer too, so the assertion below is a filter and not an
+           empty roster")
+      (is (not (some #{:rf/xray} (frames-of (:mounted-boundaries held))))
+          (str "THE SUBSCRIPTION DROPS IT — what the six views see carries no "
+               "row seated in Xray's own frame. Held frames: "
+               (pr-str (frames-of (:mounted-boundaries held)))))
+      (is (some #{app-frame} (frames-of (:mounted-boundaries held)))
+          "and the application's boundary SURVIVES, so the drop is
+           Xray-specific rather than a roster that emptied")
+      (app-side)
+      (xray-side))))
 
 (deftest the-consumer-pin-tracks-the-producer-today-and-detects-a-bump
   (testing "the pin is a LITERAL, not the producer's var — but today they agree"

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_helpers_cljs_test.cljc
@@ -616,3 +616,130 @@
   (testing "and no two views share a mnemonic"
     (let [mnems (map :mnem hh/sub-modes)]
       (is (= (count mnems) (count (set mnems)))))))
+
+;; ---------------------------------------------------------------------------
+;; XRAY'S OWN MACHINERY IS NOT APPLICATION EVIDENCE (rf2-k97c.3)
+;; ---------------------------------------------------------------------------
+;;
+;; Xray's panels became Fresco boundaries, and Fresco's census walks the
+;; collector's process-global entry table with no frame filter — so the
+;; Fresco tab listed ITSELF. Measured in the browser before the fix: with
+;; one application boundary mounted, the Mounted view committed two rows,
+;; the second `…panels.fresco/Panel · frame :rf/xray · 2 reads`.
+;;
+;; EVERY ROW BELOW CARRIES BOTH DIRECTIONS IN ONE ASSERTION — the count
+;; that survives AND the identity of the survivor. A count alone would
+;; pass just as well on a filter that dropped the wrong row, and these
+;; fixtures are two rows deep precisely so that mistake is reachable.
+
+(def ^:private mixed-evidence
+  "One turn's four envelopes, each carrying an application row AND an
+  Xray-owned one. Two rows deep in every roster on purpose: a filter that
+  dropped the WRONG row would satisfy a count and fail the identity
+  assertions below."
+  {:mounted-boundaries
+   (envelope :mounted-boundaries
+             {:boundaries [{:boundary boundary-a :views todo-row-views
+                            :instances 1 :read-orders 1 :frame :app/main
+                            :reads []}
+                           {:boundary boundary-b :views :unknown
+                            :instances 1 :read-orders 1 :frame :rf/xray
+                            :reads []}]})
+   :read-attribution
+   (envelope :read-attribution
+             {:edges [{:sub-id :todo :query [:todo 7] :frame-id :app/main
+                       :epoch 4 :fan-out 1 :readers []}
+                      {:sub-id :rf.xray.fresco/data :query [:rf.xray.fresco/data]
+                       :frame-id :rf/xray :epoch 4 :fan-out 1 :readers []}]})
+   :intents
+   (envelope :intents
+             {:frames [:app/main :rf/xray]
+              :intents [{:frames [:app/main] :dispatch-id 1
+                         :event-id :todo/toggle :arg-count 0 :sub-ids []}
+                        {:frames [:rf/xray] :dispatch-id 2
+                         :event-id :rf.xray.fresco/set-view
+                         :arg-count 1 :sub-ids []}
+                        {:frames [:app/main :rf/xray] :dispatch-id 3
+                         :event-id :todo/spans :arg-count 0 :sub-ids []}
+                        {:frames [] :dispatch-id 4
+                         :event-id :todo/frameless :arg-count 0 :sub-ids []}]})
+   :explain-render
+   (envelope :explain-render
+             {:explanations [{:boundary boundary-a :views todo-row-views
+                              :frame :app/main :instances 1
+                              :snapshot 1 :peak-epoch 4
+                              :latest-reads [] :candidates [] :loss nil}
+                             {:boundary boundary-b :views :unknown
+                              :frame :rf/xray :instances 1
+                              :snapshot 1 :peak-epoch 4
+                              :latest-reads [] :candidates [] :loss nil}]})})
+
+(deftest xray-own-frame-rows-are-dropped-from-every-roster
+  (testing "epic criterion 5 — a boundary seated in :rf/xray is the tool,
+            not the application, and none of the four rosters may carry it.
+            Same rule and same unconditional posture as `self-noise`'s
+            trace-event drop, applied to the evidence surface."
+    (let [e (hh/without-own-frame mixed-evidence)]
+      (testing "NON-VACUITY: the unfiltered input really does carry both"
+        (is (= [:app/main :rf/xray]
+               (mapv :frame (get-in mixed-evidence [:mounted-boundaries :boundaries])))))
+
+      (is (= [:app/main]
+             (mapv :frame (hh/mounted-rows (:mounted-boundaries e))))
+          "the application's boundary survives the census and Xray's own
+           does not")
+      (is (= [:app/main]
+             (mapv :frame-id (hh/attribution-rows (:read-attribution e))))
+          "an edge Xray's own boundary holds is not an application read")
+      (is (= [:app/main]
+             (mapv :frame (hh/explain-rows (:explain-render e))))
+          "and the Why view drops it too — the four are filtered TOGETHER,
+           so a boundary absent from the census cannot still appear in a
+           view derived from the same one-turn read")
+
+      (testing "intents drop on EVERY frame, not ANY"
+        (is (= [:todo/toggle :todo/spans :todo/frameless]
+               (mapv :event-id (hh/intent-rows (:intents e))))
+            "the Xray-only dispatch goes; the MIXED one stays, because a
+             dispatch that reached an application frame is the user's
+             whatever else it also touched; and the frameless one stays,
+             because an empty frame set is an absence and not a claim
+             about Xray"))
+
+      (testing "the stamp is untouched — this filters ROWS, not the claim"
+        (is (true? (:complete? (:mounted-boundaries e))))
+        (is (= hh/consumed-evidence-schema (:schema (:mounted-boundaries e))))
+        (is (hh/supported? (:mounted-boundaries e))
+            "a filtered envelope is still a parseable one, so `presence`
+             still answers `:live`/`:idle` rather than `:mismatch`")))))
+
+(deftest the-own-frame-drop-does-not-eat-an-unresolved-or-unparseable-envelope
+  (testing "rf2-k97c.3 — two things the filter must NOT do, both of which
+            would turn a STATED absence into a silent one, which is the
+            failure this whole tab is built against."
+    (testing "`unknown` is not Xray's frame"
+      ;; The shared `mounted` fixture is the control: its second row is
+      ;; `:frame :unknown`, and every other row in this file reading it
+      ;; expects TWO rows back.
+      (let [rows (hh/mounted-rows
+                   (:mounted-boundaries
+                     (hh/without-own-frame {:mounted-boundaries mounted})))]
+        (is (= [:app/main :unknown] (mapv :frame rows))
+            "both survive — the filter is `= :rf/xray` and nothing cleverer")
+        (is (some? (:frame-chip (second rows)))
+            "and the unresolved row still carries its chip")))
+
+    (testing "an absent or mismatched envelope passes through untouched"
+      (let [e (hh/without-own-frame
+                {:mounted-boundaries nil
+                 :read-attribution   {:schema :re-frame.fresco.evidence/v2
+                                      :producer :re-frame/fresco
+                                      :edges [{:frame-id :rf/xray}]}
+                 :intents            nil
+                 :explain-render     nil})]
+        (is (nil? (:mounted-boundaries e))
+            "nil stays nil — a missing door is not an empty roster")
+        (is (= :re-frame.fresco.evidence/v2 (:schema (:read-attribution e)))
+            "and a schema this build cannot parse is handed on whole, so
+             `presence` still reports `:mismatch`. Filtering it would have
+             emptied the roster and reported a mismatch as clean")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -331,75 +331,77 @@
               finish  (fn []
                         (when-some [r @release] (r))
                         (teardown! root container)
-                        (done))]
+                        (done))
+              ;; Read BEFORE anything moves: phase 3 asserts this is
+              ;; still the very same DOM node.
+              section (q container "[data-testid=\"rf-xray-fresco\"]")]
           ;; ---- phase 1: mounted, and rendering its empty arm --------------
-          (let [section (q container "[data-testid=\"rf-xray-fresco\"]")]
-            (is (some? section)
-                "the Fresco panel committed a real DOM root under React — a
-                 Fresco boundary mounted through Reagent's `:>` from the
-                 registry entry the shell holds")
-            (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
-                "the live panel rendered the EMPTY mounted census — nothing is
-                 mounted yet, so the roster this test drives in cannot already
-                 be on screen")
-            (is (empty? (boundary-rows container))
-                "NON-VACUITY: no boundary row is in the DOM before one mounts")
+          (is (some? section)
+              "the Fresco panel committed a real DOM root under React — a
+               Fresco boundary mounted through Reagent's `:>` from the
+               registry entry the shell holds")
+          (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
+              "the live panel rendered the EMPTY mounted census — nothing is
+               mounted yet, so the roster this test drives in cannot already
+               be on screen")
+          (is (empty? (boundary-rows container))
+              "NON-VACUITY: no boundary row is in the DOM before one mounts")
 
-            ;; ---- phase 2: a real boundary mounts, and the panel is deaf ---
-            (vreset! release (mount-boundary!))
-            (-> (settle)
-                (.then
-                  (fn [_]
-                    (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
-                        "CONTROL: given a full settling window, a real mount
-                         still moves nothing the panel's read watches —
-                         Fresco's tables are process-global, not Xray app-db —
-                         so the committed DOM shows the empty note yet. Without
-                         this the next phase would pass on a panel that had
-                         simply never rendered before the tick")
+          ;; ---- phase 2: a real boundary mounts, and the panel is deaf ---
+          (vreset! release (mount-boundary!))
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
+                      "CONTROL: given a full settling window, a real mount
+                       still moves nothing the panel's read watches —
+                       Fresco's tables are process-global, not Xray app-db —
+                       so the committed DOM shows the empty note yet. Without
+                       this the next phase would pass on a panel that had
+                       simply never rendered before the tick")
 
-                    ;; ---- phase 3: one tick, and the roster is on screen ----
-                    (tick-trace!)
-                    (rf.test-support/poll-until roster?
-                      {:label "the trace tick commits the roster"})))
-                (.then
-                  (fn [_]
-                    (let [rows (boundary-rows container)
-                          ;; `some->`, so an empty roster reds the row below as
-                          ;; a clean assertion failure rather than throwing on
-                          ;; nil and reporting one defect twice.
-                          row-text (str (some-> (first rows) .-textContent))]
-                      (is (= 1 (count rows))
-                          (str "the trace tick re-fired the live panel and ONE "
-                               "boundary row committed to the DOM — with no "
-                               "cache clear and no second call to the panel "
-                               "anywhere in this test.\n"
-                               "IT IS ALSO THE SELF-EXCLUSION WITNESS (epic "
-                               "criterion 5). The panel is ITSELF a Fresco "
-                               "boundary now, and Fresco's census walks the "
-                               "collector's process-global entry table with no "
-                               "frame filter — so a panel reporting its own "
-                               "two `:rf/xray` reads as application evidence "
-                               "reads TWO rows here, not one. DOM: "
-                               (.-textContent container)))
-                      (is (string/includes? row-text "[:hlive/left]")
-                          (str "and the row names the read the boundary really "
-                               "holds, so the assertion above cannot pass on a "
-                               "row projected from nothing. row text: "
-                               (pr-str row-text))))
-                    (is (nil? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
-                        "the empty note is gone from the DOM — the roster
-                         REPLACED it rather than rendering beside it")
-                    (is (identical? section (q container "[data-testid=\"rf-xray-fresco\"]"))
-                        "and it is the SAME <section> node — React reconciled
-                         the live tree in place, so the roster did not arrive by
-                         the panel being remounted from scratch, which would not
-                         be liveness")))
-                (.catch (fn [e]
-                          (is false (str "W0 poll timed out: " (.-message e)
-                                         " DOM: " (.-textContent container)))
-                          nil))
-                (.then (fn [_] (finish))))))))))
+                  ;; ---- phase 3: one tick, and the roster is on screen ----
+                  (tick-trace!)
+                  (rf.test-support/poll-until roster?
+                    {:label "the trace tick commits the roster"})))
+              (.then
+                (fn [_]
+                  (let [rows (boundary-rows container)
+                        ;; `some->`, so an empty roster reds the row below as
+                        ;; a clean assertion failure rather than throwing on
+                        ;; nil and reporting one defect twice.
+                        row-text (str (some-> (first rows) .-textContent))]
+                    (is (= 1 (count rows))
+                        (str "the trace tick re-fired the live panel and ONE "
+                             "boundary row committed to the DOM — with no "
+                             "cache clear and no second call to the panel "
+                             "anywhere in this test.\n"
+                             "IT IS ALSO THE SELF-EXCLUSION WITNESS (epic "
+                             "criterion 5). The panel is ITSELF a Fresco "
+                             "boundary now, and Fresco's census walks the "
+                             "collector's process-global entry table with no "
+                             "frame filter — so a panel reporting its own "
+                             "two `:rf/xray` reads as application evidence "
+                             "reads TWO rows here, not one. DOM: "
+                             (.-textContent container)))
+                    (is (string/includes? row-text "[:hlive/left]")
+                        (str "and the row names the read the boundary really "
+                             "holds, so the assertion above cannot pass on a "
+                             "row projected from nothing. row text: "
+                             (pr-str row-text))))
+                  (is (nil? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
+                      "the empty note is gone from the DOM — the roster
+                       REPLACED it rather than rendering beside it")
+                  (is (identical? section (q container "[data-testid=\"rf-xray-fresco\"]"))
+                      "and it is the SAME <section> node — React reconciled
+                       the live tree in place, so the roster did not arrive by
+                       the panel being remounted from scratch, which would not
+                       be liveness")))
+              (.catch (fn [e]
+                        (is false (str "W0 poll timed out: " (.-message e)
+                                       " DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_] (finish)))))))))
 
 ;; ===========================================================================
 ;; W1 — first display, and the reads land in the frame the tree named

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -1,6 +1,68 @@
 (ns day8.re-frame2-xray.panels.fresco-live-panel-dom-cljs-test
   "The Fresco tab is LIVE under real React — the running panel's own DOM
-  (rf2-r98a, merged-PR audit of #7881).
+  (rf2-r98a, merged-PR audit of #7881) — AND, since rf2-k97c.3, the
+  boundary witness for this panel's migration onto Fresco.
+
+  ## This file is the panel's `*_fresco_boundary_dom_cljs_test`
+
+  The five migrated siblings each ship one; this panel's sits here under
+  an older and better name, because it already mounted this panel into a
+  real `reagent.dom.client` root before the migration existed. Extending
+  it was cheaper and better than standing a near-duplicate fixture up
+  beside it, and it keeps ONE file answering \"what does this panel do
+  under a real React commit\".
+
+  The rows below the original one are written against
+  `module_view_fresco_boundary_dom_cljs_test`, which is the template the
+  remaining panels are migrated against. Four of the epic's six
+  behavioural criteria are answerable at a panel's own boundary, and a
+  FIFTH is answerable here and nowhere yet:
+
+    1 FIRST DISPLAY                 — W0 phase 1, and W1
+    2 UPDATES ON A REAL CHANGE      — W0 phase 3, with W0 phase 2's deaf
+                                      control
+    3 XRAY'S OWN INTERACTIONS       — W2. The template says in terms that
+                                      it has no row for criterion 3
+                                      because that panel dispatches
+                                      nothing, and that \"the panels that
+                                      DO carry interactions are migrated
+                                      after this one and bring their own
+                                      rows\". This is one of those panels:
+                                      the sub-strip is its only dispatch.
+    4 FRAME TARGETING               — W1, read off the frame's OWN
+                                      sub-cache rather than off the DOM
+    5 TOOL ACTIVITY NEVER
+      MASQUERADING AS APPLICATION
+      EVIDENCE                      — W3, in both directions. It matters
+                                      more here than anywhere: this panel
+                                      IS the Fresco census, so a boundary
+                                      of its own appearing in its own
+                                      roster would be the tool reporting
+                                      itself as the application.
+    6 CLEAN TEARDOWN                — W4
+
+  ## THE MOUNT IS THE SHELL'S MOUNT, TAKEN FROM THE REGISTRY
+
+  `shell/detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and reaches `:panel` THROUGH
+  `panel-registry/tab-by-id` rather than naming the var — so the bridge
+  the registry actually holds is the thing under test, and a bridge that
+  regressed to something the shell cannot mount reddens here rather than
+  in a browser.
+
+  ## `flush-render!` IS NOT THE INSTRUMENT ANY MORE, AND THAT IS THE ONE
+  ## THING A READER OF THE OLD FILE MUST NOT CARRY OVER
+
+  A Fresco boundary is NOT in Reagent's render queue, so the adapter's
+  `:flush-render!` — exactly the right instrument for the `reg-view`
+  panels beside this one, and what this file used before rf2-k97c.3 —
+  does not commit this panel's update. Used unchanged it reads a DOM
+  that has not moved, which presents as the panel being DEAD. Every row
+  below therefore drives the WORLD synchronously (a `flushSync` mount,
+  or a `dispatch-sync`) and POLLS the committed DOM afterwards; an
+  absence is asserted only after [[settle]], so it is a decision and not
+  a race.
 
   ## The claim this row exists to carry, and the one it replaces
 
@@ -14,13 +76,15 @@
   panel, and only the second was witnessed. The audit of #7881 named the
   gap; this row closes it.
 
-  Here `Panel` is mounted ONCE, into a real `reagent.dom.client` root,
+  Here the panel is mounted ONCE, into a real `reagent.dom.client` root,
   wrapped in `[rf/frame-provider {:frame :rf/xray}]` exactly as
   `shell/shell-view` wraps it in production. **Nothing in this file ever
-  calls `Panel` again.** Every later assertion reads
+  calls the panel again** — and since rf2-k97c.3 it could not: `Panel` is
+  an `rf.fresco/defview`, a React component whose body runs only inside a
+  render window. Every later assertion reads
   `container.querySelector…` — the DOM React committed on its own.
 
-  ## The three phases, and which one is the control
+  ## W0's three phases, and which one is the control
 
   1. **Mounted, empty.** The committed DOM carries
      `rf-xray-fresco-empty-mounted`, so the panel really did render its
@@ -28,12 +92,12 @@
   2. **A real boundary mounts, and the panel does NOT move.** This is the
      load-bearing control. Fresco's tables are process-global rather than
      part of Xray's app-db, so a mount invalidates nothing the panel's
-     reaction watches — a tab wired to no tick at all would sit on an
+     read watches — a tab wired to no tick at all would sit on an
      empty roster forever while the application it inspects mounts
-     boundaries. The render queue is DRAINED here (same
-     `:flush-render!` op as phase 3), so the staleness asserted is a
-     reaction that never invalidated and not a commit that never
-     happened.
+     boundaries. A full [[settle]] window is given here, the same one the
+     positive phase below is allowed to poll within, so the staleness
+     asserted is a read that never invalidated and not a commit that had
+     not happened yet.
   3. **One trace tick, and the roster arrives in the DOM.** The tick is
      the collector's own seam — `refresh-trace-rings!` dispatches
      `:rf.xray/sync-trace-buffer` on every coalesced drain (rf2-43koh) —
@@ -51,7 +115,8 @@
   it was in phase 1. React reconciled the live tree in place; the roster
   did not arrive because something remounted the panel from scratch, which
   is the one other way a fresh roster could reach the screen and is not
-  liveness.
+  liveness. W2 pins the same identity across a CLICK, where a remount is
+  the specific failure a bridge minting its component per render causes.
 
   ## Substrate
 
@@ -61,7 +126,7 @@
   `reagent.ratom/Reaction` (`impl/collector.cljs` §`wire-cell!`), while
   plain-atom's is not `IWatchable`.
 
-  `:ambient-frame nil` is load-bearing: the panel's `rf/subscribe` calls
+  `:ambient-frame nil` is load-bearing: the panel's `rf.fresco/sub` calls
   must resolve `:rf/xray` through the React-context tier the
   `frame-provider` establishes, the way the shipped shell resolves them.
   The fixture's default ambient `:rf/default` scope is still in effect
@@ -78,20 +143,34 @@
   new build id, no `:dev-http` port. The `:node-test` build's `cljs-test$`
   regex also matches the ns, so it loads under Node too, where the body
   short-circuits via `(browser?)`."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as string]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.frame :as rf.frame]
             [re-frame.test-support :as rf.test-support]
             [re-frame.fresco :as rf.fresco]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
-            [day8.re-frame2-xray.panels.fresco :as fresco]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (def ^:private app-frame ::fresco-live-app)
+
+(def ^:private data-q
+  "The panel's evidence read. Named once because three rows key off it —
+  the sub-cache is keyed by the query vector itself
+  (`re-frame.subs/cache-key` is identity), so this value IS the cache key."
+  [:rf.xray.fresco/data])
+
+(def ^:private view-q
+  "The panel's OTHER read — the selected sub-view. Rostered beside
+  [[data-q]] because this panel takes TWO reads where the migrated
+  siblings take one, and a row asserting only the first would pass on a
+  boundary that had lost the second."
+  [:rf.xray.fresco/view])
 
 (rf/reg-sub :hlive/left (fn [db _] (:left db)))
 (rf/reg-event :hlive/seed (fn [_ [_ db]] {:db db}))
@@ -115,17 +194,23 @@
   (and (exists? js/document)
        (some? (.-createElement js/document))))
 
-(defn- flush-render!
-  "Run `thunk`, then SYNCHRONOUSLY commit whatever re-render it scheduled.
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask.
 
-  The adapter's own `:flush-render!` contract slot (Spec 006), which is
-  what the Pair MCP drives a headless render with — not a test-only
-  mechanism. Reagent schedules a dependent component's re-render on a
-  `requestAnimationFrame` turn, so without this the committed DOM would
-  lag every phase below by a frame and the assertions would be about
-  timing rather than about liveness."
-  [thunk]
-  ((:flush-render! rf.adapter.reagent/adapter) thunk))
+  rf2-k97c.3 REPLACED the adapter's `:flush-render!` here. That slot
+  commits Reagent's own render queue, and a Fresco boundary is not in it,
+  so after the migration it returned a DOM that had not moved — which
+  would have been reported as the panel being dead. An absence asserted
+  immediately after an event is a race; an absence asserted after this is
+  a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
 
 (defn- setup! []
   (registry/register-xray-handlers!)
@@ -136,19 +221,48 @@
   nil)
 
 (defn- mount-panel!
-  "Mount the real `Panel` into a real React root, committed synchronously
-  (React 19's `root.render` is otherwise async). The `frame-provider` is
-  the shell's own wrapper — `shell/shell-view` renders every panel inside
-  `[rf/frame-provider {:frame :rf/xray}]`."
-  []
-  (let [container (.createElement js/document "div")
-        root      (rdc/create-root container)]
-    (.appendChild (.-body js/document) container)
-    (react-dom/flushSync
-      (fn []
-        (rdc/render root [rf/frame-provider {:frame :rf/xray}
-                          [fresco/Panel]])))
-    {:container container :root root}))
+  "Mount the Fresco tab the way `shell/detail-panel` mounts it: the
+  REGISTRY's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and phase 1 would assert against an empty container.
+
+  Reaching `:panel` through `panel-registry/tab-by-id` rather than naming
+  the var is deliberate: after rf2-k97c.3 the registry holds a BRIDGE
+  (`rf.fresco/as-component` behind a callable), and it is the bridge the
+  shell will actually mount that these rows are about. A bridge that
+  regressed to something the shell cannot mount reddens here."
+  ([] (mount-panel! :rf/xray))
+  ([frame]
+   (let [container (.createElement js/document "div")
+         root      (rdc/create-root container)
+         tab       (panel-registry/tab-by-id :dynamic :fresco)]
+     (.appendChild (.-body js/document) container)
+     (react-dom/flushSync
+       (fn []
+         (rdc/render root [rf/frame-provider {:frame frame}
+                           [(:panel tab)]])))
+     {:container container :root root :tab tab})))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
 
 (defn- mount-boundary!
   "A real Fresco boundary, rendered and committed through the runtime's
@@ -182,22 +296,38 @@
   (vec (js/Array.from
          (.querySelectorAll container "li[data-testid^=\"rf-xray-fresco-boundary-\"]"))))
 
-(deftest the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick
+;; ===========================================================================
+;; W0 — the original row: the mounted panel is LIVE (criteria 1 and 2)
+;; ===========================================================================
+
+(deftest w0-the-mounted-panel-picks-up-a-new-boundary-on-the-trace-tick
   (testing "rf2-r98a — a REAL React root holding the Fresco tab re-renders
             itself on a `:rf.xray/trace-buffer` tick and commits the
-            populated roster to the DOM. Nothing here calls `Panel` a second
+            populated roster to the DOM. Nothing here calls the panel a second
             time; the roster arrives because the panel is live. Reddens if
-            `:rf.xray.fresco/data` stops composing off `:rf.xray/trace-buffer`."
+            `:rf.xray.fresco/data` stops composing off `:rf.xray/trace-buffer`.
+
+            rf2-k97c.3 kept every claim and changed the INSTRUMENT: the panel
+            is a Fresco boundary now, which is not in Reagent's render queue,
+            so `flush-render!` no longer commits its update and both phases
+            below poll instead."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
-      (let [_          (setup!)
-            {:keys [container root]} (mount-panel!)
-            release    (volatile! nil)]
-        (try
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel!)
+              release (volatile! nil)
+              roster? (fn [] (seq (boundary-rows container)))
+              finish  (fn []
+                        (when-some [r @release] (r))
+                        (teardown! root container)
+                        (done))]
           ;; ---- phase 1: mounted, and rendering its empty arm --------------
           (let [section (q container "[data-testid=\"rf-xray-fresco\"]")]
             (is (some? section)
-                "the Fresco Panel committed a real DOM root under React")
+                "the Fresco panel committed a real DOM root under React — a
+                 Fresco boundary mounted through Reagent's `:>` from the
+                 registry entry the shell holds")
             (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
                 "the live panel rendered the EMPTY mounted census — nothing is
                  mounted yet, so the roster this test drives in cannot already
@@ -206,41 +336,237 @@
                 "NON-VACUITY: no boundary row is in the DOM before one mounts")
 
             ;; ---- phase 2: a real boundary mounts, and the panel is deaf ---
-            ;; The render queue is drained here too, so what is asserted is a
-            ;; reaction that never invalidated — not a commit that never ran.
-            (flush-render! (fn [] (vreset! release (mount-boundary!))))
-            (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
-                "CONTROL: a real mount moves nothing the panel's reaction
-                 watches — Fresco's tables are process-global, not Xray
-                 app-db — so the committed DOM still shows the empty note.
-                 Without this the last phase would pass on a panel that had
-                 simply never rendered before the tick")
+            (vreset! release (mount-boundary!))
+            (-> (settle)
+                (.then
+                  (fn [_]
+                    (is (some? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
+                        "CONTROL: given a full settling window, a real mount
+                         still moves nothing the panel's read watches —
+                         Fresco's tables are process-global, not Xray app-db —
+                         so the committed DOM shows the empty note yet. Without
+                         this the next phase would pass on a panel that had
+                         simply never rendered before the tick")
 
-            ;; ---- phase 3: one tick, and the roster is on screen -----------
-            (flush-render! tick-trace!)
-            (let [rows (boundary-rows container)
-                  ;; `some->`, so an empty roster reds the row below as a
-                  ;; clean assertion failure rather than throwing on nil and
-                  ;; reporting the same defect twice — once as a failure and
-                  ;; once as an uncaught error.
-                  row-text (str (some-> (first rows) .-textContent))]
-              (is (= 1 (count rows))
-                  (str "the trace tick re-fired the live panel and ONE boundary "
-                       "row committed to the DOM — with no cache clear and no "
-                       "second call to Panel anywhere in this test. DOM: "
-                       (.-textContent container)))
-              (is (string/includes? row-text "[:hlive/left]")
-                  (str "and the row names the read the boundary really holds, so "
-                       "the assertion above cannot pass on a row projected from "
-                       "nothing. row text: " (pr-str row-text))))
-            (is (nil? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
-                "the empty note is gone from the DOM — the roster REPLACED it
-                 rather than rendering beside it")
-            (is (identical? section (q container "[data-testid=\"rf-xray-fresco\"]"))
-                "and it is the SAME <section> node — React reconciled the live
-                 tree in place, so the roster did not arrive by the panel being
-                 remounted from scratch, which would not be liveness"))
+                    ;; ---- phase 3: one tick, and the roster is on screen ----
+                    (tick-trace!)
+                    (rf.test-support/poll-until roster?
+                      {:label "the trace tick commits the roster"})))
+                (.then
+                  (fn [_]
+                    (let [rows (boundary-rows container)
+                          ;; `some->`, so an empty roster reds the row below as
+                          ;; a clean assertion failure rather than throwing on
+                          ;; nil and reporting one defect twice.
+                          row-text (str (some-> (first rows) .-textContent))]
+                      (is (= 1 (count rows))
+                          (str "the trace tick re-fired the live panel and ONE "
+                               "boundary row committed to the DOM — with no "
+                               "cache clear and no second call to the panel "
+                               "anywhere in this test.\n"
+                               "IT IS ALSO THE SELF-EXCLUSION WITNESS (epic "
+                               "criterion 5). The panel is ITSELF a Fresco "
+                               "boundary now, and Fresco's census walks the "
+                               "collector's process-global entry table with no "
+                               "frame filter — so a panel reporting its own "
+                               "two `:rf/xray` reads as application evidence "
+                               "reads TWO rows here, not one. DOM: "
+                               (.-textContent container)))
+                      (is (string/includes? row-text "[:hlive/left]")
+                          (str "and the row names the read the boundary really "
+                               "holds, so the assertion above cannot pass on a "
+                               "row projected from nothing. row text: "
+                               (pr-str row-text))))
+                    (is (nil? (q container "[data-testid=\"rf-xray-fresco-empty-mounted\"]"))
+                        "the empty note is gone from the DOM — the roster
+                         REPLACED it rather than rendering beside it")
+                    (is (identical? section (q container "[data-testid=\"rf-xray-fresco\"]"))
+                        "and it is the SAME <section> node — React reconciled
+                         the live tree in place, so the roster did not arrive by
+                         the panel being remounted from scratch, which would not
+                         be liveness")))
+                (.catch (fn [e]
+                          (is false (str "W0 poll timed out: " (.-message e)
+                                         " DOM: " (.-textContent container)))
+                          nil))
+                (.then (fn [_] (finish))))))))))
+
+;; ===========================================================================
+;; W1 — first display, and the reads land in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-reads-land-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Fresco tab commits real DOM through the
+            registry entry the shell mounts, and its two `rf.fresco/sub` reads
+            resolve against the frame the enclosing `frame-provider` named
+            rather than the ambient one. Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half below is
+            ;; measured with an instrument demonstrably able to see an entry
+            ;; in that frame's cache.
+            _probe (rf/subscribe [:hlive/left] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container "[data-testid=\"rf-xray-fresco\"]"))
+              "the panel committed a real DOM root under React")
+          (is (some? (q container "[data-testid=\"rf-xray-fresco-sub-strip\"]"))
+              "and the sub-strip rendered, so the body ran rather than
+               short-circuiting to nil")
+
+          ;; ---- criterion 4: the reads are where the tree said ------------
+          (is (pos? (ref-count-of :rf/xray data-q))
+              (str "the panel's evidence read holds a reference in :rf/xray's "
+                   "sub-cache — the frame the enclosing frame-provider named. "
+                   "Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
+          (is (pos? (ref-count-of :rf/xray view-q))
+              "and so does its sub-view read — BOTH reads are targeted, not
+               just the one a single-read panel would have")
+          (is (zero? (ref-count-of app-frame data-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [:hlive/left]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
           (finally
-            (when-some [r @release] (r))
-            (try (.unmount root) (catch :default _ nil))
-            (.remove container)))))))
+            ;; Release the imperative probe explicitly: an imperative
+            ;; subscriber must not rely on a view's reaction lifecycle.
+            (rf/unsubscribe [:hlive/left] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — Xray's OWN interaction: the sub-strip click (criterion 3)
+;; ===========================================================================
+
+(deftest w2-the-sub-strip-click-switches-the-view-through-the-boundary
+  (testing "rf2-k97c.3 — clicking a sub-strip tab dispatches through the
+            FRAME THE BOUNDARY CARRIES and the panel commits the other view.
+            Epic criterion 3, which the migrated siblings have no row for:
+            `module_view_fresco_boundary_dom_cljs_test` says in terms that it
+            omits criterion 3 because that panel dispatches nothing, and that
+            the panels which DO carry interactions bring their own rows. This
+            is one of them — the sub-strip is this tab's only dispatch.
+
+            WHAT WOULD BREAK IT, precisely. `reg-view` LEXICALLY INJECTED a
+            frame-bound `dispatch`; a `defview` binds no name inside a body,
+            so the panel builds one from `rf/current-frame-id`. A bare global
+            `rf/dispatch` in its place fires after render unwinds, when the
+            ambient frame is gone, and lands on `:rf/default` — where
+            `:rf.xray.fresco/set-view` writes a `:fresco-view` nobody reads,
+            and the DOM below never changes."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-panel!)
+              section  (q container "[data-testid=\"rf-xray-fresco\"]")
+              intents? (fn [] (q container "[data-testid=\"rf-xray-fresco-intents\"]"))
+              finish   (fn [] (teardown! root container) (done))]
+          (is (some? (q container "[data-testid=\"rf-xray-fresco-mounted\"]"))
+              "the panel opens on the Mounted view — the default
+               `normalise-sub-mode` answers for an unset slot")
+          (is (nil? (intents?))
+              "NON-VACUITY: the Intents view is NOT on screen before the click")
+          (let [btn (q container "[data-testid=\"rf-xray-fresco-sub-intents\"]")]
+            (is (some? btn)
+                "the Intents sub-tab button is in the committed DOM — a plain
+                 fn at an `:on-click` prop crosses Fresco's codec untouched, so
+                 the control itself survived the migration")
+            (.click btn)
+            (-> (rf.test-support/poll-until intents?
+                  {:label "the click committed the Intents view"})
+                (.then
+                  (fn [_]
+                    (is (some? (intents?))
+                        "the click switched the sub-view and the panel committed
+                         it — so the dispatch reached :rf/xray, the frame the
+                         boundary carries, and not :rf/default")
+                    (is (nil? (q container "[data-testid=\"rf-xray-fresco-mounted\"]"))
+                        "and the Mounted view is gone — the views REPLACED each
+                         other rather than both rendering")
+                    (is (identical? section (q container "[data-testid=\"rf-xray-fresco\"]"))
+                        "and the root <section> is the SAME node: React
+                         reconciled in place. A bridge minting its component
+                         type per render would remount the panel here instead,
+                         which is the specific failure `Panel-component` being
+                         a top-level def prevents")))
+                (.catch (fn [e]
+                          (is false (str "W2 poll timed out — the click did not "
+                                         "reach the panel's frame: "
+                                         (.-message e)))
+                          nil))
+                (.then (fn [_] (finish))))))))))
+
+;; ===========================================================================
+;; W3 — clean teardown: the reads are released, and reopening is not growth
+;; ===========================================================================
+
+(defn- released?
+  "Both of the panel's reads are fully released from `:rf/xray`'s cache."
+  []
+  (and (zero? (ref-count-of :rf/xray data-q))
+       (zero? (ref-count-of :rf/xray view-q))))
+
+(deftest w3-unmount-releases-the-reads-and-reopen-does-not-grow-them
+  (testing "rf2-k97c.3 — unmounting the panel releases BOTH subscription
+            references completely, and mounting it again returns to the SAME
+            counts rather than higher ones. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, so this row polls rather
+            than reading once: `impl.collector`'s cell reapers give a cell
+            whose last reader unmounts one macrotask of grace, so that a keyed
+            reorder which unmounts and remounts within a turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; Polled rather than asserted: a neighbouring row's teardown grace
+        ;; may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel!)
+                      mounted-data (ref-count-of :rf/xray data-q)
+                      mounted-view (ref-count-of :rf/xray view-q)]
+                  (is (pos? mounted-data)
+                      "the mount took a reference for the evidence read —
+                       otherwise the release below is vacuous")
+                  (is (pos? mounted-view)
+                      "and one for the sub-view read")
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released both reads"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released BOTH completely, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          (let [{c2 :container r2 :root} (mount-panel!)
+                                again-data (ref-count-of :rf/xray data-q)
+                                again-view (ref-count-of :rf/xray view-q)]
+                            (is (= [mounted-data mounted-view]
+                                   [again-data again-view])
+                                (str "reopening returns to the SAME reference "
+                                     "counts " (pr-str [mounted-data mounted-view])
+                                     " rather than accumulating — accumulation "
+                                     "across open/close cycles is the signature "
+                                     "of a release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: "
+                                     (pr-str [again-data again-view])))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released them too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases them too")))
+            (.catch (fn [e] (is false (str "W3 poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -179,6 +179,16 @@
   (rf.test-support/make-reset-runtime-fixture
     {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
+     ;; `:async? true` because every row below W0 is an `async` one, and
+     ;; `cljs.test` refuses a FUNCTION fixture in any namespace carrying
+     ;; one — "Async tests require fixtures to be specified as maps.
+     ;; Testing aborted." ABORTED is the word that matters: it stops the
+     ;; whole page, so every namespace after this one never runs and the
+     ;; log still looks plausible. The flag is what makes
+     ;; `make-reset-runtime-fixture` hand back the `{:before :after}` map
+     ;; form. rf2-k97c.3 turned this file async; before it, the function
+     ;; form was correct here.
+     :async?        true
      :init-fn       (fn []
                       (xray-test-support/reset-all!)
                       ;; Fresco's tables are process-global `defonce`s that


### PR DESCRIPTION
Migrates the Xray Fresco tab's own mount onto the re-frame-native view layer. It was the last Dynamic L4 tab still registered as an `rf/reg-view`.

## The migration reached past the head

`Panel` is an `rf.fresco/defview` now, mounted through the same `as-component` bridge the four migrated siblings use. Three things followed that a head-only change would have missed:

**Eight plain-fn hiccup heads.** Under Fresco a plain function in head position is a loud `:rf.error/fresco-bad-head` (HD-016). This file had the six view fns in `Panel`'s `case`, plus `advice-row` and `causal-link` inside the keyed fragments rf2-a38l introduced. All eight are calls now. The two fragments went with them: a call's return value has its own `:li` props map, so each row carries its own `:key` again, which is the spelling Fresco's codec reads.

**`panel-tree` split out of the boundary** — `defview`'s own documented extract-a-helper spelling. A boundary body runs only inside a React render window, so `(Panel)` no longer answers hiccup, and the two node suites that called it drive the projection directly with the values taken from the two subs.

**The dispatcher.** `reg-view`'s lexically injected `dispatch` is gone, as its contract says. The sub-strip's is built from `rf/current-frame-id`, so the click still lands on the surrounding instance frame (rf2-nesy9) and still is not a `:rf/xray` literal.

Naming follows RULING 1: the boundary takes the natural name. The bridge is private, like the L4-only `module_view.cljs` template and unlike `resources.cljs` — this tab has no `mount-*!` facade and no `panel_enum` entry, so `install!` is its only consumer.

## The defect the migration created, and the fix

**Measured, not anticipated.** With the panel migrated and one application boundary mounted, the browser witness committed TWO rows to the Mounted view, the second reading `…panels.fresco/Panel · frame :rf/xray · 2 reads`. Fresco's census walks the collector's process-global entry table with no frame filter, so the moment this panel became a boundary it appeared in its own roster — epic criterion 5, reachable only because the migration made it so.

The rule is not new: `self-noise` already drops any trace event whose frame resolves to `:rf/xray`, unconditionally and with no "show internals" toggle. `fresco-helpers/without-own-frame` applies that rule to the evidence rosters.

Where it lives is forced from both sides. Not in `fresco-reads`, which answers the producer's envelope verbatim under a byte-for-byte contract with the AI pair. Not in the four row projections either, because `fresco-advisor/advise` and `fresco-causal/slice` read the ENVELOPES — a row-level filter would have left the Advisor ranking Xray's own panel and the Causal slice, drawn for whichever boundary the advisor ranked first, narrating the tool's own render as the application's. One filter in the sub, upstream of all six views.

It deliberately does not eat three things: `:unknown` is not Xray's frame; an intent is dropped only when EVERY frame it touched is `:rf/xray`; an absent or schema-mismatched envelope passes through whole.

**It also caught a byte claim going vacuous.** 027 claimed the whole chain — seam and the subscription the view derefs — is `pr-str` identical to the producer's answer. The seam half is unchanged and still pinned; the subscription half now holds only while no `:rf/xray` boundary is mounted, true of that fixture and false of a running Xray. A new row mounts an application boundary and an Xray-framed one together and pins both halves against each other: the door carries both, the views carry only the application's.

## The witness

`fresco_live_panel_dom_cljs_test` already mounted this panel into a real React root, so it is extended into this panel's `*_fresco_boundary_dom_cljs_test` rather than duplicated. It mounts through `panel-registry/tab-by-id`, so the bridge the shell actually holds is the thing under test.

| Row | Epic criterion |
|---|---|
| W0 | 1 and 2 — liveness on a trace tick, with a settled deaf control; also the self-exclusion witness (exactly ONE row) |
| W1 | 1 and 4 — first paint, and BOTH reads land in `:rf/xray`'s sub-cache and none in the application frame's |
| W2 | 3 — the sub-strip click, which no migrated sibling has a row for: `module_view`'s says in terms that panels carrying interactions bring their own |
| W3 | 6 — unmount releases both reads within the collector's grace macrotask; reopening does not grow them |

Its `flush-render!` is gone. A Fresco boundary is not in Reagent's render queue, so that slot returned a DOM that had not moved, which reads as the panel being dead. Every row polls now, and the fixture takes `:async? true` — cljs.test refuses a function fixture in a namespace carrying an async row and ABORTS the whole page, which is how the first browser run ended with no summary at all.

**Key sweep (RULING 2): ZERO `^{:key …}` or `with-meta` sites in this file.** rf2-a38l had already converted both; this change moves those keys from a wrapping fragment into each row's own props map. A new row grades both rows through Fresco's codec AND Reagent and asserts they agree, using head+attrs (`subvec node 0 2`) rather than the whole node.

## Quality gates

All run in this worktree, each exit code captured on the runner's own line, none piped.

| Gate | Exit | Result |
|---|---|---|
| `node scripts/compile-node-test.cjs node-test` | 0 | 1945 files, 0 warnings |
| `node out/node-test.js` (`test:cljs`) | 0 | **11657 tests / 58458 assertions, 0 failures, 0 errors** |
| `shadow-cljs compile browser-test` | 0 | clean |
| `serve-and-run-browser-tests.cjs` (`test:browser`) | 0 | **928 tests / 5124 assertions, 0 failures, 0 errors** |
| `npm run test:xray-feature-gate` (FULL, not `:smoke`) | 0 | **16 scenarios, 0 failures, 13 matrix rows** |
| `tools/xray` `clojure -M:test` (JVM) | 0 | **1278 tests / 6130 assertions, 0 failures** |
| `check_require_alias_dialect.py --verbose` | 0 | 2847 files, 11212 edges, 0 non-canonical |
| `check_doc_slugs.py` | 0 | clean |
| `check_flattened_lists.py` | 0 | 291 files, 0 flattened |
| `check_retired_spellings.py` | 0 | 4638 files, none |
| `clj-kondo --fail-level error --lint tools/xray` | 0 | 0 errors; **0 findings in any file this PR touches** |
| `clojure -M:splint --fail-on-errors` | 0 | tree warnings 4246 to 4242, all four this slice's |

**`test:browser` is the lane that grades the DOM witness, and it is not optional.** A `-dom-cljs-test` namespace belongs to the `:browser-test` build; under `test:cljs` it merely loads and every row short-circuits on `(browser?)`. The feature gate does not grade it either.

**The JVM lane is not a substitute for `test:cljs` but it was necessary here**: `frame_singleton_guard_test` is a JVM source-text scan over Xray source asserting the sub-strip never wires a bare global dispatch, and this change rewrites exactly that line. It passes, and the lane ran the two new `.cljc` rows (1278/6130 against a sibling's 1276/6118 baseline).

**Sabotage, on `test:browser`.** Stripping `{:frame frame}` from the sub-strip's dispatcher — the one thing W2 exists to catch — gave exit **1** with exactly one failure, `w2-the-sub-strip-click-switches-the-view-through-the-boundary`, by name. **Test counts were IDENTICAL either side, 928 and 928** (assertions 5124 to 5122, the three post-poll assertions replaced by the timeout's one), which is what separates a real runtime failure from a suite that loaded and executed nothing. Restore verified by git blob hash in the default filtered form — the file is `i/lf`, so that is the right one — and by `git diff --quiet` exit 0.

**W0's self-exclusion assertion has a natural red as well as a planted one**: it failed `(not (= 1 2))` on the unfixed tree and passes on the fixed one, which is how the defect was found.

## Not touched

No fenced file: `shell.cljs`, `panels.cljs`, `panel_enum.cljc`, `panels/epoch/view.cljs`, `docs/xray/api/reference.md` and `tools/xray/spec/API.md` are all untouched, and `git diff --name-only origin/main...HEAD` is six files, all in this slice's own family. The premise that this slice needs no `panels.cljs` change held: it has no `mount-*!` there and nothing requires it from that file.

`git merge-tree --write-tree` against current `origin/main` exits 0.
