### PR TITLE
fix(xray): the palette's empty row raises, and the plain-fn prose that mis-describes why (rf2-ap5w, rf2-78wg)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -456,7 +456,7 @@
 
 ;; ---- Scenario 4: cross-frame subscribe resolution -------------------------
 ;;
-;; Per Spec 006 §706 / rf2-d4sf: `(rf/subscribe ...)` inside a wrapped
+;; Per Spec 006 §Plain-fn footgun / rf2-d4sf: `(rf/subscribe ...)` inside a wrapped
 ;; view consults the React-context tier and resolves the query against
 ;; the wrapped frame's app-db. This is also covered by
 ;; cross_spec_cljs_test/subscribe-routes-via-react-context-under-non-

--- a/tools/xray/spec/Conventions.md
+++ b/tools/xray/spec/Conventions.md
@@ -110,16 +110,20 @@ The facade's `reg-view` body is either:
 
   **Do not write `[views/subscriptions-panel]` here.** The vector
   form would mount the leaf as a separate plain Reagent fn component;
-  it would drop out of the surrounding frame and any `subscribe` /
-  `dispatch` inside the leaf would silently route to `:rf/default`
-  (Spec 000 §Plain Reagent fns / Spec 006 §706). The plain-call form
-  keeps the leaf body executing within the facade reg-view wrapper's
-  render — the wrapper IS the in-flight Reagent component, so
-  `current-frame-id` reads `:rf/xray` from React context and the leaf's
-  subs/dispatches see the Xray frame. (rf2-043uz pinned this — an
-  earlier slash-popover surface never opened because the input-row
-  leaf's input-text subscribe was routed to `:rf/default` while the
-  dispatch wrote to `:rf/xray`.)
+  it would drop out of the surrounding frame, and any ambient
+  `subscribe` / `dispatch` inside the leaf would then **raise**
+  `:rf.error/no-frame-context` (Spec 000 §Plain Reagent fns / Spec 006
+  §Plain-fn footgun). Under EP-0002 there is no `:rf/default` floor to
+  route to: the read resolves to nil and the operation fails fast. The
+  plain-call form keeps the leaf body executing within the facade
+  reg-view wrapper's render — the wrapper IS the in-flight Reagent
+  component, so `current-frame-id` reads `:rf/xray` from React context
+  and the leaf's subs/dispatches see the Xray frame. (rf2-043uz pinned
+  this — an earlier slash-popover surface never opened because the
+  input-row leaf's input-text subscribe went to `:rf/default` while the
+  dispatch wrote to `:rf/xray`. That was the pre-EP-0002 runtime, which
+  still had the silent floor; the same mistake today is the loud error
+  above, which is the improvement EP-0002 bought.)
 
   The same rule applies recursively to sibling leaves the view-leaf
   itself invokes (`chrome` / `feed` / `input` / `conversation` /

--- a/tools/xray/src/day8/re_frame2_xray/palette.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette.cljs
@@ -19,8 +19,10 @@
   Mounting at the shell-root means the modal's subscribes resolve
   through the same `frame-provider` the shell installed —
   `:rf/xray` reads land on Xray's app-db, not the host's. A
-  top-level `js/document.body` portal would lose the frame context
-  and silently read from `:rf/default`."
+  top-level `js/document.body` portal would lose the frame context,
+  and under EP-0002 that is a LOUD failure rather than a quiet
+  misroute: there is no `:rf/default` floor, so the ambient read
+  raises `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.palette.events :as events]
             [day8.re-frame2-xray.palette.subs :as subs]

--- a/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
@@ -57,13 +57,15 @@
 
   Dispatches from `:on-click` / `:on-change` / `:on-key-down` /
   `:on-mouse-enter` fire LATER — after render commits and React has
-  POPPED `_currentValue` back to the context's default (`:rf/default`).
-  At click time the 3-tier frame resolution chain (dynamic var →
-  React-context tier → `:rf/default`) falls all the way through, the
-  dispatch lands on `:rf/default`'s router, and the `:rf.xray/palette-*`
-  handler reduces `:rf/default`'s db — leaving Xray's `:palette-*`
-  slots untouched. Symptom: palette appears frozen — arrow keys,
-  Enter, click on a row, ESC, backdrop click all no-op.
+  POPPED `_currentValue` back to the context's default, which is
+  `re-frame.adapter.context/no-provider-sentinel` and NOT `:rf/default`.
+  At click time BOTH tiers of the frame resolution chain come up empty —
+  the dynamic var has unwound and the React-context tier reads the
+  sentinel, which the resolver maps to nil — and under EP-0002 there is
+  no third tier to land on: an ambient `rf/dispatch` RAISES
+  `:rf.error/no-frame-context` rather than routing to a synthesised
+  `:rf/default`. Symptom: the palette appears frozen — arrow keys,
+  Enter, click on a row, ESC, backdrop click all refuse.
 
   So each deferred handler captures the SURROUNDING instance frame:
   `palette.cljs`'s `Modal` `reg-view` body has a frame-aware `dispatch`
@@ -204,14 +206,35 @@
     (str "No matches for " (pr-str query) ".")
     "Type to search. ↑↓ navigate · Enter invokes · Ctrl+Enter pops out · ESC closes."))
 
-(defn- empty-row []
+(defn- empty-row
+  "The empty-results `<li>`, as a pure function of the `query` its
+  message quotes.
+
+  TAKES `query` RATHER THAN READING IT, AND IS CALLED RATHER THAN HEADED
+  (rf2-ap5w). It used to do neither: `palette-view` HEADED it, and it
+  re-read `:rf.xray/palette-query` ambiently. A head makes Reagent mint a
+  component for this plain `defn`, a plain `defn` carries no
+  `:contextType`, so `(.-context cmp)` is React's empty default,
+  `current-frame` coerces that to nil and the ambient read RAISES
+  `:rf.error/no-frame-context` — Spec 006 §Plain-fn footgun, and the
+  mechanism [[handle-input-keydown]] records below for the deferred-
+  handler seam. React discards the whole subtree, so the palette painted
+  NOTHING: `empty_row_frame_context_dom_cljs_test` measured the dialog
+  and this row both absent, with the refusal reaching a window `error`
+  listener.
+
+  `palette-view` already binds `query` from the same subscription, so
+  passing it removes the duplicate read outright rather than donating it
+  upward into the enclosing boundary's window — strictly better than a
+  bare `(empty-row)` inline, which is the other spelling of the repair."
+  [query]
   [:li {:data-testid "rf-xray-palette-empty"
         :style       (merge (row-style false)
                             {:cursor "default"
                              :color  (:text-tertiary tokens)})}
    [:span {:style (icon-style :handler)} "·"]
    [:span {:style {:flex 1}}
-    (empty-message @(rf/subscribe [:rf.xray/palette-query]))]])
+    (empty-message query)]])
 
 ;; ---- row ----------------------------------------------------------------
 
@@ -376,7 +399,10 @@
               ;; avoids a "listbox, 0 items" announcement.
               :id          listbox-id
               :style       (list-style)}
-         [empty-row]]
+         ;; CALLED, not headed, and handed the `query` this body already
+         ;; bound — see [[empty-row]] for why a head here refuses
+         ;; (rf2-ap5w).
+         (empty-row query)]
         (into [:ul {:data-testid "rf-xray-palette-list"
                     :id          listbox-id
                     :role        "listbox"

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -112,8 +112,11 @@
   enclosing Provider's `:rf/xray` flowed through React-context to a
   `(rf/subscribe …)` in the body); with plain `defn`s the React-context
   tier would be skipped (Spec 000 §Plain Reagent fns do not pick up the
-  surrounding frame) and subscribe would fall through to `:rf/default`,
-  silently routing every Xray panel query into the host's app-db.
+  surrounding frame) and the ambient subscribe would RAISE
+  `:rf.error/no-frame-context` — under EP-0002 there is no `:rf/default`
+  floor for it to fall through to, so an unregistered reading region is
+  a loud refusal rather than a silent query into the host's app-db
+  (Spec 006 §Plain-fn footgun).
 
   ## rf2-k97c.3 — the Dynamic chrome is a FRESCO TREE
 
@@ -1083,8 +1086,11 @@
   registered against `:rf/xray` via `registry/register-xray-handlers!`).
   A plain `defn` rendered inside the shell's `:rf/xray` frame-provider
   would not pick up the surrounding frame (Spec 000 §Plain Reagent fns
-  / Spec 006 §Plain-fn-under-non-default-frame warning) — the read here
-  would route to `:rf/default` and read the host app's app-db.
+  / Spec 006 §Plain-fn footgun) — so the read here would RAISE
+  `:rf.error/no-frame-context` rather than route anywhere. The
+  `:rf.warning/plain-fn-under-non-default-frame-once` this line once
+  cited is retired: EP-0002 removed the `:rf/default` floor the warning
+  existed to flag, and the loud error superseded it.
 
   The READ is `rf.fresco/sub`, a plain call the shipped collector records
   an edge for — no deref, no reaction owned by the installed adapter, and

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -378,10 +378,13 @@
   [dispatch {:keys [id label mnem active?]}]
   ;; `dispatch` is the frame-bound dispatcher [[tab-bar]]'s boundary body
   ;; captures and threads in here. A plain fn invoked as a Reagent
-  ;; component would render in its OWN cycle, so `current-frame-id` would
-  ;; fall through to `:rf/default`; threading the captured `dispatch` is
-  ;; the reliable path, and under a Fresco boundary it is the only one —
-  ;; an AMBIENT dispatch inside a boundary body is a loud refusal.
+  ;; component would render in its OWN cycle with no `:contextType`, so
+  ;; `current-frame-id` would resolve nil and an ambient dispatch would
+  ;; RAISE `:rf.error/no-frame-context` — there is no `:rf/default` floor
+  ;; under EP-0002 (Spec 006 §Plain-fn footgun). Threading the captured
+  ;; `dispatch` is the reliable path, and under a Fresco boundary it is
+  ;; the only one — an AMBIENT dispatch inside a boundary body is a loud
+  ;; refusal too.
   ;;
   ;; rf2-k97c.3 (RULING 2) — the React `:key` rides in this button's own
   ;; ATTRIBUTE MAP. It used to be `^{:key id}` reader metadata on the

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -524,9 +524,11 @@
   imperatively from its own view tree).
 
   `reg-view`-registered so its `subscribe` / `dispatch` calls resolve
-  against the frame it is mounted under rather than silently routing
-  to `:rf/default` (the class of bug
-  `:rf.warning/plain-fn-under-non-default-frame-once` catches). The
+  against the frame it is mounted under. As a plain fn they would not
+  resolve at all: no `:contextType`, so the ambient read returns nil and
+  RAISES `:rf.error/no-frame-context` — there is no `:rf/default` floor
+  under EP-0002 (Spec 006 §Plain-fn footgun, which superseded the retired
+  `:rf.warning/plain-fn-under-non-default-frame-once`). The
   view-id is auto-derived from the symbol per the canonical reg-view
   convention; the surrounding shell mounts this stack under `:rf/xray`,
   so all its `subscribe` calls resolve through the React-context tier

--- a/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
@@ -1,0 +1,227 @@
+(ns day8.re-frame2-xray.palette.empty-row-frame-context-dom-cljs-test
+  "Real-DOM witness for the palette's EMPTY-RESULTS row (rf2-ap5w).
+
+  ## The fault this file was written to reproduce
+
+  `palette/view.cljs` used to HEAD its empty row — `[empty-row]` — and
+  `empty-row` performed an ambient `(rf/subscribe [:rf.xray/palette-query])`
+  of its own. A head makes Reagent mint a component for the plain `defn`,
+  and a plain `defn` carries no `:contextType`, so `(.-context cmp)` is
+  React's empty default, `re-frame.views.provider/current-frame` coerces
+  that to nil, and the ambient subscribe raises
+  `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun). The repair
+  passes the already-bound `query` down — `(empty-row query)` — which
+  both inlines the call and removes the duplicate read.
+
+  ## Why no existing lane could see it
+
+  Three independent reasons, and all three had to hold at once:
+
+  1. `sources/rank`'s contract is \"Empty query keeps every item\", so the
+     palette's OPEN state renders RESULTS. The empty row needs a TYPED
+     query that matches nothing.
+  2. `rf-xray-palette-empty` had no reference in any lane — node, browser
+     or `scenarios.cjs`. Nothing drove the branch.
+  3. THE NODE LANE CANNOT SEE THIS EVEN IF IT DROVE THE BRANCH. Xray's
+     node rows build the tree with `(rf/with-frame :rf/xray …)` and walk
+     it with a hiccup walker that CALLS function heads — inside that
+     dynamic scope, so the dynamic-var tier answers and the ambient read
+     resolves. Only a committed React render puts the plain fn in its own
+     component with no context to read.
+
+  ## Two traps this suite is shaped around
+
+  THE FIXTURE MUST OPT OUT OF THE AMBIENT FRAME. The core fixture
+  establishes `*current-frame*` `:rf/default` unless `:ambient-frame nil`
+  says otherwise, and that binding is the very dynamic-var tier the fault
+  depends on being absent — a suite that takes the default masks the
+  refusal and reports a clean palette.
+
+  REACT SWALLOWS THE RENDER THROW. A `try/catch` around `flushSync` never
+  fires; React 19 reports the failure and re-raises it as an UNCAUGHT
+  window error, so only a window `error` listener can name the refusal.
+  [[w0-the-listener-bites]] exercises that listener against a PLANTED
+  throw, so a silent run in [[w1-empty-row-commits-under-a-provider]]
+  means \"did not raise\" rather than \"was not watching\".
+
+  ## Node-lane behaviour
+
+  This ns matches the `:browser-test` build's `-dom-cljs-test$` regex and
+  also loads under `:node-test`, where every row short-circuits through
+  [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.palette :as palette]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private palette-frame
+  "The frame this suite's palette instance owns. NOT `:rf/xray`: that is
+  the production singleton, shared with every other suite on the page.
+  Naming a private one is what keeps these rows independent."
+  ::palette)
+
+;; `:ambient-frame nil` is LOAD-BEARING — see the ns docstring. The core
+;; fixture is used directly rather than `xray-test-support/make-xray-runtime-
+;; fixture` precisely because that wrapper does not thread the key.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (xray-test-support/reset-all!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the uncaught-error channel -----------------------------------------
+
+(defonce ^:private !last-uncaught (atom nil))
+
+(defonce ^:private error-capture-armed?
+  (when (exists? js/window)
+    (.addEventListener js/window "error"
+                       (fn [^js e] (reset! !last-uncaught (.-error e))))
+    true))
+
+(defn- uncaught-id
+  "The `:rf.error/id` of the last uncaught render error, or its message
+  when it carries no re-frame payload, or nil when nothing was raised."
+  []
+  (when-some [e @!last-uncaught]
+    (or (:rf.error/id (ex-data e)) (ex-message e) (str e))))
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — and, for this suite, once an uncaught error
+  raised during that commit has had a chance to reach the window."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+;; ---- mount helpers -------------------------------------------------------
+
+(defn- setup!
+  "Register Xray's handlers — which is what fills the palette index — and
+  make the frames. `:rf/xray` is made as well as this suite's own because
+  several Xray registrations reach the production singleton by name."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id shell/default-frame-id})
+  (rf/make-frame {:id palette-frame})
+  nil)
+
+(defn- mount!
+  "Mount `body` the way `shell.cljs:3100` mounts the palette — under the
+  outer `frame-provider` `mount.cljs` installs. That wrapper is the whole
+  point: a BARE mount raises `:rf.error/no-frame-context` for an entirely
+  different reason (`Modal` is itself a `reg-view`, and a `reg-view` at a
+  bare root has no context to read), which would be a false positive for
+  the fault under test.
+
+  Committed synchronously — React 19's `root.render` is otherwise async
+  and the first assertion would read an empty container."
+  [frame body]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame} body])))
+    {:container container :root root}))
+
+(defn- teardown! [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- testid [container id]
+  (.querySelector container (str "[data-testid=\"" id "\"]")))
+
+;; ===========================================================================
+;; W0 — the control: the listener bites
+;; ===========================================================================
+
+(deftest w0-the-listener-bites
+  (testing "rf2-ap5w — a refusal raised inside a React render reaches
+            this suite's window `error` listener and arrives with its
+            `ex-data` intact. Without this row a silent W1 could mean
+            either 'nothing raised' or 'nobody was watching', and those
+            are opposite findings."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (reset! !last-uncaught nil)
+        (let [{:keys [container root]}
+              (try
+                (mount! palette-frame
+                        [(fn [] (throw (ex-info "planted"
+                                                {:rf.error/id ::planted})))])
+                (catch :default _ {:container nil :root nil}))]
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (true? error-capture-armed?)
+                      "the window `error` listener is armed")
+                  (is (= ::planted (uncaught-id))
+                      (str "the planted throw reached the listener with its "
+                           "payload; got " (pr-str (uncaught-id))))
+                  (when (and root container) (teardown! root container))
+                  (reset! !last-uncaught nil)
+                  (done)))))))))
+
+;; ===========================================================================
+;; W1 — the witness
+;; ===========================================================================
+
+(deftest w1-empty-row-commits-under-a-provider
+  (testing "rf2-ap5w — a typed query that matches nothing drives the
+            palette to its empty-results branch, and that branch COMMITS
+            under the production provider shape instead of refusing with
+            `:rf.error/no-frame-context`.
+
+            This is the row the fault failed: with `[empty-row]` in head
+            position, the plain `defn`'s ambient subscribe reads a nil
+            frame and raises, React discards the whole subtree, and the
+            palette paints nothing at all."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (reset! !last-uncaught nil)
+        (rf/with-frame palette-frame
+          (rf/dispatch-sync [:rf.xray/palette-open])
+          ;; Gibberish, deliberately: an EMPTY query keeps every item
+          ;; (`sources/rank`), so the open palette would render RESULTS
+          ;; and never reach the branch under test.
+          (rf/dispatch-sync [:rf.xray/palette-set-query "zzqqxxjjvvww"]))
+        (is (empty? (rf/with-frame palette-frame
+                      (rf/subscribe-once [:rf.xray/palette-results])))
+            "the query matches nothing — the empty branch is the one that
+             will render")
+        (let [{:keys [container root]} (mount! palette-frame [palette/Modal])]
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (nil? (uncaught-id))
+                      (str "no uncaught refusal during render; got "
+                           (pr-str (uncaught-id))))
+                  (is (some? (testid container "rf-xray-palette-dialog"))
+                      "the palette dialog committed")
+                  (is (some? (testid container "rf-xray-palette-empty"))
+                      "the empty-results row committed")
+                  (teardown! root container)
+                  (reset! !last-uncaught nil)
+                  (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
@@ -40,9 +40,26 @@
   REACT SWALLOWS THE RENDER THROW. A `try/catch` around `flushSync` never
   fires; React 19 reports the failure and re-raises it as an UNCAUGHT
   window error, so only a window `error` listener can name the refusal.
-  [[w0-the-listener-bites]] exercises that listener against a PLANTED
-  throw, so a silent run in [[w1-empty-row-commits-under-a-provider]]
-  means \"did not raise\" rather than \"was not watching\".
+  [[w0-the-listener-bites]] exercises that listener, so a silent run in
+  [[w1-empty-row-commits-under-a-provider]] means \"did not raise\"
+  rather than \"was not watching\".
+
+  THE CONTROL DISPATCHES AN `ErrorEvent` RATHER THAN PLANTING A REAL
+  THROW, and that is the lane's rule rather than a softening. The browser
+  runner fails any run in which the page emitted an uncaught error at all
+  — a dedicated `pageerror` array, deliberately independent of the
+  `cljs.test` summary (rf2-mwx08 / rf2-wf5al) — so a suite that plants
+  one reddens the whole lane with a green summary beside it. Measured:
+  with a planted throw here the run read `0 failures, 0 errors` and
+  still exited 1, naming `1 uncaught pageerror(s)`.
+
+  What the synthetic event leaves unproven — that React really does
+  re-raise a render refusal onto `window` — was measured directly rather
+  than assumed. Before the repair, W1 caught
+  `:rf.error/no-frame-context` through this very listener, with neither
+  the dialog nor the empty row committed. That run is the end-to-end
+  evidence for the channel; W0 is the standing check that the listener
+  is still armed and still reads the payload off the event.
 
   ## Node-lane behaviour
 
@@ -154,33 +171,35 @@
 ;; ===========================================================================
 
 (deftest w0-the-listener-bites
-  (testing "rf2-ap5w — a refusal raised inside a React render reaches
-            this suite's window `error` listener and arrives with its
-            `ex-data` intact. Without this row a silent W1 could mean
-            either 'nothing raised' or 'nobody was watching', and those
-            are opposite findings."
+  (testing "rf2-ap5w — the window `error` listener this suite reads W1's
+            verdict through is armed, and extracts the `ex-data` off the
+            event rather than merely noting that something happened.
+            Without this row a silent W1 could mean either 'nothing
+            raised' or 'nobody was watching', and those are opposite
+            findings.
+
+            Synthetic rather than planted: see the ns docstring — the
+            runner fails a run on any uncaught page error, so a real
+            throw here would redden the lane with a green summary."
     (if-not (browser?)
       (is true "skipped: no DOM (node lane)")
       (async done
-        (setup!)
         (reset! !last-uncaught nil)
-        (let [{:keys [container root]}
-              (try
-                (mount! palette-frame
-                        [(fn [] (throw (ex-info "planted"
-                                                {:rf.error/id ::planted})))])
-                (catch :default _ {:container nil :root nil}))]
-          (-> (settle)
-              (.then
-                (fn [_]
-                  (is (true? error-capture-armed?)
-                      "the window `error` listener is armed")
-                  (is (= ::planted (uncaught-id))
-                      (str "the planted throw reached the listener with its "
-                           "payload; got " (pr-str (uncaught-id))))
-                  (when (and root container) (teardown! root container))
-                  (reset! !last-uncaught nil)
-                  (done)))))))))
+        (.dispatchEvent js/window
+                        (js/ErrorEvent.
+                          "error"
+                          #js {:error (ex-info "planted"
+                                               {:rf.error/id ::planted})}))
+        (-> (settle)
+            (.then
+              (fn [_]
+                (is (true? error-capture-armed?)
+                    "the window `error` listener is armed")
+                (is (= ::planted (uncaught-id))
+                    (str "the listener read the payload off the event; got "
+                         (pr-str (uncaught-id))))
+                (reset! !last-uncaught nil)
+                (done))))))))
 
 ;; ===========================================================================
 ;; W1 — the witness

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -288,17 +288,18 @@
 ;; Before rf2-1yif8 `edn-inspector-popup-stack` was a plain Reagent `defn`.
 ;; Plain fns are substrate-level Reagent components: they do not carry the
 ;; `:rf/frame` React-context that `reg-view` automatically wires up, so the
