### PR TITLE
test(xray): witness the Dynamic chrome's captured dispatcher and measure its teardown (rf2-fxwj)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
@@ -29,6 +29,18 @@
   the mount reads `container.querySelector…` — the DOM React committed
   on its own.
 
+  ## The four rows
+
+  W1 asks whether the chrome PAINTS and W2 whether its reads are LIVE.
+  W3 and W4 close the two claims those leave untouched (rf2-fxwj): W3
+  presses a real L3 tab button, so the dispatcher the boundary CAPTURES
+  is exercised rather than bypassed by the test's own `dispatch-sync`,
+  and holds a second live frame as the control that makes it a routing
+  claim; W4 MEASURES the teardown W1 and W2 merely call, against the
+  frame's sub-cache reference, the collector's cell watch, its reader
+  edges and the whole collector census — and reopens once, because a
+  release that releases nothing still reads clean on a first mount.
+
   ## Substrate: the Reagent adapter, deliberately
 
   A ratom-family adapter, which is the family Xray already supports —
@@ -48,7 +60,9 @@
             ["react-dom" :as react-dom]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.fresco.test.runtime :as rf.fresco.test.runtime]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
@@ -337,3 +351,407 @@
               (.then step-1)
               (.then step-2)
               (.then step-3)))))))
+
+;; ===========================================================================
+;; Shared by W3 and W4 — the one read both rows key off, and the controls
+;; ===========================================================================
+
+(def ^:private selected-tab-q
+  "The read the L3 tab bar and the L4 detail panel BOTH make
+  (`shell.cljs`'s `tab-bar` and `detail-panel` boundaries), and the one
+  a tab click invalidates. Named once because it is three things at
+  once: W3's state assertion, W4's sub-cache key, and — paired with a
+  frame — the collector's own cell address."
+  [:rf.xray/selected-tab])
+
+(def ^:private clicked-tab
+  "The tab W3 presses. `:trace` is a registered Dynamic tab that is NOT
+  the default, so the L4 panel moving to it is the click's doing."
+  :trace)
+
+(def ^:private deaf-frame-tab
+  "The DISTINCT value [[other-frame]] is held at across W3. Not the
+  default and not [[clicked-tab]], so `unchanged` names a specific tab
+  rather than the value every frame answers with anyway."
+  :machines)
+
+(defn- panel-testid-for [tab-id]
+  (str "rf-xray-detail-panel-" (name tab-id)))
+
+(defn- tab-node
+  "The committed `<button role=\"tab\">` for one Dynamic tab id, or nil.
+  NOTE the two ids on that element are different strings: the testid is
+  `rf-xray-tab-<id>` and the DOM `id` is `rf-xray-tab-button-<id>`."
+  [container tab-id]
+  (testid container (str "rf-xray-tab-" (name tab-id))))
+
+(defn- click!
+  "Click a committed node, or FAIL THIS ROW rather than aborting the lane.
+
+  A raw `.click` on nil throws a `TypeError` out of the async block, and
+  `cljs.test/run-block` has no try/catch — under a plant that emptied the
+  chrome that took the WHOLE browser lane down with no cljs.test summary,
+  and every namespace scheduled after it never ran. A row whose subject
+  has vanished should redden; it must not silence its neighbours."
+  [node label]
+  (if (some? node)
+    (do (.click node) true)
+    (do (is false (str "cannot click " label ": it is not in the committed "
+                       "DOM, so this row's subject is already gone"
+                       (uncaught-note)))
+        false)))
+
+(defn- selected-tab-in
+  "One frame's current `:rf.xray/selected-tab`, read WITHOUT taking a
+  reference. `subscribe-once` subscribes, derefs and unsubscribes, so a
+  row may read as many frames as it likes without moving the numbers W4
+  measures."
+  [frame-id]
+  (rf/subscribe-once selected-tab-q {:frame frame-id}))
+
+;; ===========================================================================
+;; W3 — a REAL CLICK on the migrated L3 tab bar, through the dispatcher the
+;;      boundary CAPTURED, into the frame the tree named
+;; ===========================================================================
+;;
+;; W2 above moves the world with `rf/dispatch-sync` and watches the chrome
+;; follow. That is a reactivity claim and it is deliberately silent about the
+;; boundary's OTHER half: `tab-bar` does not merely READ through the
+;; collector, it CAPTURES a dispatcher with `(:dispatch (rf/capture-frame))`
+;; and threads it into every tab button as `:dispatch-fn`. No row above ever
+;; makes it do so, which is the gap this one closes — the boundary's whole job
+;; is to capture a dispatcher, and nothing was making it capture one.
+;;
+;; THE NEGATIVE HALF IS WHAT MAKES IT A FRAME CLAIM RATHER THAN A CLICK TEST.
+;; `tab-button` ends `(or dispatch-fn rf/dispatch)`, a defensive fallback for
+;; node-lane callers that build the button directly. So a capture lost
+;; anywhere between the boundary body and the button's props map does not
+;; crash — it DEGRADES SILENTLY to the ambient dispatcher, which resolves a
+;; frame that is not this shell's. A positive-only row passes on a dispatcher
+;; that routes everywhere and on one that routes somewhere else; a second live
+;; frame held at a distinct value is the only thing that separates those from
+;; a dispatcher that routes HERE.
+;;
+;; THE THEME TOGGLE CANNOT CARRY THIS ROW, and that is worth recording so the
+;; next author does not spend the afternoon finding out. `ribbon-theme-toggle`
+;; is the tidier boundary — its own head, one read, one dispatch — but its read
+;; is `[:rf.xray/setting :theme nil]`, and `settings/subs.cljs` falls that path
+;; through to `config/get-setting`, a PROCESS-GLOBAL atom rather than any
+;; frame's `app-db`. Two shells at two frames see one theme, so the toggle can
+;; witness that a click reached a handler and nothing whatever about WHERE it
+;; landed.
+
+(deftest w3-a-real-tab-click-routes-through-the-captured-dispatcher
+  (testing "rf2-fxwj — pressing a real migrated L3 tab button moves the L4
+            panel in the frame the enclosing `frame-provider` NAMED, and
+            leaves a second live frame exactly where it was. The event
+            travels the shipped path end to end: React's own click, the
+            `:on-click` closure, the `:dispatch-fn` `tab-bar` captured, the
+            handler, the invalidated read, the recommitted boundary.
+
+            THIS ROW IS NOT A SECOND W2. W2's lever is the test's own
+            `dispatch-sync`, which supplies the frame from the OUTSIDE; here
+            the frame comes from the boundary's capture, and nothing in the
+            row names it at the moment of dispatch. That difference is the
+            whole subject."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        ;; The deaf frame is loaded BEFORE the mount, so the control below
+        ;; compares against a value a misrouted write would have to
+        ;; overwrite. Held at the `:epoch` default instead, a dispatcher that
+        ;; had fallen through to an ambient frame and written `:epoch` there
+        ;; would be indistinguishable from one that never wrote at all.
+        (rf/dispatch-sync [:rf.xray/select-tab deaf-frame-tab]
+                          {:frame other-frame})
+        (let [{:keys [container root]} (mount-shell! shell-frame)
+              tab-testid (fn [] (some-> (detail-panel-node container)
+                                        (.getAttribute "data-testid")))
+              aria-of    (fn [] (some-> (tab-node container clicked-tab)
+                                        (.getAttribute "aria-selected")))]
+          (-> (poll-until tab-testid)
+              (.then
+                (fn [_]
+                  (let [btn (tab-node container clicked-tab)]
+                    (is (some? btn)
+                        (str "PRECONDITION: the L3 `" (name clicked-tab)
+                             "` tab button is committed, so there is a real "
+                             "control to press" (uncaught-note)))
+                    (is (= "false" (aria-of))
+                        (str "PRECONDITION: and it is not already the selected "
+                             "tab, so the flip below is the click's doing. Got: "
+                             (pr-str (aria-of))))
+                    (is (= (panel-testid-for :epoch) (tab-testid))
+                        (str "PRECONDITION: the L4 panel is showing the default "
+                             "tab. Got: " (pr-str (tab-testid))))
+                    (is (= :epoch (selected-tab-in shell-frame))
+                        "PRECONDITION: and the shell's own frame holds the default")
+                    (is (= deaf-frame-tab (selected-tab-in other-frame))
+                        (str "PRECONDITION: while the second live frame holds a "
+                             "DISTINCT value, so `unchanged` below is a claim "
+                             "about a real value. Got: "
+                             (pr-str (selected-tab-in other-frame))))
+                    ;; ---- the act: a REAL browser click on a REAL node ----
+                    (if (click! btn (str "the L3 " (name clicked-tab) " tab button"))
+                      (poll-until #(= (panel-testid-for clicked-tab) (tab-testid)))
+                      (js/Promise.resolve nil)))))
+              (.then
+                (fn [_]
+                  (is (= (panel-testid-for clicked-tab) (tab-testid))
+                      (str "the click reached the handler, the dispatcher "
+                           "`tab-bar` captured delivered the event, the read "
+                           "was invalidated and the L4 boundary recommitted "
+                           "on the new tab — the whole round trip, in a "
+                           "browser. Got: " (pr-str (tab-testid))
+                           (uncaught-note)))
+                  (is (= "true" (aria-of))
+                      (str "and the pressed button now reports itself selected, "
+                           "so the L3 boundary recommitted too rather than only "
+                           "the L4 one. Got: " (pr-str (aria-of))))
+                  (is (= clicked-tab (selected-tab-in shell-frame))
+                      (str "the write landed in the frame the tree named. Got: "
+                           (pr-str (selected-tab-in shell-frame))))
+                  (is (= deaf-frame-tab (selected-tab-in other-frame))
+                      (str "CROSS-FRAME CONTROL: and NOT in the second live "
+                           "frame, which still holds "
+                           (pr-str deaf-frame-tab) ". A dispatcher that had "
+                           "lost its capture and fallen back to the ambient "
+                           "one would write here, or nowhere. Got: "
+                           (pr-str (selected-tab-in other-frame))))))
+              (.catch (fn [e]
+                        (is false (str "W3 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)
+                                       (uncaught-note)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W4 — unmount returns the chrome's reads to BASELINE, watches and listener
+;;      edges included, and reopening does not accumulate
+;; ===========================================================================
+
+(def ^:private shell-cell-key
+  "The collector's own address for the shell's headline read under this
+  suite's frame. `[frame-kw query-v]` — finer than the frame's sub-cache
+  key, and what `!cells` is keyed by (`collector/read-key!`)."
+  [shell-frame selected-tab-q])
+
+(def ^:private empty-runtime
+  "What `test.runtime/residue` reads when the collector holds nothing.
+  Spelled out rather than captured, so W4's baseline assertion is a claim
+  about ZERO rather than about whatever happened to be standing — a
+  baseline taken from a dirty runtime would let a leak hide inside it."
+  {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0})
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in this row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- chrome-residue
+  "Everything that must return to baseline once the chrome is gone, as one
+  map, so a failure message names WHICH instrument still sees something.
+
+  FOUR INSTRUMENTS ANSWERING DIFFERENT QUESTIONS, which is the point —
+  `teardown!` being CALLED is not one of them.
+
+  - `:ref-count` is the REFERENCE half: what the frame's own sub-cache
+    still holds for the shell's headline read.
+  - `:live-cell?` is the WATCH half. A live collector cell holds
+    `add-watch` on its derived reaction for as long as it exists, so this
+    is `no retained watches` read off the runtime rather than inferred.
+  - `:reader-edges` is the LISTENER half: one reader slot per boundary
+    registration reading that cell — the fused reference AND dependency
+    edge.
+  - `:runtime` is the WHOLE collector census, which is what makes this a
+    claim about the CHROME rather than about one query. The Dynamic chrome
+    is seven boundaries reading a dozen-odd subs between them; enumerating
+    them here would be the per-control matrix this work is explicitly not,
+    and would go stale the first time a region gains a read. The census
+    cannot go stale and cannot miss one.
+
+  A release that dropped the reference and left the cell wired answers
+  clean to the first and dirty to the other three."
+  []
+  {:ref-count    (ref-count-of shell-frame selected-tab-q)
+   :live-cell?   (some? (rf.fresco.test.runtime/cell-reaction shell-cell-key))
+   :reader-edges (count (rf.fresco.test.runtime/cell-readers shell-cell-key))
+   :runtime      (rf.fresco.test.runtime/residue)})
+
+(deftest w4-unmount-returns-the-chrome-to-baseline-and-reopen-does-not-accumulate
+  (testing "rf2-fxwj — unmounting the Dynamic chrome releases everything it
+            took: the frame's sub-cache reference, the collector cell and
+            its watch, every reader edge, and the whole collector census
+            back to the zero it started from. Then a REOPEN takes the same
+            numbers rather than higher ones.
+
+            THE REOPEN IS THE HALF THAT CATCHES A RELEASE THAT RELEASES
+            NOTHING. A first mount's teardown can look clean for reasons
+            that are not the teardown's — a page that never had anything
+            to lose reads zero whatever the code does. Growth across an
+            open/close/open cycle is the signature of a release the
+            substrate's own reaction lifecycle cannot see, and it is only
+            visible on the second mount.
+
+            THE SETTLING POINT IS THE KIT'S OWN `quiesced!`, NOT A
+            MACROTASK. The collector gives a cell whose last reader
+            unmounts one macrotask of grace, deliberately, so that a keyed
+            reorder which unmounts and remounts within one turn reuses the
+            reaction instead of rebuilding it; and the entry reaper's
+            horizon sits outside a bare `setTimeout 0`. A residue read
+            before that point reports a LEAK against a runtime behaving
+            exactly as documented.
+
+            THIS IS A VERIFICATION GAP BEING CLOSED, NOT AN ALLEGATION.
+            W1 and W2 both CALL `teardown!` and neither measures anything
+            after it, and a call is not a measurement. If the numbers come
+            back at baseline — and they do — that IS the deliverable."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (let [!baseline (atom nil)
+              !mounted  (atom nil)
+              !handles  (atom nil)
+              mount!    (fn []
+                          (reset! !handles (mount-shell! shell-frame))
+                          (poll-until #(detail-panel-node (:container @!handles))))
+              unmount!  (fn []
+                          (when-some [{:keys [container root]} @!handles]
+                            (reset! !handles nil)
+                            (teardown! root container)))
+              census    (fn [k] (-> @!baseline (get :runtime) (get k)))]
+          (-> ;; The BASELINE is taken after the runtime settles, never at the
+              ;; top of the row: a neighbouring suite's teardown grace may
+              ;; still be in flight, and a baseline read early is a baseline
+              ;; that is non-zero for reasons which are not this chrome's.
+              (rf.fresco.test.runtime/quiesced!)
+              (.then
+                (fn [_]
+                  (let [b (chrome-residue)]
+                    (reset! !baseline b)
+                    (is (= empty-runtime (:runtime b))
+                        (str "BASELINE: the collector holds nothing before the "
+                             "first mount, so `returns to baseline` below is a "
+                             "return to ZERO rather than to a residue a leak "
+                             "could hide inside. Got: " (pr-str (:runtime b))))
+                    (is (zero? (:ref-count b))
+                        (str "BASELINE: and the frame holds no sub-cache "
+                             "reference for the shell's read. Cache keys: "
+                             (pr-str (keys (cache-of shell-frame)))))
+                    (is (false? (:live-cell? b))
+                        "BASELINE: and no collector cell, so no watch")
+                    (is (zero? (:reader-edges b))
+                        "BASELINE: and no reader edge, so no listener"))
+                  (mount!)))
+              (.then
+                (fn [_]
+                  (let [m (chrome-residue)]
+                    (reset! !mounted m)
+                    (is (pos? (:ref-count m))
+                        (str "NON-VACUITY: the mount TOOK a sub-cache reference "
+                             "— otherwise the release below is a claim about "
+                             "nothing. Got: " (pr-str m) (uncaught-note)))
+                    (is (true? (:live-cell? m))
+                        "NON-VACUITY: and a live collector cell, so there is a
+                         watch to lose")
+                    (is (pos? (:reader-edges m))
+                        (str "NON-VACUITY: and reader edges on it, so there are "
+                             "listeners to lose. Got: " (:reader-edges m)))
+                    (is (pos? (:cells (:runtime m)))
+                        (str "NON-VACUITY: and the chrome's SEVEN boundaries "
+                             "between them lit the collector up. Census: "
+                             (pr-str (:runtime m))))
+                    (is (pos? (:boundaries (:runtime m)))
+                        "NON-VACUITY: with registrations holding reader slots")
+                    (is (pos? (:edges (:runtime m)))
+                        "NON-VACUITY: and dependency edges across the whole tree"))
+                  (unmount!)
+                  (rf.fresco.test.runtime/quiesced!)))
+              (.then
+                (fn [_]
+                  (let [a (chrome-residue)]
+                    (is (zero? (:ref-count a))
+                        (str "the unmount released the sub-cache reference "
+                             "COMPLETELY. Residue: " (pr-str a)
+                             " — frame cache keys: "
+                             (pr-str (keys (cache-of shell-frame)))))
+                    (is (false? (:live-cell? a))
+                        (str "NO RETAINED WATCHES: the collector cell for the "
+                             "shell's read is gone, so no `add-watch` on a "
+                             "derived reaction survives the unmount. Residue: "
+                             (pr-str a)))
+                    (is (zero? (:reader-edges a))
+                        (str "NO RETAINED LISTENERS: and no reader edge survives "
+                             "either. Residue: " (pr-str a)))
+                    (is (= (:runtime @!baseline) (:runtime a))
+                        (str "and the WHOLE collector census is back at baseline "
+                             "— every cell, edge, boundary registration and "
+                             "cached read-set entry the chrome's seven "
+                             "boundaries took. Baseline: "
+                             (pr-str (:runtime @!baseline))
+                             " — after unmount: " (pr-str (:runtime a)))))
+                  ;; ---- reopen: the same numbers, not higher ones ----------
+                  (mount!)))
+              (.then
+                (fn [_]
+                  (let [r (chrome-residue)
+                        m @!mounted
+                        shape (fn [c] (select-keys c [:cells :cell-refs
+                                                      :boundaries :edges]))]
+                    (is (= (:ref-count m) (:ref-count r))
+                        (str "reopening takes the SAME sub-cache reference count "
+                             "(" (:ref-count m) ") rather than accumulating. "
+                             "Got: " (:ref-count r)))
+                    (is (= (:reader-edges m) (:reader-edges r))
+                        (str "and the same reader-edge count ("
+                             (:reader-edges m) ") — an edge left behind by the "
+                             "first teardown would show here as growth. Got: "
+                             (:reader-edges r)))
+                    (is (= (shape (:runtime m)) (shape (:runtime r)))
+                        (str "and the whole census is identical across the "
+                             "open/close/open cycle. First mount: "
+                             (pr-str (shape (:runtime m)))
+                             " — reopen: " (pr-str (shape (:runtime r)))))
+                    ;; Read-set entries are CACHED and reaped on their own
+                    ;; horizon, so a reopen inside the window may legitimately
+                    ;; reuse or rebuild them. What may never happen is growth.
+                    (is (<= (:entries (:runtime r)) (:entries (:runtime m)))
+                        (str "and the cached read-set entries did not grow. "
+                             "First mount: " (:entries (:runtime m))
+                             " — reopen: " (:entries (:runtime r)))))
+                  (unmount!)
+                  (rf.fresco.test.runtime/quiesced!)))
+              (.then
+                (fn [_]
+                  (let [a (chrome-residue)]
+                    (is (= (:runtime @!baseline) (:runtime a))
+                        (str "and the SECOND unmount returns to baseline too, so "
+                             "the release is a property of teardown rather than "
+                             "of the first one happening to be clean. Baseline: "
+                             (pr-str (:runtime @!baseline))
+                             " — after second unmount: " (pr-str (:runtime a))))
+                    (is (zero? (:reader-edges a))
+                        (str "with no reader edge surviving it either. Residue: "
+                             (pr-str a))))))
+              (.catch (fn [e]
+                        (is false (str "W4 never settled: " (.-message e)
+                                       " — baseline cells: " (pr-str (census :cells))
+                                       (uncaught-note)))
+                        nil))
+              (.then (fn [_]
+                       ;; Defensive: a row that reddened mid-flight may still
+                       ;; hold a mounted root, and a live root leaks into the
+                       ;; next namespace's baseline.
+                       (unmount!)
+                       (done)))))))))


### PR DESCRIPTION
Closes rf2-fxwj.

The merged-PR audit of #9653 found the seven Dynamic chrome boundaries and their
required islands wired consistently, and the browser lane confirming paint plus a
real named-frame dependency update. What it could not find was verification of the
remaining interaction and lifetime claims. This is that verification. **Test-only:
no runtime defect is alleged and none was found.**

`shell_fresco_boundary_dom_cljs_test.cljs` had W1 (the chrome paints) and W2 (its
reads are live). Two rows join them.

## W3 — the captured dispatcher, exercised

W2's lever is the test's own `rf/dispatch-sync`, which supplies the frame from the
*outside*. So no row ever made `tab-bar` use the dispatcher it captures with
`(:dispatch (rf/capture-frame))` and threads into every tab button as
`:dispatch-fn` — which is the boundary's whole job. W3 presses a real
`<button role="tab">` and lets that captured dispatcher carry the event: click →
`:on-click` closure → captured dispatcher → handler → invalidated read →
recommitted L3 and L4 boundaries, in a browser.

**The second live frame is what makes it a routing claim rather than a click test.**
`tab-button` ends `(or dispatch-fn rf/dispatch)`, a defensive fallback for node-lane
callers that build the button directly. A capture lost anywhere between the boundary
body and the button's props map therefore does not crash — it degrades *silently* to
the ambient dispatcher. A positive-only row passes on a dispatcher that routes
everywhere as readily as on one that routes here. So `::other` is loaded with a
distinct, non-default tab *before* the mount, and asserted unmoved afterwards: held
at the `:epoch` default instead, a misrouted write of `:epoch` would be
indistinguishable from no write at all.

## W4 — the teardown, measured

W1 and W2 both *call* `teardown!` and neither reads anything after it. A call is not
a measurement. W4 reads four instruments across an open / close / open cycle:

| instrument | question |
|---|---|
| frame sub-cache `:ref-count` | the **reference** released? |
| `test.runtime/cell-reaction` | the **watch** — a live cell holds `add-watch` on its reaction |
| `test.runtime/cell-readers` | the **listener edges** — one reader slot per boundary |
| `test.runtime/residue` | the **whole collector census**, so this is a claim about the chrome rather than one query |

A release that dropped the reference and left the cell wired answers clean to the
first and dirty to the other three.

The census stands in for enumerating the seven boundaries' reads deliberately: that
list would be the per-control matrix this work is explicitly *not*, and would go
stale the first time a region gains a read. The census cannot go stale and cannot
miss one. It reads `{:cells 14, :cell-refs 16, :boundaries 7, :edges 16}` on a live
mount — seven boundaries, which is the number the migration landed.

The settling point is the kit's own `quiesced!`, not a macrotask: the collector gives
a cell whose last reader unmounts one macrotask of grace (so a keyed reorder that
unmounts and remounts within a turn reuses the reaction), and the entry reaper's
horizon sits deliberately outside a bare `setTimeout 0`. A residue read before that
point reports a leak against a runtime behaving exactly as documented.

**The reopen is the half that catches a release which releases nothing.** A first
mount's teardown reads clean whatever the code does, because a page with nothing to
lose reads zero. Growth is only visible on the second mount.

## A correction worth recording

The theme toggle cannot carry the routing claim, and W3's preamble says so in the
file. `ribbon-theme-toggle` is the tidier boundary — its own head, one read, one
dispatch — but its read is `[:rf.xray/setting :theme nil]`, and `settings/subs.cljs`
falls that path through to `config/get-setting`, a **process-global atom** rather
than any frame's `app-db`. Two shells at two frames see one theme, so the toggle can
witness that a click reached a handler and nothing whatever about where it landed.
The L3 tab bar is the control that can carry it.

## Both colours, proved

Green, then each row's subject broken, then green again on a byte-identical restore.

Both plants live in the test file only — `tools/xray/src/**` was not touched.

| plant | result |
|---|---|
| W3: the dispatcher misrouted into the second live frame instead of the click | 4 reds. Panel stayed `rf-xray-detail-panel-epoch`; `aria-selected` stayed `"false"`; the shell frame stayed `:epoch`; and the cross-frame control named where it went — `(not (= :machines :trace))` |
| W4: the release skipped — container detached, React root never unmounted | 8 reds. `:ref-count 1`, `:live-cell? true`, `:reader-edges 2`, census `{:cells 14, :cell-refs 16, :boundaries 7, :edges 16, :entries 8}` against an all-zero baseline. The reopen half caught the accumulation exactly: cell-refs 16→32, boundaries 7→14, edges 16→32, reader-edges 2→4 |

All 12 failures landed in these two rows; no other namespace reddened. Test and
assertion counts were **identical** to the control run (939 / 5215), so neither plant
crashed the lane or silenced a neighbour. Restore verified by blob hash —
`git rev-parse HEAD:<path>` and `git hash-object <path>` both `af7d88d1`, and
`git diff --quiet HEAD` exit 0 — then the lane re-run green.

## Quality gates

Run in the worktree `re-frame2-worktrees/chromewit-a` on `BROWSER_TEST_PORT=8131`.
Every exit code below is the runner's own, captured with `echo $?` to a file on the
same command line; none is piped through a filter.

| gate | exit | result |
|---|---|---|
| `shadow-cljs compile browser-test` | 0 | 0 warnings attributable to this file (control: a file that *is* warned about reads 5 hits in the same log) |
| `npm run test:browser` — runner phase, **THE lane for these rows** | 0 | **939 tests / 5215 assertions, 0 failures, 0 errors** |
| same, with both plants in | 1 | 12 failures, all in W3/W4, counts unchanged at 939 / 5215 |
| same, after restore | 0 | 939 / 5215, 0 failures — green → red → green |
| `compile-node-test.cjs node-test` | 0 | 1949 files, 0 warnings |
| node lane run (`out/node-test.js`) | 0 | 11672 tests / 58509 assertions, 0 failures |
| `clj-kondo --lint <file>` | 0 | 0 errors, 0 warnings |
| `clojure -M:splint --fail-on-errors <file>` | 0 | 2 style warnings, both at lines 138 / 233 — pre-existing code, neither from a line this PR adds |
| `check_require_alias_dialect.py` | 0 | |
| `check_retired_spellings.py` | 0 | |
| `check_escaped_continuations.py` | 0 | |
| `check_flattened_lists.py` | 0 | |

The browser lane's log names this worktree's `out/browser-test` as the served root,
so the run read this tree and not a sibling's.

**`npm run test:xray-feature-gate` is NOT nominated, and the reason is measured
rather than assumed.** Its roster is 16 scenarios (5 carry `smoke: true`). One —
`feature matrix shell and panel handoff` — does walk every L3 tab in a real browser,
so it bears on the interaction claim at a coarse level. It cannot carry either
witness here: it has no second live frame to hold as a negative control, and no
scenario in the roster measures collector state at all (`residue`, `cell-readers`
and `reader-edges` read 0 across `scenarios.cjs`; the one `unmount` mention is about
a dialog).

Not run, with reasons: `mkdocs build --strict` and the two link gates — no markdown
changed. `api-manifest` — no public name changed. `eslint` — no JS changed.
`check_provenance_pins.py` — nothing under `docs/design/fresco/`.

## Scope

One file, **418 insertions, 0 deletions**. Nothing is reverted and nothing existing
is modified beyond two `:require` lines and a docstring paragraph. The working
Reagent islands and the sequenced event-list/root migration are untouched, as are
`tools/xray/src/**` and every fenced file.
