### PR TITLE
feat(xray): migrate the Dynamic chrome to Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2318,7 +2318,7 @@
   `mount-resources!`.
 
   `panels.cljs` and `panel_enum.cljc` (whose `:event-spine` row names
-  `"shell/event-list"`) were both held by another worker when this
+  `shell/event-list` as a string) were both held by another worker when this
   slice was written, so that one line could not be changed and the
   migration would have shipped a BROKEN embed — silently, because
   `panels_mount_cljs_test` drives `render-panel!` through a render STUB
@@ -2686,9 +2686,9 @@
   [selected tab as-child]
   [:div {:data-testid (str "rf-xray-detail-panel-" (name selected))
          ;; rf2-plajx — L4 closes the tab/tabpanel loop. The L3
-         ;; tablist owns `role=\"tablist\"` + per-tab `role=\"tab\"` +
+         ;; tablist owns `role="tablist"` + per-tab `role="tab"` +
          ;; `aria-selected`; the panel completes the WAI-ARIA APG
-         ;; tabs pattern with `role=\"tabpanel\"` + `aria-labelledby`
+         ;; tabs pattern with `role="tabpanel"` + `aria-labelledby`
          ;; pointing at the active tab button (per `tab-button`
          ;; the id is `rf-xray-tab-button-<tab-id>`).
          :id              (str "rf-xray-tabpanel-" (name selected))

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -106,15 +106,41 @@
   own registrations under `:rf.xray/*` operate against `:rf/xray`'s
   db when called from inside the shell.
 
-  Per rf2-in6l2 every subscribing region of the shell is `reg-view`-
-  registered so its rendered React component carries `:contextType
-  frame-context` — the closest enclosing Provider's `:rf/xray`
-  flows through React-context and `(rf/subscribe …)` inside the body
-  resolves to the registered frame. With plain `defn`s the
-  React-context tier would be skipped (Spec 000 §Plain Reagent fns
-  do not pick up the surrounding frame) and subscribe would fall
-  through to `:rf/default` — silently routing every Xray panel
-  query into the host's app-db.
+  Per rf2-in6l2 every reading region of the shell carries the frame by
+  construction rather than by ambient lookup. That was originally
+  `reg-view` registration (`:contextType frame-context`, so the closest
+  enclosing Provider's `:rf/xray` flowed through React-context to a
+  `(rf/subscribe …)` in the body); with plain `defn`s the React-context
+  tier would be skipped (Spec 000 §Plain Reagent fns do not pick up the
+  surrounding frame) and subscribe would fall through to `:rf/default`,
+  silently routing every Xray panel query into the host's app-db.
+
+  ## rf2-k97c.3 — the Dynamic chrome is a FRESCO TREE
+
+  Seven regions are `rf.fresco/defview` BOUNDARIES now —
+  [[ribbon-theme-toggle]], [[ribbon]], [[events-ribbon]], [[tab-bar]],
+  [[detail-panel]], [[dynamic-chrome]] and [[surface-composer]].
+  [[event-list]] is the ONE exception and its docstring carries the
+  measured reason. A boundary declares its frame, so the guarantee
+  above is stronger rather than different: reads are `rf.fresco/sub`
+  (plain calls the shipped collector records an edge for) and writes go
+  through `(:dispatch (rf/capture-frame))`, core's own door, which
+  answers the boundary's DECLARED frame. An AMBIENT read or dispatch
+  inside a boundary body is a LOUD REFUSAL rather than a silent
+  fall-through to `:rf/default`, which is the whole point.
+
+  [[shell-view]] is STILL an `rf/reg-view`, deliberately: it is the
+  Reagent root `mount.cljs` renders through the installed adapter's
+  `:render`, and severing that is the parent epic's coupling (1) — a
+  later slice. It reaches the Fresco tree through ONE private
+  `as-component` bridge.
+
+  Each boundary's body is thin: it reads, and calls a pure `*-tree` fn
+  that owns the hiccup. That is `defview`'s own documented
+  extract-a-helper spelling, and it is what gives the node lane a door —
+  `test-helpers.dynamic-shell-tree` drives the same `*-tree` fns with
+  `rf/subscribe` in place of `rf.fresco/sub`, so a node-lane row walks
+  the shipped tree rather than a parallel fixture.
 
   ## Pure hiccup
 
@@ -123,7 +149,9 @@
   `mount.cljs`. No per-substrate switches in view code."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.interop :as rf.interop]
+            [reagent.core :as r]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.filters :as filters]
@@ -469,7 +497,7 @@
   drives the lifecycle without a real DOM.
 
   `dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the surrounding `reg-view` body — stashed in the drag-state so the
+  the surrounding boundary body — stashed in the drag-state so the
   document-level move handler (which fires after render unwinds) lands
   its width writes on the instance frame, not a `:rf/xray` literal.
   Defaults to `rf/dispatch` for the test-driven lifecycle."
@@ -547,7 +575,7 @@
   column floor. Returns true iff the keypress was handled.
 
   `dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the surrounding `reg-view` body so the keyboard resize lands on the
+  the surrounding boundary body so the keyboard resize lands on the
   instance frame; defaults to `rf/dispatch` for the test lifecycle."
   ([^js e col-id current-width]
    (col-divider-handle-keydown! e col-id current-width rf/dispatch))
@@ -585,7 +613,7 @@
   layout stays consistent across surfaces.
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the surrounding `reg-view` body (the L2 event-list views) — threaded
+  the surrounding boundary body (the L2 event-list views) — threaded
   through the drag / keyboard / double-click affordances so every
   width write lands on the instance frame, not a `:rf/xray` literal."
   [{:keys [col-id col-px row-height dispatch-fn]}]
@@ -877,7 +905,7 @@
   so the disabled glyph dimmed the wrong button.)
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the `ribbon` `reg-view` body — the nav `on-click` handlers fire after
+  the [[ribbon]] boundary's body — the nav `on-click` handlers fire after
   render unwinds, so they dispatch through the captured closure to land
   on the surrounding instance frame, not a `:rf/xray` literal."
   [{:keys [at-head? at-tail? live? dispatch-fn]}]
@@ -950,7 +978,7 @@
   "Filter pills cluster per spec/018 §3 + §7 Ribbon pills. Thin
   delegate to `filters.pills/pills-view` — the proper pill UI lives in
   the filters ns, which also owns the edit popup mount. Mounted here
-  inside the ribbon's `reg-view` so subscribes still resolve through
+  inside the ribbon's boundary so reads still resolve through
   React context to `:rf/xray`.
 
   Per rf2-ak4ms the legacy `js/window.prompt` stub is gone — the add-
@@ -959,11 +987,15 @@
   event-row context (add).
 
   `dispatch-fn` (rf2-nesy9) is the frame-aware dispatcher captured by
-  the `events-ribbon` `reg-view` body so each pill's edit / remove
+  the [[events-ribbon]] boundary's body so each pill's edit / remove
   click lands on the surrounding instance frame, not a `{:frame
-  :rf/xray}` literal."
+  :rf/xray}` literal.
+
+  rf2-k97c.3 — `pills-view` is a plain fn answering hiccup, so it is
+  CALLED rather than headed: a plain function in head position is a loud
+  error under Fresco, and this delegate renders inside a boundary now."
   [dispatch-fn {:keys [filters]}]
-  [filter-pills/pills-view dispatch-fn {:filters filters}])
+  (filter-pills/pills-view dispatch-fn {:filters filters}))
 
 (defn- ribbon-redacted-indicator
   "REDACTED indicator (rf2-azls9) — preserved next to the mode pill for
@@ -988,7 +1020,42 @@
      [:span {:aria-hidden "true"} "● "]
      (str "REDACTED " redacted-count)]))
 
-(rf/reg-view ribbon-theme-toggle
+(defn theme-toggle-tree
+  "The theme toggle's whole hiccup, as a pure function of the frame-bound
+  `dispatch` and the resolved `:theme` setting.
+
+  SPLIT OUT OF [[ribbon-theme-toggle]] BY rf2-k97c.3, for the reason
+  every migrated view in this epic splits: a boundary's body may only run
+  inside a React render window, so `(ribbon-theme-toggle)` is no longer a
+  callable that answers hiccup. This is `defview`'s OWN documented
+  extract-a-helper spelling, not an invention."
+  [dispatch theme]
+  (let [dark? (= theme :dark)
+        next  (if dark? :light :dark)]
+    [:button {:data-testid "rf-xray-theme-toggle"
+              :title       (if dark? "Switch to light theme" "Switch to dark theme")
+              :aria-label  (if dark? "Switch to light theme" "Switch to dark theme")
+              ;; rf2-r0o63 / rf2-k97c.3 — dispatch through the frame-bound
+              ;; dispatcher the boundary captured, so the theme write lands
+              ;; on the surrounding instance frame, not a `:rf/xray`
+              ;; literal.
+              :on-click    #(dispatch [:rf.xray/settings-update :theme nil next])
+              :style       {:background      "transparent"
+                            :border          "none"
+                            :border-radius   "4px"
+                            :color           (:chrome-ribbon-text-muted tokens)
+                            :cursor          "pointer"
+                            :font-size       "14px"
+                            :line-height     "1"
+                            :display         "inline-flex"
+                            :align-items     "center"
+                            :justify-content "center"
+                            :width           "22px"
+                            :height          "22px"
+                            :padding         "0"}}
+     [:span {:aria-hidden "true"} (if dark? "☀" "☾")]]))
+
+(rf.fresco/defview ribbon-theme-toggle
   "rf2-xawwb — theme toggle (Figma-Make surface). A sun/moon icon-button
   on the chrome ribbon's right cluster that flips light ⇄ dark.
 
@@ -1009,47 +1076,37 @@
   go dark). Muted `chrome-ribbon-text-muted` ink to sit quietly beside
   the `⚙`/`✕` icons on the dark band.
 
-  ## rf2-uu3lp — `reg-view` so the subscribe routes to `:rf/xray`
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
 
   The `:theme` setting lives in Xray's `:rf/xray` frame (the
   `:rf.xray/setting` sub + `:rf.xray/settings-update` event are
   registered against `:rf/xray` via `registry/register-xray-handlers!`).
   A plain `defn` rendered inside the shell's `:rf/xray` frame-provider
   would not pick up the surrounding frame (Spec 000 §Plain Reagent fns
-  / Spec 006 §Plain-fn-under-non-default-frame warning) — the subscribe
-  here would route to `:rf/default` and read the host app's app-db.
-  The dispatch ALREADY carries an explicit `{:frame :rf/xray}` arg, but
-  the subscribe was relying on React-context which the plain fn does
-  not consult. `reg-view`-registration makes the component
-  `:contextType frame-context`-aware so the subscribe resolves to
-  `:rf/xray` through the enclosing Provider — same shape as every other
-  Xray shell region (rf2-in6l2)."
-  []
-  (let [theme @(rf/subscribe [:rf.xray/setting :theme nil])
-        dark? (= theme :dark)
-        next  (if dark? :light :dark)]
-    [:button {:data-testid "rf-xray-theme-toggle"
-              :title       (if dark? "Switch to light theme" "Switch to dark theme")
-              :aria-label  (if dark? "Switch to light theme" "Switch to dark theme")
-              ;; rf2-r0o63 — dispatch through the reg-view-injected
-              ;; frame-aware dispatcher so the theme write lands on the
-              ;; surrounding instance frame (captured at render time),
-              ;; not a `:rf/xray` literal.
-              :on-click    #(dispatch [:rf.xray/settings-update :theme nil next])
-              :style       {:background      "transparent"
-                            :border          "none"
-                            :border-radius   "4px"
-                            :color           (:chrome-ribbon-text-muted tokens)
-                            :cursor          "pointer"
-                            :font-size       "14px"
-                            :line-height     "1"
-                            :display         "inline-flex"
-                            :align-items     "center"
-                            :justify-content "center"
-                            :width           "22px"
-                            :height          "22px"
-                            :padding         "0"}}
-     [:span {:aria-hidden "true"} (if dark? "☀" "☾")]]))
+  / Spec 006 §Plain-fn-under-non-default-frame warning) — the read here
+  would route to `:rf/default` and read the host app's app-db.
+
+  The READ is `rf.fresco/sub`, a plain call the shipped collector records
+  an edge for — no deref, no reaction owned by the installed adapter, and
+  a re-wire that NOTIFIES when the substrate disposes the underlying
+  derived value. That is the third of the epic's three couplings, and the
+  one a first-paint smoke test cannot see.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body and replaces
+  the `dispatch` the `reg-view` body used to inject lexically.
+
+  It is its OWN boundary rather than folded into [[ribbon]] because the
+  two read different things at different rates: hoisting the `:theme`
+  read into the ribbon would repaint the whole L1 chrome — nav cluster,
+  frame picker and filter add-button included — on every theme flip.
+  Boundary count tracks reads.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[ribbon]] mounts it with none, so it is destructured away."
+  [_props]
+  (theme-toggle-tree (:dispatch (rf/capture-frame))
+                     (rf.fresco/sub [:rf.xray/setting :theme nil])))
 
 (defn- ribbon-right-icons
   "Right-icons cluster — `⛶` pop-out · `⚙` settings · `✕` close. Per
@@ -1082,7 +1139,7 @@
   lucide's `X`.
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the `ribbon` `reg-view` body so the settings / close clicks land on
+  the [[ribbon]] boundary's body so the settings / close clicks land on
   the surrounding instance frame, not a `:rf/xray` literal."
   [{:keys [dispatch-fn]}]
   (let [icon-style {:background      "transparent"
@@ -1159,60 +1216,45 @@
      :at-tail? at-tail?
      :live?    live?}))
 
-(rf/reg-view ribbon
-  "L1 **chrome ribbon** (bar-1) — reconciled to the authoritative
-  reference chrome-ribbon (`tools/xray/design-reference/xray_devtools_
-  reference.cljs`, rf2-3f2di A4/A5). 34px tall (`:top-strip-height`).
+(defn ribbon-tree
+  "The L1 chrome ribbon's WHOLE hiccup, as a pure function of the
+  frame-bound `dispatch`, the six values [[ribbon]] reads, and the
+  `as-child` spelling for the ribbon's two REAGENT ISLANDS.
 
-    - **LEFT** — the `Events` label (the reference leads with it; the
-      `❖ Xray` wordmark was DROPPED per A4), the `[◀ ▶ ⏭]` blue-filled
-      nav cluster (A2), then the `+ filter` add-pill (A5). (rf2-pjjwh
-      retired the `focus` button + focus-chip with the focus feature.)
-      The chrome `+ filter` is mutually-exclusive with the events-ribbon
-      (rf2-8zd80): when ≥1 filter is committed the events-ribbon owns the
-      `[+]` add affordance and the chrome `+ filter` collapses to zero
-      width via the `.rf-xray-filters-collapse-h` horizontal-grid track
-      (250ms, same cadence + reduced-motion seam as the events-ribbon
-      vertical collapse).
-    - **RIGHT** — the Frame dropdown (`frame-switcher/frame-switcher-
-      view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`)
-      + the mute (🔇 N) / REDACTED (● N) silent-by-default indicators +
-      the `⚙` settings · `✕` close icon-buttons.
+  SPLIT OUT OF [[ribbon]] BY rf2-k97c.3, for the reason every migrated
+  view in this epic splits: a boundary's body may only run inside a React
+  render window, so `(ribbon nil)` is no longer a callable that answers
+  hiccup.
 
-  The committed filter pills (green/red) live on bar-2 (the events
-  ribbon, `events-ribbon`); only the add(+) sits up here, matching the
-  reference's chrome-ribbon (add) / events-ribbon (pills) split.
+  IT TAKES THE RAW READ VALUES, not derived ones — `nav-boundary-state`
+  and the `no-filters?` gate are computed HERE. That keeps the node lane's
+  door (`test-helpers.dynamic-shell-tree`) a reproduction of the READS
+  alone, with no second copy of the derivation to drift.
 
-  The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
-  #2 — the single GitHub-blue accent in both modes, rf2-ad7zx.13) stays
-  as the chrome-edge accent; the understated mode dropdown carries the
-  mode state via its active option + `data-active-mode`.
+  PURE HEADS: `ribbon-nav-cluster`, `ribbon-redacted-indicator`,
+  `ribbon-right-icons`, `filter-pills/chrome-add-filter-button` and
+  `spine-filters/ribbon-mute-indicator` are all plain fns answering
+  hiccup, so they are CALLED rather than headed — Fresco grades a plain
+  function in head position a loud error. [[ribbon-theme-toggle]] IS a
+  boundary, so it stays a head.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`."
-  [_props]
-  (let [redacted-count @(rf/subscribe [:rf.xray/suppressed-sensitive-count])
-        ;; rf2-ikuwt — mute-count drives the chrome ribbon's silent-by-
-        ;; default indicator next to the REDACTED indicator. Reading the
-        ;; count sub (not the raw set) means the ribbon re-renders only
-        ;; when the count changes; the indicator's click opens the
-        ;; unmute manager.
-        muted-count    @(rf/subscribe [:rf.xray/muted-event-ids-count])
-        ;; rf2-3f2di A5 — the nav cluster moved UP to the chrome ribbon
-        ;; per the authority reference, so the chrome ribbon subscribes to
-        ;; the spine state the events ribbon used to own.
-        focus          @(rf/subscribe [:rf.xray/focus])
-        event-bundles       @(rf/subscribe [:rf.xray/filtered-event-bundles])
-        show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
-        ;; rf2-8zd80 — the chrome `+ filter` and the events-ribbon are
-        ;; mutually-exclusive add affordances. Hide the chrome button
-        ;; when ≥1 filter is committed (the events-ribbon's own `[+]`
-        ;; takes over). Open when zero filters, closed otherwise.
-        filters        @(rf/subscribe [:rf.xray/active-filters])
-        no-filters?    (zero? (+ (count (:in filters)) (count (:out filters))))
+  TWO REAGENT ISLANDS, both reached through `as-child` — `identity` for a
+  hiccup caller and the node lane, `reagent.core/as-element` for the
+  boundary:
+
+    * `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`, both
+      still `rf/reg-view`s and both ALSO headed by the STATIC shell's
+      ribbon (`static/shell.cljs`), which islands them the same way.
+      Migrating them is a slice of its own that deletes FOUR islands at
+      once — two here and two there — rather than two now and two later."
+  [dispatch
+   {:keys [redacted-count muted-count focus event-bundles show-ungrouped? filters]}
+   as-child
+   theme-toggle*]
+  (let [no-filters? (zero? (+ (count (:in filters)) (count (:out filters))))
         {:keys [at-head? at-tail? live?]}
         (nav-boundary-state {:focus           focus
-                             :event-bundles        event-bundles
+                             :event-bundles   event-bundles
                              :show-ungrouped? show-ungrouped?})]
     [:div {:data-testid "rf-xray-ribbon"
            :style {:display          "flex"
@@ -1273,8 +1315,8 @@
       ;; rf2-3f2di A2/A5 — blue-filled nav cluster, promoted to bar-1.
       ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
       ;; nav on-clicks land on the surrounding instance frame.
-      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail? :live? live?
-                           :dispatch-fn dispatch}]
+      (ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail? :live? live?
+                           :dispatch-fn dispatch})
       ;; rf2-xawwb — `+ filter` text button (Figma-Make chrome-ribbon).
       ;; Replaces the prior `Filters:` label + plus-icon affordance with a
       ;; single outlined `+ filter` text button. Opens the same edit
@@ -1296,7 +1338,7 @@
              :class       "rf-xray-filters-collapse-h"
              :data-open   (if no-filters? "true" "false")
              :aria-hidden (if no-filters? "false" "true")}
-       [:div [filter-pills/chrome-add-filter-button dispatch]]]]
+       [:div (filter-pills/chrome-add-filter-button dispatch)]]]
      ;; RIGHT cluster — scope selectors (Frame + Dynamic/Static) then the
      ;; silent-by-default indicators + chrome actions. Per the authority
      ;; reference chrome-ribbon right side (rf2-3f2di A5).