-;; body's `rf/subscribe` calls fell through to `:rf/default` even when the
-;; component was mounted under a non-default frame (the shell mounts the
-;; stack under `:rf/xray`). The runtime fires
-;; `:rf.warning/plain-fn-under-non-default-frame-once` to catch exactly
-;; this class of bug.
+;; body's `rf/subscribe` calls could not see the frame the component was
+;; mounted under (the shell mounts the stack under `:rf/xray`). On the
+;; runtime of the day that meant a silent fall-through to `:rf/default`,
+;; flagged by `:rf.warning/plain-fn-under-non-default-frame-once`. BOTH
+;; HALVES OF THAT SENTENCE ARE HISTORY: EP-0002 removed the `:rf/default`
+;; floor and retired the warning, so the same plain `defn` today RAISES
+;; `:rf.error/no-frame-context` instead (Spec 006 §Plain-fn footgun).
 ;;
 ;; Post-fix the symbol is registered via `rf/reg-view`, so the auto-derived
 ;; id `:day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-
 ;; stack` is resolvable through `(rf/view id)`, and subscribes inside the
-;; render body route through the surrounding `:rf/xray` frame instead of
-;; silently landing on `:rf/default`.
+;; render body resolve the surrounding `:rf/xray` frame from React context.
 
 (def ^:private popup-stack-view-id
   :day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-stack)
