### PR TITLE
fix(xray): let a caller name two managed-fx mounts in one frame (rf2-5ykm)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1797,9 +1797,10 @@ a master `mount-shell!` for the full 4-layer chrome. This per-panel
 surface is **internal-but-stable**, NOT a v1.0 host-facing embed
 contract: the 4-layer shell + the test suite depend on it and hosts
 MAY use it, but it carries no host-facing-contract guarantee (the
-opts vocabulary is two keys wide and one of them is a single
-panel's: `:frame` on every mount fn, defaulting to `:rf/xray`, and
-`:instance-id` on `mount-app-db-diff!` alone, per rf2-2n8q) — the
+opts vocabulary is two keys wide and one of them is only two
+panels': `:frame` on every mount fn, defaulting to `:rf/xray`, and
+`:instance-id` on `mount-app-db-diff!` (rf2-2n8q) and
+`mount-managed-fx!` (rf2-5ykm)) — the
 v1.0 host-facing embed contract is the **full-shell** embed per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
 §Full-shell embed contract. (rf2-jw2ny — one honest status across

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -547,7 +547,8 @@ that needs it, not in a central shim layer.
   [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract for
   internal use (shell composition, tests, future tools); it carries
   `:frame` universally and `:instance-id` on `mount-app-db-diff!`
-  alone (rf2-2n8q), and is not a host-facing embed contract.
+  (rf2-2n8q) and `mount-managed-fx!` (rf2-5ykm) — the two panels whose
+  view accepts it — and is not a host-facing embed contract.
 - **No two-way binding.** Beyond the `configure!` slots and the
   one-way **focus command** (§Host-facing focus API — the host pushes
   a focus *intent*, not arbitrary state, and Xray owns what it means),

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -407,8 +407,9 @@ embed contract. The `mount-<panel>!` aggregator surface enumerated in
 [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract is
 internal-but-stable (used by shell composition and tests); it accepts
 `:frame` — defaulting to `:rf/xray` — on every mount fn, plus
-`:instance-id` on `mount-app-db-diff!` alone (rf2-2n8q), which names
-one of two standalone app-db mounts sharing a frame.
+`:instance-id` on `mount-app-db-diff!` (rf2-2n8q) and
+`mount-managed-fx!` (rf2-5ykm), which names one of two standalone
+mounts of that panel sharing a frame.
 
 ### Static-mode Panel reg-views
 

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -12,9 +12,9 @@
   contract.** The mount fns are stable (the shell + tests depend on
   them; hosts MAY use them) but carry NO v1.0 host-facing-contract
   guarantee — the props vocabulary is two keys wide and one of them is
-  a single panel's: `:frame` (every mount fn, defaulting to `:rf/xray`)
-  and `:instance-id` (`mount-app-db-diff!` only — see §`:instance-id`
-  opt below). The v1.0 host-facing embed
+  only two panels': `:frame` (every mount fn, defaulting to `:rf/xray`)
+  and `:instance-id` (`mount-app-db-diff!` and `mount-managed-fx!` — see
+  §`:instance-id` opt below). The v1.0 host-facing embed
   contract is the **full-shell** embed per
   `tools/xray/spec/008-Embedding-Contract.md` §Full-shell embed
   contract. This matches the status stated in
@@ -143,7 +143,7 @@
   Xray's own UI state, while the panel-internal frame-selection sub
   (`:rf.xray/observed-frame`) drives the data axis.
 
-  ## `:instance-id` opt — `mount-app-db-diff!` ONLY (rf2-2n8q)
+  ## `:instance-id` opt — `mount-app-db-diff!` and `mount-managed-fx!`
 
   Two mounts under two DIFFERENT `:frame`s are already told apart:
   rf2-d2aj keys the edn-inspector's per-mount store by `[frame-id
@@ -156,15 +156,27 @@
       (mount-app-db-diff! left-el  {:instance-id \"left\"})
       (mount-app-db-diff! right-el {:instance-id \"right\"})
 
-  rf2-t3fz gave `app-db-diff/Panel` the prop; this opt is the door for
-  a caller that mounts rather than renders, which passes opts and never
-  props. Omit it and every id is byte-for-byte what it was.
+  rf2-t3fz gave `app-db-diff/Panel` the prop; this opt (rf2-2n8q) is the
+  door for a caller that mounts rather than renders, which passes opts and
+  never props. Omit it and every id is byte-for-byte what it was.
 
-  It is ONE panel's opt rather than the surface's, and deliberately so:
+  rf2-5ykm — `mount-managed-fx!` takes the SAME key for the same reason,
+  and it arrived as a REGRESSION rather than a gap: that panel's mount was
+  an `rf/reg-view` until rf2-fcy5, and the Reagent head minted a per-mount
+  identity the boundary cannot. Two managed-fx lists of one focused event
+  in one frame therefore shared one ResizeObserver and one width slot, and
+  detaching either released the survivor's — measured on a real
+  two-container commit in
+  `panels/managed_fx_mount_instance_id_dom_cljs_test`.
+
+  It is SOME panels' opt rather than the surface's, and deliberately so:
   it is only meaningful where a panel's view accepts it, and handing a
   props map to a panel whose view takes none is an arity error rather
   than an ignored key. `render-panel!`'s `props` argument is the seam —
-  see its docstring.
+  see its docstring. The two panels that take it each own their own
+  normaliser (`app-db-diff-state/instance-token`,
+  `managed-fx-template/instance-token`) so a refusal names the caller's
+  own panel.
 
   See `tools/xray/spec/007-UX-IA.md` §Mountable panel contract and
   `tools/xray/spec/008-Embedding-Contract.md` for the full
@@ -268,7 +280,9 @@
     provider at all — each one's docstring says its isolation comes
     from the ENCLOSING provider, which is this one.
   - `props` — OPTIONAL (rf2-2n8q), and it is the PANEL's props map, not
-    the mount opts. nil — every caller but `mount-app-db-diff!` — mounts
+    the mount opts. nil — every caller but `mount-app-db-diff!` and
+    `mount-managed-fx!` (rf2-5ykm), and those two only when the caller
+    named an instance — mounts
     `[panel-view]`, the element this fn has always built. A map mounts
     `[panel-view props]`. The caller decides, because only the caller
     knows whether its panel's view takes props at all: `[trace/Panel
@@ -503,9 +517,16 @@
   travels as an argument (the same shape `views/edn-inspector` uses for
   its own expansion slot).
 
+  `instance-id` (rf2-5ykm) is the optional per-mount name from
+  [[mount-managed-fx!]]'s opts, threaded down to the four inspector sites
+  so two lists in one frame compose disjoint widget identities. nil — the
+  3-arity, and every single-mount call site — composes what it always did.
+
   PURE: every helper it calls is a plain fn of its arguments."
-  [focused expanded dispatch]
-  (managed-fx/records-list dispatch expanded (:records focused)))
+  ([focused expanded dispatch]
+   (managed-fx-list-tree focused expanded dispatch nil))
+  ([focused expanded dispatch instance-id]
+   (managed-fx/records-list dispatch expanded instance-id (:records focused))))
 
 (rf.fresco/defview ManagedFxList
   "The managed-fx wire-boundary diff template's mountable wrapper — a
@@ -538,12 +559,40 @@
   surrounding instance frame rather than on a `{:frame :rf/xray}` literal.
 
   The argument is the ordinary one-props-map vector every `defview` takes.
-  This panel reads nothing from props — `mount-managed-fx!` passes none —
-  so it is destructured away."
-  [_props]
+
+  ## `:instance-id` — OPTIONAL, and it names ONE LIVE MOUNT (rf2-5ykm)
+
+  This panel reads no DATA from props: everything it renders comes from the
+  two subs below and from nothing else. The one prop it takes is an
+  IDENTITY, and it exists because rf2-fcy5 dropped one. Every node-key the
+  template composes names a logical SURFACE and is deliberately stable, so
+  two lists of the same focused event present the same ones; rf2-d2aj
+  qualified the edn-inspector's per-mount store by the FRAME, which
+  separates two mounts under two `frame-provider`s and cannot separate two
+  under one. Left unnamed the two share one store entry, one
+  ResizeObserver, one projection cache and one width slot, and detaching
+  either releases the survivor's.
+
+  So the distinction is the caller's to make, and this prop is how:
+
+      [ManagedFxList-bridge {:instance-id \"left\"}]
+      (mount-managed-fx! el {:instance-id \"right\"})
+
+  A non-blank string or a keyword, whose NAMESPACE is part of the name.
+  `managed-fx-template/instance-token` refuses, loudly, the shapes that
+  could not be stable across renders. OMIT IT when only one managed-fx
+  list renders in this frame, which is every call site in this tree today:
+  the ids are then byte-for-byte what they were.
+
+  BOTH DOORS ANSWER THE SAME. Mounted from a Fresco body the prop arrives
+  as written; mounted through [[ManagedFxList-bridge]] it arrives already
+  tokenised, because `[:>]` would otherwise convert a keyword with
+  `cljs.core/name` and drop its namespace — see that fn's own note."
+  [{:keys [instance-id]}]
   (managed-fx-list-tree (rf.fresco/sub [:rf.xray/managed-fx-for-focused-event])
                         (rf.fresco/sub [:rf.xray/managed-fx-expanded-sections])
-                        (:dispatch (rf/capture-frame))))
+                        (:dispatch (rf/capture-frame))
+                        instance-id))
 
 (def ^:private ManagedFxList-component
   "The React component `ManagedFxList` presents as, for a non-Fresco
@@ -567,21 +616,71 @@
 
   THIS IS SCAFFOLDING WITH A DEFINED END. When `render-panel!` itself
   builds a Fresco tree, it takes `ManagedFxList` directly, `[:>]` goes,
-  and both defs here are deleted with every other `*-bridge`."
-  []
-  [:> ManagedFxList-component {}])
+  and both defs here are deleted with every other `*-bridge`.
+
+  rf2-5ykm — the 1-arity is how a caller names one of two lists sharing a
+  frame; the 0-arity stays because that is what an unnamed standalone mount
+  takes (`[panel-view]`, one list per frame, no instance to name).
+
+  ## The prop is TOKENISED HERE, before the crossing
+
+  `[:>]` converts each prop VALUE before React sees it, and Reagent's
+  `convert-prop-value` converts a named value with `cljs.core/name` — which
+  DROPS THE NAMESPACE. Passed through raw, `:left/list` and `:right/list`
+  would both arrive at the boundary as `\"list\"`, restoring the very
+  collision this opt repairs. `app-db-diff/Panel-bridge` carries the full
+  account (rf2-4bsq); the remedy is the same one — run the panel's own
+  normaliser so a STRING crosses, which Reagent preserves intact, and a
+  refused shape throws naming the CALLER's value rather than whatever the
+  crossing had turned it into. The boundary's own call on the far side is
+  then a no-op, because the fn is idempotent on its own output.
+
+  A blank string tokenises to nil and so mounts with no props, exactly as
+  naming no instance does."
+  ([] (ManagedFxList-bridge nil))
+  ([props]
+   [:> ManagedFxList-component
+    (if-let [instance-id (managed-fx/instance-token (:instance-id props))]
+      {:instance-id instance-id}
+      {})]))
 
 (defn mount-managed-fx!
   "Mount the managed-fx wire-boundary diff list in isolation at
   `mount-point`. Renders one record-panel per managed-fx invocation
   inside the focused event-bundle's managed-fx records. Empty when the
-  focused event-bundle had no managed-fx records."
+  focused event-bundle had no managed-fx records.
+
+  `opts :instance-id` — OPTIONAL (rf2-5ykm). A non-blank string or a
+  keyword naming THIS mount, for the case where two standalone managed-fx
+  lists share one `:frame`. It qualifies every inspector node-key the
+  template composes, and that one string is BOTH the edn-inspector's
+  `:mount-id` and its `:panel-id`, so one qualifier separates the widget's
+  lifecycle key, its measured-width slot and its expansion/zoom identity
+  together. Left unnamed, two mounts in one frame share one store entry and
+  one ResizeObserver, the second is never observed at all, and detaching
+  either releases the survivor's state.
+
+  RECORD IDENTITY AND DISCLOSURE ARE DELIBERATELY UNQUALIFIED. The
+  disclosure slot is keyed by `record-key` in the frame's app-db, so two
+  lists of the same records open and close together — the same records, the
+  same sections, one operator decision.
+
+  OMIT IT when only one managed-fx list is on screen in this frame, which
+  is every call site in this tree today: the ids are then byte-for-byte
+  what they were. `managed-fx-template/instance-token` refuses, loudly, the
+  shapes that could not be stable across renders."
   ([mount-point]      (mount-managed-fx! mount-point nil))
   ;; rf2-fcy5 — `ManagedFxList-bridge`, not `ManagedFxList`, for the reason
   ;; `mount-resources!` records above: the view is now a Fresco boundary
   ;; and `render-panel!` builds a Reagent tree, which `defview`'s contract
   ;; forbids mounting a boundary into. `render-panel!` itself is untouched.
-  ([mount-point opts] (render-panel! ManagedFxList-bridge mount-point opts)))
+  ;; rf2-5ykm — and the props map is what carries `:instance-id` across that
+  ;; bridge; the bridge's 1-arity is the door, its 0-arity is what an
+  ;; unnamed mount still takes.
+  ([mount-point opts]
+   (render-panel! ManagedFxList-bridge mount-point opts
+                  (when-let [id (:instance-id opts)]
+                    {:instance-id id}))))
 
 ;; ---- full-shell mount ---------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/managed_fx_template.cljs
@@ -259,9 +259,97 @@
 ;; every record in every list shared one. `record-key` is this file's own
 ;; per-record identity — already the React `:key` and the expansion key —
 ;; so deriving all three from it is what stops them drifting apart.
+;;
+;; rf2-5ykm — AND `record-key` SEPARATES RECORDS WITHIN ONE LIST, NEVER TWO
+;; LISTS. That is the half the migration dropped: the Reagent head this
+;; panel used to be minted a per-mount identity, and a Fresco boundary
+;; cannot — it is a React function component with no per-instance storage
+;; its body may use. So two `mount-managed-fx!` mounts of the SAME focused
+;; event under ONE frame composed identical node-keys, and the paragraph
+;; above then describes them exactly: one memoised ref between them, the
+;; second element never observed, and `release-mount!` tearing the shared
+;; entry down when EITHER detached. Measured on a real two-container commit
+;; before the repair — `panels/managed_fx_mount_instance_id_dom_cljs_test`.
+;;
+;; The caller names them, which is the ruling rf2-d2aj closed with and the
+;; shape `app-db-diff` already ships: an optional `:instance-id`, threaded
+;; from `mount-managed-fx!` through the bridge and the boundary to
+;; [[node-key]] below. ONE qualifier does both halves here where app-db
+;; needs two, because `edn-widget/inspect-view` builds the `:mount-id` AND
+;; the `:panel-id` from this one string and passes no `:site-id` (so the
+;; widget's `effective-id` falls back to the mount-id).
+;;
+;; WHAT IT DELIBERATELY DOES NOT TOUCH is record identity and disclosure.
+;; `record-key` stays the React `:key` and stays the expansion key, which
+;; lives in the frame's app-db and is therefore shared by two lists of the
+;; same records ON PURPOSE — they open and close together, and what they
+;; no longer share is a ResizeObserver.
+
+(defn instance-token
+  "Normalise `panels/ManagedFxList`'s optional `:instance-id` prop to the
+  string that qualifies one mount's inspector ids, or nil when the caller
+  named no instance — the single-mount default, which composes every id
+  byte-for-byte as it did before rf2-5ykm.
+
+  A KEYWORD is accepted alongside a string, and its NAMESPACE is part of
+  the name: `:left/list` tokenises to `left/list`. `(subs (str id) 1)` is
+  the whole of it — the keyword minus its leading colon.
+
+  IDEMPOTENT, because it is called TWICE on the way in and must compose one
+  answer for one value. [[panels/ManagedFxList-bridge]] calls it BEFORE
+  handing the prop across `[:>]`, and that is a repair rather than tidiness
+  (rf2-4bsq, met first on `app-db-diff`): Reagent's `convert-prop-value`
+  converts a named value with `cljs.core/name`, which DROPS the namespace,
+  so `:left/list` and `:right/list` would both arrive as `\"list\"` and the
+  two mounts a caller had deliberately named apart would collide again.
+  Normalising first means a STRING crosses, which Reagent preserves.
+
+  Anything else is REFUSED rather than `str`-ed, and that is the point of
+  the fn. The token has to be stable across the mount's renders; a value
+  whose printed form is minted per render — a map, a JS object — would
+  compose a fresh `:mount-id` and `:panel-id` every pass and silently throw
+  away expansion, zoom and the measured column width each time. That is the
+  same failure `edn-inspector-view`'s own `:mount-id` refusal exists to
+  prevent, one level up.
+
+  It is this panel's own normaliser rather than a call into
+  `app-db-diff-state`'s: the two panels are independent surfaces, they
+  migrate on their own schedules, and the refusal has to name the caller's
+  OWN panel to be worth reading."
+  [instance-id]
+  (cond
+    (nil? instance-id)     nil
+    (keyword? instance-id) (subs (str instance-id) 1)
+    (string? instance-id)  (when (seq instance-id) instance-id)
+    :else
+    (throw (ex-info
+             (str "The managed-fx list's :instance-id must be a non-blank "
+                  "string or a keyword naming ONE live mount of the panel; "
+                  "it was " (pr-str instance-id) ". It is composed into the "
+                  "edn-inspector's :mount-id and :panel-id, so it must be "
+                  "stable across that mount's renders — a value minted per "
+                  "render would lose expansion, zoom and the measured column "
+                  "width on every pass. Omit it entirely when only one "
+                  "managed-fx list is on screen in this frame.")
+             {:instance-id instance-id}))))
+
+(defn- node-key
+  "The inspector node-key for one record's `role` section — the string
+  `edn-widget/inspect-view` turns into BOTH the boundary's `:mount-id` and
+  its `:panel-id`.
+
+  `instance` is the already-tokenised per-mount name, or nil. It is spliced
+  in AFTER the panel's own prefix and BEFORE the record key, mirroring
+  `app-db-diff-state`'s `app-db-state/<instance>/<render-id>`: the
+  qualifier names the mount, the record key still names the record inside
+  it, and an unnamed mount composes exactly the string it always did."
+  [instance record role]
+  (if instance
+    (str "managed-fx/" instance "/" (h/record-key record) "/" role)
+    (str "managed-fx/" (h/record-key record) "/" role)))
 
 (defn- request-section
-  [{:keys [req surface] :as record}]
+  [instance {:keys [req surface] :as record}]
   (cond
     (and (nil? req) (= surface :flow))
     [:span {:style {:color (:text-tertiary tokens)}} "(flow input — see registration)"]
@@ -270,7 +358,7 @@
     [:span {:style {:color (:text-tertiary tokens)}} "(no request payload)"]
 
     :else
-    (edn/inspect-view req (str "managed-fx/" (h/record-key record) "/req"))))
+    (edn/inspect-view req (node-key instance record "req"))))
 
 (defn- wire-section
   "Wire timing section. When the surface emits per-phase wire data we
@@ -288,7 +376,7 @@
      "n/a — this surface does not emit per-phase wire timing today."]))
 
 (defn- response-section
-  [{:keys [res surface failure] :as record}]
+  [instance {:keys [res surface failure] :as record}]
   (cond
     failure
     [:div
@@ -297,7 +385,7 @@
                     :margin-bottom "4px"}}
       (str "✗ " (or (some-> failure :kind name) "FAILURE"))]
      (edn/inspect-view (or (:tags failure) failure)
-                       (str "managed-fx/" (h/record-key record) "/failure"))]
+                       (node-key instance record "failure"))]
 
     (and (nil? res) (= surface :flow))
     [:span {:style {:color (:text-tertiary tokens)}}
@@ -308,20 +396,20 @@
      "(no response payload yet)"]
 
     :else