@@ -1306,24 +1348,113 @@
       ;; frame` + `:rf.xray/available-frames` and writes via
       ;; `:rf.xray/select-frame`. The frame is a view SCOPE, not a
       ;; filter (rf2-4vp5j Workstream C).
-      [frame-switcher/frame-switcher-view]
+      ;; rf2-k97c.3 — REAGENT ISLAND. Still an `rf/reg-view`, which
+      ;; Fresco grades `:invalid` as a head down the same arm a plain
+      ;; `defn` does. See [[ribbon-tree]]'s docstring.
+      (as-child [frame-switcher/frame-switcher-view])
       ;; Dynamic/Static dropdown (rf2-4vp5j) — compact, understated; the
       ;; accent stripe carries the mode signal so the control stays
       ;; quiet. Always rendered (the `:rf.xray/static-mode?` feature
       ;; gate was removed per rf2-8l3uk).
-      [mode-pill/mode-pill]
+      ;; rf2-k97c.3 — the second REAGENT ISLAND.
+      (as-child [mode-pill/mode-pill])
       ;; rf2-ikuwt — mute indicator (🔇 N) renders inline next to the
       ;; REDACTED indicator. Both are silent-by-default surfaces that
       ;; only paint when their count is positive. Click → unmute
       ;; manager modal.
-      [spine-filters/ribbon-mute-indicator dispatch muted-count]
-      [ribbon-redacted-indicator redacted-count]
+      (spine-filters/ribbon-mute-indicator dispatch muted-count)
+      (ribbon-redacted-indicator redacted-count)
       ;; rf2-xawwb — theme toggle (sun/moon) sits before the settings/close
       ;; icons per the Figma-Make chrome-ribbon right cluster.
-      [ribbon-theme-toggle]
+      ;; rf2-k97c.3 — it is its OWN boundary, so it arrives here as an
+      ;; ALREADY-COMPOSED NODE rather than as a head this fn writes:
+      ;; [[ribbon]] passes `[ribbon-theme-toggle {}]` and the node lane
+      ;; passes the expanded `theme-toggle-tree`. Same shape as
+      ;; `static/shell.cljs`'s `surface-tree`, and for the same reason —
+      ;; a boundary head cannot be walked by a hiccup walker, because its
+      ;; body only runs inside a React render window.
+      theme-toggle*
       ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
       ;; settings / close icon clicks land on the instance frame.
-      [ribbon-right-icons {:dispatch-fn dispatch}]]]))
+      (ribbon-right-icons {:dispatch-fn dispatch})]]))
+
+(rf.fresco/defview ribbon
+  "L1 **chrome ribbon** (bar-1) — reconciled to the authoritative
+  reference chrome-ribbon (`tools/xray/design-reference/xray_devtools_
+  reference.cljs`, rf2-3f2di A4/A5). 34px tall (`:top-strip-height`).
+
+    - **LEFT** — the `Events` label (the reference leads with it; the
+      `❖ Xray` wordmark was DROPPED per A4), the `[◀ ▶ ⏭]` blue-filled
+      nav cluster (A2), then the `+ filter` add-pill (A5). (rf2-pjjwh
+      retired the `focus` button + focus-chip with the focus feature.)
+      The chrome `+ filter` is mutually-exclusive with the events-ribbon
+      (rf2-8zd80): when ≥1 filter is committed the events-ribbon owns the
+      `[+]` add affordance and the chrome `+ filter` collapses to zero
+      width via the `.rf-xray-filters-collapse-h` horizontal-grid track
+      (250ms, same cadence + reduced-motion seam as the events-ribbon
+      vertical collapse).
+    - **RIGHT** — the Frame dropdown (`frame-switcher/frame-switcher-
+      view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`)
+      + the mute (🔇 N) / REDACTED (● N) silent-by-default indicators +
+      the `⚙` settings · `✕` close icon-buttons.
+
+  The committed filter pills (green/red) live on bar-2 (the events
+  ribbon, `events-ribbon`); only the add(+) sits up here, matching the
+  reference's chrome-ribbon (add) / events-ribbon (pills) split.
+
+  The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
+  #2 — the single GitHub-blue accent in both modes, rf2-ad7zx.13) stays
+  as the chrome-edge accent; the understated mode dropdown carries the
+  mode state via its active option + `data-active-mode`.
+
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
+
+  SIX READS, ONE BOUNDARY. They are read together and rendered together
+  — the nav cluster's boundary state alone needs three of them — so
+  splitting them would buy nothing and cost component types. Boundary
+  count tracks reads and head-position use, not file size.
+
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. They keep the `reg-view` body's ORDER, which
+  is the order the node lane reproduces.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body and replaces
+  the `dispatch` the `reg-view` body used to inject lexically.
+  `defview` binds NO name inside the body, so the bare `dispatch` this
+  body used to close over would be a LOUD compile error.
+
+  `r/as-element` is the `as-child` spelling for the two Reagent islands;
+  [[ribbon-tree]] records which they are and why.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[dynamic-chrome]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (ribbon-tree
+    (:dispatch (rf/capture-frame))
+    {:redacted-count  (rf.fresco/sub [:rf.xray/suppressed-sensitive-count])
+     ;; rf2-ikuwt — mute-count drives the chrome ribbon's silent-by-
+     ;; default indicator next to the REDACTED indicator. Reading the
+     ;; count sub (not the raw set) means the ribbon re-renders only
+     ;; when the count changes; the indicator's click opens the
+     ;; unmute manager.
+     :muted-count     (rf.fresco/sub [:rf.xray/muted-event-ids-count])
+     ;; rf2-3f2di A5 — the nav cluster moved UP to the chrome ribbon
+     ;; per the authority reference, so the chrome ribbon reads the
+     ;; spine state the events ribbon used to own.
+     :focus           (rf.fresco/sub [:rf.xray/focus])
+     :event-bundles   (rf.fresco/sub [:rf.xray/filtered-event-bundles])
+     :show-ungrouped? (rf.fresco/sub [:rf.xray/show-ungrouped?])
+     ;; rf2-8zd80 — the chrome `+ filter` and the events-ribbon are
+     ;; mutually-exclusive add affordances. Hide the chrome button
+     ;; when ≥1 filter is committed (the events-ribbon's own `[+]`
+     ;; takes over). Open when zero filters, closed otherwise.
+     :filters         (rf.fresco/sub [:rf.xray/active-filters])}
+    r/as-element
+    [ribbon-theme-toggle {}]))
 
 ;; ---- L2 event list -------------------------------------------------------
 
@@ -1574,7 +1705,7 @@
         body-click  (fn [_e]
                       ;; rf2-r0o63 — dispatch through the captured
                       ;; instance-frame dispatcher (threaded from the
-                      ;; `event-list` reg-view) so the focus-event
+                      ;; `event-list` boundary) so the focus-event
                       ;; write lands on this shell's frame.
                       (dispatch-fn [:rf.xray/focus-event id (:frame event-bundle)]))]
     ;; Density (rf2-htik0 Bug 2): height 22px + padding "1px 6px" tightens
@@ -1589,7 +1720,17 @@
     ;; context menu (Mute / Hide event-type) — the same affordance
     ;; right-click users get. The audit (2026-05-20) flagged this
     ;; surface as P1 because the menu's actions had no keyboard path.
-    [:li (cond-> {:data-testid (str "rf-xray-event-row-" (str id))
+    [:li (cond-> {;; rf2-k97c.3 — the React `:key` rides THIS row's own
+                  ;; attribute map. It used to ride the `:key` slot of the
+                  ;; opts map at `event-list`'s call site, which worked
+                  ;; while `event-row` was a hiccup HEAD (React reads the
+                  ;; head's props). `event-row` is now CALLED — Fresco
+                  ;; grades a plain fn in head position a loud error — so
+                  ;; the opts map is an ordinary argument React never
+                  ;; sees, and the seq element that needs the key is the
+                  ;; `<li>` this returns. Same expression, one level down.
+                  :key         (str id)
+                  :data-testid (str "rf-xray-event-row-" (str id))
                   ;; rf2-b8guz — machine-readable issue-row flag so the
                   ;; light-pink-wash contract is pinnable from a CLJS unit
                   ;; test (issue epoch → "true"; clean row → absent) without
@@ -1745,10 +1886,10 @@
      ;; `flex 1 1 auto` column — rf2-8i1tg3 inverted the drag delta in
      ;; `col-divider-on-move` so dragging this handle tracks the
      ;; pointer instead of receding from it.
-     [col-divider {:col-id    :source
+     (col-divider {:col-id    :source
                    :col-px    (:source col-widths)
                    :row-height "22px"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      ;; rf2-ad7zx.12 + rf2-lnod7 — the `source` COLUMN (Figma EventList).
      ;; A user-resizable cell (rf2-6ni62) aligned under the header's
      ;; `source` label, carrying the dispatch-origin as a short text tag.
@@ -1770,19 +1911,19 @@
                      :font-size (:caption type-scale)}}
       (when source-tag source-tag)]
      ;; rf2-6ni62 — divider sits between `source` and `timestamp`.
-     [col-divider {:col-id    :timestamp
+     (col-divider {:col-id    :timestamp
                    :col-px    (:timestamp col-widths)
                    :row-height "22px"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      ;; Timestamp column (rf2-3f2di A8) — absolute wall-clock
      ;; `HH:MM:SS.mmm`, right-aligned. The chip carries an absolute-time
      ;; `:title` tooltip as the power-user reveal.
      (relative-time-chip event-bundle now-ms (:timestamp col-widths))
      ;; rf2-6ni62 — divider sits between `timestamp` and `duration`.
-     [col-divider {:col-id    :duration
+     (col-divider {:col-id    :duration
                    :col-px    (:duration col-widths)
                    :row-height "22px"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      ;; Duration cell (rf2-lnod7) — the trailing `duration` column,
      ;; restoring the Figma EventList's fourth column. Handler wall-time
      ;; (`1.2 ms`), right-aligned, flush against the row's trailing edge.
@@ -1834,44 +1975,20 @@
              :style {:font-weight 500 :color (:warning tokens) :white-space "nowrap"}}
       (str hidden " " (common/pluralize hidden "event") " filtered out")]]))
 
-(rf/reg-view events-ribbon
-  "L1.5 **events ribbon** (bar-2) — reconciled to the Figma-Make surface
-  (rf2-xawwb) + rf2-pjjwh. The second stratum below the chrome ribbon.
-  LEFT → RIGHT:
+(defn events-ribbon-tree
+  "The L1.5 events ribbon's WHOLE hiccup, as a pure function of the
+  frame-bound `dispatch` and the two values [[events-ribbon]] reads.
 
-    - the `↳ filters:` contextual label (corner-down-right glyph);
-    - the add-filter `+` ICON button
-      (`filter-pills/events-add-filter-button`) — opens the edit popup;
-    - the committed green-bordered IN pills + red-bordered OUT pills
-      (`filter-pills/pills-view`), each with a vertical divider before
-      its `✕`;
-    - pushed to the FAR RIGHT (via `margin-left: auto`): the `N events
-      filtered out` warning text (when N > 0, `:warning` colour).
+  SPLIT OUT OF [[events-ribbon]] BY rf2-k97c.3, for the reason every
+  migrated view in this epic splits: a boundary's body may only run
+  inside a React render window.
 
-  ## rf2-pjjwh — conditional + animated
-
-  The whole `filters:` ribbon is HIDDEN when there are zero filters and
-  appears only after the user creates the first filter via `[+ filter]`.
-  It animates OPEN when the first filter is added and animates CLOSED when
-  the last filter is removed. The collapse uses a CSS
-  `grid-template-rows: 0fr ⇄ 1fr` transition (the modern jank-free
-  height-collapse technique) keyed off the `data-open` attribute — see
-  `theme/global-styles/motion-css` for the rule. The outer collapse track
-  stays mounted so the transition can run in both directions; the inner
-  content is the actual bar-2 surface.
-
-  rf2-pjjwh also REMOVED the `Clear Filters` button from the trailing
-  edge — pills are removed individually via each pill's `✕` (the
-  `[+ filter]` add affordance lives up on the chrome ribbon).
-
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`. A distinct `bg-2` background + `border-subtle` hairline
-  separate it from the chrome ribbon's `bg-1` as a distinct layer."
-  []
-  (let [filters        @(rf/subscribe [:rf.xray/active-filters])
-        hidden-summary @(rf/subscribe [:rf.xray/hidden-by-filters])
-        filter-count   (+ (count (:in filters)) (count (:out filters)))
-        open?          (pos? filter-count)]
+  PURE HEADS: `filter-pills/events-add-filter-button`,
+  `ribbon-filter-pills` and `filters-hidden-message` all answer hiccup,
+  so all three are CALLED rather than headed."
+  [dispatch {:keys [filters hidden-summary]}]
+  (let [filter-count (+ (count (:in filters)) (count (:out filters)))
+        open?        (pos? filter-count)]
     ;; rf2-pjjwh — collapse track. Always mounted so the height/opacity
     ;; transition runs in BOTH directions (open when the first filter is
     ;; added, closed when the last is removed). `data-open` drives the
@@ -1909,9 +2026,9 @@
                       :white-space  "nowrap"}}
        [:span {:aria-hidden "true"} "↳"]
        "filters:"]
-      [filter-pills/events-add-filter-button dispatch]
+      (filter-pills/events-add-filter-button dispatch)
       ;; rf2-3f2di A6 — the committed green/red filter pills.
-      [ribbon-filter-pills dispatch {:filters filters}]
+      (ribbon-filter-pills dispatch {:filters filters})
       ;; rf2-xawwb — the `N events filtered out` warning is pushed to the
       ;; RIGHT end (Figma-Make surface). The `margin-left: auto` shoves it
       ;; to the trailing edge regardless of pill count. Renders only when
@@ -1921,6 +2038,56 @@
                :style {:display "flex" :align-items "center" :gap "12px"
                        :margin-left "auto"}}
          (filters-hidden-message hidden-summary)])]]))
+
+(rf.fresco/defview events-ribbon
+  "L1.5 **events ribbon** (bar-2) — reconciled to the Figma-Make surface
+  (rf2-xawwb) + rf2-pjjwh. The second stratum below the chrome ribbon.
+  LEFT → RIGHT:
+
+    - the `↳ filters:` contextual label (corner-down-right glyph);
+    - the add-filter `+` ICON button
+      (`filter-pills/events-add-filter-button`) — opens the edit popup;
+    - the committed green-bordered IN pills + red-bordered OUT pills
+      (`filter-pills/pills-view`), each with a vertical divider before
+      its `✕`;
+    - pushed to the FAR RIGHT (via `margin-left: auto`): the `N events
+      filtered out` warning text (when N > 0, `:warning` colour).
+
+  ## rf2-pjjwh — conditional + animated
+
+  The whole `filters:` ribbon is HIDDEN when there are zero filters and
+  appears only after the user creates the first filter via `[+ filter]`.
+  It animates OPEN when the first filter is added and animates CLOSED when
+  the last filter is removed. The collapse uses a CSS
+  `grid-template-rows: 0fr ⇄ 1fr` transition (the modern jank-free
+  height-collapse technique) keyed off the `data-open` attribute — see
+  `theme/global-styles/motion-css` for the rule. The outer collapse track
+  stays mounted so the transition can run in both directions; the inner
+  content is the actual bar-2 surface.
+
+  rf2-pjjwh also REMOVED the `Clear Filters` button from the trailing
+  edge — pills are removed individually via each pill's `✕` (the
+  `[+ filter]` add affordance lives up on the chrome ribbon).
+
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
+
+  TWO READS, ONE BOUNDARY — the pill inventory and the hidden-count
+  summary are read together and rendered together. The READS are
+  `rf.fresco/sub`, plain calls the shipped collector records an edge for;
+  the DISPATCHER is `(:dispatch (rf/capture-frame))`, which replaces the
+  `dispatch` the `reg-view` body used to inject lexically.
+
+  A distinct `bg-2` background + `border-subtle` hairline separate it
+  from the chrome ribbon's `bg-1` as a distinct layer.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[dynamic-chrome]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (events-ribbon-tree
+    (:dispatch (rf/capture-frame))
+    {:filters        (rf.fresco/sub [:rf.xray/active-filters])
+     :hidden-summary (rf.fresco/sub [:rf.xray/hidden-by-filters])}))
 
 ;; rf2-ad7zx.12 + rf2-lnod7 + rf2-xawwb + rf2-pjjwh — the L2 list's
 ;; column-header row, reconciled to the Figma-Make EventList. The header
@@ -1945,7 +2112,7 @@
   arrow keys do a fine resize, double-click resets to default.
 
   rf2-r0o63 — `dispatch-fn` is the frame-aware dispatcher captured by
-  the `event-list` reg-view body, threaded to each divider so resize
+  the `event-list` boundary body, threaded to each divider so resize
   writes land on the instance frame."
   [col-widths dispatch-fn]
   (let [dispatch-fn (or dispatch-fn rf/dispatch)
@@ -1994,28 +2161,28 @@
                                  :text-align "left"})}
       "event id"]
      ;; rf2-6ni62 — divider between `event id` (flex) and `source`.
-     [col-divider {:col-id    :source
+     (col-divider {:col-id    :source
                    :col-px    (:source col-widths)
                    :row-height "100%"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      [:span {:data-testid "rf-xray-event-list-col-source"
              :style (merge cell {:width (->px (:source col-widths))
                                  :flex-shrink 0})}
       "source"]
      ;; rf2-6ni62 — divider between `source` and `timestamp`.
-     [col-divider {:col-id    :timestamp
+     (col-divider {:col-id    :timestamp
                    :col-px    (:timestamp col-widths)
                    :row-height "100%"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      [:span {:data-testid "rf-xray-event-list-col-timestamp"
              :style (merge cell {:flex-shrink 0 :text-align "right"
                                  :width (->px (:timestamp col-widths))})}
       "timestamp"]
      ;; rf2-6ni62 — divider between `timestamp` and `duration`.
-     [col-divider {:col-id    :duration
+     (col-divider {:col-id    :duration
                    :col-px    (:duration col-widths)
                    :row-height "100%"
-                   :dispatch-fn dispatch-fn}]
+                   :dispatch-fn dispatch-fn})
      ;; rf2-lnod7 — the fourth Figma column. Restored after the gap
      ;; audit (rf2-4297k) found the live header carried only three
      ;; columns and the duration was clipped off the right edge.
@@ -2024,94 +2191,32 @@
                                  :width (->px (:duration col-widths))})}
       "duration"]]))
 
-(rf/reg-view event-list
-  "L2 event list — per spec/018 §4 Event list. Single-line rows,
-  latest-on-bottom, ~8 visible at the tightened 22px row height
-  (rf2-htik0 Bug 2 — was 28px row × 224px container; Xray is
-  info-dense and the earlier rhythm wasted vertical canvas).
+(defn event-list-tree
+  "The L2 event list's WHOLE hiccup, as a pure function of the frame-bound
+  `dispatch` and the six values [[event-list]] reads.
 
-  Container default height: 8 rows × 22px + 7 × 2px gap + 8px outer
-  padding ≈ 200px. The live height reads from
-  `:rf.xray/events-list-height-px` (rf2-t2dsh) so the L2/L3 seam
-  handle's drag writes lift the list reactively. `min-height` drops
-  to `config/min-events-list-height-px` (48px == 2 rows + chrome) —
-  the same floor the seam-handle clamp enforces.
+  SPLIT OUT OF [[event-list]] BY rf2-k97c.3, for the reason every migrated
+  view in this epic splits: a boundary's body may only run inside a React
+  render window.
 
-  Per rf2-t2dsh the bottom-right browser-native `:resize \"vertical\"`
-  corner-grip was retired — the seam handle that sits on the L2/L3
-  boundary is the single resize affordance now, carrying persistence
-  + keyboard + reset that the corner-grip lacked.
+  PURE HEADS: `l2-column-header` and `event-row` both answer hiccup, so
+  both are CALLED rather than headed. `event-row`'s React key moved down
+  one level into the `<li>` it returns when that head became a call — see
+  its attribute map.
 
-  Per spec/018 §6 sub-graph + rf2-ak4ms: reads `:rf.xray/filtered-
-  event-bundles` (NOT raw `:rf.xray/event-bundles`) so the L1 ribbon's IN/OUT
-  pills drive the list at the data layer — virtualisation budgets
-  the post-filter row count, and the ribbon's `[◀ ▶ ⏭]` nav walks
-  the same filtered list (per spec/018 §6 'Atomicity contract').
-
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`.
-
-  Per rf2-639lc the list filters out `:ungrouped` event-bundles (those
-  with no `:event` vector — registry-time emits / frame lifecycle
-  outside a drain / REPL evals). Without the filter the L2 list
-  rendered a leading `<no event>` placeholder row that leaked the
-  projection's internal bucket into the user-facing event timeline.
-  Other panels (Performance, etc.) keep reading
-  `:rf.xray/event-bundles` directly so the bucket remains available where
-  it is meaningful.
-
-  Per rf2-ieg6d Bug 1 the focused row carries a `:ref` callback that
-  scrolls it into view when (a) focus has just moved to a new id AND
-  (b) the spine is in LIVE+head mode (i.e. the auto-tracking branch
-  from `spine/compose-focus`). RETRO clicks place the row where the
-  user clicked, so the scroll-into-view is suppressed there to avoid
-  stealing the cursor. Per rf2-ieg6d Bug 2 the container carries
-  Firefox's standardised `scrollbar-width`/`-color`; WebKit/Blink
-  rules ship via a one-shot `<style>` injection (see
-  `inject-scrollbar-style!`)."
-  []
-  ;; rf2-ieg6d Bug 2 — idempotent stylesheet injection. Lives in the
-  ;; reg-view body so it runs on first paint of the L2 list (which is
-  ;; mounted by the shell-view); defonce + DOM guards keep it a
-  ;; no-op everywhere it matters.
-  (inject-scrollbar-style!)
-  (let [;; rf2-6ni62 — subscribe ONCE per L2 paint; thread the resolved
-        ;; widths map through to the header + every row so the two
-        ;; surfaces never drift out of column alignment.
-        col-widths     @(rf/subscribe [:rf.xray/event-list-col-widths])
-        ;; rf2-t2dsh — list height is driven by the L2/L3 seam handle.
-        ;; The sub returns a clamped px value; default == 200 px.
-        list-height-px @(rf/subscribe [:rf.xray/events-list-height-px])
-        event-bundles       @(rf/subscribe [:rf.xray/filtered-event-bundles])
-        ;; rf2-4vp5j — the hidden-by-filters message moved UP to the
-        ;; events ribbon (`events-ribbon`); the L2 list no longer renders
-        ;; the banner itself. The events ribbon is the always-present
-        ;; second stratum so the count surfaces above the list rather
-        ;; than as an inline banner inside it.
-        focus          @(rf/subscribe [:rf.xray/focus])
-        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-event-bundle
-        ;; bucket. Default OFF preserves silent-by-default; ON
-        ;; surfaces the bucket as a muted L2 row that focuses the
-        ;; bucket on click so downstream panels populate.
-        show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
-        ;; rf2-0s2at — one subscribe per render drives every chip's
-        ;; relative-time text. The sub returns the dispatched-time of
-        ;; the most recent event-bundle (the anchor flips on event arrival,
-        ;; not on a per-second tick). Falls back to `(rf.interop/now-ms)`
-        ;; when the buffer is empty / no event-bundle carries a stamp — at
-        ;; that point there are no rows to render against the anchor
-        ;; anyway, but the chip's render-time guard keeps the bucket
-        ;; computation defined.
-        now-ms         (or @(rf/subscribe [:rf.xray/relative-time-now-ms])
-                           (rf.interop/now-ms))
-        focused-id     (:dispatch-id focus)
+  THE VISIBILITY FILTER LIVES HERE, not in the boundary, so the node
+  lane's door reproduces the READS alone and there is no second copy of
+  the derivation to drift."
+  [dispatch {:keys [col-widths list-height-px event-bundles focus
+                    show-ungrouped? now-ms]}]
+  (let [focused-id    (:dispatch-id focus)
         ;; LIVE+head+not-paused = the auto-tracking branch from
         ;; spine/compose-focus. Only here do we want scroll-into-view
         ;; to fire on focus change; RETRO + paused-LIVE leave the
         ;; user's scroll position alone.
-        auto-track?    (and (= :live (:mode focus))
-                            (:head? focus)
-                            (not (:paused? focus)))
+        auto-track?   (and (= :live (:mode focus))
+                           (:head? focus)
+                           (not (:paused? focus)))
         event-bundles (filterv #(l2-event-bundle-visible? % show-ungrouped?) event-bundles)]
     [:div {:data-testid "rf-xray-event-list-wrap"
            :style {:display "flex" :flex-direction "column"}}
@@ -2151,31 +2256,146 @@
         ;; the header dividers + every row's out-of-render dispatches
         ;; (body-click focus, context menu, col resize) so they land on
         ;; the surrounding instance frame.
-        ;; rf2-a38l — these three sibling keys ride an ATTRIBUTE MAP, never
+        ;; rf2-a38l — these two sibling keys ride an ATTRIBUTE MAP, never
         ;; `^{:key …}` reader meta. Meta on a vector literal reaches React
         ;; under Reagent and reaches it NOWHERE under Fresco, whose codec
         ;; reads a literal `:key` from the attribute map and Clojure
-        ;; metadata not at all — so the meta spelling works today and would
-        ;; drop every key here, silently, the day this list renders under a
-        ;; boundary. `l2-column-header` takes both arguments positionally,
-        ;; so its key rides a KEYED FRAGMENT (the rf2-k97c.3 shape) rather
-        ;; than a props map that would shift them; `event-row` already
-        ;; takes one opts map, so its key rides that, which is where a
-        ;; boundary head reads `:key` from and where the body never sees it.
+        ;; metadata not at all. `l2-column-header` is a CALL now, so its
+        ;; key rides a KEYED FRAGMENT (the rf2-k97c.3 shape) — a fragment
+        ;; carries the key and adds no DOM node.
         (list
-         [:<> {:key "header"} [l2-column-header col-widths dispatch]]
+         [:<> {:key "header"} (l2-column-header col-widths dispatch)]
          (into [:ul {:key "rows"
                      :style {:list-style "none" :margin 0 :padding 0
                              :display "flex" :flex-direction "column"
                              :gap "2px"}}]
-              (for [event-bundle event-bundles]
-                [event-row {:key              (str (:dispatch-id event-bundle))
-                            :event-bundle     event-bundle
-                            :focused-id  focused-id
-                            :auto-track? auto-track?
-                            :now-ms      now-ms
-                            :col-widths  col-widths
-                            :dispatch-fn dispatch}]))))]]))
+               (for [event-bundle event-bundles]
+                 (event-row {:event-bundle event-bundle
+                             :focused-id   focused-id
+                             :auto-track?  auto-track?
+                             :now-ms       now-ms
+                             :col-widths   col-widths
+                             :dispatch-fn  dispatch})))))]]))
+
+(rf/reg-view event-list
+  "L2 event list — per spec/018 §4 Event list. Single-line rows,
+  latest-on-bottom, ~8 visible at the tightened 22px row height
+  (rf2-htik0 Bug 2 — was 28px row × 224px container; Xray is
+  info-dense and the earlier rhythm wasted vertical canvas).
+
+  Container default height: 8 rows × 22px + 7 × 2px gap + 8px outer
+  padding ≈ 200px. The live height reads from
+  `:rf.xray/events-list-height-px` (rf2-t2dsh) so the L2/L3 seam
+  handle's drag writes lift the list reactively. `min-height` drops
+  to `config/min-events-list-height-px` (48px == 2 rows + chrome) —
+  the same floor the seam-handle clamp enforces.
+
+  Per rf2-t2dsh the bottom-right browser-native `:resize \"vertical\"`
+  corner-grip was retired — the seam handle that sits on the L2/L3
+  boundary is the single resize affordance now, carrying persistence
+  + keyboard + reset that the corner-grip lacked.
+
+  Per spec/018 §6 sub-graph + rf2-ak4ms: reads `:rf.xray/filtered-
+  event-bundles` (NOT raw `:rf.xray/event-bundles`) so the L1 ribbon's IN/OUT
+  pills drive the list at the data layer — virtualisation budgets
+  the post-filter row count, and the ribbon's `[◀ ▶ ⏭]` nav walks
+  the same filtered list (per spec/018 §6 'Atomicity contract').
+
+  ## rf2-k97c.3 — THE ONE REGION THAT STAYED AN `rf/reg-view`, and why
+
+  The other five chrome regions are Fresco boundaries. This one is not,
+  and the reason is a CALLER rather than anything about the view:
+  `panels.cljs`'s `mount-event-spine!` — a SHIPPED public embed, the L2
+  spine Story mounts beside a focus-keyed panel (`tools/xray/spec/
+  008-Embedding-Contract.md` §Embeddable event spine) — passes this var
+  to `panels/render-panel!`, which builds `[rf/frame-provider … [view]]`
+  and hands it to the installed adapter's `:render`. `defview`'s own
+  contract is that a boundary is mounted as `[head props]` inside a
+  Fresco body or through `as-component` from OUTSIDE, never as a hiccup
+  render fn in a Reagent tree — which is exactly what `render-panel!`
+  builds. Migrating this view therefore needs a PUBLIC bridge here AND
+  a one-line change at that call site, the shape PR #9581 recorded for
+  `mount-resources!`.
+
+  `panels.cljs` and `panel_enum.cljc` (whose `:event-spine` row names
+  `"shell/event-list"`) were both held by another worker when this
+  slice was written, so that one line could not be changed and the
+  migration would have shipped a BROKEN embed — silently, because
+  `panels_mount_cljs_test` drives `render-panel!` through a render STUB
+  that captures the tree and never renders it.
+
+  EVERYTHING ELSE IS ALREADY IN PLACE. The body below is the thin
+  read-and-call shape every migrated view has, [[event-list-tree]] is
+  the pure fn, and the node lane's door already drives it. Making this a
+  boundary is: swap `rf/reg-view` for `rf.fresco/defview`, swap the six
+  `@(rf/subscribe …)` for `rf.fresco/sub`, add a public
+  `event-list-bridge`, and pass it at `panels.cljs`'s
+  `mount-event-spine!`.
+
+  [[dynamic-chrome]] therefore mounts it as a REAGENT ISLAND through
+  `as-child`, exactly as it does the L2/L3 seam handle.
+
+  Per rf2-639lc the list filters out `:ungrouped` event-bundles (those
+  with no `:event` vector — registry-time emits / frame lifecycle
+  outside a drain / REPL evals). Without the filter the L2 list
+  rendered a leading `<no event>` placeholder row that leaked the
+  projection's internal bucket into the user-facing event timeline.
+  Other panels (Performance, etc.) keep reading
+  `:rf.xray/event-bundles` directly so the bucket remains available where
+  it is meaningful.
+
+  Per rf2-ieg6d Bug 1 the focused row carries a `:ref` callback that
+  scrolls it into view when (a) focus has just moved to a new id AND
+  (b) the spine is in LIVE+head mode (i.e. the auto-tracking branch
+  from `spine/compose-focus`). RETRO clicks place the row where the
+  user clicked, so the scroll-into-view is suppressed there to avoid
+  stealing the cursor. Per rf2-ieg6d Bug 2 the container carries
+  Firefox's standardised `scrollbar-width`/`-color`; WebKit/Blink
+  rules ship via a one-shot `<style>` injection (see
+  `inject-scrollbar-style!`).
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  documented for exactly this position (`re-frame.core/capture-frame`'s
+  own example is a `reg-view` body) — rather than the lexically injected
+  `dispatch`, so this body is the same shape as its five boundary
+  siblings and the swap above stays a one-line one."
+  []
+  ;; rf2-ieg6d Bug 2 — idempotent stylesheet injection. Lives in the
+  ;; view body so it runs on first paint of the L2 list (which is
+  ;; mounted by the shell-view); defonce + DOM guards keep it a
+  ;; no-op everywhere it matters.
+  (inject-scrollbar-style!)
+  (event-list-tree
+    (:dispatch (rf/capture-frame))
+    {;; rf2-6ni62 — read ONCE per L2 paint; thread the resolved
+     ;; widths map through to the header + every row so the two
+     ;; surfaces never drift out of column alignment.
+     :col-widths      @(rf/subscribe [:rf.xray/event-list-col-widths])
+     ;; rf2-t2dsh — list height is driven by the L2/L3 seam handle.
+     ;; The sub returns a clamped px value; default == 200 px.
+     :list-height-px  @(rf/subscribe [:rf.xray/events-list-height-px])
+     :event-bundles   @(rf/subscribe [:rf.xray/filtered-event-bundles])
+     ;; rf2-4vp5j — the hidden-by-filters message moved UP to the
+     ;; events ribbon (`events-ribbon`); the L2 list no longer renders
+     ;; the banner itself. The events ribbon is the always-present
+     ;; second stratum so the count surfaces above the list rather
+     ;; than as an inline banner inside it.
+     :focus           @(rf/subscribe [:rf.xray/focus])
+     ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-event-bundle
+     ;; bucket. Default OFF preserves silent-by-default; ON
+     ;; surfaces the bucket as a muted L2 row that focuses the
+     ;; bucket on click so downstream panels populate.
+     :show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
+     ;; rf2-0s2at — one read per render drives every chip's
+     ;; relative-time text. The sub returns the dispatched-time of
+     ;; the most recent event-bundle (the anchor flips on event arrival,
+     ;; not on a per-second tick). Falls back to `(rf.interop/now-ms)`
+     ;; when the buffer is empty / no event-bundle carries a stamp — at
+     ;; that point there are no rows to render against the anchor
+     ;; anyway, but the chip's render-time guard keeps the bucket
+     ;; computation defined.
+     :now-ms          (or @(rf/subscribe [:rf.xray/relative-time-now-ms])
+                          (rf.interop/now-ms))}))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 
@@ -2215,7 +2435,7 @@
   `getByRole('tab')` lookups in host integration tests resolve here.
 
   `:dispatch-fn` (rf2-r0o63) is the frame-aware dispatcher captured by
-  the `tab-bar` reg-view so the select-tab click lands on the instance
+  the [[tab-bar]] boundary so the select-tab click lands on the instance
   frame, not a `:rf/xray` literal."
   [{:keys [id label mnem active? dispatch-fn]}]
   (let [;; rf2-plajx — stable per-tab id so the controlled L4 panel's
@@ -2257,49 +2477,20 @@
                       :transition    "background-color 120ms ease-out, color 120ms ease-out"}}
      label]))
 