@@ -307,9 +308,11 @@
   (testing "rf2-1yif8 — `edn-inspector-popup-stack` is `reg-view`-
             registered under its auto-derived ns/sym id, so the body's
             subscribes inherit the surrounding frame from React context
-            (the symptom under a plain `defn` was the
+            (the symptom under a plain `defn` was, on the runtime of the
+            day, the now-retired
             `:rf.warning/plain-fn-under-non-default-frame-once` warning
-            firing on every panel-gallery `:rf/xray` render)."
+            firing on every panel-gallery `:rf/xray` render; under
+            EP-0002 the same shape raises `:rf.error/no-frame-context`)."
     (setup-xray-frame!)
     (is (some? (rf/view popup-stack-view-id))
         "view is registered under the auto-derived ns/sym id")))
@@ -320,15 +323,17 @@
             We open a popup in `:rf/xray` and confirm the rendered chrome
             reflects `:rf/xray`'s stack; a popup written into
             `:rf/default` MUST NOT leak in.
-            Plain-fn regression would render `:rf/default`'s entry (or
-            nil when `:rf/xray`'s slot is empty) — that is exactly the
-            bug this test pins."
+            A plain-fn regression cannot read the surrounding frame at
+            all: under EP-0002 it raises `:rf.error/no-frame-context`
+            and this row's tree never renders — that is the bug this
+            test pins, and on the pre-EP-0002 runtime it presented as
+            `:rf/default`'s entry rendering instead."
     (setup-xray-frame!)
     ;; `:rf.xray/modal-positioning` is already registered by
     ;; `register-xray-handlers!` inside `setup-xray-frame!`.
     ;; Seed contradicting data in :rf/default + :rf/xray. If the
