### PR TITLE
feat(xray): mount the three remaining panels through their bridge name, unblocking parallel panel migrations (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -301,7 +301,14 @@
   FX → SUBSCRIPTIONS → VIEWS) with conditional rendering per the
   trace stream."
   ([mount-point]      (mount-epoch-panel! mount-point nil))
-  ([mount-point opts] (render-panel! epoch-panel/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`, the name RULING 1's spelling has the
+  ;; CALLER pass. Today it is a plain alias of the `reg-view` (the same
+  ;; object, so this line delivers byte-for-byte the element it always
+  ;; did); when this panel migrates it becomes the real bridge inside
+  ;; `panels/epoch/view.cljs` and THIS FILE IS NOT TOUCHED AGAIN. Moving
+  ;; every remaining mount to its bridge name in one pass is what lets the
+  ;; panel migrations run in parallel instead of queueing on this file.
+  ([mount-point opts] (render-panel! epoch-panel/Panel-bridge mount-point opts)))
 
 (defn mount-app-db-diff!
   "Mount Xray's App-DB tab in isolation at `mount-point`. Renders the
@@ -352,7 +359,9 @@
   "Mount Xray's Trace tab in isolation at `mount-point`. Renders the
   trace-buffer feed for the focused event-bundle."
   ([mount-point]      (mount-trace! mount-point nil))
-  ([mount-point opts] (render-panel! trace/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`; see `mount-epoch-panel!` above for why
+  ;; the mount moves to the bridge name BEFORE the panel migrates.
+  ([mount-point opts] (render-panel! trace/Panel-bridge mount-point opts)))
 
 (defn mount-machine-inspector!
   "Mount Xray's Machines tab in isolation at `mount-point`. Renders
@@ -362,7 +371,9 @@
   — they are not independently mountable (see ns docstring §Internal
   sub-components)."
   ([mount-point]      (mount-machine-inspector! mount-point nil))
-  ([mount-point opts] (render-panel! machine-inspector/Panel mount-point opts)))
+  ;; rf2-k97c.3 — `Panel-bridge`; see `mount-epoch-panel!` above for why
+  ;; the mount moves to the bridge name BEFORE the panel migrates.
+  ([mount-point opts] (render-panel! machine-inspector/Panel-bridge mount-point opts)))
 
 (defn mount-routing!
   "Mount Xray's Routing tab in isolation at `mount-point`. Renders

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -227,11 +227,25 @@
   render fn. Returns the adapter's unmount fn so the caller can
   tear the mount down without going through this ns again.
 
-  - `panel-view` — the panel's `reg-view`-registered Var (e.g.
-    `epoch-panel/Panel`). Wrapped in a Reagent component-vector so
-    React-context flows correctly per Spec 006 §706 (a plain `defn`
-    invoked as a fn-call would skip the React-context tier and the
-    panel's subscribes would route to `:rf/default`).
+  - `panel-view` — the view (or `*-bridge` callable) this panel is
+    mounted through, e.g. `epoch-panel/Panel-bridge`. Wrapped in a
+    component-VECTOR rather than CALLED, and the reason is specific to
+    this seam: THIS FN RUNS OUTSIDE ANY REACT RENDER, so calling
+    `panel-view` here would evaluate its body with no in-flight
+    component for the React-context tier to read. The ambient frame then
+    resolves to nil and a `subscribe` / `dispatch` RAISES
+    `:rf.error/no-frame-context`. There is no `:rf/default` fallback —
+    the runtime never synthesises one (Spec 006 §Plain-fn footgun;
+    `re-frame.views.provider/current-frame`).
+
+    THAT IS A FACT ABOUT THE MOUNT SEAM, NOT A GENERAL RULE ABOUT
+    CALLING VIEWS, and this docstring used to read as the general claim.
+    Inside an already-provided tree the direction REVERSES: the context
+    is read off whatever component is in flight, so a plain helper
+    CALLED from a `reg-view` / boundary body resolves through its
+    caller's `:contextType` and is fine, while the same helper in HEAD
+    position mints a `:contextType`-less component of its own and is
+    what raises. Here the problem is the absent render, not the call.
   - `mount-point` — a DOM element (or substrate-equivalent mount
     target).
   - `opts` — `{:frame <frame-id>}` minimum, defaulting to

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -5826,3 +5826,36 @@
 
         :else
         (empty-state-view (or status :no-focus)))]]))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `panels/mount-epoch-panel!` mounts this panel BY NAME (reaching it
+;; through `panels.epoch-panel`'s re-export), and RULING 1's surviving
+;; spelling puts the Fresco boundary on the natural name with a PUBLIC
+;; bridge passed by the caller — the shape `resources/Panel-bridge` already
+;; ships. Pointing the mount facade at the bridge name NOW, while it is
+;; still a plain alias, is what lets this panel's migration happen entirely
+;; INSIDE THIS FILE: `Panel` becomes the `defview` boundary and this def
+;; becomes the real `rf.fresco/as-component` bridge, with `panels.cljs`
+;; never touched again (`epoch-panel`'s re-export is a `def` of whatever
+;; this is, so it is correct in both eras). It adopts RULING 1 early rather
+;; than bending it.
+;;
+;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
+;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
+;; SAME OBJECT — nothing downstream can tell the two names apart, which is
+;; exactly what `epoch-panel`'s existing `(def Panel view/Panel)` has been
+;; demonstrating in production. And `render-panel!` always builds the
+;; component VECTOR `[panel-view]`, so head position is the only position
+;; either name is used in: the fn-call hazard `render-panel!`'s docstring
+;; warns about (a plain `defn` INVOKED, skipping the React-context tier so
+;; subscribes route to `:rf/default`) is about call-versus-head position
+;; and is not reached here.
+(def Panel-bridge
+  "The name `panels/mount-epoch-panel!` mounts this panel through, via
+  `panels.epoch-panel`'s re-export — a plain alias of `Panel` until this
+  panel migrates to Fresco, when it becomes the `as-component` bridge
+  without the mount facade moving. Scaffolding with a defined end: it is
+  deleted with every other `*-bridge` when the shell itself becomes a
+  Fresco tree. See the comment above."
+  Panel)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -5847,10 +5847,12 @@
 ;; exactly what `epoch-panel`'s existing `(def Panel view/Panel)` has been
 ;; demonstrating in production. And `render-panel!` always builds the
 ;; component VECTOR `[panel-view]`, so head position is the only position
-;; either name is used in: the fn-call hazard `render-panel!`'s docstring
-;; warns about (a plain `defn` INVOKED, skipping the React-context tier so
-;; subscribes route to `:rf/default`) is about call-versus-head position
-;; and is not reached here.
+;; either name is used in, and the hazard `render-panel!`'s docstring warns
+;; about is not reached: what is unsafe there is CALLING the view, because
+;; that fn runs outside any React render and an ambient subscribe with no
+;; in-flight component resolves to nil and RAISES
+;; `:rf.error/no-frame-context` (there is no `:rf/default` fallback — Spec
+;; 006 §Plain-fn footgun).
 (def Panel-bridge
   "The name `panels/mount-epoch-panel!` mounts this panel through, via
   `panels.epoch-panel`'s re-export — a plain alias of `Panel` until this

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -143,6 +143,14 @@
 ;; ns when added to the per-panel mount inventory.
 (def Panel view/Panel)
 
+;; rf2-k97c.3 — the same re-export for the migration bridge name, which is
+;; what `panels/mount-epoch-panel!` now mounts through. A `def` of whatever
+;; `view/Panel-bridge` is, so this line is correct both while the bridge is
+;; a plain alias of the `reg-view` and after the panel migrates and it
+;; becomes a real `as-component` bridge — the migration stays inside
+;; `panels/epoch/view.cljs`, which is the whole point of the bridge name.
+(def Panel-bridge view/Panel-bridge)
+
 ;; ---- registration --------------------------------------------------------
 
 (defn install!

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -664,6 +664,39 @@
        :else
        (blank-state))]))
 
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `panels/mount-machine-inspector!` mounts this panel BY NAME, and
+;; RULING 1's surviving spelling puts the Fresco boundary on the natural
+;; name with a PUBLIC bridge passed by the caller — the shape
+;; `resources/Panel-bridge` already ships. Pointing the mount facade at the
+;; bridge name NOW, while it is still a plain alias, is what lets this
+;; panel's migration happen entirely INSIDE THIS FILE: `Panel` becomes the
+;; `defview` boundary and this def becomes the real
+;; `rf.fresco/as-component` bridge, with `panels.cljs` never touched again.
+;; It adopts RULING 1 early rather than bending it.
+;;
+;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
+;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
+;; SAME OBJECT — nothing downstream can tell the two names apart. And
+;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
+;; head position is the only position either name is used in: the fn-call
+;; hazard `render-panel!`'s docstring warns about (a plain `defn` INVOKED,
+;; skipping the React-context tier so subscribes route to `:rf/default`) is
+;; about call-versus-head position and is not reached here.
+;;
+;; The Tier 4 sub-components (after-rings overlay, arc/cluster overlays,
+;; scrubber strip, sim side-rail) render UNDER `Panel` and are not
+;; independently mountable, so they need no bridge of their own.
+(def Panel-bridge
+  "The name `panels/mount-machine-inspector!` mounts this panel through —
+  a plain alias of `Panel` until this panel migrates to Fresco, when it
+  becomes the `as-component` bridge without the mount facade moving.
+  Scaffolding with a defined end: it is deleted with every other
+  `*-bridge` when the shell itself becomes a Fresco tree. See the comment
+  above."
+  Panel)
+
 ;; ---- production value sources --------------------------------------------
 ;;
 ;; The raw values the production data subs read. Shared with the

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -680,10 +680,12 @@
 ;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
 ;; SAME OBJECT — nothing downstream can tell the two names apart. And
 ;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