-(rf/reg-view tab-bar
-  "L3 tab bar — renders `panel-registry/tabs-for-mode :dynamic` in
-  `:order`, per spec/018 §5 (Routing promoted per rf2-nrbs9 — follows
-  the cohesive-sub-domain rule; the Issues tab was removed per
-  rf2-gbz39 — issues surface inline in the Epoch panel + the L2
-  event-row pink-wash + the ribbon).
+(defn tab-bar-tree
+  "The L3 tab bar's WHOLE chrome, as a pure function of the frame-bound
+  `dispatch` and the four values [[tab-bar]] reads.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`.
+  SPLIT OUT OF [[tab-bar]] BY rf2-k97c.3, for the reason every migrated
+  view in this epic splits: a boundary's body may only run inside a React
+  render window.
 
-  Per rf2-lvf8t (rf2-q7who Thread B) the wrapping element is a
-  generic `<div>` carrying `role='tablist'` — the proper ARIA pattern
-  for a tab strip. The earlier `<nav>` was both semantically wrong
-  (tabs aren't site navigation) and a strict-mode hazard for host
-  apps that also expose a `<nav>` landmark: Playwright's
-  `getByRole('navigation')` lookup became ambiguous when Xray was
-  mounted alongside a host nav, every Story integration test using
-  the role failed (rf2-q7who Thread B — discovered via rf2-drprn).
-  Per-tab buttons carry `role='tab'` + `aria-selected` (see
-  `tab-button`). `data-testid='rf-xray-tab-bar'` is unchanged.
-
-  ## rf2-hga49 — `Reset` rewind button (far right)
-
-  The ribbon's far-right (after a `margin-left:auto` spacer) carries
-  the `Reset` button — the UI half of the inspect-vs-rewind principle.
-  It dispatches `:rf.xray/reset-to-epoch` with the OBSERVED frame
-  (`:rf.xray/observed-frame` — the frame-switcher selection, NOT
-  `:rf/xray`) and the currently-focused epoch-id
-  (`:rf.xray/focus-epoch-id`), rewinding that frame's live `app-db` to
-  the epoch's `:db-after`. No dialog, no confirmation. Disabled when
-  no epoch is focused. On the rare framework failure (epoch aged out /
-  restore-during-drain) the effect sets `:rf.xray/reset-flash` — a
-  brief inline message, never a modal, never a silent lie."
-  []
-  (let [selected     @(rf/subscribe [:rf.xray/selected-tab])
-        ;; rf2-hga49 — rewind target: the OBSERVED app frame + the
-        ;; focused epoch. `:subscribe` (the reg-view-injected handle)
-        ;; resolves both off `:rf/xray`'s own app-db where the spine
-        ;; lives, but the values it returns point at the OBSERVED frame.
-        observed     @(subscribe [:rf.xray/observed-frame])
-        focus-epoch  @(subscribe [:rf.xray/focus-epoch-id])
-        reset-flash  @(subscribe [:rf.xray/reset-flash])
-        can-reset?   (some? focus-epoch)]
+  PURE: `tab-button` is CALLED rather than headed, and answers keyword
+  hiccup. The tab INVENTORY still comes from `(dynamic-tabs)` — the
+  registry read this bar has always made, and process-global rather than
+  frame-scoped, so it is not one of the boundary's reads."
+  [dispatch {:keys [selected observed focus-epoch reset-flash]}]
+  (let [can-reset? (some? focus-epoch)]
     [:div {:data-testid "rf-xray-tab-bar"
            :role        "tablist"
            :aria-label  "Xray panel tabs"
@@ -2343,12 +2534,14 @@
      ;; Reagent honours and Fresco's codec reads nowhere. `tab-button`'s one
      ;; argument is the tab map itself, so the key does NOT go there: it is
      ;; registry-derived domain data the body destructures, and `:key` is
-     ;; React's. The fragment keeps the two apart.
+     ;; React's. The fragment keeps the two apart, and it survives
+     ;; `tab-button` becoming a CALL (rf2-k97c.3) — the key was never on
+     ;; the head.
      (for [{:keys [id] :as tab} (dynamic-tabs)]
        [:<> {:key id}
         ;; rf2-r0o63 — thread the captured frame-aware dispatcher so the
         ;; tab click's select-tab write lands on the instance frame.
-        [tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch)]])
+        (tab-button (assoc tab :active? (= id selected) :dispatch-fn dispatch))])
      ;; rf2-hga49 — `margin-left:auto` spacer pushes the Reset cluster to
      ;; the FAR RIGHT of the ribbon, past the tab buttons.
      [:span {:data-testid "rf-xray-tab-bar-spacer"
@@ -2398,6 +2591,62 @@
       "Reset"
       [:span {:aria-hidden "true"} "↺"]]]))
 
+(rf.fresco/defview tab-bar
+  "L3 tab bar — renders `panel-registry/tabs-for-mode :dynamic` in
+  `:order`, per spec/018 §5 (Routing promoted per rf2-nrbs9 — follows
+  the cohesive-sub-domain rule; the Issues tab was removed per
+  rf2-gbz39 — issues surface inline in the Epoch panel + the L2
+  event-row pink-wash + the ribbon).
+
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
+
+  FOUR READS, ONE BOUNDARY — the selected tab plus the three slots the
+  Reset cluster needs. The READS are `rf.fresco/sub`, plain calls the
+  shipped collector records an edge for, and they keep the `reg-view`
+  body's ORDER, which is the order the node lane reproduces. The three
+  Reset reads replace the `reg-view`-injected `subscribe` the body used
+  to close over — `defview` binds no such name, so the bare spelling
+  would be a LOUD compile error.
+
+  Per rf2-lvf8t (rf2-q7who Thread B) the wrapping element is a
+  generic `<div>` carrying `role='tablist'` — the proper ARIA pattern
+  for a tab strip. The earlier `<nav>` was both semantically wrong
+  (tabs aren't site navigation) and a strict-mode hazard for host
+  apps that also expose a `<nav>` landmark: Playwright's
+  `getByRole('navigation')` lookup became ambiguous when Xray was
+  mounted alongside a host nav, every Story integration test using
+  the role failed (rf2-q7who Thread B — discovered via rf2-drprn).
+  Per-tab buttons carry `role='tab'` + `aria-selected` (see
+  `tab-button`). `data-testid='rf-xray-tab-bar'` is unchanged.
+
+  ## rf2-hga49 — `Reset` rewind button (far right)
+
+  The ribbon's far-right (after a `margin-left:auto` spacer) carries
+  the `Reset` button — the UI half of the inspect-vs-rewind principle.
+  It dispatches `:rf.xray/reset-to-epoch` with the OBSERVED frame
+  (`:rf.xray/observed-frame` — the frame-switcher selection, NOT
+  `:rf/xray`) and the currently-focused epoch-id
+  (`:rf.xray/focus-epoch-id`), rewinding that frame's live `app-db` to
+  the epoch's `:db-after`. No dialog, no confirmation. Disabled when
+  no epoch is focused. On the rare framework failure (epoch aged out /
+  restore-during-drain) the effect sets `:rf.xray/reset-flash` — a
+  brief inline message, never a modal, never a silent lie.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[dynamic-chrome]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (tab-bar-tree
+    (:dispatch (rf/capture-frame))
+    {:selected    (rf.fresco/sub [:rf.xray/selected-tab])
+     ;; rf2-hga49 — rewind target: the OBSERVED app frame + the
+     ;; focused epoch. These resolve off `:rf/xray`'s own app-db where
+     ;; the spine lives, but the values they return point at the
+     ;; OBSERVED frame.
+     :observed    (rf.fresco/sub [:rf.xray/observed-frame])
+     :focus-epoch (rf.fresco/sub [:rf.xray/focus-epoch-id])
+     :reset-flash (rf.fresco/sub [:rf.xray/reset-flash])}))
+
 ;; ---- L4 detail panel -----------------------------------------------------
 
 (defn- unknown-tab-stub
@@ -2408,7 +2657,89 @@
                  :font-family sans-stack}}
    "Unknown tab: " [:code (pr-str selected)]])
 
-(rf/reg-view detail-panel
+(defn detail-panel-tree
+  "The Dynamic L4 detail panel's WHOLE chrome, as a pure function of the
+  selected tab id, that tab's registry entry (or `nil`) and the
+  `as-child` spelling for the L4 REAGENT ISLAND.
+
+  SPLIT OUT OF [[detail-panel]] BY rf2-k97c.3, for the reason every
+  migrated view in this epic splits: a boundary's body may only run
+  inside a React render window.
+
+  THE MOUNT IS AN ISLAND, and for the Dynamic registry it stays one for
+  a while yet. `reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE,
+  and the ten Dynamic entries are MIXED at this tip: five register an
+  `as-component` BRIDGE (a plain fn answering `[:> Component {}]`) while
+  `epoch-panel/Panel`, `trace/Panel`, `machine-inspector/Panel` and
+  `fresco/Panel` are still `rf/reg-view`s. Both grade `:invalid` as a
+  Fresco head, down the same arm. `as-child` is `identity` for a hiccup
+  caller and the node lane, which leaves `[(:panel tab)]` exactly the
+  vector it has always been, and `reagent.core/as-element` for the
+  boundary, which answers a React element — a legal child anywhere per
+  Fresco's component ABI.
+
+  MIGRATION SCAFFOLDING WITH A DEFINED END: when every Dynamic panel is
+  a boundary the registry takes them directly, the `[:>]` bridges go, and
+  this seam goes with them. That end is NOT reachable from this slice —
+  `panels/epoch/view.cljs` is held by another worker and three more
+  panels are unmigrated."
+  [selected tab as-child]
+  [:div {:data-testid (str "rf-xray-detail-panel-" (name selected))
+         ;; rf2-plajx — L4 closes the tab/tabpanel loop. The L3
+         ;; tablist owns `role=\"tablist\"` + per-tab `role=\"tab\"` +
+         ;; `aria-selected`; the panel completes the WAI-ARIA APG
+         ;; tabs pattern with `role=\"tabpanel\"` + `aria-labelledby`
+         ;; pointing at the active tab button (per `tab-button`
+         ;; the id is `rf-xray-tab-button-<tab-id>`).
+         :id              (str "rf-xray-tabpanel-" (name selected))
+         :role            "tabpanel"
+         :aria-labelledby (str "rf-xray-tab-button-" (name selected))
+         :style {:flex        "1 1 auto"
+                 :min-height  "0"
+                 :overflow    "auto"
+                 :background  (:bg-2 tokens)
+                 :color       (:text-primary tokens)}}
+   ;; rf2-5kfxe.3 — re-mount on selected-tab change so the fade-in
+   ;; keyframes auto-play.
+   ;;
+   ;; rf2-a38l — the remount key rides the ATTRIBUTE MAP below. It used
+   ;; to be `^{:key selected}` reader meta on that vector literal, which
+   ;; Reagent's `get-react-key` does read — but Fresco's codec takes a
+   ;; literal `:key` from the attribute map and reads Clojure metadata
+   ;; nowhere, so under a boundary the wrapper would keep ONE identity
+   ;; across every tab change and the fade would simply stop playing:
+   ;; no error, no warning, just an animation that never re-triggers.
+   ;; The attribute map is honoured by both substrates.
+   [:div {:key         selected
+          :data-testid (str "rf-xray-detail-panel-fade-"
+                            (name selected))
+          :style {:height     "100%"
+                  ;; Keyframes named in `global-styles/motion-css`.
+                  ;; Duration interpolated through the
+                  ;; `--rf-xray-motion-scale` seam (rf2-5kfxe.5)
+                  ;; via `theme.tokens/duration-css` so the
+                  ;; 180ms constant + the seam-var name both live
+                  ;; in tokens.cljc — one source of truth.
+                  ;; `forwards` pins the end state (opacity 1) so
+                  ;; the panel stays visible after the fade settles.
+                  :animation  (str "rf-xray-fade-in "
+                                   (duration-css (:fade-duration-ms motion))
+                                   " ease-out forwards")}}
+    ;; rf2-2moh1 — registry-driven panel mount. Each tab's per-panel
+    ;; `install!` declares `:panel <view-fn>` via
+    ;; `panel-registry/reg-l4-tab!`; the case-switch this replaced
+    ;; enumerated `{:event :app-db :views :trace :machines :routing}`
+    ;; — a literal that went stale on every tab added or retired.
+    ;; A lookup against `tab-by-id :dynamic` has no inventory to keep
+    ;; in step: EVERY registered tab's view fn lives colocated with
+    ;; the panel's own subs / events / fxs in `panels/<panel>.cljs`
+    ;; rather than the panel-cum-shell coupling the literal case-
+    ;; switch encoded.
+    (if tab
+      (as-child [(:panel tab)])
+      (unknown-tab-stub selected))]])
+
+(rf.fresco/defview detail-panel
   "L4 detail panel — mounts the active `:rf.xray/selected-tab`'s panel
   via the registry-driven `panel-registry/tab-by-id :dynamic` lookup
   (rf2-2moh1). Every registered Dynamic tab mounts a real panel — the
@@ -2417,10 +2748,20 @@
   (Option (c) — issues surface inline + event-row + ribbon).
   An unrecognised tab falls back to `unknown-tab-stub`.
 
-  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/xray`. The wrapping `<div>` paints `bg-2` as a contrast
-  safety net (rf2-q8154 — defence-in-depth for panels that fail to
-  set their own background).
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
+
+  ONE READ, ONE BOUNDARY. The READ is `rf.fresco/sub`. It is its OWN
+  boundary rather than folded into [[dynamic-chrome]] because the L4
+  mount is the most expensive subtree in the surface, and hoisting the
+  tab read above it would re-render the ribbon, the events ribbon, the
+  L2 list and the tab bar with it. Boundary count tracks reads.
+
+  `r/as-element` is the `as-child` spelling for the L4 island;
+  [[detail-panel-tree]] records why it is still an island.
+
+  The wrapping `<div>` paints `bg-2` as a contrast safety net
+  (rf2-q8154 — defence-in-depth for panels that fail to set their own
+  background).
 
   ## rf2-5kfxe.3 — 180ms cross-fade on tab switch
 
@@ -2436,64 +2777,17 @@
 
   The outer `<div>` keeps its `data-testid` stable across tab swaps so
   existing tests + `getByTestId` lookups still resolve — the cross-fade
-  wrapper is purely internal."
-  []
-  (let [selected (or @(rf/subscribe [:rf.xray/selected-tab])
+  wrapper is purely internal.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[dynamic-chrome]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (let [selected (or (rf.fresco/sub [:rf.xray/selected-tab])
                      default-tab)]
-    [:div {:data-testid (str "rf-xray-detail-panel-" (name selected))
-           ;; rf2-plajx — L4 closes the tab/tabpanel loop. The L3
-           ;; tablist owns `role="tablist"` + per-tab `role="tab"` +
-           ;; `aria-selected`; the panel completes the WAI-ARIA APG
-           ;; tabs pattern with `role="tabpanel"` + `aria-labelledby`
-           ;; pointing at the active tab button (per `tab-button`
-           ;; the id is `rf-xray-tab-button-<tab-id>`).
-           :id              (str "rf-xray-tabpanel-" (name selected))
-           :role            "tabpanel"
-           :aria-labelledby (str "rf-xray-tab-button-" (name selected))
-           :style {:flex        "1 1 auto"
-                   :min-height  "0"
-                   :overflow    "auto"
-                   :background  (:bg-2 tokens)
-                   :color       (:text-primary tokens)}}
-     ;; rf2-5kfxe.3 — re-mount on selected-tab change so the fade-in
-     ;; keyframes auto-play.
-     ;;
-     ;; rf2-a38l — the remount key rides the ATTRIBUTE MAP below. It used
-     ;; to be `^{:key selected}` reader meta on that vector literal, which
-     ;; Reagent's `get-react-key` does read — but Fresco's codec takes a
-     ;; literal `:key` from the attribute map and reads Clojure metadata
-     ;; nowhere, so under a boundary the wrapper would keep ONE identity
-     ;; across every tab change and the fade would simply stop playing:
-     ;; no error, no warning, just an animation that never re-triggers.
-     ;; The attribute map is honoured by both substrates.
-     [:div {:key         selected
-            :data-testid (str "rf-xray-detail-panel-fade-"
-                              (name selected))
-            :style {:height     "100%"
-                    ;; Keyframes named in `global-styles/motion-css`.
-                    ;; Duration interpolated through the
-                    ;; `--rf-xray-motion-scale` seam (rf2-5kfxe.5)
-                    ;; via `theme.tokens/duration-css` so the
-                    ;; 180ms constant + the seam-var name both live
-                    ;; in tokens.cljc — one source of truth.
-                    ;; `forwards` pins the end state (opacity 1) so
-                    ;; the panel stays visible after the fade settles.
-                    :animation  (str "rf-xray-fade-in "
-                                     (duration-css (:fade-duration-ms motion))
-                                     " ease-out forwards")}}
-      ;; rf2-2moh1 — registry-driven panel mount. Each tab's per-panel
-      ;; `install!` declares `:panel <view-fn>` via
-      ;; `panel-registry/reg-l4-tab!`; the case-switch this replaced
-      ;; enumerated `{:event :app-db :views :trace :machines :routing}`
-      ;; — a literal that went stale on every tab added or retired.
-      ;; A lookup against `tab-by-id :dynamic` has no inventory to keep
-      ;; in step: EVERY registered tab's view fn lives colocated with
-      ;; the panel's own subs / events / fxs in `panels/<panel>.cljs`
-      ;; rather than the panel-cum-shell coupling the literal case-
-      ;; switch encoded.
-      (if-let [tab (panel-registry/tab-by-id :dynamic selected)]
-        [(:panel tab)]
-        [unknown-tab-stub selected])]]))
+    (detail-panel-tree selected
+                       (panel-registry/tab-by-id :dynamic selected)
+                       r/as-element)))
 
 ;; ---- Dynamic / Static surface composer (rf2-o5f5f.1) --------------------
 ;;
@@ -2504,11 +2798,35 @@
 ;; `:rf.xray/static-mode?` feature gate was removed — Static mode
 ;; is unconditionally available.
 ;;
-;; The composer is `reg-view`-registered so the subscribe inside its
-;; body resolves through React-context to `:rf/xray` — same
-;; discipline as the rest of the shell.
+;; rf2-k97c.3 — the composer is a Fresco BOUNDARY now; its read is
+;; `rf.fresco/sub` and both arms are boundary heads.
 
-(rf/reg-view dynamic-chrome
+(defn dynamic-chrome-tree
+  "The Dynamic chrome's outer envelope, as a pure function of its five
+  already-composed layers plus the L2/L3 seam handle. Genuinely shared
+  between the two lanes rather than reproduced for them:
+  [[dynamic-chrome]] passes the five BOUNDARY-headed vectors and
+  `test-helpers.dynamic-shell-tree` passes the layers' already-expanded
+  plain hiccup, so a node-lane row that walks this envelope walks the
+  real thing.
+
+  SPLIT OUT OF [[dynamic-chrome]] BY rf2-k97c.3."
+  [ribbon* events-ribbon* event-list* seam-handle* tab-bar* detail-panel*]
+  [:div {:data-rf-xray-dynamic-chrome ""
+         :style {:display "contents"}}
+   ribbon*
+   events-ribbon*
+   event-list*
+   ;; rf2-t2dsh — L2/L3 seam handle. Click-and-drag anywhere along the
+   ;; horizontal seam between the event list and the tab bar resizes
+   ;; the events list. Replaces the previous browser-native
+   ;; `:resize "vertical"` corner-grip per spec/007-UX-IA.md
+   ;; §Splitter affordance.
+   seam-handle*
+   tab-bar*
+   detail-panel*])
+
+(rf.fresco/defview dynamic-chrome
   "The Dynamic chrome wrapped as a single component. Per rf2-3f2di the
   top splits into two strata reconciled to the authority reference — the
   **chrome ribbon** (`ribbon`, bar-1: `Events` label + blue-filled nav +
@@ -2522,8 +2840,28 @@
   the Static surface can swap in alongside it via the mode composer
   (rf2-o5f5f.1).
 
-  Per rf2-in6l2 `reg-view`-registered for parity with every other
-  shell region.
+  ## rf2-k97c.3 — a FRESCO BOUNDARY, not an `rf/reg-view`
+
+  IT READS NOTHING and is a boundary anyway, for the reason
+  `static/shell.cljs`'s `surface` is: a boundary is the only legal
+  hiccup head for the five region boundaries under it, so this is where
+  the composition has to live.
+
+  TWO REAGENT ISLANDS, both still `rf/reg-view`s, both reached through
+  `reagent.core/as-element` (the node lane's door passes `identity`, so
+  each stays the fn-headed vector a hiccup walker expands):
+
+    * [[event-list]] — held back by a SHIPPED EMBED in a file another
+      worker was holding, not by anything about the view. Its own
+      docstring carries the measurement and the four-line recipe.
+    * `resize-handle/SeamHandle`. `resize_handle.cljs` also owns
+      `Handle`, which [[shell-view]] still mounts from a Reagent tree,
+      so migrating only the seam would split one small file across two
+      substrates for no gain.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface-composer]] mounts it with none, so it is destructured
+  away.
 
   ## rf2-uu3lp — DOM-rooted via `display: contents`
 
@@ -2538,22 +2876,27 @@
   shell-view's column. The `data-rf-xray-dynamic-chrome` attr is a
   test-friendly handle if a future selector needs it; no production
   code reads it today."
-  []
-  [:div {:data-rf-xray-dynamic-chrome ""
-         :style {:display "contents"}}
-   [ribbon {}]
-   [events-ribbon]
-   [event-list]
-   ;; rf2-t2dsh — L2/L3 seam handle. Click-and-drag anywhere along the
-   ;; horizontal seam between the event list and the tab bar resizes
-   ;; the events list. Replaces the previous browser-native
-   ;; `:resize \"vertical\"` corner-grip per spec/007-UX-IA.md
-   ;; §Splitter affordance.
-   [resize-handle/SeamHandle]
-   [tab-bar]
-   [detail-panel]])
+  [_props]
+  (dynamic-chrome-tree [ribbon {}]
+                       [events-ribbon {}]
+                       (r/as-element [event-list])
+                       (r/as-element [resize-handle/SeamHandle])
+                       [tab-bar {}]
+                       [detail-panel {}]))
 