-    ;; subscribes silently route to :rf/default, the test would see
-    ;; the "default-only" mount-id; the correct routing sees "xray-only".
+    ;; subscribes read :rf/default, the test would see the
+    ;; "default-only" mount-id; the correct routing sees "xray-only".
     (rf/dispatch-sync
       [:rf.xray.edn-inspector-popup/open
        "default-only" {:value :default-payload :opts {}}])


### PR DESCRIPTION
Closes rf2-ap5w and rf2-78wg. Two items, one PR: the same kind of change in the same tool, on files nobody holds.

## rf2-ap5w — the palette's empty row raised, and it REPRODUCED

`palette-view` HEADED `[empty-row]`, and `empty-row` performed an ambient `(rf/subscribe [:rf.xray/palette-query])` of its own. A head makes Reagent mint a component for the plain `defn`; a plain `defn` carries no `:contextType`, so `(.-context cmp)` is React's empty default, `current-frame` coerces that to nil, and the ambient read raises `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun).

**Reproduced at runtime, not merely reasoned about.** The new browser row mounts `[rf/frame-provider {:frame f} [palette/Modal]]` — the production shape `shell.cljs:3100` and `mount.cljs` install — drives a typed query that matches nothing, and caught the refusal on a window `error` listener:

```
FAIL in (w1-empty-row-commits-under-a-provider)
expected: (nil? (uncaught-id))
  actual: (not (nil? :rf.error/no-frame-context))
expected: (some? (testid container "rf-xray-palette-dialog"))
  actual: (not (some? nil))
expected: (some? (testid container "rf-xray-palette-empty"))
  actual: (not (some? nil))
```