-;; head position is the only position either name is used in: the fn-call
-;; hazard `render-panel!`'s docstring warns about (a plain `defn` INVOKED,
-;; skipping the React-context tier so subscribes route to `:rf/default`) is
-;; about call-versus-head position and is not reached here.
+;; head position is the only position either name is used in, and the hazard
+;; `render-panel!`'s docstring warns about is not reached: what is unsafe
+;; there is CALLING the view, because that fn runs outside any React render
+;; and an ambient subscribe with no in-flight component resolves to nil and
+;; RAISES `:rf.error/no-frame-context` (there is no `:rf/default` fallback —
+;; Spec 006 §Plain-fn footgun).
 ;;
 ;; The Tier 4 sub-components (after-rings overlay, arc/cluster overlays,
 ;; scrubber strip, sim side-rail) render UNDER `Panel` and are not

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -850,6 +850,34 @@
          ;; attach to the list and never reach React.
          (flat-row-list rows expanded-ids)])]]))
 
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `panels/mount-trace!` mounts this panel BY NAME, and RULING 1's
+;; surviving spelling puts the Fresco boundary on the natural name with a
+;; PUBLIC bridge passed by the caller — the shape `resources/Panel-bridge`
+;; already ships. Pointing the mount facade at the bridge name NOW, while
+;; it is still a plain alias, is what lets this panel's migration happen
+;; entirely INSIDE THIS FILE: `Panel` becomes the `defview` boundary and
+;; this def becomes the real `rf.fresco/as-component` bridge, with
+;; `panels.cljs` never touched again. It adopts RULING 1 early rather than
+;; bending it.
+;;
+;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
+;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
+;; SAME OBJECT — nothing downstream can tell the two names apart. And
+;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
+;; head position is the only position either name is used in: the fn-call
+;; hazard `render-panel!`'s docstring warns about (a plain `defn` INVOKED,
+;; skipping the React-context tier so subscribes route to `:rf/default`) is
+;; about call-versus-head position and is not reached here.
+(def Panel-bridge
+  "The name `panels/mount-trace!` mounts this panel through — a plain
+  alias of `Panel` until this panel migrates to Fresco, when it becomes
+  the `as-component` bridge without the mount facade moving. Scaffolding
+  with a defined end: it is deleted with every other `*-bridge` when the
+  shell itself becomes a Fresco tree. See the comment above."
+  Panel)
+
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -866,10 +866,12 @@
 ;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
 ;; SAME OBJECT — nothing downstream can tell the two names apart. And
 ;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