-(rf/reg-view surface-composer
+(defn surface-composer-tree
+  "The mode composer's envelope, as a pure function of the mode and its
+  two already-composed arms.
+
+  SPLIT OUT OF [[surface-composer]] BY rf2-k97c.3."
+  [mode static* dynamic*]
+  [:div {:data-rf-xray-surface-composer ""
+         :style {:display "contents"}}
+   (case mode
+     :static static*
+     dynamic*)])
+
+(rf.fresco/defview surface-composer
   "Mode-aware composer (rf2-o5f5f.1). Reads `:rf.xray/mode` and renders
   either the Dynamic 4-layer chrome OR the Static 3-layer surface.
 
@@ -2561,131 +2904,105 @@
   — Static mode is unconditionally available; the active mode drives
   the swap.
 
-  Per rf2-in6l2 `reg-view`-registered so the subscribe resolves to
-  `:rf/xray` via React-context.
-
   ## rf2-uu3lp — DOM-rooted via `display: contents`
 
   Returning the inner component head directly (`[dynamic-chrome]` /
-  `[static-shell/surface-bridge]`) would skip the source-coord DOM
+  `[static-shell/surface]`) would skip the source-coord DOM
   annotation (Spec 006 §Documented exemption: component head) and
   emit a one-shot warning. A `display: contents` wrapper lets
   `data-rf2-source-coord` land on a real DOM node while keeping the
   inner surface as the effective layout child of `shell-view`'s flex
   column.
 
-  ## rf2-k97c.3 — the Static arm is a Fresco boundary behind a bridge
+  ## rf2-k97c.3 — BOTH ARMS ARE NOW BOUNDARY HEADS, and the Static
+  bridge is GONE
 
-  `static-shell/surface` is now an `rf.fresco/defview`, so this
-  `reg-view` body mounts `static-shell/surface-bridge` — the
-  `as-component` crossing Fresco documents for exactly this direction.
-  The Static chrome therefore renders under THIS shell's enclosing
-  `rf/frame-provider`, taking `:rf/xray` from React context rather than
-  from a second root, and a hiccup walk of this composer now STOPS at
-  the bridge's `[:>]` interop head: what the composer owes is that the
-  Static arm mounts the bridge, and the Static surface's own first
-  paint is `static/shell_fresco_boundary_dom_cljs_test`'s subject."
+  This composer is itself a `rf.fresco/defview`, so
+  `static-shell/surface` is a legal hiccup head here and the
+  `as-component` bridge that #9644 shipped as SCAFFOLDING has been
+  deleted — its own comment named this as the condition
+  (\"when `shell.cljs` is itself a Fresco tree, `surface-composer` heads
+  `surface` directly, `[:>]` goes\"). One crossing remains for the whole
+  Dynamic tree and it now sits one level UP, at [[shell-view]], which is
+  still the Reagent root the installed adapter renders.
+
+  ONE READ, ONE BOUNDARY, and it is the right place for it: the mode
+  read swaps the entire surface, so nothing below needs to see it.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[surface-bridge]] mounts it with none, so it is destructured
+  away."
+  [_props]
+  (surface-composer-tree (rf.fresco/sub [:rf.xray/mode])
+                         [static-shell/surface {}]
+                         [dynamic-chrome {}]))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's mount path still paints through the INSTALLED ADAPTER's
+;; `:render` (`mount.cljs:396` and the pop-out at `:1688`), so
+;; [[shell-view]] is still an `rf/reg-view` — a Reagent tree — and a
+;; React component is not a legal hiccup head there. Severing that call
+;; is the epic's coupling (1) and is a LATER slice; this bridge is what
+;; keeps the tree green at every step in between.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI.
+;;
+;; THE BRIDGE IS PRIVATE, and that is measured rather than defaulted:
+;; [[shell-view]] is the only caller and it lives in this namespace, so no
+;; name has to cross. `surface-composer` itself KEEPS THE NATURAL NAME —
+;; the #9581 spelling the mayor's RULING 1 fixed as the surviving one —
+;; and neither `spec/api-manifest.edn` nor its curated sidecar rows
+;; anything in this namespace, so no hot-zone file moves.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When `mount.cljs` owns a
+;; Fresco root, `shell-view` becomes a boundary too, it heads
+;; `surface-composer` directly, `[:>]` goes, and both defs below are
+;; deleted.
+
+(def ^:private surface-composer-component
+  "The React component [[surface-composer]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the whole
+  Dynamic surface on each parent render."
+  (rf.fresco/as-component surface-composer))
+
+(defn ^:private surface-bridge
+  "The callable [[shell-view]] mounts. Returns Reagent-shaped hiccup
+  interoping to the React component above; the shell's enclosing
+  `rf/frame-provider` is what puts the instance frame in React context
+  for it."
   []
-  (let [mode @(rf/subscribe [:rf.xray/mode])]
-    [:div {:data-rf-xray-surface-composer ""
-           :style {:display "contents"}}
-     (case mode
-       :static  [static-shell/surface-bridge]
-       [dynamic-chrome])]))
+  [:> surface-composer-component {}])
 
 ;; ---- shell view ----------------------------------------------------------
 
-(rf/reg-view shell-view
-  "The full Xray shell — wraps the 4-layer chrome in a frame-provider
-  so descendant `subscribe` / `dispatch` resolve to the isolated
-  frame. Default `:inline` mode renders in normal document flow inside
-  the app-provided right layout host. `:overlay` and `:popout` remain
-  available debug/manual modes.
+(defn shell-view-tree
+  "The shell's outer envelope — the root `<div>`, the
+  `rf/frame-provider`, the left-edge resize handle and the seven
+  shell-root modal / popover mounts — as a pure function of its resolved
+  opts, the live lens mode and its ONE already-composed surface node.
 
-  ## `:frame-id` opt (rf2-lnluk) — de-singletoned shell frame
+  SPLIT OUT OF [[shell-view]] BY rf2-k97c.3. Genuinely shared between the
+  two lanes rather than reproduced for them: [[shell-view]] passes
+  `[surface-bridge]` (the `as-component` crossing into the Fresco tree)
+  and `test-helpers.dynamic-shell-tree` passes the chrome's
+  already-expanded plain hiccup, so a node-lane row that walks this
+  envelope walks the shipped definitions of the testids, the flex column,
+  the landmark role and every modal mount.
 
-  The shell's app-db lives in a frame. The PRODUCTION singleton mounts
-  against `default-frame-id` (`:rf/xray`) — pass no `:frame-id` and the
-  production behaviour is unchanged. Testbeds that mount N shells
-  side-by-side (the panel-gallery `:variants-grid`, a Story workspace)
-  pass DISTINCT `:frame-id`s so each cell's state (focused epoch,
-  selected tab, theme) is fully isolated — driving one shell does not
-  move the others.
-
-  The frame-id flows two ways: it parameterizes the wrapping
-  `[frame-provider {:frame frame-id}]` (so every reg-view descendant
-  resolves to it through React-context), AND it backs the few
-  out-of-render subscribes/dispatches `shell-view` itself issues from
-  OUTSIDE its own provider (the modal-positioning + mode reads below).
-  Handlers register GLOBALLY once under `:rf.xray/*`; only the frame-id
-  for app-db isolation threads through (no per-instance registration).
-
-  Per rf2-in6l2 `reg-view`-registered for parity with every other
-  shell region. The shell-view itself sits OUTSIDE its own frame-
-  provider (it's the mount root) so React-context inside `shell-view`'s
-  body still resolves to the default — every subscribing child is its
-  own reg-view component so the surrounding Provider reaches them via
-  React context.
-
-  ## `:modal-positioning` opt (rf2-om6fa)
-
-  Default `:fixed` — modal backdrops use `position: fixed; inset: 0`
-  with max-int z-indexes so they cover the entire host viewport. The
-  right shape for production where the shell IS the global overlay.
-
-  Story testbeds that mount N shell cells side-by-side pass
-  `:modal-positioning :absolute` so each cell's modals stay confined
-  to the cell (backdrop becomes `position: absolute; inset: 0` with
-  a sane z-index of 100). The cell wrapper must establish a
-  positioning context (`position: relative`) for the absolute backdrop
-  to be contained — `:inline` mode already sets that on the shell's
-  outer `<div>`, so the contract is satisfied out of the box.
-
-  Note: with `:absolute` positioning the modals are visually contained
-  per-cell. Per rf2-lnluk the open-state flags (`:rf.xray/<modal>-
-  open?`) are now also per-instance — pass a distinct `:frame-id` per
-  cell and opening Settings in one cell opens Settings in that cell
-  only. (Cells that share a frame-id still share state — that's the
-  contract: one frame, one app-db.)"
-  [& [{:keys [mode modal-positioning frame-id]
-       :or   {mode :inline modal-positioning :fixed
-              frame-id default-frame-id}}]]
-  ;; rf2-5kfxe.1 — wire Inter + JetBrains Mono once on first paint of
-  ;; the shell. Idempotent (`defonce` + id-keyed DOM probe inside) so
-  ;; shadow-cljs `:after-load` and repeated mounts are no-ops. Future
-  ;; cluster commits extend this install with `@keyframes` + the
-  ;; reduced-motion seam so all global stylesheet writes converge on
-  ;; one entry point.
-  (global-styles/install!)
-  ;; Idempotent app-db write so every modal can read the positioning
-  ;; via the `:rf.xray/modal-positioning` sub. Guarded against
-  ;; re-dispatch by comparing the current slot to the prop — once the
-  ;; slot matches the prop, the `when` short-circuits and the render
-  ;; quiesces. `dispatch-sync` so the slot lands BEFORE the modal
-  ;; children mount and read the sub on this same render pass; without
-  ;; sync the first paint of a fresh shell would render every modal's
-  ;; backdrop at the default `:fixed` before the async router drains.
-  ;; Sub + dispatch route via the instance `frame-id` so the read/write
-  ;; lands on THIS shell's app-db (`shell-view` itself sits OUTSIDE the
-  ;; `frame-provider` in the tree below — the React-context tier
-  ;; doesn't reach this call site, hence the explicit frame arg). Per
-  ;; rf2-lnluk the explicit frame is the instance `frame-id`, not a
-  ;; `:rf/xray` literal — N shells stay isolated.
-  (let [current-positioning @(rf/subscribe [:rf.xray/modal-positioning] {:frame frame-id})]
-    (when (not= current-positioning modal-positioning)
-      (rf/dispatch-sync [:rf.xray/set-modal-positioning modal-positioning]
-                        {:frame frame-id})))
-  ;; rf2-ad7zx.13 / spec/022 — the lens mode (`:rf.xray/mode` =
-  ;; :dynamic | :static) drives the `mode-dynamic` / `mode-static`
-  ;; root class, which still gates functional behaviour (motion / pulse
-  ;; dampening in Static). Post rf2-ad7zx.13 the Figma export carries a
-  ;; SINGLE accent (GitHub blue) — the mode class no longer re-points
-  ;; `--rf-xray-accent`, so the chrome accent is the same blue in both
-  ;; modes. Subscribed via the explicit instance `frame-id` (same shape
-  ;; as the modal-positioning read above — `shell-view` sits outside
-  ;; its own frame-provider; rf2-lnluk threads the instance frame, not
-  ;; a `:rf/xray` literal).
-  (let [lens-mode @(rf/subscribe [:rf.xray/mode] {:frame frame-id})]
+  EVERYTHING HERE IS STILL REAGENT and stays so until the epic's coupling
+  (1) is severed: `resize-handle/Handle` and the seven modals are
+  `rf/reg-view`s mounted from a `reg-view` tree, which is exactly what
+  they have always been. They are NOT islands — nothing above them is a
+  boundary."
+  [{:keys [mode modal-positioning lens-mode frame-id]} surface*]
    ;; rf2-uu3lp — the outer `<div>` IS the shell-view's root so the
    ;; source-coord walk has a DOM node to annotate (Spec 006
    ;; §Source-coord annotation; would otherwise warn-once because the
@@ -2766,7 +3083,16 @@
     ;; chrome or the Static 3-layer surface. Per rf2-8l3uk the
     ;; `:rf.xray/static-mode?` feature gate was removed — Static
     ;; mode is unconditionally available.
-    [surface-composer]
+    ;;
+    ;; rf2-k97c.3 — `surface-composer` is a Fresco BOUNDARY now, so
+    ;; this Reagent tree mounts it through the private
+    ;; `as-component` bridge above. A hiccup walk of `shell-view`
+    ;; therefore STOPS at the bridge's `[:>]` interop head; what this
+    ;; view owes is that the surface mounts, and the chrome's own
+    ;; composition is `test-helpers.dynamic-shell-tree`'s subject in
+    ;; the node lane and `shell_fresco_boundary_dom_cljs_test`'s in
+    ;; the browser.
+    surface*
     ;; Command palette (rf2-wm7z4) — mounted at shell root so it
     ;; overlays the chrome. Modal short-circuits to nil when
     ;; `:rf.xray/palette-open?` is false; closed-state cost is one
@@ -2831,4 +3157,110 @@
     ;; one subscribe + a when-gate). Mount discipline matches the
     ;; other modal stacks: shell-root mount so the stack's subscribes
     ;; resolve through the shell's `:rf/xray` frame-provider.
-    [edn-inspector-popup/edn-inspector-popup-stack]]]))
+    [edn-inspector-popup/edn-inspector-popup-stack]]])
+
+(rf/reg-view shell-view
+  "The full Xray shell — wraps the 4-layer chrome in a frame-provider
+  so descendant `subscribe` / `dispatch` resolve to the isolated
+  frame. Default `:inline` mode renders in normal document flow inside
+  the app-provided right layout host. `:overlay` and `:popout` remain
+  available debug/manual modes.
+
+  ## `:frame-id` opt (rf2-lnluk) — de-singletoned shell frame
+
+  The shell's app-db lives in a frame. The PRODUCTION singleton mounts
+  against `default-frame-id` (`:rf/xray`) — pass no `:frame-id` and the
+  production behaviour is unchanged. Testbeds that mount N shells
+  side-by-side (the panel-gallery `:variants-grid`, a Story workspace)
+  pass DISTINCT `:frame-id`s so each cell's state (focused epoch,
+  selected tab, theme) is fully isolated — driving one shell does not
+  move the others.
+
+  The frame-id flows two ways: it parameterizes the wrapping
+  `[frame-provider {:frame frame-id}]` (so every reg-view descendant
+  resolves to it through React-context), AND it backs the few
+  out-of-render subscribes/dispatches `shell-view` itself issues from
+  OUTSIDE its own provider (the modal-positioning + mode reads below).
+  Handlers register GLOBALLY once under `:rf.xray/*`; only the frame-id
+  for app-db isolation threads through (no per-instance registration).
+
+  ## rf2-k97c.3 — this one stays an `rf/reg-view`, and deliberately
+
+  Everything under [[surface-composer]] is a Fresco boundary now, but
+  `shell-view` is the ROOT `mount.cljs` renders through the installed
+  adapter's `:render` (`mount.cljs:396`, and the pop-out at `:1688`).
+  Severing that call is the parent epic's coupling (1) and is a later
+  slice; until then the root must stay a Reagent tree, and it reaches
+  the Fresco tree through the one private `surface-bridge` above.
+
+  The shell-view itself sits OUTSIDE its own frame-provider (it's the
+  mount root) so React-context inside `shell-view`'s body still resolves
+  to the default — hence the two explicit `{:frame frame-id}` reads
+  below. Every reading child is its own component (a `reg-view` for the
+  modals, a boundary for the chrome) so the surrounding Provider reaches
+  them.
+
+  ## `:modal-positioning` opt (rf2-om6fa)
+
+  Default `:fixed` — modal backdrops use `position: fixed; inset: 0`
+  with max-int z-indexes so they cover the entire host viewport. The
+  right shape for production where the shell IS the global overlay.
+
+  Story testbeds that mount N shell cells side-by-side pass
+  `:modal-positioning :absolute` so each cell's modals stay confined
+  to the cell (backdrop becomes `position: absolute; inset: 0` with
+  a sane z-index of 100). The cell wrapper must establish a
+  positioning context (`position: relative`) for the absolute backdrop
+  to be contained — `:inline` mode already sets that on the shell's
+  outer `<div>`, so the contract is satisfied out of the box.
+
+  Note: with `:absolute` positioning the modals are visually contained
+  per-cell. Per rf2-lnluk the open-state flags (`:rf.xray/<modal>-
+  open?`) are now also per-instance — pass a distinct `:frame-id` per
+  cell and opening Settings in one cell opens Settings in that cell
+  only. (Cells that share a frame-id still share state — that's the
+  contract: one frame, one app-db.)"
+  [& [{:keys [mode modal-positioning frame-id]
+       :or   {mode :inline modal-positioning :fixed
+              frame-id default-frame-id}}]]
+  ;; rf2-5kfxe.1 — wire Inter + JetBrains Mono once on first paint of
+  ;; the shell. Idempotent (`defonce` + id-keyed DOM probe inside) so
+  ;; shadow-cljs `:after-load` and repeated mounts are no-ops. Future
+  ;; cluster commits extend this install with `@keyframes` + the
+  ;; reduced-motion seam so all global stylesheet writes converge on
+  ;; one entry point.
+  (global-styles/install!)
+  ;; Idempotent app-db write so every modal can read the positioning
+  ;; via the `:rf.xray/modal-positioning` sub. Guarded against
+  ;; re-dispatch by comparing the current slot to the prop — once the
+  ;; slot matches the prop, the `when` short-circuits and the render
+  ;; quiesces. `dispatch-sync` so the slot lands BEFORE the modal
+  ;; children mount and read the sub on this same render pass; without
+  ;; sync the first paint of a fresh shell would render every modal's
+  ;; backdrop at the default `:fixed` before the async router drains.
+  ;; Sub + dispatch route via the instance `frame-id` so the read/write
+  ;; lands on THIS shell's app-db (`shell-view` itself sits OUTSIDE the
+  ;; `frame-provider` in the tree below — the React-context tier
+  ;; doesn't reach this call site, hence the explicit frame arg). Per
+  ;; rf2-lnluk the explicit frame is the instance `frame-id`, not a
+  ;; `:rf/xray` literal — N shells stay isolated.
+  (let [current-positioning @(rf/subscribe [:rf.xray/modal-positioning] {:frame frame-id})]
+    (when (not= current-positioning modal-positioning)
+      (rf/dispatch-sync [:rf.xray/set-modal-positioning modal-positioning]
+                        {:frame frame-id})))
+  (shell-view-tree
+    {:mode              mode
+     :modal-positioning modal-positioning
+     :frame-id          frame-id
+     ;; rf2-ad7zx.13 / spec/022 — the lens mode (`:rf.xray/mode` =
+     ;; :dynamic | :static) drives the `mode-dynamic` / `mode-static`
+     ;; root class, which still gates functional behaviour (motion /
+     ;; pulse dampening in Static). Post rf2-ad7zx.13 the Figma export
+     ;; carries a SINGLE accent (GitHub blue) — the mode class no longer
+     ;; re-points `--rf-xray-accent`, so the chrome accent is the same
+     ;; blue in both modes. Subscribed via the explicit instance
+     ;; `frame-id` (same shape as the modal-positioning read above —
+     ;; `shell-view` sits outside its own frame-provider; rf2-lnluk
+     ;; threads the instance frame, not a `:rf/xray` literal).
+     :lens-mode         @(rf/subscribe [:rf.xray/mode] {:frame frame-id})}
+    [surface-bridge]))

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -107,20 +107,24 @@
   `reagent.core/as-element` for a boundary:
 
     * the L1 ribbon's `frame-switcher/frame-switcher-view` and