Neither the dialog nor the empty row committed — React discards the whole subtree, so the palette painted **nothing at all**, not merely a wrong row. After the repair the same three assertions pass.

**The repair takes the better of the two spellings.** `palette-view` already binds `query` from the same subscription, so `(empty-row query)` both inlines the call and removes the duplicate read, where a bare `(empty-row)` merely donates the read upward into the enclosing boundary's window.

**Why nothing caught it.** Three reasons had to hold at once. `sources/rank`'s contract is "Empty query keeps every item", so the palette's OPEN state renders RESULTS and the empty branch needs a typed query that matches nothing. `rf-xray-palette-empty` had no reference in any lane. And **the node lane cannot see this even when it drives the branch**: Xray's node rows build the tree inside `(rf/with-frame :rf/xray …)` and walk it with a hiccup walker that CALLS function heads — inside that dynamic scope, so the dynamic-var tier answers and the ambient read resolves.

**Two traps the new suite is shaped around, both measured.** The core fixture establishes `*current-frame*` `:rf/default` unless `:ambient-frame nil` says otherwise — that binding is the very tier the fault depends on being absent, so a suite taking the default reports a clean palette. And the browser runner fails a run on any uncaught `pageerror`, tracked in a dedicated array independent of the `cljs.test` summary (rf2-mwx08 / rf2-wf5al): with a planted throw as the control, the run read `0 failures, 0 errors` and still exited 1 naming `1 uncaught pageerror(s)`. The control now dispatches a synthetic `ErrorEvent`; the pre-repair run is the end-to-end evidence that React really does re-raise onto `window`.