-;; head position is the only position either name is used in: the fn-call
-;; hazard `render-panel!`'s docstring warns about (a plain `defn` INVOKED,
-;; skipping the React-context tier so subscribes route to `:rf/default`) is
-;; about call-versus-head position and is not reached here.
+;; head position is the only position either name is used in, and the hazard
+;; `render-panel!`'s docstring warns about is not reached: what is unsafe
+;; there is CALLING the view, because that fn runs outside any React render
+;; and an ambient subscribe with no in-flight component resolves to nil and
+;; RAISES `:rf.error/no-frame-context` (there is no `:rf/default` fallback —
+;; Spec 006 §Plain-fn footgun).
 (def Panel-bridge
   "The name `panels/mount-trace!` mounts this panel through — a plain
   alias of `Panel` until this panel migrates to Fresco, when it becomes

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -97,7 +97,7 @@
 
 (deftest mount-epoch-panel-wraps-in-frame-provider-and-delegates-to-adapter
   (testing "rf2-crhr8 + rf2-5gl5r — mount-epoch-panel! installs
-            handlers, wraps epoch-panel/Panel in `[rf/frame-provider
+            handlers, wraps epoch-panel/Panel-bridge in `[rf/frame-provider
             {:frame :rf/xray} [Panel]]`, delegates to substrate-
             adapter/render, and returns the adapter's unmount fn.
             (Replaces the prior mount-event-detail! coverage; the
@@ -108,7 +108,7 @@
         (let [unmount (panels/mount-epoch-panel! mount-point)]
           (is (= 1 (count @capture))
               "rf.substrate.adapter/render invoked exactly once")
-          (is (frame-provider-wrap? (captured-tree capture) epoch-panel/Panel)
+          (is (frame-provider-wrap? (captured-tree capture) epoch-panel/Panel-bridge)
               "tree is wrapped in rf/frame-provider :rf/xray around Panel")
           (is (= mount-point (-> @capture first :mount-point))
               "mount-point passed through unchanged")
@@ -143,13 +143,13 @@
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-trace! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) trace/Panel)))))
+      (is (frame-provider-wrap? (captured-tree capture) trace/Panel-bridge)))))
 
 (deftest mount-machine-inspector-wraps-in-frame-provider
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-machine-inspector! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) machine-inspector/Panel)))))
+      (is (frame-provider-wrap? (captured-tree capture) machine-inspector/Panel-bridge)))))
 
 (deftest mount-routing-wraps-in-frame-provider
   (let [[capture _ render-stub] (make-render-stub)]
@@ -498,9 +498,9 @@
       (with-redefs [rf.substrate.adapter/render render-stub]
         (panels/mount-trace! :mount-point {:instance-id "left"})
         (panels/mount-epoch-panel! :mount-point {:instance-id "left"})
-        (is (= [trace/Panel] (delivered-element capture))
+        (is (= [trace/Panel-bridge] (delivered-element capture))
             "the trace mount delivers its view with no props")
-        (is (= [epoch-panel/Panel] (nth (:tree (second @capture)) 2))
+        (is (= [epoch-panel/Panel-bridge] (nth (:tree (second @capture)) 2))
             "and so does the epoch mount")))))
 
 ;; ---- contract — idempotency under repeat mount ------------------------


### PR DESCRIPTION
Touches the `panels.cljs` funnel ONCE so the remaining Xray panel migrations can run in parallel.

## Why

RULING 1's surviving spelling puts the Fresco boundary on a panel's natural name and has the CALLER pass a public `Panel-bridge`. That makes `panels.cljs` a single-toucher funnel: every remaining panel migration must edit it, so at most one can be in flight at a time however many workers are free.

This moves all three free unmigrated mounts to their bridge name now, while each bridge is still a plain alias. After this, a panel migration turns `Panel` into a `defview` boundary and `Panel-bridge` into a real `as-component` bridge **entirely inside that panel's own file**, and `panels.cljs` is not touched again. The ceiling goes from one panel migration at a time to three at once.

It **adopts** RULING 1 early rather than bending it: the shape created is precisely the one the ruling selected.

## The premise, and how it was verified

The slice rests on one fact: a plain `def` alias of a `reg-view` behaves identically in head position. Verified three ways rather than reasoned:

1. **By expansion.** `expand-reg-view` (`implementation/core/src/re_frame/core_reg_view_macro.cljc:133-135`) emits `(def <sym> (re-frame.core/view <id>))`. `Panel` is a VALUE, so the alias copies the same object.
2. **By the tree.** `panels/epoch_panel.cljs` has shipped `(def Panel view/Panel)` — a plain `def` alias of a `reg-view`, already mounted in head position through `render-panel!` — for as long as the epoch mount has existed.
3. **By running it.** A temporary probe asserted `identical?` between each `Panel` and its `Panel-bridge`, plus `ifn?` and a negative control that two different panel heads are *not* identical. Green. To prove the probe actually executed rather than being silently absent, one assertion was then flipped to a known-false pairing: the run went red at captured exit 1, naming `tmp-bridge-alias-is-the-same-object` and reporting `#object[cljs.core.MetaFn]` on both sides. The probe was removed before commit and the file restored, verified by blob hash against the committed object.

The hazard `render-panel!`'s docstring warns about does not bite here — see below.

## Rosters: nothing moved, and that was checked rather than assumed

* `panel_enum.cljc` names each view by its NATURAL name (`epoch-panel/Panel`, `trace/Panel`, `machine-inspector/Panel`), which this change leaves in place. Its own docstring calls `:view` a "documentation / cross-check axis; not load-bearing for the guard", and the guard reconciles `:mount` names against live vars and spec references — neither touched. Same precedent as the already-migrated rows, which still read `app-db-diff/Panel` beside a `Panel-bridge` call site.
* `tools/xray/spec/007-UX-IA.md` §Mountable surface inventory and `008-Embedding-Contract.md` likewise name the natural view. Unchanged.
* The api-manifest trio (`spec/API.md`, `spec/api-manifest.edn`, `spec/api-manifest-metadata.edn`) contains no `Panel-bridge` at all, though three already ship in the tree — so it does not grade panel view vars. Control: "xray" appears 6 / 50 / 86 times in those files, so the instrument is live.
* `panels_mount_cljs_test.cljs` DID name the delivered head in five places. Those are repointed, so they assert what the mount fn actually hands the renderer and the future migration need not touch this file either. They would have passed unchanged today (the alias is `=` to the view), which is exactly why they were worth correcting rather than leaving.

## A docstring correction carried in the same file

`render-panel!`'s docstring warned that a plain `defn` invoked as a fn-call "would skip the React-context tier and the panel's subscribes would route to `:rf/default`". Wrong twice, and it has been quoted as a general rule about calling views:

1. **There is no `:rf/default` fallback.** `spec/006-ReactiveSubstrate.md` §Plain-fn footgun: the ambient read "resolves to nil and RAISES `:rf.error/no-frame-context` — the operation fails fast rather than silently routing to a conventional default. There is no silent fall-through to `:rf/default`." `re-frame.views.provider/current-frame` says the same.
2. **Inside an already-provided tree the direction reverses.** `current-frame` reads the context off the component IN FLIGHT, so a plain helper CALLED from a reg-view or boundary body resolves through its caller's `:contextType` and is fine, while the same helper in HEAD position mints a `:contextType`-less component of its own and is what raises.

The conclusion still holds for `render-panel!`'s own site, so the warning is narrowed rather than deleted: that fn runs OUTSIDE any React render, so calling the view would evaluate its body with no in-flight component at all. The hazard is the absent render, not the call. The stale `Spec 006 §706` citation (that anchor exists nowhere in the file) is re-pointed at the section that does exist.

`shell.cljs:1020` carries the same wrong claim and is deliberately NOT touched — it is inside a live peer's edit closure.

## Not in scope, deliberately

* `mount-segment-inspector!` / `app_db_segment_inspector.cljs` — required by `shell.cljs:134`, inside a live peer's closure.
* `mount-routing!` — the #9578 spelling that RULING 1 converges at step 3.
* `mount-managed-fx!` — set by #9651; that line is untouched.
* `render-panel!` itself — still the single chokepoint where the frame-provider and `adapter/render` couplings get severed later.

## Quality gates

| Gate | Result |
|---|---|
| `node scripts/compile-node-test.cjs node-test out/node-test.js` (phase 1 of `npm run test:cljs`) | captured exit **0** — 1947 files, 0 warnings |
| `node out/node-test.js` (phase 2) | captured exit **0** — **11660 tests, 58445 assertions, 0 failures, 0 errors** |
| `python scripts/check_retired_spellings.py --verbose` | captured exit **0** |
| `python scripts/check_view_lifetime_residue.py --verbose` | captured exit **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | captured exit **0** (no requires added; run anyway) |

The compound `npm run test:cljs` was split into its two phases so each exit code is captured separately rather than reading the chain's.

**Which tree the gate read** — two independent confirmations. The compile log names this branch's own `implementation/shadow-cljs.edn` path; and the planted fault below went red.

**Sabotage.** One call site was pointed at `trace/Panel-bridge-SABOTAGE-DOES-NOT-EXIST`. The compile went RED at captured exit **1** with `Use of undeclared Var day8.re-frame2-xray.panels.trace/Panel-bridge-SABOTAGE-DOES-NOT-EXIST`, quoting the planted line. Restored and verified by blob hash against the committed object (`git diff --quiet HEAD` exit 0).

**Lane.** `test:cljs` is the right lane per `TESTING.md`'s command catalogue: it grades every `*_cljs_test.cljs` across `implementation/*` + `tools/*`, and `panels_mount_cljs_test.cljs` is a plain (non-DOM) suite. **No `*_dom_cljs_test.cljs` namespace covers these three panels** — checked with a control that bites: a grep for `Panel-bridge` across DOM suites returns a hit, while a grep for these three mount fns and their views returns a true zero. So `npm run test:browser` has nothing to say about this diff and is not nominated.

**Not covered by any gate:** the prose in the comments and docstrings this change adds. Verified by hand — the three bridge comments and the `render-panel!` docstring were each re-read after editing, every spec claim in them was checked at source (`spec/006-ReactiveSubstrate.md` §Plain-fn footgun, `re-frame.views.provider/current-frame`, `core_reg_view_macro.cljc`), and all four touched files were confirmed to carry no bare carriage returns (CR count equals CRLF count in every one).

**Merge-base diff read for reverts.** `git diff origin/main...HEAD` over `panels.cljs` deletes exactly eight lines: the five docstring lines deliberately rewritten and the three call sites deliberately repointed. Nothing from #9651's landing (`ManagedFxList-component`, `ManagedFxList-bridge`, `mount-managed-fx!`) and nothing from routing or segment-inspector is touched.