-      `mode-pill/mode-pill`, both still `rf/reg-view`s and both ALSO
-      headed by the Dynamic `shell.cljs` ribbon, which is still a
-      `reg-view` tree. Migrating them would move a fenced Dynamic
-      head; islanding them does not.
+      `mode-pill/mode-pill`, both still `rf/reg-view`s. The Dynamic
+      `shell.cljs` ribbon is a BOUNDARY as of rf2-k97c.3 and islands
+      the same two widgets the same way, so migrating them now deletes
+      FOUR islands in one slice — two here and two there — rather than
+      two now and two later.
     * [[detail-panel]]'s `[(:panel tab)]`, because
-      `panel-registry/reg-l4-tab!` stores a CALLABLE and four of the
-      five Static panels register an `as-component` bridge while
-      `static.routes.panel/Panel` is still an `rf/reg-view`.
+      `panel-registry/reg-l4-tab!`'s `:pre` requires `:panel` to be
+      CALLABLE. All five Static panels are boundaries as of PR #9648,
+      so every one of them registers an `as-component` BRIDGE — a plain
+      fn answering `[:> Component {}]` — rather than the view itself.
+      A bridge is a plain fn, which Fresco grades `:invalid` as a head
+      down the same arm a `reg-view` goes, so the island stands until
+      the registry can take a boundary directly.
 
   Both are MIGRATION SCAFFOLDING WITH A DEFINED END: the ribbon seam
   goes when those two widgets are boundaries, and the L4 seam goes
-  when all five Static panels are boundaries and the registry stores
-  them directly — the deletion each panel's own bridge comment
-  already promises.
+  when `reg-l4-tab!` stores boundaries directly — the deletion each
+  panel's own bridge comment already promises.
 
   ## Mode-signal mechanism (4 stacked signals)
 
@@ -493,19 +497,22 @@
   render window.
 
   THE MOUNT IS AN ISLAND, and deliberately. `reg-l4-tab!`'s `:pre`
-  requires `:panel` to be CALLABLE, so four of the five Static panels
-  register an `as-component` BRIDGE — a plain fn answering
-  `[:> Component {}]` — while `static.routes.panel/Panel` is still an
-  `rf/reg-view`. Both grade `:invalid` as a Fresco head, down the same
-  arm. `as-child` is `identity` for a hiccup caller and the node lane,
-  which leaves `[(:panel tab)]` exactly the vector it has always been,
-  and `reagent.core/as-element` for the boundary, which answers a React
-  element — a legal child anywhere per Fresco's component ABI, and the
-  crossing every Static panel's own bridge comment already describes.
+  requires `:panel` to be CALLABLE, so ALL FIVE Static panels register
+  an `as-component` BRIDGE — a plain fn answering `[:> Component {}]` —
+  rather than the boundary itself (`static.routes.panel/Panel`, the last
+  `rf/reg-view` of the five, became a boundary behind its own bridge in
+  PR #9648). A plain fn grades `:invalid` as a Fresco head, so the
+  island stands. `as-child` is `identity` for a hiccup caller and the
+  node lane, which leaves `[(:panel tab)]` exactly the vector it has
+  always been, and `reagent.core/as-element` for the boundary, which
+  answers a React element — a legal child anywhere per Fresco's
+  component ABI, and the crossing every Static panel's own bridge
+  comment already describes.
 
-  MIGRATION SCAFFOLDING WITH A DEFINED END: when all five Static panels
-  are boundaries the registry takes them directly, the `[:>]` bridges
-  go, and this seam goes with them."
+  MIGRATION SCAFFOLDING WITH A DEFINED END: when `reg-l4-tab!` stores
+  boundaries directly the `[:>]` bridges go, and this seam goes with
+  them. Widening that `:pre` is a registry change with both shells'
+  panels behind it, so it is not this slice's."
   [selected tab as-child]
   [:div {:data-testid (str "rf-xray-static-detail-panel-" (name selected))
            ;; Static L4 closes the tab/tabpanel loop.
@@ -597,49 +604,24 @@
   region boundaries below it.
 
   The argument is the ordinary one-props-map vector every `defview`
-  takes. [[surface-bridge]] mounts it with none, so it is destructured
-  away."
+  takes. `shell.cljs`'s `surface-composer` mounts it with none, so it is
+  destructured away."
   [_props]
   (surface-tree [ribbon {}] [tab-bar] [detail-panel]))
 
-;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;; ---- THE MIGRATION BRIDGE IS GONE (rf2-k97c.3) ---------------------------
 ;;
-;; Xray's DYNAMIC shell is still a `reg-view` tree rendered by the
-;; installed adapter, and `shell.cljs`'s `surface-composer` mounts this
-;; surface as the hiccup head `[static-shell/surface]` — which a React
-;; component is not.
-;;
-;; `rf.fresco/as-component` is Fresco's own outward door for exactly
-;; this: it answers a real React component for a boundary, which a React
-;; parent (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS
-;; ALREADY IN, taking the frame from React context rather than from a
-;; second root. So there is no second root here, no adapter-kind branch,
-;; and no props ABI.
-;;
-;; THE BRIDGE IS PUBLIC, unlike the Static panels' private ones, and
-;; that is measured rather than defaulted: `surface-composer` mounts it
-;; BY NAME from another namespace, so a name has to cross. `surface`
-;; itself keeps the natural name — the #9581 spelling the mayor's
-;; RULING 1 fixed as the surviving one — and neither
-;; `spec/api-manifest.edn` nor its curated sidecar rows anything in this
-;; namespace, so no hot-zone file moves.
-;;
-;; THIS IS SCAFFOLDING WITH A DEFINED END. When `shell.cljs` is itself a
+;; #9644 shipped `surface-component` + a PUBLIC `surface-bridge` here,
+;; because `shell.cljs`'s `surface-composer` was an `rf/reg-view` and a
+;; React component is not a legal hiccup head in a Reagent tree. That
+;; comment named its own end condition: "when `shell.cljs` is itself a
 ;; Fresco tree, `surface-composer` heads `surface` directly, `[:>]` goes,
-;; and both defs below are deleted.
-
-(def ^:private surface-component
-  "The React component [[surface]] presents as, for a non-Fresco parent.
-  Declared once at top level beside the view, as
-  `rf.fresco/as-component`'s contract requires — deriving it per render
-  would mint a new component type every time and remount the whole
-  Static surface on each parent render."
-  (rf.fresco/as-component surface))
-
-(defn surface-bridge
-  "The callable `shell.cljs`'s `surface-composer` mounts for Static
-  mode. Returns Reagent-shaped hiccup interoping to the React component
-  above; the shell's enclosing `rf/frame-provider` is what puts
-  `:rf/xray` in React context for it."
-  []
-  [:> surface-component {}])
+;; and both defs below are deleted."
+;;
+;; `surface-composer` IS a `rf.fresco/defview` now, so it heads
+;; `[static-shell/surface {}]` directly and both defs are deleted. The
+;; ONE crossing into this tree moved up a level to `shell.cljs`'s own
+;; private `surface-bridge`, which is what `shell-view` — still the
+;; Reagent root the installed adapter renders — mounts. When the epic's
+;; coupling (1) is severed and `mount.cljs` owns a Fresco root, that last
+;; bridge goes too.

--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -22,6 +22,8 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -72,7 +74,7 @@
     (setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             dividers (rf.test-helpers/find-by-testid-prefix
                        tree "rf-xray-event-list-col-divider-")]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-list-col-divider-source"))
@@ -111,7 +113,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-event-list-col-width :timestamp 120]))
     (rf/with-frame :rf/xray
-      (let [tree        (shell/shell-view)
+      (let [tree        (dynamic-shell-tree/shell-view-tree)
             h-timestamp (rf.test-helpers/find-by-testid tree "rf-xray-event-list-col-timestamp")
             r-time      (rf.test-helpers/find-by-testid tree "rf-xray-row-time-chip")]
         (is (some? h-timestamp) "header timestamp cell renders")
@@ -129,7 +131,7 @@
     (setup!)
     (trace-collector/seed-trace-for-test! (timer-cascade-trace-ev 1 [:poll/tick]))
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             h-source (rf.test-helpers/find-by-testid tree "rf-xray-event-list-col-source")
             r-source (rf.test-helpers/find-by-testid tree "rf-xray-row-origin-after-timer")
             h-time   (rf.test-helpers/find-by-testid tree "rf-xray-event-list-col-timestamp")
@@ -336,7 +338,7 @@
                                       ([ev]       (swap! dispatches conj ev) nil)
                                       ([ev _opts] (swap! dispatches conj ev) nil))]
       (rf/with-frame :rf/xray
-        (let [tree    (shell/shell-view)
+        (let [tree    (dynamic-shell-tree/shell-view-tree)
               divider (rf.test-helpers/find-by-testid
                         tree "rf-xray-event-list-col-divider-source")
               handler (:on-double-click (second divider))]
@@ -356,7 +358,7 @@
     (setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree    (shell/shell-view)
+      (let [tree    (dynamic-shell-tree/shell-view-tree)
             divider (rf.test-helpers/find-by-testid
                       tree "rf-xray-event-list-col-divider-source")
             props   (second divider)]

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -31,6 +31,8 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -113,7 +115,7 @@
             semantics."
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree    (shell/shell-view {:mode :inline})
+      (let [tree    (dynamic-shell-tree/shell-view-tree {:mode :inline})
             testids (all-testids tree)
             list-idx (.indexOf (clj->js testids) "rf-xray-event-list")
             seam-idx (.indexOf (clj->js testids) "rf-xray-event-list-seam")
@@ -133,7 +135,7 @@
             sole vertical-resize affordance."
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view {:mode :inline})
+      (let [tree  (dynamic-shell-tree/shell-view-tree {:mode :inline})
             list  (rf.test-helpers/find-by-testid tree "rf-xray-event-list")
             style (:style (second list))]
         (is (some? list) "event-list container present")
@@ -380,7 +382,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-events-list-height-px 360]))
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view {:mode :inline})
+      (let [tree  (dynamic-shell-tree/shell-view-tree {:mode :inline})
             list  (rf.test-helpers/find-by-testid tree "rf-xray-event-list")
             style (:style (second list))]
         (is (= "360px" (:height style))

--- a/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/hidden_indicator_cljs_test.cljs
@@ -19,6 +19,8 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -160,7 +162,7 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 3 [:noise/tick]))
   (frame-dispatch [:rf.xray/add-filter :out {:pattern :noise/tick}])
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)
+    (let [tree (dynamic-shell-tree/shell-view-tree)
           indicator (rf.test-helpers/find-by-testid tree "rf-xray-filters-hidden-indicator")
           count-node (rf.test-helpers/find-by-testid tree "rf-xray-filters-hidden-count")]
       (is (some? indicator) "banner renders when rows are hidden")
@@ -185,7 +187,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 3 [:noise/tick]))
     (frame-dispatch [:rf.xray/add-filter :out {:pattern :noise/tick}])
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         ;; the committed OUT pill renders ONCE — in the left cluster.
         (is (= 1 (count-by-testid tree "rf-xray-filter-pill-out-0"))
             "the committed pill renders exactly once (left cluster)")
@@ -205,7 +207,7 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:a]))
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:b]))
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)]
+    (let [tree (dynamic-shell-tree/shell-view-tree)]
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-filters-hidden-indicator"))
           "no banner when filtered == raw"))))
 

--- a/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/right_click_integration_cljs_test.cljs
@@ -15,6 +15,8 @@
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -70,7 +72,7 @@
                                         ([ev]       (swap! dispatches conj ev) nil)
                                         ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree (shell/shell-view)
+          (let [tree (dynamic-shell-tree/shell-view-tree)
                 row  (rf.test-helpers/find-by-testid tree "rf-xray-event-row-7")
                 h    (:on-context-menu (second row))]
             (is (some? row) "row mounted")
@@ -127,14 +129,14 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 3 [:order/submit]))
   (rf/with-frame :rf/xray
     ;; Sanity — all three rows present pre-filter.
-    (let [tree (shell/shell-view)]
+    (let [tree (dynamic-shell-tree/shell-view-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-3"))))
     ;; Install the OUT pill via the canonical add-filter event.
     (rf/dispatch-sync [:rf.xray/add-filter :out {:pattern :mouse-move}])
     ;; Re-render and assert :mouse-move dropped.
-    (let [tree (shell/shell-view)]
+    (let [tree (dynamic-shell-tree/shell-view-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2"))
           "row 2 (:mouse-move) filtered out")

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -35,6 +35,8 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.view :as settings-view]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.test-helpers.static-shell-tree
@@ -80,7 +82,7 @@
             cycle. The overlay was previously a bare <div>."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             shell (rf.test-helpers/find-by-testid tree "rf-xray-shell")
             attrs (props shell)]
         (is (some? shell) "shell root mounts")
@@ -103,7 +105,7 @@
             back to the active tab's id."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree         (shell/shell-view)
+      (let [tree         (dynamic-shell-tree/shell-view-tree)
             active-tab   :epoch ;; default (post rf2-5gl5r — supersedes :event)
             tab-button   (rf.test-helpers/find-by-testid tree (str "rf-xray-tab-" (name active-tab)))
             tab-attrs    (props tab-button)
@@ -309,7 +311,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/note-sensitive-suppressed :rf/default]))
     (rf/with-frame :rf/xray
-      (let [tree      (shell/shell-view)
+      (let [tree      (dynamic-shell-tree/shell-view-tree)
             indicator (rf.test-helpers/find-by-testid tree "rf-xray-redacted-indicator")
             ;; the glyph is the first <span> child carrying aria-hidden
             glyph     (some (fn [node]
@@ -334,7 +336,7 @@
             the visible label by construction."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree      (shell/shell-view)
+      (let [tree      (dynamic-shell-tree/shell-view-tree)
             event-tab (rf.test-helpers/find-by-testid tree "rf-xray-tab-event")
             glyph     (some (fn [node]
                               (when (and (vector? node)

--- a/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
@@ -37,6 +37,8 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.panels.trace :as trace]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.theme.tokens :as tokens]
@@ -107,7 +109,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (trace-collector/seed-trace-for-test! (handler-exception-ev 99 1))
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             row   (find-by-testid tree "rf-xray-event-row-1")
             attrs (second row)]
         (is (some? row) "L2 row renders for the cascade")

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -28,6 +28,8 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -82,7 +84,7 @@
             mount)"
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view {:mode :inline})]
+      (let [tree (dynamic-shell-tree/shell-view-tree {:mode :inline})]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-resize-handle"))
             "resize handle present in :inline mode")))))
 
@@ -90,7 +92,7 @@
   (testing "popout mode hides the handle — separate OS window owns resize"
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view {:mode :popout})]
+      (let [tree (dynamic-shell-tree/shell-view-tree {:mode :popout})]
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-resize-handle"))
             "resize handle absent in :popout mode")))))
 

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -44,8 +44,13 @@
   hiccup tree by `data-testid` rather than mounting to a DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            ;; rf2-k97c.3 — the codec's own hiccup->element door, so the
+            ;; L2 row key is graded by the SHIPPED renderer rather than by
+            ;; reading the attribute map back.
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
@@ -1004,6 +1009,76 @@
             rows (find-all-by-testid-prefix tree "rf-xray-event-row-")]
         (is (= 2 (count rows))
             "one row per cascade")))))
+
+;; ---- the L2 row key, graded at the renderer (rf2-k97c.3) -----------------
+;;
+;; `event-row` used to be a hiccup HEAD, so the React key rode the `:key`
+;; slot of the opts map at `event-list`'s call site and React read it off
+;; the head's props. Fresco grades a plain fn in head position a loud
+;; error, so `event-list-tree` CALLS it — the opts map is now an ordinary
+;; argument React never sees, and the key moved one level down into the
+;; `<li>` the fn returns.
+;;
+;; A LOST KEY DOES NOT FAIL, IT DEGRADES into index-based reconciliation,
+;; which paints identically and corrupts row identity only once the list
+;; changes shape. No existing row can see that, which is why this pair is
+;; graded at the RENDERERS rather than by reading the map.
+;;
+;; BOTH DOORS TAKE HEAD + ATTRS ONLY (`subvec node 0 2`). The key is read
+;; off the attribute map by both renderers, so dropping the subtree
+;; changes nothing about the answer — and it is NECESSARY, because the
+;; codec lowers children eagerly and an `<li>`'s subtree reaches
+;; `col-divider` / `relative-time-chip` / `duration-cell`, plain fns that
+;; are CALLED here but whose refusal would otherwise hide the key answer
+;; behind an HD-016 throw. There is no metadata in play at either site, so
+;; subvec'ing both sides costs nothing (the asymmetric form — whole node
+;; for Reagent — is only needed when grading metadata against attrs).
+
+(defn- reagent-row-key
+  "The key Reagent hands React. It reads metadata AND props, so it cannot
+  see the defect alone; it pins the move as a no-op under the substrate
+  Xray ships on today."
+  [node]
+  (.-key (r/as-element (subvec node 0 2))))
+
+(defn- fresco-row-key
+  "The key the shipped Fresco codec commits, read off the node's own
+  attribute map — the ONE spelling that reaches React under a boundary."
+  [node]
+  (.-key (rf.fresco.impl.codec/as-element (subvec node 0 2))))
+
+(deftest l2-rows-reach-react-with-a-key-on-both-renderers
+  (testing "rf2-k97c.3 — every L2 row's React key survives `event-row`
+            becoming a CALL. Graded at both renderers: Reagent's answer
+            pins today's behaviour, and the codec's is the one that can
+            see the key go missing, because it reads the attribute map
+            and Clojure metadata nowhere.
+
+            The keys must also be DISTINCT and derived from the
+            dispatch-id — a constant key is as wrong as no key, and
+            neither shows up in a paint."
+    (xray-setup!)
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:baz/qux]))
+    (rf/with-frame :rf/xray
+      (let [tree (dynamic-shell-tree/shell-view-tree)
+            rows (find-all-by-testid-prefix tree "rf-xray-event-row-")]
+        ;; The control: a zero here would make every assertion below
+        ;; vacuous, and a broken seed reads exactly like a passing sweep.
+        (is (= 2 (count rows))
+            "CONTROL — two seeded cascades produce two rows to grade")
+        (doseq [row rows]
+          (is (some? (fresco-row-key row))
+              (str "the codec reads a key off this row's attribute map. "
+                   "Got: " (pr-str (:key (second row)))))
+          (is (some? (reagent-row-key row))
+              "Reagent reads a key off this row too"))
+        (is (= (mapv fresco-row-key rows) (mapv reagent-row-key rows))
+            "both renderers answer the SAME key — the attribute-map
+             spelling is the one both honour")
+        (is (= #{"1" "2"} (set (map fresco-row-key rows)))
+            (str "each row is keyed by its own dispatch-id. Got: "
+                 (pr-str (mapv fresco-row-key rows))))))))
 
 (deftest event-list-renders-figma-column-header
   (testing "rf2-ad7zx.12 + rf2-lnod7 — the L2 list carries the Figma

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -50,6 +50,8 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.theme.tokens :refer [tokens layout]]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
@@ -132,7 +134,7 @@
             plus all four chrome layers per spec/018 §2"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-shell"))
             "shell envelope present")
         (is (some? (find-by-testid tree "rf-xray-ribbon"))
@@ -156,11 +158,11 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/set-mode :dynamic])
-      (let [shell (find-by-testid (shell/shell-view) "rf-xray-shell")]
+      (let [shell (find-by-testid (dynamic-shell-tree/shell-view-tree) "rf-xray-shell")]
         (is (= "mode-dynamic" (:class (second shell)))
             "Dynamic mode → mode-dynamic root class"))
       (rf/dispatch-sync [:rf.xray/set-mode :static])
-      (let [shell (find-by-testid (shell/shell-view) "rf-xray-shell")]
+      (let [shell (find-by-testid (dynamic-shell-tree/shell-view-tree) "rf-xray-shell")]
         (is (= "mode-static" (:class (second shell)))
             "Static mode → mode-static root class")))))
 
@@ -169,7 +171,7 @@
             None of the historical sidebar-item testids may surface."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (empty? (find-all-by-testid-prefix tree "rf-xray-sidebar-item-"))
             "no legacy sidebar rows render")
         (is (nil? (find-by-testid tree "rf-xray-bottom-rail"))
@@ -204,30 +206,38 @@
             previously triggered it."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [shell-tree (shell/shell-view)]
+      (let [shell-tree (dynamic-shell-tree/shell-view-tree)]
         (is (vector? shell-tree) "shell-view returns a hiccup vector")
         (is (keyword? (first shell-tree))
             (str "shell-view root is a keyword DOM tag — was "
                  (pr-str (first shell-tree)))))
-      (let [composer-tree (shell/surface-composer)]
+      (let [composer-tree (dynamic-shell-tree/surface-composer-tree)]
         (is (vector? composer-tree) "surface-composer returns a hiccup vector")
         (is (keyword? (first composer-tree))
             (str "surface-composer root is a keyword DOM tag — was "
                  (pr-str (first composer-tree)))))
-      (let [chrome-tree (shell/dynamic-chrome)]
+      (let [chrome-tree (dynamic-shell-tree/dynamic-chrome-tree)]
         (is (vector? chrome-tree) "dynamic-chrome returns a hiccup vector")
         (is (keyword? (first chrome-tree))
             (str "dynamic-chrome root is a keyword DOM tag — was "
                  (pr-str (first chrome-tree))))))))
 