**Other heads in that file: none.** `[empty-row]` was the only head position, checked per-symbol against all sixteen local `defn`s; `result-row` and the leaf views are called. `empty-row` was the only thing in the file that read the substrate.

## rf2-78wg — the wrong `:rf/default` claim and the dead §706 citation

**Part A.** Under EP-0002 there is no `:rf/default` floor, so an ambient read that cannot find a frame does not route anywhere: it resolves to nil and raises. Corrected at six surviving sites, keeping each warning's MOUNT-SEAM subject and replacing only the destination — `shell.cljs` (two), `static/shell.cljs`, `palette.cljs`, `views/edn_inspector_popup.cljs`, and `views/edn_inspector_popup_wireup_cljs_test.cljs`. Three of those also cited the retired `:rf.warning/plain-fn-under-non-default-frame-once`; each now says it is retired and what superseded it. Past-tense accounts of the pre-EP-0002 runtime are left standing and marked as history where a reader could take them for current behaviour — the `:rf/default` leaks rf2-043uz and rf2-1yif8 record really did happen, on a runtime that really did have the floor.

**Part B.** `Spec 006 §706` is cited in prose and that anchor exists nowhere in `spec/006-ReactiveSubstrate.md`. Both surviving sites re-pointed at `§Plain-fn footgun` — the section that carries the material and the spelling 17 other citations already use. Repo-wide `§706` count is now **0**. No gate added, per the item: a bare prose citation is neither a markdown link nor a heading anchor, so `check_doc_slugs.py` cannot see it by construction.