-    (edn/inspect-view res (str "managed-fx/" (h/record-key record) "/res"))))
+    (edn/inspect-view res (node-key instance record "res"))))
 
 (defn- handler-section
   "Renders the dispatched handler event vector + a click-to-focus
   affordance that pivots the spine to that child event-bundle. Anchors the
   F.3 'failed response handler' diagnostic."
-  [dispatch {:keys [handler frame dispatch-id] :as record}]
+  [dispatch instance {:keys [handler frame dispatch-id] :as record}]
   (if (and (vector? handler) (seq handler))
     [:div {:style {:display "flex"
                    :align-items "center"
                    :gap "12px"
                    :flex-wrap "wrap"}}
      [:div {:style {:flex 1 :min-width 0}}
-      (edn/inspect-view handler (str "managed-fx/" (h/record-key record) "/handler"))]
+      (edn/inspect-view handler (node-key instance record "handler"))]
      [:button {:data-testid "rf-xray-managed-fx-focus-handler"
                :on-click    #(dispatch [:rf.xray/focus-event dispatch-id frame])
                :style       {:background  "transparent"
@@ -460,10 +548,19 @@
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
   `panels/ManagedFxList` `reg-view` body, threaded to the header /
   handler / disclosure affordances. Defaults to `rf/dispatch` so the test
-  seam (and any pre-sweep caller) renders without a captured dispatcher."
-  ([record] (record-panel rf/dispatch nil record))
-  ([dispatch record] (record-panel dispatch nil record))
-  ([dispatch expanded record]
+  seam (and any pre-sweep caller) renders without a captured dispatcher.
+
+  `instance-id` (rf2-5ykm) is the optional per-mount name the caller gave
+  `mount-managed-fx!`, normalised ONCE here by [[instance-token]] so the
+  four inspector sites can never disagree about it. nil — every arity below
+  the 4-arity, and every single-mount call site in this tree — composes the
+  node-keys byte-for-byte as it did before. It qualifies the INSPECTOR ids
+  only: `rec-key` below is untouched, so the React `:key` and the
+  disclosure state stay exactly where they were."
+  ([record] (record-panel rf/dispatch nil nil record))
+  ([dispatch record] (record-panel dispatch nil nil record))
+  ([dispatch expanded record] (record-panel dispatch expanded nil record))
+  ([dispatch expanded instance-id record]
   ;; rf2-hxfy — the React key lives in this ATTRIBUTE MAP rather than as
   ;; `^{:key …}` reader meta on the `(record-panel …)` call in
   ;; `records-list` below. Reader meta on a CALL form attaches to the
@@ -475,7 +572,10 @@
   ;; Reagent reads meta THEN props — so one attribute satisfies both
   ;; substrates. The composed value is unchanged from the call site's:
   ;; the same three record fields, same order, same separator.
-  (let [rec-key (h/record-key record)
+  (let [rec-key  (h/record-key record)
+        ;; rf2-5ykm — tokenised (and type-refused) ONCE, so the four
+        ;; inspector sites below compose one answer for one value.
+        instance (instance-token instance-id)
         ;; One `section` per row: resolve this record's stored state for
         ;; the section (falling back to its default) and hand the whole
         ;; lot to the disclosure wrapper.
@@ -501,13 +601,13 @@
    (panel-header dispatch record)
    [:div {:style {:padding "8px 12px"}}
     (section :request  "REQUEST"
-             "rf-xray-managed-fx-section-request"  (request-section record))
+             "rf-xray-managed-fx-section-request"  (request-section instance record))
     (section :wire     "WIRE TIMING"
              "rf-xray-managed-fx-section-wire"     (wire-section record))
     (section :response "RESPONSE"
-             "rf-xray-managed-fx-section-response" (response-section record))
+             "rf-xray-managed-fx-section-response" (response-section instance record))
     (section :handler  "HANDLER DISPATCHED"
-             "rf-xray-managed-fx-section-handler"  (handler-section dispatch record))
+             "rf-xray-managed-fx-section-handler"  (handler-section dispatch instance record))
     (section :app-db   "APP-DB SLICE TOUCHED"
              "rf-xray-managed-fx-section-app-db"   (app-db-slice-section record))]])))
 
@@ -524,10 +624,16 @@
 
   `expanded` is the per-section override map threaded to each
   `record-panel`; `nil` renders every section at its default. Keyed per
-  record, so opening one panel's REQUEST leaves its siblings shut."
-  ([records] (records-list rf/dispatch nil records))
-  ([dispatch records] (records-list dispatch nil records))
-  ([dispatch expanded records]
+  record, so opening one panel's REQUEST leaves its siblings shut.
+
+  `instance-id` (rf2-5ykm) is the optional per-mount name, threaded to each
+  `record-panel` and normalised there. nil — the shape every arity below
+  the 4-arity passes — composes the inspector node-keys exactly as they
+  were."
+  ([records] (records-list rf/dispatch nil nil records))
+  ([dispatch records] (records-list dispatch nil nil records))
+  ([dispatch expanded records] (records-list dispatch expanded nil records))
+  ([dispatch expanded instance-id records]
   (when (seq records)
     [:div {:data-testid "rf-xray-managed-fx-list"
            :style {:padding "8px 0"
@@ -543,4 +649,4 @@
      ;; attribute map `record-panel` returns (see the comment there).
      ;; Reader meta here would attach to the CALL form and be lost.
      (for [rec records]
-       (record-panel dispatch expanded rec))])))
+       (record-panel dispatch expanded instance-id rec))])))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_mount_instance_id_dom_cljs_test.cljs
@@ -1,0 +1,338 @@
+(ns day8.re-frame2-xray.panels.managed-fx-mount-instance-id-dom-cljs-test
+  "TWO STANDALONE `mount-managed-fx!` MOUNTS IN ONE FRAME, read off a real
+  React commit (rf2-5ykm).
+
+  ## The claim, and why it needs a DOM
+
+  rf2-fcy5 migrated this panel's mount to a Fresco boundary and gave each
+  record's inspector a per-record node-key, which fixed the collisions
+  WITHIN one list. It introduced one ACROSS lists: `mount-managed-fx!`
+  delegated with no props, `ManagedFxList-bridge` always passed `{}`, the
+  boundary ignored props, and `managed_fx_template`'s four
+  `edn/inspect-view` sites derived every node-key from `record-key` and the
+  section role alone. So the same focused event mounted into two containers
+  under one frame emitted IDENTICAL mount-ids — the per-mount identity the
+  Reagent head used to mint was what the migration dropped.
+
+  A row asserting the opts key was THREADED would pass while both mounts
+  still collided, which is the failure one level up. So nothing here reads
+  the opts map, the captured tree, or the props. Two mounts are made
+  through the public facade into two real containers, and every assertion
+  below reads `container.querySelector` — the DOM React committed on its
+  own — or the widget's own per-mount store.
+
+  ## The two observables, and the SECOND is the one the defect breaks
+
+  `data-rf-mount-id` is stamped by the edn-inspector widget on every
+  committed container. It is not decoration: `edn-widget/inspect-view`
+  hands the node-key straight to the boundary as `:mount-id`, and that one
+  string composes BOTH ids the widget keys on —
+  `edn-inspector/container-ref-for` memoises the ref callback on
+  `[frame-id mount-id]`, and `inspect-opts` composes
+  `:rf.xray.inspect/<node-key>` as the `:panel-id` that keys expansion and
+  zoom. (This panel passes no `:site-id`, so the widget's
+  `effective-id` falls back to the mount-id — qualifying the node-key
+  qualifies both halves at once, which is why there is one qualifier here
+  where `app-db-diff` needs two.)
+
+  [[two-named-mounts-each-hold-their-own-observer]] is the half a
+  distinctness row would miss. Under the shared identity the SECOND mount
+  never installs a ResizeObserver at all (`container-ref-for` hands back
+  the memoised callback, whose mount arm is guarded on
+  `(nil? (:observer entry))`), and `release-mount!` then tears the SHARED
+  entry down when EITHER mount detaches — leaving the survivor on screen
+  with no observer and no width updates. So that row asserts the observer
+  is held by each mount and STILL held by the survivor afterwards.
+
+  ## The negative control IS the defect, and it is a row rather than a note
+
+  [[two-unnamed-mounts-still-collide]] mounts the same two lists with NO
+  `:instance-id` and asserts the id sets are IDENTICAL. It carries two
+  claims at once: the instrument can see a collision (so the disjointness
+  above is separation and not silence), and omitting the opt leaves every
+  id byte-for-byte what it always was — which is every call site in this
+  tree today.
+
+  ## Substrate: the Reagent adapter, and the mount is the PUBLIC one
+
+  `mount-managed-fx!` delegates to `rf.substrate.adapter/render`, so the
+  installed adapter is what renders. Nothing here reaches past the facade
+  to build a tree of its own — the thing under test is the mount fn.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`. The `:node-test` build's `cljs-test$`
+  regex also matches, so it LOADS under Node — where every row
+  short-circuits through [[browser?]] and reports the skip rather than
+  passing silently. A green node lane is therefore NOT evidence about this
+  file; `npm run test:browser` is."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.panels :as panels]
+            [day8.re-frame2-xray.panels.managed-fx-helpers :as h]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            ;; READ-ONLY, and only for the per-mount store's public test
+            ;; surface (`lifecycle-key`, `mount-state-held`). The widget's own
+            ;; lifecycle rows live in `views/edn_inspector_mount_state_cljs_test`;
+            ;; what W2 below asserts is that two STANDALONE MOUNTS hand that
+            ;; store two distinct keys, each with its own observer.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about, and
+                      ;; `ManagedFxList` is a Fresco boundary — a neighbour's
+                      ;; entry left in the cache would make these rows read a
+                      ;; residue that is not this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the seeded cascade --------------------------------------------------
+
+(def ^:private dispatch-id 620)
+
+(defn- cascade-evs
+  "One cascade carrying two `:rf.http/managed` invocations — the same shape
+  `managed_fx_mount_dom_cljs_test` seeds, so the two files disagree about
+  nothing but how many containers they mount it into."
+  []
+  [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
+    :tags {:rf.trace/dispatch-id dispatch-id :rf.event/v [:user/load]}}
+   {:id 2 :op-type :rf.fx :operation :rf.fx/do-fx
+    :tags {:rf.trace/dispatch-id dispatch-id}}
+   {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/1"}
+                        :request-id :req-a
+                        :on-success [:user/loaded]}}}
+   {:id 4 :op-type :rf.fx :operation :rf.fx/handled
+    :tags {:rf.trace/dispatch-id dispatch-id
+           :rf.fx/id :rf.http/managed
+           :rf.fx/args {:request    {:method :get :url "/api/users/2"}
+                        :request-id :req-b
+                        :on-success [:user/loaded]}}}])
+
+(defn- records
+  "The composite sub's records vector, read the way the boundary reads it."
+  []
+  (rf/with-frame :rf/xray
+    (:records @(rf/subscribe [:rf.xray/managed-fx-for-focused-event]))))
+
+(defn- setup!
+  "Seed the trace buffer, focus the cascade, and open the payload-bearing
+  sections BEFORE anything mounts, so the inspector widgets are in the very
+  first commit of each container.
+
+  The disclosure slot is keyed by `record-key` and lives in the frame's
+  app-db, which both mounts share DELIBERATELY: this bead qualifies the
+  inspector's own identities and leaves record identity and disclosure
+  semantics exactly where they were. Two lists of the same records open and
+  close together; what they no longer share is a ResizeObserver."
+  []
+  (registry/register-xray-handlers!)
+  (mount/ensure-xray-frame! :rf/xray)
+  (doseq [ev (cascade-evs)]
+    (trace-collector/seed-trace-for-test! ev))
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/focus-event dispatch-id :rf/default])
+    (doseq [rec  (records)
+            sect [:request :response :handler]]
+      (rf/dispatch-sync [:rf.xray/managed-fx-toggle-section
+                         (h/record-key rec) sect])))
+  nil)
+
+;; ---- mounting, and reading the DOM back ----------------------------------
+
+(defn- mount!
+  "Mount the managed-fx list through the PUBLIC facade with `opts`,
+  committed synchronously.
+
+  `react-dom/flushSync` rather than a Reagent queue drain: the panel's view
+  is a Fresco boundary, which is not in Reagent's render queue at all, so
+  draining that queue commits nothing of this panel's and a row written
+  that way reads a container that never moved."
+  [opts]
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    (let [unmount (react-dom/flushSync
+                    (fn [] (panels/mount-managed-fx! container opts)))]
+      {:container container :unmount unmount})))
+
+(defn- unmount!
+  "Tear one mount down inside `flushSync` so React's ref-detach has RUN by
+  the time the next line reads the per-mount store. A bare unmount
+  schedules it."
+  [{:keys [container unmount]}]
+  (react-dom/flushSync (fn [] (unmount)))
+  (.remove container))
+
+(defn- mount-ids
+  "Every `data-rf-mount-id` in `container`'s committed DOM, in document
+  order. Reads the DOM React wrote — nothing here reproduces the panel."
+  [container]
+  (->> (.querySelectorAll container "[data-rf-mount-id]")
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % "data-rf-mount-id"))))
+
+(def ^:private id-prefix
+  "What `edn-widget/inspect-view` puts in front of every node-key. Named so
+  W3's splice assertion states the qualifier's position rather than a
+  literal."
+  "rf-xray-inspect-managed-fx/")
+
+;; ===========================================================================
+;; W1 — two NAMED standalone mounts compose two disjoint sets of ids
+;; ===========================================================================
+
+(deftest two-named-mounts-compose-disjoint-inspector-ids
+  (testing "rf2-5ykm — `mount-managed-fx!` given two different
+            `:instance-id`s mounts two lists whose committed DOM carries two
+            disjoint sets of `data-rf-mount-id`, in the ONE `:rf/xray` frame
+            they both default to. Each id composes the widget's lifecycle
+            key AND its `:panel-id`, so disjointness here is disjointness of
+            both."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})]
+        (try
+          (let [ids-l (mount-ids (:container left))
+                ids-r (mount-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (seq ids-l)
+                "control: the left mount committed at least one edn-inspector
+                 widget, so an empty intersection below means separation and
+                 not an empty list that rendered no widget at all")
+            (is (= (count ids-l) (count ids-r))
+                "naming an instance changes the ids, never the records — two
+                 mounts of the same focused event over the same records")
+
+            ;; ---- the claim ---------------------------------------------
+            (is (nil? (some (set ids-l) ids-r))
+                (str "no mount-id survives from one standalone mount to the "
+                     "other — the store's lifecycle key, the measured width "
+                     "slot and the expansion/zoom panel-id are all derived "
+                     "from this string. left=" (pr-str ids-l)
+                     " right=" (pr-str ids-r)))
+            (is (every? #(string/starts-with? % (str id-prefix "left/")) ids-l)
+                (str "each id carries the name THIS mount was given, rather "
+                     "than a per-render nonce or a shared string: "
+                     (pr-str ids-l))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W2 — the lifecycle half: each mount owns an observer, and keeps it
+;; ===========================================================================
+
+(deftest two-named-mounts-each-hold-their-own-observer
+  (testing "rf2-5ykm — two named standalone mounts hold two entries in the
+            widget's per-mount store, each with its OWN ResizeObserver, and
+            unmounting one releases ONLY its own. Under the shared identity
+            the second mount never installs an observer at all and
+            `release-mount!` tears the shared entry down when either
+            detaches, so the survivor is left on screen unobserved — which a
+            distinctness row alone cannot see."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})
+            id-l  (first (mount-ids (:container left)))
+            id-r  (first (mount-ids (:container right)))]
+        (try
+          (is (some? id-l)
+              "control: the left mount committed a widget, so the store keys
+               below name something that really mounted")
+          (is (not= id-l id-r)
+              "the two mounts composed two mount-ids")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "the left mount installed its own ResizeObserver")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r))
+                         :observer)
+              "and so did the right — two live mounts, two observers. Under
+               the shared identity the second element's ref callback finds an
+               observer already on the entry and installs none")
+
+          (unmount! right)
+
+          (is (nil? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r)))
+              "the detached mount is gone")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "and the mount STILL ON SCREEN is still observed — releasing
+               the survivor's entry is what the shared key did, and it left a
+               live node with no observer and no width updates")
+          (finally
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W3 — the negative control: unnamed mounts collide, and are unchanged
+;; ===========================================================================
+
+(deftest two-unnamed-mounts-still-collide
+  (testing "rf2-5ykm — the defect verbatim, kept as a row. Two standalone
+            mounts with NO `:instance-id` present the SAME ids, which is what
+            makes W1's disjointness a measurement rather than a coincidence;
+            and the ids they present carry no instance segment at all, so
+            every existing single-mount call site composes exactly what it
+            always did."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            a     (mount! nil)
+            b     (mount! {})
+            named (mount! {:instance-id "left"})]
+        (try
+          (let [ids-a (mount-ids (:container a))
+                ids-b (mount-ids (:container b))
+                ids-n (mount-ids (:container named))]
+            (is (seq ids-a)
+                "control: both unnamed mounts committed widgets")
+            (is (= ids-a ids-b)
+                (str "two unnamed mounts present the SAME ids — so the "
+                     "instrument W1 uses CAN see a collision, and its "
+                     "disjointness is a measurement rather than silence. a="
+                     (pr-str ids-a)))
+            (is (= ids-n
+                   (mapv #(str id-prefix "left/" (subs % (count id-prefix)))
+                         ids-a))
+                (str "and a named mount's ids are the UNNAMED ids with the "
+                     "caller's name spliced in after the panel's own prefix "
+                     "— which says both halves at once: naming qualifies the "
+                     "id without disturbing the record key inside it, and an "
+                     "unnamed mount composes byte-for-byte what it always "
+                     "did. unnamed=" (pr-str ids-a) " named=" (pr-str ids-n)))
+            (is (= ids-a (mount-ids (:container a)))
+                "re-reading the same container is stable — these are
+                 identities, not per-render nonces"))
+          (finally
+            (unmount! named)
+            (unmount! b)
+            (unmount! a)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/managed_fx_template_cljs_test.cljs
@@ -751,3 +751,159 @@
             label (str (:surface r) "/" (:status r))]
         (assert-no-internal-refs! (str "visible-text[" label "]") (visible-text panel))
         (assert-no-internal-refs! (str "tooltip-text[" label "]") (tooltip-text panel))))))
+
+;; ---- the per-mount qualifier (rf2-5ykm) ----------------------------------
+;;
+;; THIS IS THE NODE LANE'S HALF AND IT IS NOT THE WHOLE CLAIM. The rows
+;; below grade the template's PURE COMPOSITION — that a named mount qualifies
+;; both ids the widget keys on, that an unnamed one composes byte-for-byte
+;; what it always did, and what `instance-token` refuses. What they cannot
+;; see is the thing the defect actually broke: two REAL mounts sharing one
+;; memoised ref callback and one ResizeObserver, and the survivor being
+;; released when its sibling detached. That needs a real React commit and
+;; lives in `panels/managed_fx_mount_instance_id_dom_cljs_test`, under
+;; `npm run test:browser`.
+;;
+;; BOTH IDS COME FROM ONE STRING HERE. `edn-widget/inspect-view` builds the
+;; boundary's `:mount-id` as `"rf-xray-inspect-" + node-key` and its
+;; `:panel-id` as `:rf.xray.inspect/<node-key>`, and this panel passes no
+;; `:site-id` — so the widget's `effective-id` falls back to the mount-id
+;; and one qualifier separates lifecycle, width and expansion together.
+;; That is why there is one qualifier here where `app-db-diff` needs two.
+
+(defn- inspect-view-props
+  "Every `edn-inspector-view` props map in a hiccup tree, in document order.
+  Identified by the `:mount-id` key the boundary REQUIRES, so this finds the
+  widgets rather than a shape we assumed they had."
+  [node]
+  (->> (hiccup-vectors node)
+       (map second)
+       (filter #(and (map? %) (contains? % :mount-id)))))
+
+(defn- widget-mount-ids [node] (mapv :mount-id (inspect-view-props node)))
+(defn- widget-panel-ids [node] (mapv #(get-in % [:opts :panel-id]) (inspect-view-props node)))
+
+(deftest instance-token-normalises-and-refuses
+  (testing "rf2-5ykm — nil and blank name no instance; a keyword's NAMESPACE
+            is part of the name (the property Reagent's `[:>]` crossing would
+            otherwise drop); and the fn is idempotent, which is what lets the
+            bridge and the boundary both call it and compose one answer."
+    (is (nil? (template/instance-token nil)))
+    (is (nil? (template/instance-token "")))
+    (is (= "left" (template/instance-token "left")))
+    (is (= "left" (template/instance-token :left)))
+    (is (= "left/list" (template/instance-token :left/list))
+        "the namespace survives — `:left/list` and `:right/list` are two
+         instances, not one")
+    (is (= "left/list" (template/instance-token (template/instance-token :left/list)))
+        "idempotent: a non-blank string answers itself")
+    (doseq [bad [{:a 1} [:left] 42]]
+      (is (thrown? js/Error (template/instance-token bad))
+          (str "a shape that could not be stable across renders is refused: "
+               (pr-str bad))))))
+
+(deftest unnamed-record-panel-composes-the-ids-it-always-did
+  (testing "rf2-5ykm — the regression guard. Every single-mount call site in
+            this tree passes no instance, and those composed ids must not
+            move: they key the operator's expansion state and the measured
+            column width."
+    (let [tree (template/record-panel noop-dispatch (open-all disclosure-record)
+                                      disclosure-record)
+          rk   (h/record-key disclosure-record)]
+      ;; Control, taken from the target: the open tree really carries the
+      ;; widgets, so the equalities below are about content and not emptiness.
+      (is (= 3 (count (widget-mount-ids tree)))
+          (str "control: REQUEST, RESPONSE and HANDLER each emitted a widget — "
+               (pr-str (widget-mount-ids tree))))
+      (is (= [(str "rf-xray-inspect-managed-fx/" rk "/req")
+              (str "rf-xray-inspect-managed-fx/" rk "/res")
+              (str "rf-xray-inspect-managed-fx/" rk "/handler")]
+             (widget-mount-ids tree)))
+      (is (= [(keyword (str "rf.xray.inspect/managed-fx/" rk "/req"))
+              (keyword (str "rf.xray.inspect/managed-fx/" rk "/res"))
+              (keyword (str "rf.xray.inspect/managed-fx/" rk "/handler"))]
+             (widget-panel-ids tree))))))
+
+(deftest a-named-record-panel-qualifies-both-widget-ids
+  (testing "rf2-5ykm — naming the mount splices the instance in after the
+            panel's own prefix and before the record key, so the qualifier
+            names the MOUNT while `record-key` still names the record inside
+            it. Both ids move together because both are built from the one
+            node-key — qualifying only the lifecycle key would leave two
+            mounts sharing one expansion identity."
+    (let [expanded (open-all disclosure-record)
+          plain    (template/record-panel noop-dispatch expanded nil disclosure-record)
+          named    (template/record-panel noop-dispatch expanded "left" disclosure-record)
+          kw       (template/record-panel noop-dispatch expanded :left/list disclosure-record)]
+      (is (seq (widget-mount-ids plain))
+          "control: the unnamed tree carries widgets to compare against")
+      (is (= (mapv #(str "rf-xray-inspect-managed-fx/left/"
+                         (subs % (count "rf-xray-inspect-managed-fx/")))
+                   (widget-mount-ids plain))
+             (widget-mount-ids named))
+          (str "the named ids are the unnamed ids with the instance spliced "
+               "in: " (pr-str (widget-mount-ids named))))
+      (is (= (mapv #(keyword (str "rf.xray.inspect/managed-fx/left/"
+                                  (subs (str %)
+                                        (count ":rf.xray.inspect/managed-fx/"))))
+                   (widget-panel-ids plain))
+             (widget-panel-ids named))
+          (str "and so are the panel-ids, which key expansion and zoom: "
+               (pr-str (widget-panel-ids named))))
+      (is (empty? (filter (set (widget-mount-ids plain)) (widget-mount-ids named)))
+          "no id survives from the unnamed mount to the named one")
+      (is (every? #(str/starts-with? % "rf-xray-inspect-managed-fx/left/list/")
+                  (widget-mount-ids kw))
+          (str "a keyword instance keeps its namespace — "
+               (pr-str (widget-mount-ids kw))))
+      (is (= (widget-mount-ids named)
+             (widget-mount-ids (template/record-panel noop-dispatch expanded "left"
+                                                     disclosure-record)))
+          "stable across renders — an identity, not a per-render nonce"))))
+
+(deftest record-identity-and-disclosure-survive-the-qualifier
+  (testing "rf2-5ykm — the qualifier composes WITH `record-key`; it does not
+            replace it. The React key and the disclosure toggle are that
+            identity's two consumers and BOTH stay untouched, or naming a
+            mount would remount every row and orphan the operator's open
+            sections."
+    (let [recs    [(record {:surface :http :fx-id :rf.http/managed
+                            :status :ok :http-status 200})
+                   (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})]
+          plain   (template/records-list noop-dispatch nil nil recs)
+          named   (template/records-list noop-dispatch nil "left" recs)
+          keys-of #(mapv react-key (record-panel-nodes %))]
+      (is (every? some? (keys-of plain))
+          "control: the unnamed list really carries React keys")
+      (is (= (keys-of plain) (keys-of named))
+          (str "the React keys are identical — " (pr-str (keys-of named))))
+      ;; The disclosure toggle carries `rec-key` in its dispatch payload and
+      ;; `body-shown?` reads the testid that payload is keyed to, so an
+      ;; override map built from `record-key` alone must still open a NAMED
+      ;; mount's sections.
+      (let [rec    (first recs)
+            opened (template/record-panel noop-dispatch (open-all rec) "left" rec)]
+        (is (body-shown? opened :request)
+            "a `record-key`-keyed override still opens a named mount's
+             REQUEST — disclosure is deliberately shared between two lists
+             of the same records")))))
+
+(deftest records-list-threads-the-instance-to-every-record
+  (testing "rf2-5ykm — the 4-arity reaches every record, not just the first."
+    (let [recs  [(record {:surface :http :fx-id :rf.http/managed
+                          :status :ok :http-status 200})
+                 (record {:surface :websocket :fx-id :rf.ws/connect :status :ok})]
+          named (template/records-list noop-dispatch
+                                       (into {} (mapcat open-all recs))
+                                       "right" recs)
+          ids   (widget-mount-ids named)]
+      (is (< 1 (count ids))
+          (str "control: more than one widget emitted — " (pr-str ids)))
+      (is (every? #(str/starts-with? % "rf-xray-inspect-managed-fx/right/") ids)
+          (str "every widget in the list carries the mount's name — "
+               (pr-str ids)))
+      (is (every? (fn [rec] (some #(str/includes? % (h/record-key rec)) ids))
+                  recs)
+          (str "and each record's own key is still inside them, so the "
+               "qualifier composed WITH `record-key` rather than replacing "
+               "it — " (pr-str ids))))))


### PR DESCRIPTION
Closes rf2-5ykm.

## The defect, reproduced before it was repaired

PR #9651 migrated the Managed FX list mount to a Fresco boundary. It fixed the record collisions WITHIN one list and introduced one ACROSS lists: the `rf/reg-view` head it replaced minted a per-mount identity, and a boundary cannot — it is a React function component with no per-instance storage its body may use.

The item established this from the landed data flow and the ref implementation rather than from an executed reproduction, and said so. **It reproduces.** The new witness was written first and run against the unrepaired tree on `npm run test:browser`: **5 failures, 0 errors, all five in the new file**, on a tree otherwise green.

Two mounts of one focused event, under the default `:rf/xray` frame, into two real containers:

* **Identical ids.** Both containers committed the same four `data-rf-mount-id`s, e.g. `rf-xray-inspect-managed-fx/:http-3-:rf.http/managed/req` in both — so `{:instance-id "left"}` and `{:instance-id "right"}` were indistinguishable.
* **The survivor loses its observer.** After unmounting the sibling, the survivor's per-mount store read `nil` — `(not (contains? nil :observer))`. `container-ref-for` memoises the ref callback on `[frame-id mount-id]`, its mount arm is guarded on `(nil? (:observer entry))` so the second element installs nothing, and `release-mount!` then tears the SHARED entry down when either detaches. That is the half a distinctness-only witness would have passed while the real defect stood.

## The repair

The shipped `mount-app-db-diff!` shape, not a new identity framework: an optional `:instance-id` threaded through the public facade, `ManagedFxList-bridge`, the `ManagedFxList` boundary and the four `edn/inspect-view` sites.

**One qualifier does both halves here where app-db needs two.** `edn-widget/inspect-view` builds the boundary's `:mount-id` AND its `:panel-id` from one node-key, and this panel passes no `:site-id` — so the widget's `effective-id` falls back to the mount-id and qualifying the node-key separates lifecycle, width slot and expansion/zoom together.

The prop is tokenised at the bridge before the `[:>]` crossing. That is rf2-4bsq's landed repair carried over rather than re-derived: Reagent converts a named prop value with `cljs.core/name`, which would drop a keyword's namespace and restore the very collision the opt repairs.

**Record identity and disclosure are deliberately untouched.** `record-key` stays the React key and stays the expansion key, which lives in the frame's app-db — two lists of the same records still open and close together, and what they no longer share is a ResizeObserver. Omitting the opt composes every id byte-for-byte as before, which is every call site in this tree today; a row asserts exactly that.

## Which lane graded which half

* **`npm run test:browser` (CI `cljs-browser`)** grades the real claim — two React commits, two containers, the observer surviving its sibling's unmount. The new `managed_fx_mount_instance_id_dom_cljs_test.cljs` is a `*_dom_cljs_test` namespace for this reason; under the node lane it only LOADS and short-circuits on `(browser?)`, a stated green skip that grades nothing (TESTING.md lines 28 and 196).
* **`npm run test:cljs` (CI `cljs`)** grades the template's pure composition — the node-key splice, the unnamed regression guard, `instance-token`'s normalisation and refusals, the React keys and disclosure staying put.

## Three spec sentences corrected

`tools/xray/spec/007-UX-IA.md`, `008-Embedding-Contract.md` and `API.md` each stated `:instance-id` was `mount-app-db-diff!`'s **alone**. This change makes all three false, so they are corrected here — the same coordinated set rf2-s2g7 updated when the opt first shipped, plus the `panels.cljs` ns docstring.

## Quality gates

Each number below is the runner's own captured exit code, taken with the redirect and the echo on one command line.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:browser` — pre-fix reproduction | **1** | 940 tests / 5200 assertions, **5 failures**, 0 errors — all five in the new file |
| `shadow-cljs compile browser-test` (post-fix) | **0** | clean |
| `npm run test:browser` (post-fix, `BROWSER_TEST_PORT=8123`) | **0** | 940 tests / 5200 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | **0** | 11678 tests / 58534 assertions, 0 failures, 0 errors |
| `clojure -M:test` in `tools/xray` | **0** | 1278 tests / 6130 assertions, 0 failures, 0 errors (frame-singleton guard, coverage-matrix metadata) |
| `python scripts/lint_kondo.py` | **0** | errors: 0. Three warnings name my files; all three are byte-identical at the merge base |
| `clojure -M:splint --fail-on-errors` | **0** | style warnings only; the one on the new file is the same `naming/conventional-aliases` hit its sibling `managed_fx_mount_dom_cljs_test.cljs` carries at the same position |
| `check_require_alias_dialect.py` (+ `--self-test`) | **0** / **0** | clean |
| `api-manifest` `gen --check` / `xray-spec-check` / `api-md-check` | **0** / **0** / **0** | 471 vars in sync; 39 xray refs; 147 var-rows |
| `check_doc_slugs.py` | **0** | clean (three `tools/*/spec` pages touched) |
| `check_readme_links.py` | **0** | clean |
| `check_test_lane_bijection.py` | **0** | the new ns routes to `:browser-test` by suffix; no roster entry needed |
| `check_retired_spellings.py` | **0** | clean |
| `check_keyword_catalogue_drift.py` | **0** | clean |

The pre-fix red is the sabotage control: the failure named exactly what was planted, and it is the same file that comes back green after the repair, so the run cannot have been reading a sibling worktree.

Not run: `test:xray-feature-gate:smoke` and `cljs-examples-compile` — `mount-managed-fx!` has zero call sites outside `tools/xray` and no testbed or scenario mounts this panel, so neither can go red on this diff; CI runs both regardless.