-(deftest ribbon-theme-toggle-is-reg-view-registered
+(deftest ribbon-theme-toggle-is-view-registered
   (testing "rf2-uu3lp — the theme toggle's `:theme` setting lives in
-            `:rf/xray`, so its subscribe + dispatch must route to that
-            frame. As a plain `defn` it was leaking subscribes into
-            `:rf/default`. `reg-view`-registration installs the
-            `:contextType frame-context` static so the surrounding
-            `:rf/xray` Provider reaches the component via React-context.
-            We assert the registration is present in the view registry."
+            `:rf/xray`, so its read + dispatch must route to that frame.
+            As a plain `defn` it was leaking subscribes into
+            `:rf/default`.
+
+            rf2-k97c.3 — it is an `rf.fresco/defview` now rather than an
+            `rf/reg-view`, which is a STRONGER guarantee of the same
+            thing: a boundary DECLARES its frame, so an ambient read
+            inside its body is a loud refusal rather than a silent
+            fall-through to `:rf/default`. The registry entry survives
+            the change and is what this row asserts — `defview` publishes
+            one under `(keyword \"<ns>\" \"<sym>\")`, the id `reg-view`
+            derives from its own symbol, so `(rf/view id)` answers a
+            boundary exactly as it answered the `reg-view`. The entry is
+            debug-gated, which the node lane satisfies."
     (xray-setup!)
     (is (some? (rf/view ::shell/ribbon-theme-toggle))
         "ribbon-theme-toggle is registered under its namespaced id")))
@@ -244,7 +254,7 @@
             shell tree."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-ribbon-nav"))
             "nav cluster present (now in the chrome ribbon, bar-1)")
         (is (or (find-by-testid tree "rf-xray-ribbon-frame")
@@ -266,7 +276,7 @@
             now backed by `:rf.xray/popout-shell` → `mount/popout!`."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             icons  (find-by-testid tree "rf-xray-ribbon-icons")
             popout (find-by-testid tree "rf-xray-icon-popout")]
         (is (some? icons) "right-icons cluster still mounts")
@@ -290,7 +300,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree    (shell/shell-view)
+          (let [tree    (dynamic-shell-tree/shell-view-tree)
                 popout  (find-by-testid tree "rf-xray-icon-popout")
                 handler (:on-click (second popout))]
             (is (some? popout) "pop-out icon present in the chrome ribbon")
@@ -312,7 +322,7 @@
             retired the focus button + chip."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon (shell/ribbon nil)]
+      (let [ribbon (dynamic-shell-tree/ribbon-tree)]
         (is (some? (find-by-testid ribbon "rf-xray-ribbon-selectors"))
             "left cluster present")
         ;; A4 — the `Events` label leads the left cluster (the `❖ Xray`
@@ -349,7 +359,7 @@
             cluster."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon    (shell/ribbon nil)
+      (let [ribbon    (dynamic-shell-tree/ribbon-tree)
             selectors (find-by-testid ribbon "rf-xray-ribbon-selectors")
             label     (find-by-testid ribbon "rf-xray-ribbon-events-label")]
         (is (some? label) "the `Event History` label renders in the chrome ribbon")
@@ -370,7 +380,7 @@
             observed live 2026-05-24."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon (shell/ribbon nil)
+      (let [ribbon (dynamic-shell-tree/ribbon-tree)
             root   (find-by-testid ribbon "rf-xray-ribbon")
             style  (:style (second root))]
         (is (some? root))
@@ -390,7 +400,7 @@
             cluster overflow horizontally when necessary."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon    (shell/ribbon nil)
+      (let [ribbon    (dynamic-shell-tree/ribbon-tree)
             selectors (find-by-testid ribbon "rf-xray-ribbon-selectors")
             style     (:style (second selectors))]
         (is (some? selectors)
@@ -426,7 +436,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/add-filter :out {:pattern :noise/tick}]))
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             ribbon (find-by-testid tree "rf-xray-events-ribbon")]
         (is (some? ribbon) "events ribbon mounts as its own stratum")
         ;; A6 — the committed pills cluster lives here.
@@ -449,7 +459,7 @@
     (trace-collector/seed-trace-for-test! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             collapse (find-by-testid tree "rf-xray-events-ribbon-collapse")]
         (is (some? collapse) "the collapse track stays mounted (for the animation)")
         (is (= "false" (:data-open (second collapse)))
@@ -470,7 +480,7 @@
                                :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
     ;; before: closed
     (rf/with-frame :rf/xray
-      (is (= "false" (:data-open (second (find-by-testid (shell/shell-view)
+      (is (= "false" (:data-open (second (find-by-testid (dynamic-shell-tree/shell-view-tree)
                                                          "rf-xray-events-ribbon-collapse"))))
           "closed before any filter"))
     ;; add a filter
@@ -478,7 +488,7 @@
       (rf/dispatch-sync [:rf.xray/add-filter :in {:pattern :a}]))
     ;; after: open
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (= "true" (:data-open (second (find-by-testid tree "rf-xray-events-ribbon-collapse"))))
             "open after the first filter is added")
         (is (some? (find-by-testid tree "rf-xray-ribbon-filters"))
@@ -496,7 +506,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/add-filter :out {:pattern :noise/tick}]))
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             collapse (find-by-testid tree "rf-xray-events-ribbon-collapse")]
         (is (= "true" (:data-open (second collapse)))
             "the filters ribbon collapse track is OPEN when a filter is active")
@@ -521,7 +531,7 @@
     (trace-collector/seed-trace-for-test! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             collapse (find-by-testid tree "rf-xray-filter-add-collapse")
             button   (find-by-testid tree "rf-xray-filter-add")]
         (is (some? collapse) "the horizontal collapse track is mounted")
@@ -544,7 +554,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/add-filter :in {:pattern :a}]))
     (rf/with-frame :rf/xray
-      (let [tree         (shell/shell-view)
+      (let [tree         (dynamic-shell-tree/shell-view-tree)
             collapse     (find-by-testid tree "rf-xray-filter-add-collapse")
             events-coll  (find-by-testid tree "rf-xray-events-ribbon-collapse")
             events-add   (find-by-testid tree "rf-xray-filter-add-events")]
@@ -570,7 +580,7 @@
       (rf/dispatch-sync [:rf.xray/add-filter :in {:pattern :a}])
       (rf/dispatch-sync [:rf.xray/remove-filter :in 0]))
     (rf/with-frame :rf/xray
-      (let [tree        (shell/shell-view)
+      (let [tree        (dynamic-shell-tree/shell-view-tree)
             collapse    (find-by-testid tree "rf-xray-filter-add-collapse")
             events-coll (find-by-testid tree "rf-xray-events-ribbon-collapse")]
         (is (= "true" (:data-open (second collapse)))
@@ -588,7 +598,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree    (shell/shell-view)
+          (let [tree    (dynamic-shell-tree/shell-view-tree)
                 close   (find-by-testid tree "rf-xray-icon-close")
                 handler (:on-click (second close))]
             (is (some? close) "close icon present in the chrome ribbon")
@@ -605,7 +615,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [ribbon  (shell/ribbon nil)
+          (let [ribbon  (dynamic-shell-tree/ribbon-tree)
                 select  (find-by-testid ribbon "rf-xray-mode-pill")
                 on-chg  (:on-change (second select))]
             (is (some? on-chg) "mode dropdown carries an on-change handler")
@@ -639,7 +649,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree (shell/shell-view)
+          (let [tree (dynamic-shell-tree/shell-view-tree)
                 head (find-by-testid tree "rf-xray-nav-head")
                 handler (:on-click (second head))]
             (is (some? head) "fast-forward button present")
@@ -692,7 +702,7 @@
             / Frames / Fresco per EP-0014 / EP-0013 / rf2-hic-023."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             tabs     (find-all-by-testid-prefix tree "rf-xray-tab-")
             ;; Every `rf-xray-tab-*` testid actually in the tree, as the
             ;; ids they encode. Derived from the RENDER, never from
@@ -742,7 +752,7 @@
             lookups when Xray was embedded in Story."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             tab-bar (find-by-testid tree "rf-xray-tab-bar")
             head    (first tab-bar)
             attrs   (second tab-bar)]
@@ -756,7 +766,7 @@
       ;; Per-tab ARIA: role='tab' on every button, aria-selected matching
       ;; the active state. The active tab is the default :epoch
       ;; (post rf2-5gl5r — previously :event).
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (doseq [tab-id expected-tab-ids]
           (let [btn   (find-by-testid tree (str "rf-xray-tab-" (name tab-id)))
                 attrs (second btn)]
@@ -771,7 +781,7 @@
     ;; After switching tabs the aria-selected flips with the active tab.
     (select-tab! :machines)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (doseq [tab-id expected-tab-ids]
           (let [btn   (find-by-testid tree (str "rf-xray-tab-" (name tab-id)))
                 attrs (second btn)]
@@ -790,7 +800,7 @@
             a faint translucent-white fill + muted-white ink."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree            (shell/shell-view)
+      (let [tree            (dynamic-shell-tree/shell-view-tree)
             active-fill     (:chrome-ribbon-tab-active tokens)
             active-ink      (:chrome-ribbon-tab-active-text tokens)
             inactive-ink    (:chrome-ribbon-text-muted tokens)
@@ -832,7 +842,7 @@
     ;; selection (and the old tab reverts to the translucent fill).
     (select-tab! :machines)
     (rf/with-frame :rf/xray
-      (let [tree        (shell/shell-view)
+      (let [tree        (dynamic-shell-tree/shell-view-tree)
             active-fill (:chrome-ribbon-tab-active tokens)
             mach        (:style (second (find-by-testid tree "rf-xray-tab-machines")))
             epoch       (:style (second (find-by-testid tree "rf-xray-tab-epoch")))]
@@ -851,7 +861,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree (shell/shell-view)
+          (let [tree (dynamic-shell-tree/shell-view-tree)
                 tab  (find-by-testid tree "rf-xray-tab-trace")
                 handler (:on-click (second tab))]
             (is (some? tab))
@@ -866,13 +876,13 @@
     (xray-setup!)
     ;; default tab → :epoch (post rf2-5gl5r — supersedes :event)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-detail-panel-epoch"))
             "default detail panel is :epoch")))
     ;; flip to :app-db
     (select-tab! :app-db)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-detail-panel-app-db"))
             "detail panel rebinds to :app-db after select-tab")
         (is (nil? (find-by-testid tree "rf-xray-detail-panel-epoch"))
@@ -881,7 +891,7 @@
     ;; Option (c); flip to another real tab to pin the rebind)
     (select-tab! :machines)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-detail-panel-machines"))
             "detail panel rebinds to :machines")))))
 
@@ -892,7 +902,7 @@
             change, which auto-plays the keyframes."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree    (shell/shell-view)
+      (let [tree    (dynamic-shell-tree/shell-view-tree)
             wrapper (find-by-testid tree "rf-xray-detail-panel-fade-epoch")
             anim    (get-in wrapper [1 :style :animation])]
         (is (some? wrapper)
@@ -935,7 +945,7 @@
     (rf/with-frame :rf/xray
       (doseq [[tab-id expected-fn] expected-detail-fn]
         (select-tab! tab-id)
-        (let [rendered (#'shell/detail-panel)
+        (let [rendered (dynamic-shell-tree/detail-panel-tree)
               ;; outer = [:div {outer-style} fade-wrapper]
               ;; fade-wrapper = [:div {fade-style} [Panel-fn]]
               ;; rf2-5kfxe.3 — peel one extra level to reach the Panel.
@@ -980,7 +990,7 @@
   (testing "empty cascade list shows the spec/018 §4 empty-state hint"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-event-list-empty"))
             "empty state hint renders when no cascades")))))
 
@@ -990,7 +1000,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:baz/qux]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             rows (find-all-by-testid-prefix tree "rf-xray-event-row-")]
         (is (= 2 (count rows))
             "one row per cascade")))))
@@ -1005,7 +1015,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             header (find-by-testid tree "rf-xray-event-list-header")]
         (is (some? header) "the column-header row renders when rows exist")
         (is (some? (find-by-testid tree "rf-xray-event-list-col-source"))
@@ -1046,7 +1056,7 @@
           (assoc :time 1000)
           (assoc-in [:tags :source] :after-timer)))
     (rf/with-frame :rf/xray
-      (let [tree        (shell/shell-view)
+      (let [tree        (dynamic-shell-tree/shell-view-tree)
             ;; header cells
             header      (find-by-testid tree "rf-xray-event-list-header")
             h-source    (find-by-testid tree "rf-xray-event-list-col-source")
@@ -1113,7 +1123,7 @@
             message with no column-header chrome above it."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-event-list-empty"))
             "empty state renders")
         (is (nil? (find-by-testid tree "rf-xray-event-list-header"))
@@ -1132,7 +1142,7 @@
       (assoc-in (dispatch-trace-ev 1 [:poll/tick])
                 [:tags :source] :after-timer))
     (rf/with-frame :rf/xray
-      (let [tree    (shell/shell-view)
+      (let [tree    (dynamic-shell-tree/shell-view-tree)
             tagged  (find-by-testid tree "rf-xray-row-origin-after-timer")]
         (is (some? tagged) "the :after-timer row carries a source tag")
         (is (re-find #"after-timer" (text-nodes tagged))
@@ -1148,7 +1158,7 @@
     ;; A plain (:user / untagged) cascade — source column reads `ui`.
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             ui-tag (find-by-testid tree "rf-xray-row-origin-ui")]
         (is (some? ui-tag)
             "the default ui-origin row carries a non-blank source tag")
@@ -1163,7 +1173,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:poll/tick]))
     (trace-collector/seed-trace-for-test! (run-end-trace-ev 1 1.234))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             cell (find-by-testid tree "rf-xray-row-duration")]
         (is (some? cell) "the row's duration cell renders")
         (is (re-find #"1\.2 ms" (text-nodes cell))
@@ -1180,7 +1190,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:poll/tick]))
     (trace-collector/seed-trace-for-test! (run-end-trace-ev 1 0.4))
     (rf/with-frame :rf/xray
-      (let [tree       (shell/shell-view)
+      (let [tree       (dynamic-shell-tree/shell-view-tree)
             h-duration (find-by-testid tree "rf-xray-event-list-col-duration")
             r-duration (find-by-testid tree "rf-xray-row-duration")]
         (is (some? h-duration) "header duration column renders")
@@ -1227,7 +1237,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:standard-epochs/throw-handler]))
     (trace-collector/seed-trace-for-test! (error-trace-ev 2))
     (rf/with-frame :rf/xray
-      (let [tree       (shell/shell-view)
+      (let [tree       (dynamic-shell-tree/shell-view-tree)
             clean-row  (find-by-testid tree "rf-xray-event-row-1")
             issue-row  (find-by-testid tree "rf-xray-event-row-2")]
         (is (some? clean-row) "the clean cascade's row renders")
@@ -1264,7 +1274,7 @@
                                :operation :sub/registered
                                :tags {:rf.sub/id :foo/bar}})
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             rows (find-all-by-testid-prefix tree "rf-xray-event-row-")
             text (text-nodes tree)]
         (is (= 1 (count rows))
@@ -1282,7 +1292,7 @@
                                :operation :sub/registered
                                :tags {:rf.sub/id :foo/bar}})
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (some? (find-by-testid tree "rf-xray-event-list-empty"))
             "empty-state container present when only :ungrouped cascades exist")
         (is (empty? (find-all-by-testid-prefix tree "rf-xray-event-row-"))
@@ -1315,7 +1325,7 @@
                                  :operation :sub/registered
                                  :tags {:rf.sub/id :foo/bar}})
       (rf/with-frame :rf/xray
-        (let [tree (shell/shell-view)
+        (let [tree (dynamic-shell-tree/shell-view-tree)
               rows (find-all-by-testid-prefix tree "rf-xray-event-row-")
               ungrouped-row (find-by-testid tree "rf-xray-event-row-:ungrouped")]
           (is (= 2 (count rows))
@@ -1337,7 +1347,7 @@
                                :operation :sub/registered
                                :tags {:rf.sub/id :foo/bar}})
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             rows (find-all-by-testid-prefix tree "rf-xray-event-row-")]
         (is (= 1 (count rows))
             "only the real event renders — :ungrouped is filtered out")
@@ -1360,7 +1370,7 @@
                                      ([ev]       (swap! dispatches conj ev) nil)
                                      ([ev _opts] (swap! dispatches conj ev) nil))]
           (rf/with-frame :rf/xray
-            (let [tree (shell/shell-view)
+            (let [tree (dynamic-shell-tree/shell-view-tree)
                   row  (find-by-testid tree "rf-xray-event-row-:ungrouped")
                   handler (:on-click (second row))]
               (is (some? row) ":ungrouped row is present")
@@ -1381,7 +1391,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree (shell/shell-view)
+          (let [tree (dynamic-shell-tree/shell-view-tree)
                 row  (find-by-testid tree "rf-xray-event-row-1")
                 handler (:on-click (second row))]
             (is (some? row) "row for cascade 1 is present")
@@ -1410,7 +1420,7 @@
             <style> injection (DOM-side, not assertable in node-test)."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             list-el (find-by-testid tree "rf-xray-event-list")
             style  (:style (second list-el))]
         (is (some? list-el) "event-list container present")
@@ -1428,7 +1438,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
       (let [focus @(rf/subscribe [:rf.xray/focus])
-            tree  (shell/shell-view)
+            tree  (dynamic-shell-tree/shell-view-tree)
             row   (find-by-testid tree "rf-xray-event-row-1")]
         (is (= :live (:mode focus)) "spine starts in :live mode")
         (is (:head? focus) "focus is on head")
@@ -1448,7 +1458,7 @@
       (rf/dispatch-sync [:rf.xray/focus-event 1]))
     (rf/with-frame :rf/xray
       (let [focus @(rf/subscribe [:rf.xray/focus])
-            tree  (shell/shell-view)
+            tree  (dynamic-shell-tree/shell-view-tree)
             row   (find-by-testid tree "rf-xray-event-row-1")]
         (is (= :retro (:mode focus)) "spine is in :retro after focus-cascade")
         (is (some? row) "focused row renders")
@@ -1464,7 +1474,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:newer/event]))
     ;; Focus auto-snaps to head (id 2). Row 1 is the non-focused row.
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             row1 (find-by-testid tree "rf-xray-event-row-1")
             row2 (find-by-testid tree "rf-xray-event-row-2")]
         (is (some? row1) "row 1 present")
@@ -1567,7 +1577,7 @@
             (rf2-x5tro) so fast-forward is a no-op too."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nav-prev-disabled? tree) "◀ disabled when no events")
         (is (nav-next-disabled? tree) "▶ disabled when no events")
         (is (nav-head-disabled? tree)
@@ -1582,7 +1592,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:newer/event]))
     ;; Fresh focus auto-snaps to head (id 2) in :live mode. Sanity-check.
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             focus @(rf/subscribe [:rf.xray/focus])]
         (is (= 2 (:dispatch-id focus)) "focus snapped to head (id 2)")
         (is (= :live (:mode focus)) "spine is :live tracking head")
@@ -1602,7 +1612,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 1]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nav-prev-disabled? tree)
             "◀ DISABLED at tail — no older event to step back to")
         (is (not (nav-next-disabled? tree))
@@ -1618,7 +1628,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 2]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (not (nav-prev-disabled? tree))
             "◀ ENABLED — older event (1) reachable")
         (is (not (nav-next-disabled? tree))
@@ -1638,7 +1648,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/toggle-live-pause]))
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             focus @(rf/subscribe [:rf.xray/focus])]
         (is (= :live (:mode focus)) "mode is still :live (only paused)")
         (is (true? (:paused? focus)) "LIVE feed paused")
@@ -1657,7 +1667,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             head   (find-by-testid tree "rf-xray-nav-head")
             style  (:style (second head))
             active (find-by-testid tree "rf-xray-ribbon-nav")]
@@ -1708,7 +1718,7 @@
                                :operation :sub/registered
                                :tags {:rf.sub/id :foo/bar}})
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nav-prev-disabled? tree)
             "◀ DISABLED — focus is on the only real event; :ungrouped
              is not a step target")
@@ -1725,7 +1735,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             prev (find-by-testid tree "rf-xray-nav-prev")
             attrs (second prev)]
         (is (true? (:disabled attrs)) "native :disabled set")
@@ -1746,7 +1756,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree (shell/shell-view)
+          (let [tree (dynamic-shell-tree/shell-view-tree)
                 prev (find-by-testid tree "rf-xray-nav-prev")
                 handler (:on-click (second prev))]
             (is (nil? handler)
@@ -1793,7 +1803,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             row  (find-by-testid tree "rf-xray-event-row-1")
             style (:style (second row))]
         (is (some? row) "row renders")
@@ -1812,7 +1822,7 @@
             default 200px."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             list  (find-by-testid tree "rf-xray-event-list")
             style (:style (second list))]
         (is (= "200px" (:height style))
@@ -1832,7 +1842,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add-item]))
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             row   (find-by-testid tree "rf-xray-event-row-1")
             props (second row)]
         (is (some? row) "row renders")