**A census, not the sighting list.** Three passes over every tracked file — line-oriented, whitespace-flattened, and comment-markers-stripped-then-flattened — each controlled against a phrase taken from the target text. The flattened passes found sites the line-oriented one could not: both `shell.cljs` sites break the claim across a line. `spec/`, `skills/`, `migration/` and `docs/` are CLEAN: every mention there denies the floor rather than asserting it, which `scripts/check_skill_migration_contract_drift.py` already ratchets for the skills half.

## Two corrections to the items

1. **`panels.cljs` was NOT a surviving site, and the fence had already expired.** At `26d0b75468` — trunk when this worktree was cut — `panels.cljs:232-234` still carried both defects. `9c16c6deeb` landed twenty minutes later and fixed both. Nothing here touches that file, nor any other file inside PR #9654.
2. **`palette/view.cljs` contradicted itself.** Its ns docstring described a "3-tier frame resolution chain (dynamic var → React-context tier → `:rf/default`)" while its `handle-input-keydown` comment sixty lines below stated the same mechanism correctly. Corrected while in the file: the React context's default is `adapter.context/no-provider-sentinel`, not `:rf/default`.

## A finding filed rather than fixed

The census surfaced a **second, larger class** that this PR deliberately leaves alone: the DEFERRED-HANDLER claim — that a bare `rf/dispatch` from an `:on-click` fired after render "leaks to `:rf/default`". Under EP-0002 it raises, for the same reason. It spans roughly ten files in `tools/xray/src` alone (`panels/derivation_graph.cljs`, `panels/reactive_panel_view.cljs`, `settings/view.cljs`, `static/{flows,interceptors,schemas}/panel.cljs`, `static/shared/search_box.cljs`, `panels/app_db_segment_inspector.cljs` and more) and is not confined to Xray. rf2-78wg says to stop and report past about a dozen sites rather than widen, so that is a separate item with a different shape.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Node CLJS lane (final tree) | `npm run test:cljs` | **0** — 11672 tests, 58509 assertions, 0 failures, 0 errors |
| Browser compile | `npx shadow-cljs compile browser-test` | **0** — 1052 files |
| Browser lane | `serve-and-run-browser-tests.cjs --port 8124` | **0** — 939 tests, 5192 assertions, 0 failures, 0 errors, 0 pageerrors |
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| README links | `python scripts/check_readme_links.py --ci` | **0** |
| Every workflow-invoked `scripts/check_*` | 44 scripts | **0** each |
| Commit attribution | `check-commit-attribution.sh origin/main` | **0** |
| Beads PR boundary | `check-beads-pr-boundary.sh origin/main` | **0** |

Pass/fail counts: **45 gates run, 45 passed, 0 failed.**

The browser run was gated on the compile's *captured* exit rather than chained to it, so a stale artefact could not be served under a green verdict. Both phases' logs name this worktree's own `implementation/` root.

**The doc gate was verified to be reading this tree, not merely to be green.** A broken anchor planted in `tools/xray/spec/Conventions.md` returned `1 broken anchor link(s) found: BROKEN ANCHOR: tools\xray\spec\Conventions.md:116 -> #no-such-heading-anywhere-xyz`; the restore was verified by blob hash (`git hash-object` default form == `git rev-parse HEAD:<path>`, this file being `i/lf`) and by `git diff --quiet HEAD`.

**Checked by hand, because no gate covers it.** Neither link gate looks inside fenced code blocks, and the `Conventions.md` edit sits in prose immediately below a fence — the fenced `reg-view Panel` sample is unchanged. The edited paragraph carries no markdown links and adds none; its one cross-reference (`Spec 006 §Plain-fn footgun`) is prose by design. No tables were touched, so no column counts changed. Every `.cljs` change outside `palette/view.cljs` is confined to comments and docstrings, so the node lane's clean compile is the whole of what those need.