@@ -1863,7 +1873,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree    (shell/shell-view)
+          (let [tree    (dynamic-shell-tree/shell-view-tree)
                 row     (find-by-testid tree "rf-xray-event-row-1")
                 handler (:on-key-down (second row))
                 ;; Synthetic key event — preventDefault is a no-op stub
@@ -1892,7 +1902,7 @@
                                    ([ev]       (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/xray
-          (let [tree    (shell/shell-view)
+          (let [tree    (dynamic-shell-tree/shell-view-tree)
                 row     (find-by-testid tree "rf-xray-event-row-1")
                 handler (:on-key-down (second row))
                 evt     #js {:key "F10"
@@ -1913,7 +1923,7 @@
     (trace-collector/seed-trace-for-test!
       (dispatch-trace-ev 1 [:cart/add-item {:item-id "apple" :qty 2}]))
     (rf/with-frame :rf/xray
-      (let [tree    (shell/shell-view)
+      (let [tree    (dynamic-shell-tree/shell-view-tree)
             row     (find-by-testid tree "rf-xray-event-row-1")
             id-node (find-by-testid tree "rf-xray-row-event-id")
             text    (text-nodes id-node)]
@@ -1951,7 +1961,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:counter/inc]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nil? (find-by-testid tree "rf-xray-row-event-vector"))
             "legacy event-vector slot is absent")
         (is (some? (find-by-testid tree "rf-xray-row-event-id"))
@@ -2029,7 +2039,7 @@
             no sensitive events have been suppressed"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nil? (find-by-testid tree "rf-xray-redacted-indicator"))
             "no REDACTED node in the tree when count is 0")))))
 
@@ -2039,7 +2049,7 @@
     (xray-setup!)
     (note-suppressed! :rf/default)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             node (find-by-testid tree "rf-xray-redacted-indicator")]
         (is (some? node) "indicator renders when count > 0")
         (is (re-find #"REDACTED 1"
@@ -2052,7 +2062,7 @@
     (xray-setup!)
     (note-suppressed! :rf/default)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             node  (find-by-testid tree "rf-xray-redacted-indicator")
             title (:title (second node))]
         (is (some? node))
@@ -2063,7 +2073,7 @@
     (note-suppressed! :rf/default)
     (note-suppressed! :rf/default)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             node  (find-by-testid tree "rf-xray-redacted-indicator")
             title (:title (second node))]
         (is (re-find #"3 sensitive trace events " title)
@@ -2074,22 +2084,22 @@
             stays until the counter is reset"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (is (nil? (find-by-testid (shell/shell-view)
+      (is (nil? (find-by-testid (dynamic-shell-tree/shell-view-tree)
                                 "rf-xray-redacted-indicator"))))
     (note-suppressed! :rf/default)
     (rf/with-frame :rf/xray
-      (let [n (find-by-testid (shell/shell-view)
+      (let [n (find-by-testid (dynamic-shell-tree/shell-view-tree)
                               "rf-xray-redacted-indicator")]
         (is (some? n) "indicator appears on first bump")
         (is (re-find #"REDACTED 1" (text-nodes n)))))
     (note-suppressed! :rf/default)
     (rf/with-frame :rf/xray
-      (let [n (find-by-testid (shell/shell-view)
+      (let [n (find-by-testid (dynamic-shell-tree/shell-view-tree)
                               "rf-xray-redacted-indicator")]
         (is (re-find #"REDACTED 2" (text-nodes n)))))
     (reset-suppressed!)
     (rf/with-frame :rf/xray
-      (is (nil? (find-by-testid (shell/shell-view)
+      (is (nil? (find-by-testid (dynamic-shell-tree/shell-view-tree)
                                 "rf-xray-redacted-indicator"))
           "indicator drops back off when the counter is reset"))))
 
@@ -2099,7 +2109,7 @@
     (xray-setup!)
     (dotimes [_ 250] (note-suppressed! :rf/default))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             node (find-by-testid tree "rf-xray-redacted-indicator")]
         (is (some? node))
         (is (re-find #"REDACTED 250" (text-nodes node))
@@ -2133,7 +2143,7 @@
       (assoc-in (dispatch-trace-ev 2 [:cart/add])
                 [:tags :frame] :app/admin))
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             picker (find-by-testid tree "rf-xray-ribbon-frame-picker")
             attrs  (when picker (second picker))]
         (is (some? picker) "picker renders as a <select> for multi-frame")
@@ -2171,7 +2181,7 @@
     (xray-setup!)
     (add-filter! :in {:pattern ":auth/*"})
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             pill (find-by-testid tree "rf-xray-filter-pill-in-0")]
         (is (some? pill) "pill renders after add")
         (is (re-find #":auth/\*" (text-nodes pill))
@@ -2184,7 +2194,7 @@
     (add-filter! :out {:pattern ":anim-frame"})
     (remove-filter! :out 0)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             pill0 (find-by-testid tree "rf-xray-filter-pill-out-0")]
         ;; after removing idx 0 the surviving pill becomes idx 0 and
         ;; carries the second pattern.
@@ -2217,7 +2227,7 @@
             fires because the sub already matches the default prop."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             shell (find-by-testid tree "rf-xray-shell")]
         (is (some? shell))
         (is (= "fixed" (:data-rf-xray-modal-positioning (second shell)))
@@ -2233,7 +2243,7 @@
             root"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view {:modal-positioning :absolute})
+      (let [tree  (dynamic-shell-tree/shell-view-tree {:modal-positioning :absolute})
             shell (find-by-testid tree "rf-xray-shell")]
         (is (some? shell))
         (is (= "absolute" (:data-rf-xray-modal-positioning (second shell)))
@@ -2246,11 +2256,11 @@
             then render with :fixed (no opt) settles back to :fixed"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (shell/shell-view {:modal-positioning :absolute}))
+      (dynamic-shell-tree/shell-view-tree {:modal-positioning :absolute}))
     (rf/with-frame :rf/xray
       (is (= :absolute @(rf/subscribe [:rf.xray/modal-positioning]))))
     (rf/with-frame :rf/xray
-      (shell/shell-view))
+      (dynamic-shell-tree/shell-view-tree))
     (rf/with-frame :rf/xray
       (is (= :fixed @(rf/subscribe [:rf.xray/modal-positioning]))
           "no-opt render re-defaults the slot to :fixed"))))
@@ -2379,7 +2389,7 @@
     (let [then-ms 1000000]
       (trace-collector/seed-trace-for-test! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
       (rf/with-frame :rf/xray
-        (let [tree   (shell/shell-view)
+        (let [tree   (dynamic-shell-tree/shell-view-tree)
               chip   (find-by-testid tree "rf-xray-row-time-chip")
               attrs  (second chip)
               label  (text-nodes chip)]
@@ -2414,7 +2424,7 @@
       ;; mirrors the old row's `:foo/bar` host event.
       (trace-collector/seed-trace-for-test! (dispatch-trace-ev-with-time 2 [:foo/baz] fresh-ms))
       (rf/with-frame :rf/xray
-        (let [tree     (shell/shell-view)
+        (let [tree     (dynamic-shell-tree/shell-view-tree)
               chips    (find-all-by-testid tree "rf-xray-row-time-chip")
               old-chip (first (filter #(= (str old-ms) (:data-then-ms (second %))) chips))
               fr-chip  (first (filter #(= (str fresh-ms) (:data-then-ms (second %))) chips))]
@@ -2434,7 +2444,7 @@
     ;; lack `:time`, so the chip MUST NOT render.
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
+      (let [tree (dynamic-shell-tree/shell-view-tree)
             chip (find-by-testid tree "rf-xray-row-time-chip")]
         (is (nil? chip)
             "chip is absent when the cascade has no dispatched :time")))))
@@ -2515,7 +2525,7 @@
             is reserved for active/selected affordances."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon (shell/ribbon nil)
+      (let [ribbon (dynamic-shell-tree/ribbon-tree)
             label  (find-by-testid ribbon "rf-xray-ribbon-events-label")
             style  (:style (second label))]
         (is (some? label) "the `Event History` label renders")
@@ -2532,7 +2542,7 @@
         "the :top-strip-height layout token is 34px (reference)")
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [ribbon (shell/ribbon nil)
+      (let [ribbon (dynamic-shell-tree/ribbon-tree)
             style  (:style (second ribbon))]
         (is (= "34px" (:height style))
             "the chrome ribbon paints the 34px height")))))
@@ -2543,7 +2553,7 @@
             no border box."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree     (shell/shell-view)
+      (let [tree     (dynamic-shell-tree/shell-view-tree)
             settings (find-by-testid tree "rf-xray-icon-settings")
             close    (find-by-testid tree "rf-xray-icon-close")]
         (doseq [[label btn] [["settings" settings] ["close" close]]]
@@ -2570,7 +2580,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 2]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (doseq [tid ["rf-xray-nav-prev" "rf-xray-nav-next" "rf-xray-nav-head"]]
           (let [btn   (find-by-testid tree tid)
                 style (:style (second btn))]
@@ -2592,7 +2602,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:cart/add-item]))
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)]
+      (let [tree (dynamic-shell-tree/shell-view-tree)]
         (is (nil? (find-by-testid tree "rf-xray-focus-button"))
             "no focus button (the focus feature was retired)")
         (is (nil? (find-by-testid tree "rf-xray-focus-chip"))
@@ -2605,7 +2615,7 @@
     (xray-setup!)
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
-      (let [tree       (shell/shell-view)
+      (let [tree       (dynamic-shell-tree/shell-view-tree)
             h-event-id (find-by-testid tree "rf-xray-event-list-col-event-id")
             r-event-id (find-by-testid tree "rf-xray-row-event-id")]
         (is (= "left" (:text-align (style-of h-event-id)))
@@ -2625,7 +2635,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 1]))
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             row   (find-by-testid tree "rf-xray-event-row-1")
             style (:style (second row))]
         (is (some? row) "the focused row renders")
@@ -2658,7 +2668,7 @@
             `selected` (was `for selected event`), keeping the ↳ glyph."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             label (find-by-testid tree "rf-xray-tab-bar-context-label")
             txt   (text-nodes label)]
         (is (some? label) "the context label renders")
@@ -2673,7 +2683,7 @@
             affordance; nothing to rewind to until an event is selected)."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree  (shell/shell-view)
+      (let [tree  (dynamic-shell-tree/shell-view-tree)
             reset (find-by-testid tree "rf-xray-tab-bar-reset")
             attrs (second reset)]
         (is (some? reset) "the Reset button renders")
@@ -2710,7 +2720,7 @@
           (with-redefs [rf/dispatch-impl (fn
                                        ([ev]       (swap! dispatches conj ev) nil)
                                        ([ev _opts] (swap! dispatches conj ev) nil))]
-            (let [tree    (shell/shell-view)
+            (let [tree    (dynamic-shell-tree/shell-view-tree)
                   reset   (find-by-testid tree "rf-xray-tab-bar-reset")
                   handler (:on-click (second reset))]
               (is (false? (:disabled (second reset)))
@@ -2806,7 +2816,7 @@
       (rf/dispatch-sync [:rf.xray/reset-flash-failed]))
     (rf/with-frame :rf/xray
       (let [flash @(rf/subscribe [:rf.xray/reset-flash])
-            tree  (shell/shell-view)
+            tree  (dynamic-shell-tree/shell-view-tree)
             el    (find-by-testid tree "rf-xray-reset-flash")]
         (is (string? flash) "the flash message is set after a failure")
         (is (some? el) "the inline flash renders on the ribbon")
@@ -2816,7 +2826,7 @@
       (rf/dispatch-sync [:rf.xray/clear-reset-flash]))
     (rf/with-frame :rf/xray
       (let [flash @(rf/subscribe [:rf.xray/reset-flash])
-            tree  (shell/shell-view)
+            tree  (dynamic-shell-tree/shell-view-tree)
             el    (find-by-testid tree "rf-xray-reset-flash")]
         (is (nil? flash) "the flash clears")
         (is (nil? el) "the inline flash is removed from the ribbon")))))
@@ -2836,7 +2846,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/focus-event 2 :rf/default]))
     (rf/with-frame :rf/xray
-      (let [tree      (shell/shell-view)
+      (let [tree      (dynamic-shell-tree/shell-view-tree)
             issue-row (find-by-testid tree "rf-xray-event-row-2")
             style     (style-of issue-row)
             caret     (find-by-testid issue-row "rf-xray-row-selection-caret")]
@@ -2864,7 +2874,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 2 [:newer/event]))
     ;; Focus auto-snaps to head (id 2); row 1 is unselected.
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
+      (let [tree   (dynamic-shell-tree/shell-view-tree)
             row1   (find-by-testid tree "rf-xray-event-row-1")
             caret1 (find-by-testid row1 "rf-xray-row-selection-caret")
             row2   (find-by-testid tree "rf-xray-event-row-2")

--- a/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,339 @@
+(ns day8.re-frame2-xray.shell-fresco-boundary-dom-cljs-test
+  "Real-DOM witnesses for Xray's DYNAMIC chrome as a Fresco tree
+  (rf2-k97c.3).
+
+  ## Why a browser row at all — the node lane cannot see this
+
+  Xray's node lane drives the shell's pure `*-tree` fns through
+  `test-helpers.dynamic-shell-tree`, which passes `identity` where the
+  boundaries pass `reagent.core/as-element`. Under `npm run test:cljs`
+  wrapping and NOT wrapping are therefore the same value, BY
+  CONSTRUCTION — so a green node lane says nothing about whether the
+  chrome paints. Only a committed DOM can answer that, and this file is
+  the Dynamic sibling of
+  `static/shell_fresco_boundary_dom_cljs_test`, which asks the same two
+  questions of the Static surface.
+
+  ## The mount is the PRODUCTION mount
+
+  `mount.cljs` renders `[rf/frame-provider {:frame …} [shell/shell-view
+  {…}]]` through the installed adapter's `:render`. `shell-view` is still
+  an `rf/reg-view` — severing that call is the parent epic's coupling (1)
+  and a later slice — and it reaches the Fresco tree through ONE private
+  `as-component` bridge. So mounting that same two-level form into a
+  Reagent root IS the shipped path, crossing included, and nothing here
+  reproduces it. [[mount-shell!]] records why the outer provider is not
+  decoration.
+
+  Nothing below ever calls a view a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed
+  on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the chrome is INDIFFERENT to it.
+  The whole point of the migration is that the chrome no longer paints
+  through the adapter's renderer; mounting it under one and watching it
+  work is what says so.
+
+  ## Node-lane behaviour
+
+  This ns matches the `:browser-test` build's regex and also loads under
+  `:node-test`, where every row short-circuits through [[browser?]] and
+  reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private shell-frame
+  "The frame this suite's shell instance owns. NOT `:rf/xray`: the
+  production singleton's frame is trace-disabled and shared with every
+  other suite on the page, and `shell-view`'s `:frame-id` opt exists
+  precisely so N instances can be isolated (rf2-lnluk). Naming a private
+  one is what makes W2's negative half mean something."
+  ::shell)
+
+(def ^:private other-frame
+  "A second live frame W2 dispatches into as its DEAF LEVER — the
+  negative control. A write here must move nothing in the shell above."
+  ::other)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about;
+                      ;; a neighbour's boundary left in the entry cache
+                      ;; would make these rows read a residue that is not
+                      ;; this shell's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission. A Fresco boundary is NOT in Reagent's render queue — its
+;; update is scheduled by the collector through React — so draining
+;; Reagent's queue commits nothing of these boundaries', and a row written
+;; that way reads a DOM that has not moved and reports a live shell as
+;; dead. Mount is committed with `flushSync` (React's own door) and
+;; everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- poll-until
+  "Resolve as soon as `pred` answers truthy, or after `budget-ms`. The
+  resolution value is `pred`'s last answer, so a caller asserts on the
+  value rather than on the fact that polling ended."
+  ([pred] (poll-until pred 2000))
+  ([pred budget-ms]
+   (js/Promise.
+     (fn [resolve]
+       (let [deadline (+ (js/Date.now) budget-ms)]
+         (letfn [(tick []
+                   (let [v (pred)]
+                     (cond
+                       v                          (resolve v)
+                       (> (js/Date.now) deadline) (resolve v)
+                       :else (js/requestAnimationFrame (fn [_] (tick))))))]
+           (tick)))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers every Dynamic
+  panel's L4 tab entry, so the L3 bar and the L4 mount both read the real
+  registry — and make the frames.
+
+  `:rf/xray` is made as well as the two this suite names. It is
+  `shell/default-frame-id`, the production singleton, and several Xray
+  registrations and panel bodies reach it by that name regardless of
+  which frame an instance is mounted at; a missing frame is a loud
+  re-frame refusal, and one raised inside a React render surfaces only as
+  'an error occurred in <shell-view>' with the message nowhere on
+  screen."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id shell/default-frame-id})
+  (rf/make-frame {:id shell-frame})
+  (rf/make-frame {:id other-frame})
+  nil)
+
+(defn- mount-shell!
+  "Mount the shell the way `mount.cljs` mounts it — the OUTER
+  `frame-provider` included:
+
+      [rf/frame-provider {:frame …} [shell/shell-view {…}]]
+
+  THAT WRAPPER IS LOAD-BEARING AND THIS ROW MEASURED IT. `shell-view` is
+  itself an `rf/reg-view`, and a `reg-view`'s frame-aware wrapper takes
+  its scope from React context; at a bare root there is none, so the
+  first frame-scoped call in its body refuses with
+  `:rf.error/no-frame-context` and NOTHING commits. `mount.cljs:396`
+  carries the provider for its own documented reason (rf2-uu3lp — so the
+  shell's render trace resolves to the trace-disabled `:rf/xray` frame
+  rather than leaking into the inspected app's epoch), and a suite that
+  drops it is not mounting what production mounts.
+
+  The provider frame and the shell's `:frame-id` are the same value here,
+  as they are in production.
+
+  Committed synchronously — React 19's `root.render` is otherwise async
+  and the first assertion would read an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [shell/shell-view {:frame-id frame}]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads anything. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+;; ---- the diagnostic ------------------------------------------------------
+;;
+;; A re-frame refusal raised inside a React render does NOT reach a
+;; `try/catch` around `flushSync`: React 19 catches it, reports "an error
+;; occurred in <shell-view>" to the console, and re-raises it as an
+;; UNCAUGHT window error. Its `ex-message` and `ex-data` — the whole of
+;; what re-frame refuses WITH — then appear nowhere a row can read, and
+;; every assertion below reddens on a nil testid saying only that the
+;; chrome is absent. Capturing the error object is what turns eight
+;; uninformative failures into one that names the refusal.
+
+(defonce ^:private !last-uncaught (atom nil))
+
+(defonce ^:private error-capture-armed?
+  (when (exists? js/window)
+    (.addEventListener js/window "error"
+                       (fn [^js e] (reset! !last-uncaught (.-error e))))
+    true))
+
+(defn- uncaught-note
+  "A suffix naming the last uncaught error, for a row whose subject is
+  missing. Empty when nothing was thrown — in which case the absence is
+  the finding rather than a hidden exception."
+  []
+  (if-some [e (when error-capture-armed? @!last-uncaught)]
+    (str " — an uncaught error was raised during render: "
+         (:rf.error/id (ex-data e) (ex-message e))
+         " · at: "
+         ;; The stack's HEAD is the message, which for a re-frame refusal
+         ;; is a paragraph. The call frames are at the TAIL.
+         (let [s (str (.-stack ^js e))]
+           (->> (str/split-lines s)
+                (remove #(str/blank? %))
+                (filter #(str/includes? % "at "))
+                (take 14)
+                (str/join " | "))))
+    ""))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid [container id]
+  (q container (str "[data-testid=\"" id "\"]")))
+
+(defn- detail-panel-node
+  "The committed L4 panel `<div>`, whatever tab it is showing. Its testid
+  carries the tab id, which is what W2 watches."
+  [container]
+  (q container "[data-testid^=\"rf-xray-detail-panel-\"][role=\"tabpanel\"]"))
+
+;; ===========================================================================
+;; W1 — first display of the WHOLE Dynamic chrome
+;; ===========================================================================
+
+(deftest w1-dynamic-chrome-paints-every-layer-through-the-bridge
+  (testing "rf2-k97c.3 — the migrated Dynamic chrome commits all four
+            layers plus the events ribbon, through the ONE private
+            `as-component` bridge `shell-view` mounts. Epic criterion 1.
+
+            THIS ROW CARRIES WHAT THE NODE LANE GAVE UP. Every chrome
+            row in `shell_cljs_test` now drives the shell's pure `*-tree`
+            fns rather than the views, because a boundary's body only
+            runs inside a React render window. Those rows are evidence
+            about COMPOSITION; this one is the only evidence that the
+            composition reaches a screen.
+
+            The theme toggle is asserted separately from the ribbon that
+            contains it because it is its OWN boundary — a nested
+            boundary head inside a boundary body, which is the shape the
+            rest of the chrome's regions take under
+            `dynamic-chrome`."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-shell! shell-frame)]
+          (-> (poll-until #(testid container "rf-xray-ribbon"))
+              (.then
+                (fn [_]
+                  (is (some? (testid container "rf-xray-shell"))
+                      (str "the shell envelope commits" (uncaught-note)))
+                  (is (some? (testid container "rf-xray-ribbon"))
+                      "L1 chrome ribbon commits")
+                  (is (some? (testid container "rf-xray-ribbon-nav"))
+                      "the ribbon's nav cluster commits — a helper CALLED
+                       rather than headed still reaches the DOM")
+                  (is (some? (testid container "rf-xray-theme-toggle"))
+                      "the theme toggle commits — a boundary head inside
+                       a boundary body")
+                  (is (some? (testid container "rf-xray-events-ribbon"))
+                      "L1.5 events ribbon commits")
+                  (is (some? (testid container "rf-xray-event-list"))
+                      "L2 event list commits — the chrome's Reagent
+                       island, crossed with `as-element`")
+                  (is (some? (testid container "rf-xray-tab-bar"))
+                      "L3 tab bar commits")
+                  (is (some? (detail-panel-node container))
+                      "L4 detail panel commits")
+                  (teardown! root container)
+                  (done)))))))))
+
+;; ===========================================================================
+;; W2 — a real dependency change repaints, and a write to another frame
+;;      does not
+;; ===========================================================================
+
+(deftest w2-chrome-repaints-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the chrome's reads are LIVE: writing
+            `:rf.xray/select-tab` into the frame the tree named moves the
+            committed L4 panel, and writing the same event into a
+            DIFFERENT live frame moves nothing. Epic criteria 3 and 4 —
+            observation, and frame context.
+
+            This is the coupling a first-paint smoke test cannot see: a
+            tree that painted once and never re-ran would pass W1 and
+            fail here. The negative half is what makes it a frame claim
+            rather than merely a reactivity one — `shell-view` is mounted
+            at a PRIVATE frame, so a boundary that resolved its read
+            ambiently would follow the wrong write."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-shell! shell-frame)
+              tab-testid (fn [] (some-> (detail-panel-node container)
+                                        (.getAttribute "data-testid")))
+              !before    (atom nil)
+              step-1     (fn [before]
+                           (reset! !before before)
+                           (is (some? before)
+                               "CONTROL — the L4 panel is committed before the lever")
+                           ;; The DEAF LEVER: the same event, into a live
+                           ;; frame this tree never named.
+                           (rf/dispatch-sync [:rf.xray/select-tab :trace]
+                                             {:frame other-frame})
+                           (settle))
+              step-2     (fn [_]
+                           (is (= @!before (tab-testid))
+                               (str "a write to another frame moves nothing. "
+                                    "Was " (pr-str @!before)
+                                    ", now " (pr-str (tab-testid))))
+                           (rf/dispatch-sync [:rf.xray/select-tab :trace]
+                                             {:frame shell-frame})
+                           (poll-until (fn [] (not= @!before (tab-testid)))))
+              step-3     (fn [_]
+                           (is (= "rf-xray-detail-panel-trace" (tab-testid))
+                               (str "the L4 panel followed the write into its "
+                                    "OWN frame. Got: " (pr-str (tab-testid))))
+                           (teardown! root container)
+                           (done))]
+          (-> (poll-until tab-testid)
+              (.then step-1)
+              (.then step-2)
+              (.then step-3)))))))

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -18,6 +18,8 @@
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -228,13 +230,13 @@
   (trace-collector/seed-trace-for-test! (dispatch-trace-ev 3 [:order/submit]))
   (rf/with-frame :rf/xray
     ;; All three rows render pre-mute.
-    (let [tree (shell/shell-view)]
+    (let [tree (dynamic-shell-tree/shell-view-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2")))
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-3"))))
     (rf/dispatch-sync [:rf.xray/mute-event-id :user/mouse-move])
     ;; Row 2 (:user/mouse-move) disappears.
-    (let [tree (shell/shell-view)]
+    (let [tree (dynamic-shell-tree/shell-view-tree)]
       (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
       (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2"))
           "muted row stripped from L2 list")
@@ -271,7 +273,7 @@
   (frame-dispatch [:rf.xray/open-row-context-menu
                    {:event-id :user/mouse-move :x 100 :y 200}])
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)
+    (let [tree (dynamic-shell-tree/shell-view-tree)
           menu (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu")
           mute (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-mute")
           hide (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-hide-event-type")]
@@ -300,7 +302,7 @@
   (frame-dispatch [:rf.xray/mute-event-id :b/y])
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)
+    (let [tree (dynamic-shell-tree/shell-view-tree)
           dialog (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-dialog")
           list   (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-list")
           row-a  (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-row-:a/x")
@@ -314,7 +316,7 @@
   (xray-setup!)
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
-    (let [tree  (shell/shell-view)
+    (let [tree  (dynamic-shell-tree/shell-view-tree)
           empty (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-empty")
           list  (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-list")]
       (is (some? empty) "empty-state copy mounts when no ids muted")
@@ -327,7 +329,7 @@
 (deftest ribbon-mute-indicator-hidden-when-no-mutes
   (xray-setup!)
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)
+    (let [tree (dynamic-shell-tree/shell-view-tree)
           ind  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-mute-indicator")]
       (is (nil? ind) "indicator absent when no event-ids muted"))))
 
@@ -336,7 +338,7 @@
   (frame-dispatch [:rf.xray/mute-event-id :a])
   (frame-dispatch [:rf.xray/mute-event-id :b])
   (rf/with-frame :rf/xray
-    (let [tree (shell/shell-view)
+    (let [tree (dynamic-shell-tree/shell-view-tree)
           ind  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-mute-indicator")
           cnt  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-mute-indicator-count")]
       (is (some? ind) "indicator mounts when mute set is non-empty")
@@ -368,7 +370,7 @@
         (with-redefs [rf/dispatch-impl (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree     (shell/shell-view)
+          (let [tree     (dynamic-shell-tree/shell-view-tree)
                 mute-btn (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-mute")
                 handler  (:on-click (second mute-btn))]
             (is (fn? handler) "'Mute' button has on-click handler")
@@ -388,12 +390,12 @@
         ;; Replay both via dispatch-sync to assert downstream effects.
         (rf/dispatch-sync [:rf.xray/mute-event-id :user/mouse-move])
         (rf/dispatch-sync [:rf.xray/close-row-context-menu])
-        (let [tree (shell/shell-view)]
+        (let [tree (dynamic-shell-tree/shell-view-tree)]
           (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
           (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2"))
               "muted row dropped from L2")
           (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu"))
               "menu closed after click"))
-        (let [tree (shell/shell-view)
+        (let [tree (dynamic-shell-tree/shell-view-tree)
               ind  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-mute-indicator")]
           (is (some? ind) "ribbon mute indicator visible"))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -46,6 +46,8 @@
             [day8.re-frame2-xray.static.shell :as static-shell]
             [day8.re-frame2-xray.test-helpers.static-shell-tree
              :as static-shell-tree]
+            [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+             :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -400,26 +402,28 @@
   (testing "with mode :static, the composer renders the Static surface
             (per rf2-8l3uk — Static mode is unconditionally available).
 
-            RE-AUTHORED ONE LEVEL UP BY rf2-k97c.3, the same repair the
-            mayor ruled correct for `static-machines-mounts-live-panel`.
-            `static-shell/surface` is now an `rf.fresco/defview` behind
-            an `as-component` bridge, so this hiccup walk reaches the
-            bridge's `[:>]` interop head and STOPS —
-            `rf-xray-static-surface` is committed by React, not present
-            in the tree. Asserting that testid here would from now on be
-            asserting the walker's reach rather than the mount, which is
-            the hollow-gate shape. What the COMPOSER owes is that the
-            Static arm mounts exactly `surface-bridge` and that no
-            Dynamic region mounts beside it; the Static surface's own
-            first paint is W1 in
-            `static/shell_fresco_boundary_dom_cljs_test`."
+            RE-AUTHORED TWICE BY rf2-k97c.3, and it is back where it
+            started. #9644 made `static-shell/surface` a `defview` behind
+            an `as-component` bridge, so the walk stopped at the
+            bridge's `[:>]` head and the row could only assert that the
+            Static arm mounted exactly `surface-bridge`. The Dynamic
+            composer is a BOUNDARY now, so it heads
+            `[static-shell/surface {}]` DIRECTLY and that bridge is
+            deleted — and the node lane's door
+            (`test-helpers.dynamic-shell-tree`) composes the Static arm
+            from `test-helpers.static-shell-tree`, which drives the
+            shell's own `*-tree` fns. So `rf-xray-static-surface` is
+            reachable again, and reaching it is not hollow: the testid,
+            the flex column and the `data-rf-xray-mode` attribute all
+            come from `static-shell/surface-tree`, the shipped
+            definition. The Static surface's own first PAINT is still
+            W1 in `static/shell_fresco_boundary_dom_cljs_test`."
     (xray-setup!)
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
-      (let [tree (shell/surface-composer)]
-        (is (= [static-shell/surface-bridge] (last tree))
-            (str "the Static arm mounts exactly `surface-bridge`. "
-                 "Got: " (pr-str (last tree))))
+      (let [tree (dynamic-shell-tree/surface-composer-tree)]
+        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-static-surface"))
+            "the Static arm mounts the Static surface")
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon"))
             "Dynamic ribbon does NOT mount")
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-list"))
@@ -431,7 +435,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/set-mode :dynamic])
     (rf/with-frame :rf/xray
-      (let [tree (shell/surface-composer)]
+      (let [tree (dynamic-shell-tree/surface-composer-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon"))
             "Dynamic ribbon mounts")
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-static-surface"))
@@ -443,7 +447,7 @@
             removed; Static mode is unconditionally available)"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/ribbon nil)]
+      (let [tree (dynamic-shell-tree/ribbon-tree)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-mode-pill"))
             "mode pill mounts in the Dynamic ribbon unconditionally")))))
 
@@ -466,7 +470,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/set-mode :dynamic])
     (rf/with-frame :rf/xray
-      (let [tree (shell/surface-composer)]
+      (let [tree (dynamic-shell-tree/surface-composer-tree)]
         (is (or (some? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker"))
                 (some? (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame")))
             "L1 frame picker (or single-frame label) present in Dynamic")))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -48,7 +48,6 @@
              :as static-shell-tree]
             [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
              :as dynamic-shell-tree]
-            [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
@@ -57,8 +57,19 @@
   ## The mount is the SHELL'S mount
 
   `shell.cljs`'s `surface-composer` mounts the Static arm as the hiccup
-  head `[static-shell/surface-bridge]` inside `shell-view`'s
-  `[rf/frame-provider {:frame …}]`. [[mount-shell!]] does exactly that.
+  head `[static-shell/surface {}]` inside `shell-view`'s
+  `[rf/frame-provider {:frame …}]`. [[mount-shell!]] does the same
+  crossing from a Reagent root.
+
+  rf2-k97c.3 — it used to mount `[static-shell/surface-bridge]`, the
+  PUBLIC `as-component` bridge #9644 shipped for a `reg-view`
+  `surface-composer`. The composer is a Fresco BOUNDARY now, so it heads
+  `surface` directly and that bridge is deleted. This suite still mounts
+  from a REAGENT root — deliberately, see §Substrate — so the crossing
+  has to happen somewhere, and it now happens HERE, in
+  [[surface-component]] / [[mount-shell!]] below. Same door
+  (`rf.fresco/as-component`), same guarantee: a React parent mounts the
+  result under the frame it is already in.
 
   Nothing below ever calls a view a second time. Every assertion after
   the mount reads `container.querySelector…` — the DOM React committed
@@ -87,6 +98,7 @@
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
@@ -211,12 +223,20 @@
   (rf/make-frame {:id app-frame})
   nil)
 
+(def ^:private surface-component
+  "The React component `static-shell/surface` presents as, for the
+  Reagent root [[mount-shell!]] builds. Declared once at top level, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the whole
+  Static surface."
+  (rf.fresco/as-component static-shell/surface))
+
 (defn- mount-shell!
   "Mount the Static shell the way `shell.cljs`'s `surface-composer`
-  mounts it: `static-shell/surface-bridge` as a hiccup head, inside a
-  `frame-provider` scoping `frame`. Committed synchronously — React 19's
-  `root.render` is otherwise async and phase 1 would assert against an
-  empty container."
+  mounts it — the boundary under a `frame-provider` scoping `frame`,
+  crossed into this suite's Reagent root through [[surface-component]].
+  Committed synchronously — React 19's `root.render` is otherwise async
+  and phase 1 would assert against an empty container."
   [frame]
   (let [container (.createElement js/document "div")
         root      (rdc/create-root container)]
@@ -224,7 +244,7 @@
     (react-dom/flushSync
       (fn []
         (rdc/render root [rf/frame-provider {:frame frame}
-                          [static-shell/surface-bridge]])))
+                          [:> surface-component {}]])))
     {:container container :root root}))
 
 (defn- teardown!

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
@@ -131,10 +131,17 @@
 (defn detail-panel-tree
   "The L4 detail panel's hiccup, read the way `shell/detail-panel` reads
   it — the same `(or … default-tab)` fallback and the same
-  `panel-registry/tab-by-id :dynamic` lookup."
+  `panel-registry/tab-by-id :dynamic` lookup.
+
+  `default-tab` is reached THROUGH ITS VAR because it is `^:private` in
+  `shell.cljs`, and deliberately: it is the Dynamic shell's own landing
+  constant (spec/018 §5 is normative on it) with no caller outside that
+  namespace, so reproducing the boundary's fallback here is not a reason
+  to widen a production surface. `static-shell/default-tab` is public
+  only because the Static tab-id family is read from `registry.cljs`."
   []
   (let [selected (or @(rf/subscribe [:rf.xray/selected-tab])
-                     shell/default-tab)]
+                     @#'shell/default-tab)]
     (shell/detail-panel-tree
       selected
       (panel-registry/tab-by-id :dynamic selected)

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
@@ -1,0 +1,210 @@
+(ns day8.re-frame2-xray.test-helpers.dynamic-shell-tree
+  "The node lane's door onto Xray's DYNAMIC shell (rf2-k97c.3).
+
+  ## Why this exists
+
+  Seven of the Dynamic chrome's eight regions are now Fresco boundaries
+  — `shell/ribbon-theme-toggle`, `/ribbon`, `/events-ribbon`, `/tab-bar`,
+  `/detail-panel`, `/dynamic-chrome` and `/surface-composer` are
+  `rf.fresco/defview`s, i.e. real React function components. (`/event-list`
+  is the exception and its own docstring says why.) A boundary's body may
+  only run inside a React render window (`rf.fresco/sub` REFUSES outside
+  one, naming the query), so `(shell/ribbon nil)` is no longer a callable
+  that answers hiccup, and `(shell/shell-view)`'s hiccup now stops at the
+  `[:>]` interop head of the private bridge the shell mounts.
+
+  The repair is `defview`'s own documented extract-a-helper spelling, the
+  one every migrated view in this epic already uses: the shell exports
+  PURE `*-tree` fns of its reads' values, each boundary is the thin thing
+  that reads and calls one, and the node lane drives the tree fns. This
+  ns is the composer that does that driving — the Dynamic sibling of
+  `test-helpers.static-shell-tree`.
+
+  ## It REPRODUCES THE BOUNDARIES' READS — same subs, same order
+
+  That is what makes a node-lane row evidence about the shipped shell
+  rather than about a parallel fixture. Each fn below mirrors the
+  boundary beside it, with `rf.fresco/sub` swapped for `rf/subscribe`
+  (the node lane has no React render window and no collector extent) and
+  nothing else changed. Where the boundary applies a fallback
+  ([[detail-panel-tree]]'s `(or … default-tab)`, [[event-list-tree]]'s
+  `now-ms`), so does this; where the DERIVATION lives in the shell's own
+  `*-tree` fn (`nav-boundary-state`, the `no-filters?` gate, the L2
+  visibility filter), this passes the raw values through and lets the
+  shipped fn do it.
+
+  ## `as-child` is `identity` here
+
+  The boundaries pass `reagent.core/as-element` for their islands — the
+  L1 ribbon's `frame-switcher-view` and `mode-pill`, the L2/L3 seam
+  handle, and the L4 `[(:panel tab)]` mount. This lane passes `identity`,
+  so each island stays the fn-headed hiccup vector that
+  `rf.test-helpers/expand-tree` walks precisely as it always has. That
+  crossing's evidence is the browser lane's, not this one's — the node
+  lane's `as-child` is `identity` BY CONSTRUCTION, so wrapping and not
+  wrapping are the same value here.
+
+  ## Call these INSIDE a frame scope
+
+  Every fn here subscribes ambiently, so each call belongs inside
+  `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
+  bodies had, and the same one every existing caller already satisfies."
+  (:require [re-frame.core :as rf]
+            [re-frame.interop :as rf.interop]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.resize-handle :as resize-handle]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
+            [day8.re-frame2-xray.theme.global-styles :as global-styles]))
+
+(defn theme-toggle-tree
+  "The L1 theme toggle's hiccup, read the way `shell/ribbon-theme-toggle`
+  reads it."
+  ([] (theme-toggle-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/theme-toggle-tree dispatch @(rf/subscribe [:rf.xray/setting :theme nil]))))
+
+(defn ribbon-tree
+  "The L1 chrome ribbon's hiccup, read the way `shell/ribbon` reads it —
+  the same six subs in the same order. `dispatch` defaults to
+  `(:dispatch (rf/capture-frame))`, the SAME door the boundary uses, so a
+  handler this lane pulls off the tree and fires later carries the frame
+  exactly as the shipped one does."
+  ([] (ribbon-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/ribbon-tree
+     dispatch
+     {:redacted-count  @(rf/subscribe [:rf.xray/suppressed-sensitive-count])
+      :muted-count     @(rf/subscribe [:rf.xray/muted-event-ids-count])
+      :focus           @(rf/subscribe [:rf.xray/focus])
+      :event-bundles   @(rf/subscribe [:rf.xray/filtered-event-bundles])
+      :show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
+      :filters         @(rf/subscribe [:rf.xray/active-filters])}
+     identity
+     (theme-toggle-tree dispatch))))
+
+(defn events-ribbon-tree
+  "The L1.5 events ribbon's hiccup, read the way `shell/events-ribbon`
+  reads it."
+  ([] (events-ribbon-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/events-ribbon-tree
+     dispatch
+     {:filters        @(rf/subscribe [:rf.xray/active-filters])
+      :hidden-summary @(rf/subscribe [:rf.xray/hidden-by-filters])})))
+
+(defn event-list-tree
+  "The L2 event list's hiccup, read the way `shell/event-list` reads it —
+  including the `now-ms` fallback to `(rf.interop/now-ms)` the boundary
+  applies when the anchor sub answers nil.
+
+  The boundary also runs `inject-scrollbar-style!` before it reads. That
+  is a `defonce`-guarded DOM side effect with no effect on the tree and
+  no DOM to write to under node, so it is deliberately NOT reproduced —
+  reproducing it would only assert that the guard holds."
+  ([] (event-list-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/event-list-tree
+     dispatch
+     {:col-widths      @(rf/subscribe [:rf.xray/event-list-col-widths])
+      :list-height-px  @(rf/subscribe [:rf.xray/events-list-height-px])
+      :event-bundles   @(rf/subscribe [:rf.xray/filtered-event-bundles])
+      :focus           @(rf/subscribe [:rf.xray/focus])
+      :show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
+      :now-ms          (or @(rf/subscribe [:rf.xray/relative-time-now-ms])
+                           (rf.interop/now-ms))})))
+
+(defn tab-bar-tree
+  "The L3 tab bar's hiccup, read the way `shell/tab-bar` reads it — the
+  raw `:rf.xray/selected-tab` value, with no `default-tab` fallback,
+  because the boundary applies none here."
+  ([] (tab-bar-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/tab-bar-tree
+     dispatch
+     {:selected    @(rf/subscribe [:rf.xray/selected-tab])
+      :observed    @(rf/subscribe [:rf.xray/observed-frame])
+      :focus-epoch @(rf/subscribe [:rf.xray/focus-epoch-id])
+      :reset-flash @(rf/subscribe [:rf.xray/reset-flash])})))
+
+(defn detail-panel-tree
+  "The L4 detail panel's hiccup, read the way `shell/detail-panel` reads
+  it — the same `(or … default-tab)` fallback and the same
+  `panel-registry/tab-by-id :dynamic` lookup."
+  []
+  (let [selected (or @(rf/subscribe [:rf.xray/selected-tab])
+                     shell/default-tab)]
+    (shell/detail-panel-tree
+      selected
+      (panel-registry/tab-by-id :dynamic selected)
+      identity)))
+
+(defn dynamic-chrome-tree
+  "The WHOLE Dynamic chrome as plain hiccup — the node lane's replacement
+  for the old `(shell/dynamic-chrome)` call.
+
+  Composes the five region trees above through the shell's own
+  `dynamic-chrome-tree` envelope, so the `display: contents` wrapper and
+  its `data-rf-xray-dynamic-chrome` handle are the shipped definitions
+  rather than a copy of them.
+
+  The chrome's TWO ISLANDS — `shell/event-list` (still an `rf/reg-view`;
+  its own docstring says why) and `resize-handle/SeamHandle` — are what
+  the boundary crosses with `reagent.core/as-element`. Here the seam
+  handle is the plain `[resize-handle/SeamHandle]` vector `expand-tree`
+  walks, and the L2 list is driven through `shell/event-list-tree` the
+  same way every other region is, so a row still walks the shipped L2
+  chrome rather than stopping at a component head."
+  ([] (dynamic-chrome-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/dynamic-chrome-tree (ribbon-tree dispatch)
+                              (events-ribbon-tree dispatch)
+                              (event-list-tree dispatch)
+                              [resize-handle/SeamHandle]
+                              (tab-bar-tree dispatch)
+                              (detail-panel-tree))))
+
+(defn surface-composer-tree
+  "The mode composer as plain hiccup — the node lane's replacement for the
+  old `(shell/surface-composer)` call. Reads `:rf.xray/mode` the way the
+  boundary does and composes BOTH arms: the Dynamic chrome from this ns,
+  the Static surface from `test-helpers.static-shell-tree`.
+
+  BOTH ARMS ARE COMPOSED EAGERLY, where the shipped `case` picks one.
+  That is deliberate and it costs nothing but a little work: the envelope
+  is what decides, so a row asserting which arm the composer mounts is
+  still asserting the shipped `case`."
+  ([] (surface-composer-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (shell/surface-composer-tree @(rf/subscribe [:rf.xray/mode])
+                                (static-shell-tree/surface-tree dispatch)
+                                (dynamic-chrome-tree dispatch))))
+
+(defn shell-view-tree
+  "The WHOLE Xray shell as plain hiccup — the node lane's replacement for
+  the old `(shell/shell-view opts)` call, and the substitution every
+  existing row makes.
+
+  It reproduces `shell-view`'s TWO SIDE EFFECTS as well as its read,
+  because rows depend on both: `global-styles/install!` (idempotent, DOM
+  guarded) and the idempotent `:rf.xray/set-modal-positioning`
+  `dispatch-sync`, which is what makes `:modal-positioning :absolute`
+  reach the modals' own sub on this same pass. Same defaults as the
+  boundary, same explicit `{:frame frame-id}` on both, because
+  `shell-view` sits OUTSIDE its own frame-provider."
+  ([] (shell-view-tree nil))
+  ([{:keys [mode modal-positioning frame-id]
+     :or   {mode :inline modal-positioning :fixed
+            frame-id shell/default-frame-id}}]
+   (global-styles/install!)
+   (let [current-positioning @(rf/subscribe [:rf.xray/modal-positioning] {:frame frame-id})]
+     (when (not= current-positioning modal-positioning)
+       (rf/dispatch-sync [:rf.xray/set-modal-positioning modal-positioning]
+                         {:frame frame-id})))
+   (shell/shell-view-tree
+     {:mode              mode
+      :modal-positioning modal-positioning
+      :frame-id          frame-id
+      :lens-mode         @(rf/subscribe [:rf.xray/mode] {:frame frame-id})}
+     (surface-composer-tree))))


### PR DESCRIPTION
Migrates the **Dynamic shell's chrome** to Fresco boundaries — the first increment of this epic to move Xray's 4-layer chrome rather than a panel, and the one that lets `static/shell.cljs` delete the public bridge #9644 shipped as scaffolding.

## What moved

Seven regions become `rf.fresco/defview` boundaries: `ribbon-theme-toggle`, `ribbon`, `events-ribbon`, `tab-bar`, `detail-panel`, `dynamic-chrome`, `surface-composer`. Each boundary is the thin read-and-call shape the epic's earlier increments established — it reads through `rf.fresco/sub`, captures its dispatcher through `(:dispatch (rf/capture-frame))`, and hands the values to a pure `*-tree` fn that owns the hiccup.

`surface-composer` heads `[static-shell/surface {}]` **directly**, so `static/shell.cljs`'s `surface-component` + public `surface-bridge` are DELETED — its own comment named exactly this condition. One crossing remains for the whole Fresco tree and it moved one level up, to `shell.cljs`'s own private `surface-bridge`.

Fourteen plain-fn hiccup HEADS inside those bodies became CALLS (`ribbon-nav-cluster`, `ribbon-right-icons`, `ribbon-redacted-indicator`, `tab-button`, `l2-column-header`, `event-row`, `unknown-tab-stub`, six `col-divider` sites, `filter-pills/*`, `spine-filters/ribbon-mute-indicator`), because Fresco grades a plain function in head position a loud error.

## Two things stayed `rf/reg-view`, both measured

**`shell-view`** — it is the root `mount.cljs` renders through the installed adapter's `:render`. Severing that is the epic's coupling (1) and a later slice.

**`event-list`** — held back by a CALLER, not by anything about the view. `panels.cljs`'s `mount-event-spine!` (a shipped public embed, `tools/xray/spec/008-Embedding-Contract.md`) passes the var to `render-panel!`, which builds a Reagent tree. Migrating it needs a public bridge here plus one line at that call site — and `panels.cljs` / `panel_enum.cljc` were held by another worker while this landed. **The break would have been silent**: `panels_mount_cljs_test` drives `render-panel!` through a render STUB that captures the tree and never renders it. Its body is already the read-and-call shape, so the follow-on is four lines plus one.

## Two premises in the brief that did not hold

1. **`[(:panel tab)]` could not stop being an island.** The brief expected `reg-l4-tab!` to take boundaries directly now that `static/routes/panel.cljs` has landed. Measured: the **Dynamic** registry is MIXED — five entries register an `as-component` bridge, while `epoch-panel/Panel`, `trace/Panel`, `machine-inspector/Panel` and `fresco/Panel` are still `rf/reg-view`s — and all five **Static** entries register a bridge, which is a plain fn and refuses as a Fresco head just as a `reg-view` does. So the L4 seam stays in both shells.
2. **Consequently the four merged Static panel DOM suites needed no repair.** They are green untouched. The only DOM suite this changes is `static/shell_fresco_boundary_dom_cljs_test`, whose mount named the deleted bridge.

## Witnesses

`shell_fresco_boundary_dom_cljs_test` is new — the Dynamic sibling of the Static one. W1 commits all five regions through the bridge; W2 drives a real dependency change against a **deaf lever** (the same event into a second live frame, which must move nothing).

Writing it produced a finding: mounting `[shell/shell-view {…}]` at a bare root refuses with `:rf.error/no-frame-context` and commits nothing, because a `reg-view`'s frame-aware wrapper takes its scope from React context. `mount.cljs:396` carries an OUTER `frame-provider`; a suite that drops it is not mounting what production mounts. The suite now captures the uncaught render error and names the refusal, because React swallows the message and eight rows otherwise redden on nil testids saying only that the chrome is absent.

A node-lane row grades the **L2 row key** at both renderers. `event-row` was a hiccup head, so React read its key off the head's props; it is CALLED now, so the key moved into the `<li>`. A lost key does not fail — it degrades into index reconciliation. Both doors take head + attrs only (`subvec node 0 2`): the codec lowers children eagerly and a whole-node call would raise HD-016 on the row's own subtree.

## RULING 2 — the `^{:key …}` sweep

**ZERO metadata-key sites in any file this PR touches.** All six `^{:key` hits across them are PROSE describing the rf2-a38l repair that already landed. Live control, same instrument, wider tree: 65 hits over 40 files (13 at form position), `with-meta` 42 — so the zero is absence, not a broken instrument.

## RULING 1

No #9578-spelled pair was converged. The one this PR meets — `cancellation-cascade/Popover`, mounted by name from `shell-view` — sits in a file whose sibling pair (`SidePanel`) is mounted from `panels.cljs`, so converging only half would leave two spellings in one file and a docstring explaining both. Recorded rather than half-done.

## Sabotage

| plant | node lane | browser lane |
|---|---|---|
| `(r/as-element [event-list])` to `[event-list]` (drop the island wrapper) | **exit 0**, 11645/58375 — IDENTICAL, completely blind | **exit 1**, 10 failures naming `:rf.error/fresco-bad-head`, totals identical |
| delete `:key (str id)` from the L2 row | **exit 1**, 5 failures, all in the key row, totals identical | — |

The first plant is the brief's own claim measured on this tree: the node lane's `as-child` is `identity`, so wrapping and not wrapping are the same value there **by construction**. Both restores verified by git blob hash in the default filtered form (`i/lf`, so that is the right form) plus `git diff --quiet` exit 0.

## Quality gates

Every number read from that run's own captured exit file, never from a pipeline or the harness. All re-run on the FINAL rebased base (`cebe6ecc16`).

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` | **0** | 11663 tests / 58454 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 934 tests / 5169 assertions, 0 failures, 0 errors |
| `npm run test:xray-feature-gate` (FULL, never `:smoke`) | **0** | 16 scenarios / 0 failures / 13 matrix rows |
| `python scripts/lint_kondo.py` (CI's pinned binary, paths, flags) | **0** | errors 0, warnings 1912 (was 1913) |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2851 files, 11230 edges, 0 non-canonical |
| `python scripts/check_require_alias_dialect.py --self-test` | **0** | 79 passed, 0 failed |
| `python scripts/check_retired_spellings.py` | **0** | clean |
| `sh scripts/check-commit-attribution.sh origin/main` | **0** | no AI attribution in the 3 commits |

**The scenarios carrying the witness**: `feature matrix shell and panel handoff` (PR-smoke tier — boots the shell and walks every L3 tab) and `static mode chrome and chord` (**nightly-only**, no `smoke: true`) — the latter exercises the Static arm through the now-bridgeless composer and is precisely the row the smoke tier would have missed.

`npm run test:browser` was run with `BROWSER_TEST_PORT=8121`: a peer worktree's http-server held the default 8021 and the runner's free-port fallback lost the race to it. Killing it was refused — it was demonstrably another worker's process.

**No hot-zone file touched.** `day8.re-frame2-xray.shell` is rowed in NEITHER `spec/api-manifest.edn` nor its curated sidecar (0 hits each, against a live control of 49 / 64 xray rows), so the new public `*-tree` vars cause no manifest drift.

**Fences held**: `panels.cljs`, `panel_enum.cljc`, `panels/managed_fx_template.cljs`, `panel_enum_guard_cljs_test`, `panels_mount_cljs_test`, `tools/xray/spec/*`, `panels/epoch/view.cljs`, `views/resizable_table.cljs`, `docs/xray/api/reference.md` — all untouched. No `.beads` path on the branch. Nothing under `implementation/` requires `tools/`. No `node_modules` junction: this worktree carries a real install from the lockfile.
