### PR TITLE
fix(xray): Fresco self-exclusion recognises a non-default Xray shell frame (rf2-bgol)

### DIFF
--- a/tools/xray/spec/027-Fresco-Evidence.md
+++ b/tools/xray/spec/027-Fresco-Evidence.md
@@ -104,7 +104,9 @@ self-exclusion below: it drops Xray's OWN boundaries, and only from the six
 views. `the-subscription-drops-XRAYs-own-boundaries-and-the-DOOR-does-not`
 pins both halves at once — the door still carries the `:rf/xray` row and what
 the views see does not — which is also what keeps the byte claim above from
-holding merely because a fixture happens to mount no Xray boundary.
+holding merely because a fixture happens to mount no Xray boundary. Its
+sibling `the-subscription-drops-a-NON-DEFAULT-shells-own-boundaries-too`
+pins the same two halves for a shell mounted under a custom `:frame-id`.
 
 The producer's rosters are sorted through one total order, so two calls over
 one runtime state print identically; that determinism is the precondition the
@@ -118,13 +120,43 @@ The census walks the collector's process-global entry table with no frame
 filter, so the tab listed ITSELF: with one application boundary mounted, the
 Mounted view committed two rows, the second naming `…panels.fresco/Panel` in
 frame `:rf/xray`. Tool activity must never present as application evidence,
-so `fresco-helpers/without-own-frame` drops every row seated in `:rf/xray`
-before any view sees it.
+so `fresco-helpers/without-own-frame` drops every row seated in a frame the
+tool owns before any view sees it.
 
 This is the rule `self-noise` already applies to the trace surface, and it
 keeps that namespace's posture: the drop is unconditional, with no "show
 internals" toggle — introspecting Xray's own machinery is a separate feature,
 not an opt-out on a user-facing feed.
+
+**WHICH FRAMES THE TOOL OWNS IS A RUNTIME FACT, NOT A LITERAL (rf2-bgol).**
+The first cut asked `(= :rf/xray frame)`. That is right for the production
+singleton and blind to every other shell
+[`008-Embedding-Contract.md`](008-Embedding-Contract.md) §Parameterized shell
+frame-id permits: the shell frame is a `:frame-id` opt, `ensure-xray-frame!`
+takes one, and a testbed mounting N shells side by side gives each cell a
+distinct id. Under such a shell the tab's own boundary, its two reads and its
+explanation were seated in a frame the filter did not know and rode into all
+four rosters.
+
+`fresco-helpers/own-frames` is the set instead: `:rf/xray` — kept
+unconditionally, because the `:rf/*` single root is RESERVED and Xray's L1
+picker already refuses it as an inspectable frame, so a row seated there is
+the tool whichever shell is doing the looking — **plus the shell this panel
+is actually inside**. That id is the `:rf.xray.fresco/data` query's argument,
+read by `Panel` with `rf/current-frame-id` in its own render. The render is
+the only honest place to read it: a subscription COMPUTATION runs under no
+frame scope at all (`subs/memo` wraps the body in a trace handler-scope and
+nothing else), so a filter reading the frame inside the sub would be right on
+the first build and wrong on every recompute.
+
+**Two things it deliberately is not.** It is not inferred from
+`:rf.trace/frame-no-emit?` — `image-reads/seat-xray-frame!` does set that on
+every shell frame, but an application frame may disable trace emission for
+its own reasons, and reading that as Xray-ownership would silently swallow
+the user's evidence, which is worse than the defect being repaired. And it is
+not a new configuration surface: the set is derived, and the pure helper takes
+it as DATA, which is the shape `palette/sources` already uses for
+`frame-switcher/internal-frames` and for the same reason.
 
 **It is a PANEL filter, not a door filter, and the distinction is the whole
 of the byte claim above.** `fresco-reads` still passes the producer's
@@ -134,7 +166,7 @@ receives every boundary including Xray's. Only the six views are filtered.
 Three things it does not do. `:unknown` is not Xray's frame, so a row whose
 frame the producer could not resolve stays on screen with its chip — silently
 dropping a stated absence is the failure this tab exists to prevent. An
-intent is dropped only when EVERY frame it touched is `:rf/xray`, so a
+intent is dropped only when EVERY frame it touched is one of the tool's, so a
 dispatch that reached an application frame survives whatever else it also
 touched. And an absent or schema-mismatched envelope passes through whole, so
 a mismatch still renders as a mismatch rather than as a clean empty roster.
@@ -594,9 +626,9 @@ Adding it moved six governance pins, each of which fails the build on drift:
 | `re-frame.fresco.evidence-schema-cljs-test` | node | the envelope door stamps a coherent read and refuses a foreign read, a foreign or unsized loss and a loss beside a completeness claim, each refusal asserting the problem it named, with a positive control |
 | `re-frame.fresco.tool-reads-cljs-test` | node (reactive substrate) | the four reads over real committed boundaries; a declared view is named on the mounted row, the attribution reader and the explanation with the coordinate `defview` captured, two declared views over one edge set are one row naming both, an unnamed body states `:unknown`, and a name minted outside the macro carries no source; the seeded-value privacy witness for a return value AND for a query argument; two frames sharing a sub id with asymmetric windows; the dispatch-ordered, fragment-merged intent stream; determinism; the production-nil arm |
 | `re-frame.fresco.erasure-sentinels-cljs-test` | node | the live half of the erasure proof — a dev render mints the `frescoViews` slot the release scan requires absent, and only the commit names a view in it |
-| `…panels.fresco-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the per-view empties, counted against the LIVE `sub-modes` list (six today) rather than a literal, so a seventh view cannot be added carrying a sixth view's sentence; labels and testids are built from the projected key; a named row leads with its view and an unnamed one carries the `unknown` chip; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v2 stamp is refused rather than mis-parsed; the schema pin; row projections; and the self-exclusion drop over all four rosters at once — the application row survives and Xray's own does not, an intent is dropped only when EVERY frame it touched is `:rf/xray`, and neither an `:unknown` frame nor an unparseable envelope is eaten by it |
+| `…panels.fresco-helpers-cljs-test` | node + JVM | the five absences and the empties are pairwise distinct — including the per-view empties, counted against the LIVE `sub-modes` list (six today) rather than a literal, so a seventh view cannot be added carrying a sixth view's sentence; labels and testids are built from the projected key; a named row leads with its view and an unnamed one carries the `unknown` chip; a row key carries the WHOLE projected identity, so two frames' boundaries over one query do not collide; two query variants do not collapse; the key is INJECTIVE as a property over a generated space of 9261 identities, 10162 boundary keys and 441 intent rows, with a non-vacuity control that the space still defeats a lossy slug; the superseded v2 stamp is refused rather than mis-parsed; the schema pin; row projections; and the self-exclusion drop over all four rosters at once — the application row survives and Xray's own does not, an intent is dropped only when EVERY frame it touched is one of the tool's, and neither an `:unknown` frame nor an unparseable envelope is eaten by it; every one of those rows runs TWICE, once for the production singleton `:rf/xray` and once for a NON-DEFAULT shell frame (rf2-bgol), with `own-frames` itself pinned as the singleton PLUS the shell being looked from |
 | `…panels.fresco-cljs-test` | node (reactive substrate) | the four EVIDENCE views answer on a running app (Advisor and Causal are the derived pair, and have their own suites per [`028-Fresco-Advisor.md`](028-Fresco-Advisor.md)); a declared view is named on the Mounted, Reads and Why pages with a `…-views` testid, and a harness body renders the `unknown` chip instead; `:rf.xray.fresco/data` INVALIDATES and RECOMPUTES on a real `:rf.xray/trace-buffer` tick with no cache clear, against a held reaction proved stale first — the SUBSCRIPTION's half of liveness, the panel's half being the browser row below; the loss states render under distinct testids, driven between two real window states; a sensitive query argument reaches neither the page nor a testid; the Reads and Why rows carry the frame on the page and in the testid; each view renders its own empty; both the superseded and an unknown stamp render the mismatch; the seam reshapes nothing |
-| `…panels.fresco-live-panel-dom-cljs-test` | browser (real React DOM) | THIS PANEL'S BOUNDARY WITNESS (rf2-k97c.3), under its older name. The panel is mounted once through the L4 registry's own `:panel` value — the bridge the shell mounts — inside `[frame-provider {:frame :rf/xray}]`, and nothing calls it again. W0: it picks up a newly-mounted boundary on a trace tick and commits the row, against a settled deaf control proving the panel stale across the mount first, and the `<section>` afterwards is the node it started with, so the roster arrived by reconciliation and not a remount. It is ALSO the self-exclusion witness — exactly ONE row, so the panel's own `:rf/xray` boundary is absent from its own census. W1: first paint, and BOTH reads hold references in `:rf/xray`'s sub-cache and none in the application frame's, against a live probe in that frame. W2: the sub-strip CLICK switches the view through the boundary's own frame, with the `<section>` identity held across it. W3: unmount releases both reads within the collector's grace macrotask, and reopening returns to the same counts rather than higher ones |
+| `…panels.fresco-live-panel-dom-cljs-test` | browser (real React DOM) | THIS PANEL'S BOUNDARY WITNESS (rf2-k97c.3), under its older name. The panel is mounted once through the L4 registry's own `:panel` value — the bridge the shell mounts — inside `[frame-provider {:frame :rf/xray}]`, and nothing calls it again. W0: it picks up a newly-mounted boundary on a trace tick and commits the row, against a settled deaf control proving the panel stale across the mount first, and the `<section>` afterwards is the node it started with, so the roster arrived by reconciliation and not a remount. It is ALSO the self-exclusion witness — exactly ONE row, so the panel's own `:rf/xray` boundary is absent from its own census. W1: first paint, and BOTH reads hold references in `:rf/xray`'s sub-cache and none in the application frame's, against a live probe in that frame. W2: the sub-strip CLICK switches the view through the boundary's own frame, with the `<section>` identity held across it. W3: unmount releases both reads within the collector's grace macrotask, and reopening returns to the same counts rather than higher ones. W4 (rf2-bgol): the same panel mounted through the same registry entry under a NON-DEFAULT shell `:frame-id` omits its OWN boundary from the committed page while the producer's door still carries it, and the application's boundary is on the page in both — the half W0 cannot see, because W0 mounts the tool under `:rf/xray` |
 | `frame_singleton_guard_test` | JVM (source text) | the sub-strip dispatches through a captured frame-bound `dispatch`, never a bare global one |
 | `feature_matrix/scenarios.cjs` | browser | the tab reaches a real panel root in the shell sweep |
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -692,14 +692,25 @@
   click still lands on the surrounding instance frame (rf2-nesy9) and is
   still not a `:rf/xray` literal.
 
+  THAT ID IS ALSO THE EVIDENCE READ'S ARGUMENT NOW (rf2-bgol), and the
+  render is the only place it can be taken from. The self-exclusion
+  filter has to know which frames are the TOOL's, Xray's shell frame is
+  parameterized (008 §Parameterized shell frame-id), and a subscription
+  COMPUTATION runs under no frame scope at all — `subs/memo` wraps the
+  body in a trace handler-scope and nothing else, so `current-frame-id`
+  inside the sub would answer whatever unrelated scope happened to be on
+  the stack, which is the render's frame on the first build and nothing
+  on every recompute. Here it is established.
+
   The argument is the ordinary one-props-map vector every `defview`
   takes. This panel reads nothing from props — the L4 registry mounts it
   with none — so it is destructured away."
   [_props]
-  (panel-tree
-    {:selected (rf.fresco/sub [:rf.xray.fresco/view])
-     :data     (rf.fresco/sub [:rf.xray.fresco/data])
-     :frame    (rf/current-frame-id)}))
+  (let [frame (rf/current-frame-id)]
+    (panel-tree
+      {:selected (rf.fresco/sub [:rf.xray.fresco/view])
+       :data     (rf.fresco/sub [:rf.xray.fresco/data frame])
+       :frame    frame})))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;
@@ -765,9 +776,17 @@
     (fn [db _query]
       (hh/normalise-sub-mode (:fresco-view db))))
 
+  ;; THE QUERY TAKES THE PANEL'S OWN FRAME (rf2-bgol). `instance-frame` is
+  ;; the id `Panel` read with `rf/current-frame-id` in its render — the
+  ;; shell this tab is actually inside, which 008 §Parameterized shell
+  ;; frame-id lets be any id rather than `:rf/xray` alone. It is an
+  ;; ARGUMENT because a sub computation has no frame scope to read one
+  ;; from; see `Panel`'s docstring. A caller that passes none (the
+  ;; byte-claim rows, which are about the door rather than about a shell)
+  ;; gets the singleton alone, which is what this filter did before.
   (rf/reg-sub :rf.xray.fresco/data
     {:inputs [[:rf.xray/trace-buffer]]}
-    (fn [[_tick] _query]
+    (fn [[_tick] [_ instance-frame]]
       ;; rf2-k97c.3 — `hh/without-own-frame` drops Xray's OWN boundaries
       ;; before anything downstream sees them. Xray's panels are Fresco
       ;; boundaries now and Fresco's census has no frame filter, so this
@@ -778,7 +797,8 @@
       ;; and HERE rather than in the row projections because the advisor
       ;; and the causal slice read the envelopes directly. See
       ;; `fresco-helpers/without-own-frame`.
-      (let [envelopes (hh/without-own-frame (reads/evidence))
+      (let [envelopes (hh/without-own-frame (reads/evidence)
+                                            (hh/own-frames instance-frame))
             ;; The window is taken in the SAME turn as the four envelopes,
             ;; for the reason the four are taken together: the advisor
             ;; joins the ring's recompute counts to the census's read

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco_helpers.cljc
@@ -648,18 +648,73 @@
 ;; one turn: dropping a boundary from the census while leaving its edges in
 ;; the attribution roster would show an edge whose boundary is not in the
 ;; census, which is the inconsistency the one-turn read exists to prevent.
+;;
+;; WHICH FRAMES ARE XRAY'S IS A RUNTIME FACT, NOT A LITERAL (rf2-bgol). The
+;; first cut of this filter asked `(= :rf/xray frame)`, which is right for
+;; the production singleton and wrong for every other supported shell: 008
+;; §Parameterized shell frame-id permits N shells side by side, each with a
+;; distinct `:frame-id`, and under one of those the tab was once again
+;; listing itself. [[own-frames]] is the set, and the panel supplies the
+;; instance it is rendering in — see that fn for why it cannot be read
+;; inside the subscription instead.
 
-(def ^:private xray-frame
-  "Xray's own frame. A row seated here is the tool, not the application."
+(def default-xray-frame
+  "Xray's PRODUCTION SINGLETON shell frame — the value
+  `defaults/default-frame-id` carries, spelled here as a literal because
+  this namespace is `.cljc` and that one is not.
+
+  It is in [[own-frames]] UNCONDITIONALLY, and that is not the defect
+  rf2-bgol fixed. `:rf/xray` is RESERVED — Conventions' `:rf/*` single
+  root belongs to the framework, and Xray's L1 frame picker already
+  refuses it as a frame a user may inspect — so a row seated here is the
+  tool whichever shell is doing the looking. The defect was that it was
+  the filter's ONLY member."
   :rf/xray)
 
+(defn own-frames
+  "The set of frames a Fresco panel rendering inside `instance-frame` must
+  read as the TOOL's own: [[default-xray-frame]], plus the shell the panel
+  is actually in.
+
+  THE SECOND MEMBER IS THE WHOLE OF rf2-bgol. Xray's shell frame is
+  PARAMETERIZED, not a hard singleton — `spec/008-Embedding-Contract.md`
+  §Parameterized shell frame-id permits N shells side by side, each
+  passing a distinct `:frame-id`, and `mount/ensure-xray-frame!` takes
+  one. The filter was `(= :rf/xray frame)` and nothing else, so the
+  moment such a shell mounted this panel its boundary, its reads and its
+  explanations were seated in a frame the filter did not know, survived
+  all four rosters, and the tool presented itself as application evidence
+  in Mounted, Reads, Why, Advisor and Causal — the very defect the
+  singleton case had just been closed against.
+
+  IT IS TAKEN FROM THE PANEL, NOT GUESSED. The `:rf.xray.fresco/data`
+  query carries the id `rf/current-frame-id` answered in the boundary's
+  own render, which is the one place the frame is established and
+  therefore the only place it can be read honestly — a sub computation is
+  not run under a frame scope, and a filter that tried to read one there
+  would be right on the first build and wrong on every recompute.
+
+  AND IT IS NOT INFERRED FROM TRACING BEING OFF. `image-reads/seat-xray-
+  frame!` does set `:rf.trace/frame-no-emit?` on every shell frame, which
+  makes a tempting proxy and is the wrong one: an APPLICATION frame may
+  disable trace emission for its own reasons, and reading that as
+  Xray-ownership would silently swallow the user's evidence — far worse
+  than the defect being repaired here.
+
+  `nil` `instance-frame` — a caller with no frame to offer — yields the
+  singleton alone, which is exactly the pre-rf2-bgol behaviour."
+  [instance-frame]
+  (cond-> #{default-xray-frame}
+    (some? instance-frame) (conj instance-frame)))
+
 (defn- own-frame?
-  "True when `frame` IS Xray's own. Deliberately `=` against a resolved
-  frame id and nothing cleverer: [[unknown]] is not Xray's frame, and a
-  row whose frame the producer could not resolve must stay on screen
-  carrying its chip rather than be silently dropped as self-noise."
-  [frame]
-  (= xray-frame frame))
+  "True when `frame` is one of `owned` (see [[own-frames]]). Deliberately
+  a set membership over resolved frame ids and nothing cleverer:
+  [[unknown]] is not Xray's frame, and a row whose frame the producer
+  could not resolve must stay on screen carrying its chip rather than be
+  silently dropped as self-noise."
+  [owned frame]
+  (contains? owned frame))
 
 (defn- own-intent?
   "True when every frame an intent touched is Xray's own.
@@ -668,8 +723,8 @@
   user's, whatever else it also touched, and dropping it would hide real
   evidence. An intent carrying no frames at all is kept for the same
   reason — an empty set is an absence, not a claim about Xray."
-  [frames]
-  (and (seq frames) (every? own-frame? frames)))
+  [owned frames]
+  (and (seq frames) (every? #(own-frame? owned %) frames)))
 
 (defn- without
   "`envelope` with `k`'s collection filtered by `keep?`. A non-envelope
@@ -682,9 +737,19 @@
     (update envelope k #(filterv keep? %))))
 
 (defn without-own-frame
-  "The four-envelope map with every row seated in Xray's OWN frame
-  removed. Pure; the caller hands it exactly what `fresco-reads/evidence`
-  answered.
+  "The four-envelope map with every row seated in one of `owned` — the
+  set [[own-frames]] answers for the shell this panel is inside —
+  removed. Pure; the caller hands it exactly what
+  `fresco-reads/evidence` answered.
+
+  `owned` IS A PARAMETER RATHER THAN A LITERAL, and that is rf2-bgol:
+  Xray's shell frame is parameterized (008 §Parameterized shell
+  frame-id), so the set is a runtime fact about which shells are on the
+  page and cannot be written down here. Passing it as data is the shape
+  the tree already uses for exactly this — `palette/sources` takes
+  `frame-switcher/internal-frames` the same way, for the same reason:
+  the pure layer stays pure and the `.cljs` seam that can see the
+  frames supplies them.
 
   APPLIED ONCE, HERE, AND NOT AT ROW PROJECTION — because the rows are
   not the only consumer. `fresco-advisor/advise` and
@@ -699,16 +764,16 @@
   time: they are read in ONE turn precisely so a reader cannot see an
   edge whose boundary is missing from the census, and a partial filter
   would manufacture exactly that."
-  [envelopes]
+  [envelopes owned]
   (-> envelopes
       (update :mounted-boundaries without :boundaries
-              (comp not own-frame? :frame))
+              #(not (own-frame? owned (:frame %))))
       (update :read-attribution   without :edges
-              (comp not own-frame? :frame-id))
+              #(not (own-frame? owned (:frame-id %))))
       (update :intents            without :intents
-              (comp not own-intent? :frames))
+              #(not (own-intent? owned (:frames %))))
       (update :explain-render     without :explanations
-              (comp not own-frame? :frame))))
+              #(not (own-frame? owned (:frame %))))))
 
 (defn mounted-rows
   "The Mounted view's rows: one per distinct edge set, carrying the

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_cljs_test.cljs
@@ -178,10 +178,14 @@
   itself: the mount, the commit and the release are
   `fresco_live_panel_dom_cljs_test`'s subject, under a real React root."
   []
-  (fresco/panel-tree
-    {:selected @(rf/subscribe [:rf.xray.fresco/view])
-     :data     @(rf/subscribe [:rf.xray.fresco/data])
-     :frame    (rf/current-frame-id)}))
+  (let [frame (rf/current-frame-id)]
+    (fresco/panel-tree
+      {:selected @(rf/subscribe [:rf.xray.fresco/view])
+       ;; The FRAME is the query's argument since rf2-bgol, exactly as
+       ;; `Panel` passes it — a harness that dropped it would drive the
+       ;; filter's nil default and never the shipped path.
+       :data     @(rf/subscribe [:rf.xray.fresco/data frame])
+       :frame    frame})))
 
 (defn- show!
   "Select `view`, refresh, and render the panel."
@@ -624,7 +628,7 @@
           door      (rf.fresco.tool/read-mounted-boundaries)
           held      (rf/with-frame :rf/xray
                       (refresh!)
-                      (:envelopes @(rf/subscribe [:rf.xray.fresco/data])))
+                      (:envelopes @(rf/subscribe [:rf.xray.fresco/data :rf/xray])))
           frames-of #(mapv :frame (:boundaries %))]
       (is (some #{:rf/xray} (frames-of door))
           (str "THE DOOR STILL CARRIES IT — the producer's own answer is "
@@ -644,6 +648,59 @@
            Xray-specific rather than a roster that emptied")
       (app-side)
       (xray-side))))
+
+(def ^:private custom-shell-frame
+  "A NON-DEFAULT Xray shell frame — 008 §Parameterized shell frame-id, the
+  `:frame-id` a testbed mounting N shells side by side passes."
+  ::fresco-tab-custom-shell)
+
+(deftest the-subscription-drops-a-NON-DEFAULT-shells-own-boundaries-too
+  (testing "rf2-bgol — the row above pins the PRODUCTION SINGLETON, and the
+            first cut of this filter asked `(= :rf/xray frame)`, so the
+            singleton was the only shell it could see. Xray's shell frame is
+            parameterized (008 §Parameterized shell frame-id): a testbed
+            mounting N shells side by side gives each a distinct `:frame-id`,
+            `mount/ensure-xray-frame!` takes one, and under such a shell the
+            tab's own boundary, reads and explanations were seated in a frame
+            the filter did not know and rode into all four rosters.
+
+            The subscription now takes the shell's id from the panel's own
+            render, so this row drives the query the way `Panel` does."
+    (setup!)
+    (rf/make-frame {:id custom-shell-frame})
+    (let [app-side  (mount! (fn [_] (rf.fresco/sub [:htab/left]) nil))
+          xray-side (mount! custom-shell-frame
+                            (fn [_] (rf.fresco/sub [:htab/right]) nil))
+          door      (rf.fresco.tool/read-mounted-boundaries)
+          held      (rf/with-frame custom-shell-frame
+                      (rf/clear-sub-cache! custom-shell-frame)
+                      (:envelopes @(rf/subscribe [:rf.xray.fresco/data
+                                                  custom-shell-frame])))
+          frames-of #(mapv :frame (:boundaries %))]
+      (is (some #{custom-shell-frame} (frames-of door))
+          (str "NON-VACUITY: the producer really did seat a boundary in the "
+               "custom shell frame, so the drop below is a filter rather "
+               "than a roster that was always empty. Door frames: "
+               (pr-str (frames-of door))))
+      (is (some #{app-frame} (frames-of door))
+          "NON-VACUITY: and the application's boundary is in the door too")
+      (is (not (some #{custom-shell-frame}
+                     (frames-of (:mounted-boundaries held))))
+          (str "THE SHELL'S OWN FRAME IS DROPPED. This is the assertion that "
+               "reddens against the literal-only filter. Held frames: "
+               (pr-str (frames-of (:mounted-boundaries held)))))
+      (is (some #{app-frame} (frames-of (:mounted-boundaries held)))
+          "and the application's boundary SURVIVES — the drop is the tool's
+           own frame and not a roster that emptied")
+      (testing "the singleton stays in the set whichever shell is looking"
+        (is (= #{:rf/xray custom-shell-frame}
+               (hh/own-frames custom-shell-frame))
+            ":rf/xray is RESERVED — a row seated there is the tool whichever
+             shell is doing the looking, so it is never dropped from the set
+             just because this panel is somewhere else"))
+      (app-side)
+      (xray-side)
+      (rf/destroy-frame! custom-shell-frame))))
 
 (deftest the-consumer-pin-tracks-the-producer-today-and-detects-a-bump
   (testing "the pin is a LITERAL, not the producer's var — but today they agree"

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_helpers_cljs_test.cljc
@@ -631,35 +631,49 @@
 ;; that survives AND the identity of the survivor. A count alone would
 ;; pass just as well on a filter that dropped the wrong row, and these
 ;; fixtures are two rows deep precisely so that mistake is reachable.
+;;
+;; AND EVERY ROW RUNS TWICE (rf2-bgol), once for the production singleton
+;; `:rf/xray` and once for a NON-DEFAULT shell frame. The first cut of this
+;; filter asked `(= :rf/xray frame)`, which is right for the singleton and
+;; blind to every other shell 008 §Parameterized shell frame-id permits —
+;; and a suite that only ever fed it `:rf/xray` could not tell the two
+;; apart. The custom arm is the one that reddens against the old filter.
 
-(def ^:private mixed-evidence
-  "One turn's four envelopes, each carrying an application row AND an
-  Xray-owned one. Two rows deep in every roster on purpose: a filter that
-  dropped the WRONG row would satisfy a count and fail the identity
-  assertions below."
+(def ^:private custom-shell-frame
+  "A NON-DEFAULT Xray shell frame — the `:frame-id` a testbed mounting N
+  shells side by side passes to `shell-view` / `ensure-xray-frame!`."
+  ::custom-shell)
+
+(defn- mixed-evidence
+  "One turn's four envelopes, each carrying an application row AND one
+  owned by the Xray shell seated in `tool-frame`. Two rows deep in every
+  roster on purpose: a filter that dropped the WRONG row would satisfy a
+  count and fail the identity assertions below."
+  [tool-frame]
   {:mounted-boundaries
    (envelope :mounted-boundaries
              {:boundaries [{:boundary boundary-a :views todo-row-views
                             :instances 1 :read-orders 1 :frame :app/main
                             :reads []}
                            {:boundary boundary-b :views :unknown
-                            :instances 1 :read-orders 1 :frame :rf/xray
+                            :instances 1 :read-orders 1 :frame tool-frame
                             :reads []}]})
    :read-attribution
    (envelope :read-attribution
              {:edges [{:sub-id :todo :query [:todo 7] :frame-id :app/main
                        :epoch 4 :fan-out 1 :readers []}
-                      {:sub-id :rf.xray.fresco/data :query [:rf.xray.fresco/data]
-                       :frame-id :rf/xray :epoch 4 :fan-out 1 :readers []}]})
+                      {:sub-id :rf.xray.fresco/data
+                       :query [:rf.xray.fresco/data tool-frame]
+                       :frame-id tool-frame :epoch 4 :fan-out 1 :readers []}]})
    :intents
    (envelope :intents
-             {:frames [:app/main :rf/xray]
+             {:frames [:app/main tool-frame]
               :intents [{:frames [:app/main] :dispatch-id 1
                          :event-id :todo/toggle :arg-count 0 :sub-ids []}
-                        {:frames [:rf/xray] :dispatch-id 2
+                        {:frames [tool-frame] :dispatch-id 2
                          :event-id :rf.xray.fresco/set-view
                          :arg-count 1 :sub-ids []}
-                        {:frames [:app/main :rf/xray] :dispatch-id 3
+                        {:frames [:app/main tool-frame] :dispatch-id 3
                          :event-id :todo/spans :arg-count 0 :sub-ids []}
                         {:frames [] :dispatch-id 4
                          :event-id :todo/frameless :arg-count 0 :sub-ids []}]})
@@ -670,48 +684,82 @@
                               :snapshot 1 :peak-epoch 4
                               :latest-reads [] :candidates [] :loss nil}
                              {:boundary boundary-b :views :unknown
-                              :frame :rf/xray :instances 1
+                              :frame tool-frame :instances 1
                               :snapshot 1 :peak-epoch 4
                               :latest-reads [] :candidates [] :loss nil}]})})
 
+(deftest the-own-frame-set-is-the-singleton-PLUS-the-shell-being-looked-from
+  (testing "rf2-bgol — `:rf/xray` is RESERVED (Conventions' `:rf/*` single
+            root is the framework's, and the L1 picker already refuses it as
+            an inspectable frame), so it stays in the set whichever shell is
+            doing the looking. What was missing was the second member."
+    (is (= #{:rf/xray} (hh/own-frames nil))
+        "no shell to name — the pre-rf2-bgol behaviour exactly, so a caller
+         with no frame context loses nothing it had")
+    (is (= #{:rf/xray} (hh/own-frames :rf/xray))
+        "the production singleton names itself and the set does not grow")
+    (is (= #{:rf/xray custom-shell-frame} (hh/own-frames custom-shell-frame))
+        "a non-default shell adds ITSELF — this is the member the literal
+         `(= :rf/xray frame)` filter could never have")
+    (is (not (contains? (hh/own-frames custom-shell-frame) :app/main))
+        "and nothing else joins it: an application frame is never owned")))
+
 (deftest xray-own-frame-rows-are-dropped-from-every-roster
-  (testing "epic criterion 5 — a boundary seated in :rf/xray is the tool,
-            not the application, and none of the four rosters may carry it.
-            Same rule and same unconditional posture as `self-noise`'s
-            trace-event drop, applied to the evidence surface."
-    (let [e (hh/without-own-frame mixed-evidence)]
-      (testing "NON-VACUITY: the unfiltered input really does carry both"
-        (is (= [:app/main :rf/xray]
-               (mapv :frame (get-in mixed-evidence [:mounted-boundaries :boundaries])))))
+  (testing "epic criterion 5 — a boundary seated in an Xray shell's frame is
+            the tool, not the application, and none of the four rosters may
+            carry it. Same rule and same unconditional posture as
+            `self-noise`'s trace-event drop, applied to the evidence surface."
+    (doseq [tool-frame [:rf/xray custom-shell-frame]]
+      (testing (str "shell frame " tool-frame)
+        (let [input (mixed-evidence tool-frame)
+              e     (hh/without-own-frame input (hh/own-frames tool-frame))]
+          (testing "NON-VACUITY: the unfiltered input really does carry both"
+            (is (= [:app/main tool-frame]
+                   (mapv :frame (get-in input [:mounted-boundaries :boundaries])))))
 
-      (is (= [:app/main]
+          (is (= [:app/main]
+                 (mapv :frame (hh/mounted-rows (:mounted-boundaries e))))
+              "the application's boundary survives the census and the shell's
+               own does not")
+          (is (= [:app/main]
+                 (mapv :frame-id (hh/attribution-rows (:read-attribution e))))
+              "an edge the shell's own boundary holds is not an application read")
+          (is (= [:app/main]
+                 (mapv :frame (hh/explain-rows (:explain-render e))))
+              "and the Why view drops it too — the four are filtered TOGETHER,
+               so a boundary absent from the census cannot still appear in a
+               view derived from the same one-turn read")
+
+          (testing "intents drop on EVERY frame, not ANY"
+            (is (= [:todo/toggle :todo/spans :todo/frameless]
+                   (mapv :event-id (hh/intent-rows (:intents e))))
+                "the tool-only dispatch goes; the MIXED one stays, because a
+                 dispatch that reached an application frame is the user's
+                 whatever else it also touched; and the frameless one stays,
+                 because an empty frame set is an absence and not a claim
+                 about Xray"))
+
+          (testing "the stamp is untouched — this filters ROWS, not the claim"
+            (is (true? (:complete? (:mounted-boundaries e))))
+            (is (= hh/consumed-evidence-schema (:schema (:mounted-boundaries e))))
+            (is (hh/supported? (:mounted-boundaries e))
+                "a filtered envelope is still a parseable one, so `presence`
+                 still answers `:live`/`:idle` rather than `:mismatch`")))))))
+
+(deftest a-shell-does-not-drop-ANOTHER-application-frames-rows
+  (testing "rf2-bgol — the set grew, and the thing to prove about a set that
+            grew is that it did not grow onto the application. Here the
+            second row is seated in an ORDINARY application frame while the
+            filter is armed for the custom shell, so nothing in the roster is
+            the tool's and nothing may be dropped."
+    (let [e (hh/without-own-frame (mixed-evidence :app/other)
+                                  (hh/own-frames custom-shell-frame))]
+      (is (= [:app/main :app/other]
              (mapv :frame (hh/mounted-rows (:mounted-boundaries e))))
-          "the application's boundary survives the census and Xray's own
-           does not")
-      (is (= [:app/main]
-             (mapv :frame-id (hh/attribution-rows (:read-attribution e))))
-          "an edge Xray's own boundary holds is not an application read")
-      (is (= [:app/main]
-             (mapv :frame (hh/explain-rows (:explain-render e))))
-          "and the Why view drops it too — the four are filtered TOGETHER,
-           so a boundary absent from the census cannot still appear in a
-           view derived from the same one-turn read")
-
-      (testing "intents drop on EVERY frame, not ANY"
-        (is (= [:todo/toggle :todo/spans :todo/frameless]
-               (mapv :event-id (hh/intent-rows (:intents e))))
-            "the Xray-only dispatch goes; the MIXED one stays, because a
-             dispatch that reached an application frame is the user's
-             whatever else it also touched; and the frameless one stays,
-             because an empty frame set is an absence and not a claim
-             about Xray"))
-
-      (testing "the stamp is untouched — this filters ROWS, not the claim"
-        (is (true? (:complete? (:mounted-boundaries e))))
-        (is (= hh/consumed-evidence-schema (:schema (:mounted-boundaries e))))
-        (is (hh/supported? (:mounted-boundaries e))
-            "a filtered envelope is still a parseable one, so `presence`
-             still answers `:live`/`:idle` rather than `:mismatch`")))))
+          "BOTH application rows survive — a filter that keyed on anything
+           softer than the shell's own id (tracing being off, say) would
+           have eaten the second one, which is far worse than the defect
+           this change repairs"))))
 
 (deftest the-own-frame-drop-does-not-eat-an-unresolved-or-unparseable-envelope
   (testing "rf2-k97c.3 — two things the filter must NOT do, both of which
@@ -721,13 +769,16 @@
       ;; The shared `mounted` fixture is the control: its second row is
       ;; `:frame :unknown`, and every other row in this file reading it
       ;; expects TWO rows back.
-      (let [rows (hh/mounted-rows
-                   (:mounted-boundaries
-                     (hh/without-own-frame {:mounted-boundaries mounted})))]
-        (is (= [:app/main :unknown] (mapv :frame rows))
-            "both survive — the filter is `= :rf/xray` and nothing cleverer")
-        (is (some? (:frame-chip (second rows)))
-            "and the unresolved row still carries its chip")))
+      (doseq [tool-frame [:rf/xray custom-shell-frame]]
+        (let [rows (hh/mounted-rows
+                     (:mounted-boundaries
+                       (hh/without-own-frame {:mounted-boundaries mounted}
+                                             (hh/own-frames tool-frame))))]
+          (is (= [:app/main :unknown] (mapv :frame rows))
+              "both survive — the filter is set membership over resolved
+               frame ids and nothing cleverer")
+          (is (some? (:frame-chip (second rows)))
+              "and the unresolved row still carries its chip"))))
 
     (testing "an absent or mismatched envelope passes through untouched"
       (let [e (hh/without-own-frame
@@ -736,7 +787,8 @@
                                       :producer :re-frame/fresco
                                       :edges [{:frame-id :rf/xray}]}
                  :intents            nil
-                 :explain-render     nil})]
+                 :explain-render     nil}
+                (hh/own-frames custom-shell-frame))]
         (is (nil? (:mounted-boundaries e))
             "nil stays nil — a missing door is not an empty roster")
         (is (= :re-frame.fresco.evidence/v2 (:schema (:read-attribution e)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -33,13 +33,24 @@
                                       sub-cache rather than off the DOM
     5 TOOL ACTIVITY NEVER
       MASQUERADING AS APPLICATION
-      EVIDENCE                      — W3, in both directions. It matters
-                                      more here than anywhere: this panel
-                                      IS the Fresco census, so a boundary
-                                      of its own appearing in its own
-                                      roster would be the tool reporting
-                                      itself as the application.
-    6 CLEAN TEARDOWN                — W4
+      EVIDENCE                      — W0 phase 3 for the PRODUCTION
+                                      SINGLETON (the row count is the
+                                      assertion), and W4 for a
+                                      NON-DEFAULT shell frame, in both
+                                      directions. It matters more here
+                                      than anywhere: this panel IS the
+                                      Fresco census, so a boundary of its
+                                      own appearing in its own roster
+                                      would be the tool reporting itself
+                                      as the application.
+    6 CLEAN TEARDOWN                — W3
+
+  THE W-NUMBERS ARE ROW ORDER, NOT CRITERION ORDER. This list read
+  `5 → W3, 6 → W4` before rf2-bgol and was wrong in both halves: W3 is the
+  teardown row and there was no W4 at all, criterion 5 living inside W0's
+  third phase. W4 exists now and carries the half W0 cannot — W0 mounts the
+  tool under `:rf/xray`, which is exactly what the defect rf2-bgol fixed
+  was blind to.
 
   ## THE MOUNT IS THE SHELL'S MOUNT, TAKEN FROM THE REGISTRY
 
@@ -153,17 +164,33 @@
             [re-frame.test-support :as rf.test-support]
             [re-frame.fresco :as rf.fresco]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.fresco.tool :as rf.fresco.tool]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (def ^:private app-frame ::fresco-live-app)
 
-(def ^:private data-q
-  "The panel's evidence read. Named once because three rows key off it —
-  the sub-cache is keyed by the query vector itself
-  (`re-frame.subs/cache-key` is identity), so this value IS the cache key."
-  [:rf.xray.fresco/data])
+(def ^:private custom-shell-frame
+  "A NON-DEFAULT Xray shell frame. 008 §Parameterized shell frame-id: the
+  shell frame is a `:frame-id` opt, not a hard singleton, and a testbed
+  mounting N shells side by side gives each cell a distinct one. W4 is
+  the row that mounts this panel under such a frame."
+  ::fresco-live-custom-shell)
+
+(defn- data-q
+  "The panel's evidence read, as the panel issues it inside `frame`.
+
+  The FRAME IS THE QUERY'S ARGUMENT since rf2-bgol — `Panel` reads
+  `rf/current-frame-id` in its render and passes it, because the
+  self-exclusion filter has to know which frames are the tool's and a sub
+  computation runs under no frame scope to read one from. The sub-cache
+  is keyed by the query vector itself (`re-frame.subs/cache-key` is
+  identity), so this value IS the cache key, and a row keying off the
+  bare vector would read a ref-count of 0 against a perfectly healthy
+  mount."
+  [frame]
+  [:rf.xray.fresco/data frame])
 
 (def ^:private view-q
   "The panel's OTHER read — the selected sub-view. Rostered beside
@@ -225,6 +252,10 @@
 (defn- setup! []
   (registry/register-xray-handlers!)
   (rf/make-frame {:id :rf/xray})
+  ;; The non-default shell W4 mounts under. Seated for every row so the
+  ;; fixture has ONE shape — an unused frame costs a record and nothing
+  ;; else, and every other row still names `:rf/xray` explicitly.
+  (rf/make-frame {:id custom-shell-frame})
   (rf/make-frame {:id app-frame})
   (rf/with-frame app-frame
     (rf/dispatch-sync [:hlive/seed {:left 1}]))
@@ -287,12 +318,16 @@
   `trace-collector/refresh-trace-rings!` dispatches
   `:rf.xray/sync-trace-buffer` with its snapshot on every coalesced task
   drain, and `:rf.xray/trace-buffer` reads the slot that dispatch writes
-  (rf2-43koh)."
-  []
-  (rf/dispatch-sync [:rf.xray/sync-trace-buffer
-                     [{:id 1 :op-type :rf.event
-                       :operation :rf.event/dispatched :tags {}}]]
-                    {:frame :rf/xray}))
+  (rf2-43koh).
+
+  The frame arity is W4's: the tick has to land in the app-db the shell
+  under test is reading, and that shell is not `:rf/xray`."
+  ([] (tick-trace! :rf/xray))
+  ([frame]
+   (rf/dispatch-sync [:rf.xray/sync-trace-buffer
+                      [{:id 1 :op-type :rf.event
+                        :operation :rf.event/dispatched :tags {}}]]
+                     {:frame frame})))
 
 (defn- q [container sel] (.querySelector container sel))
 
@@ -428,14 +463,14 @@
                short-circuiting to nil")
 
           ;; ---- criterion 4: the reads are where the tree said ------------
-          (is (pos? (ref-count-of :rf/xray data-q))
+          (is (pos? (ref-count-of :rf/xray (data-q :rf/xray)))
               (str "the panel's evidence read holds a reference in :rf/xray's "
                    "sub-cache — the frame the enclosing frame-provider named. "
                    "Cache keys: " (pr-str (keys (cache-of :rf/xray)))))
           (is (pos? (ref-count-of :rf/xray view-q))
               "and so does its sub-view read — BOTH reads are targeted, not
                just the one a single-read panel would have")
-          (is (zero? (ref-count-of app-frame data-q))
+          (is (zero? (ref-count-of app-frame (data-q :rf/xray)))
               "and NOT in the application frame's — a foreign root that
                inherited the ambient scope instead of reading React context
                would put it here")
@@ -519,7 +554,7 @@
 (defn- released?
   "Both of the panel's reads are fully released from `:rf/xray`'s cache."
   []
-  (and (zero? (ref-count-of :rf/xray data-q))
+  (and (zero? (ref-count-of :rf/xray (data-q :rf/xray)))
        (zero? (ref-count-of :rf/xray view-q))))
 
 (deftest w3-unmount-releases-the-reads-and-reopen-does-not-grow-them
@@ -547,7 +582,7 @@
             (.then
               (fn [_]
                 (let [{:keys [container root]} (mount-panel!)
-                      mounted-data (ref-count-of :rf/xray data-q)
+                      mounted-data (ref-count-of :rf/xray (data-q :rf/xray))
                       mounted-view (ref-count-of :rf/xray view-q)]
                   (is (pos? mounted-data)
                       "the mount took a reference for the evidence read —
@@ -564,7 +599,7 @@
                                    "the collector's grace macrotask. Cache: "
                                    (pr-str (keys (cache-of :rf/xray)))))
                           (let [{c2 :container r2 :root} (mount-panel!)
-                                again-data (ref-count-of :rf/xray data-q)
+                                again-data (ref-count-of :rf/xray (data-q :rf/xray))
                                 again-view (ref-count-of :rf/xray view-q)]
                             (is (= [mounted-data mounted-view]
                                    [again-data again-view])
@@ -582,3 +617,92 @@
                                "and the second unmount releases them too")))
             (.catch (fn [e] (is false (str "W3 poll timed out: " (.-message e))) nil))
             (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W4 — a NON-DEFAULT shell does not report ITSELF (criterion 5)
+;; ===========================================================================
+;;
+;; rf2-bgol. The self-exclusion filter landed asking `(= :rf/xray frame)`,
+;; which is right for the production singleton and blind to every other
+;; shell the embedding contract permits: 008 §Parameterized shell frame-id
+;; makes the shell frame a `:frame-id` OPT, `mount/ensure-xray-frame!` takes
+;; one, and a testbed mounting N shells side by side gives each cell a
+;; distinct id. Under such a shell this tab's own boundary, its two reads
+;; and its explanation were seated in a frame the filter did not know, rode
+;; through all four rosters, and the tool was presented as application
+;; evidence in Mounted, Reads, Why, Advisor and Causal.
+;;
+;; THE WITNESSES THAT EXISTED COULD NOT SEE IT, and that is the whole reason
+;; this row exists rather than an assertion added to one of them: every one
+;; of them mounts the tool under `:rf/xray`, so every one passes against the
+;; literal-only filter.
+;;
+;; IT IS A REAL REGISTERED PANEL UNDER A REAL REACT ROOT, not `panel-tree`
+;; driven with hand-made values — the `:panel` the L4 registry holds,
+;; mounted inside a `frame-provider` naming the custom shell, exactly as
+;; `shell/detail-panel` mounts it. That is what makes the frame reach the
+;; subscription the way production reaches it: `Panel` reads
+;; `rf/current-frame-id` in its own render and passes it as the query's
+;; argument.
+
+(deftest w4-a-non-default-shell-omits-its-OWN-evidence-and-keeps-the-apps
+  (testing "rf2-bgol — epic criterion 5 under a shell frame that is not
+            `:rf/xray`. Both directions: the producer's door still carries
+            the shell's own boundary, and what the panel COMMITTED does not,
+            while the application's boundary is on the page in both."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [release   (mount-boundary!)
+              {:keys [container root]} (mount-panel! custom-shell-frame)
+              finish    (fn []
+                          (release)
+                          (teardown! root container)
+                          (done))
+              roster?   (fn [] (seq (boundary-rows container)))
+              door      (fn [] (mapv :frame
+                                     (:boundaries
+                                       (rf.fresco.tool/read-mounted-boundaries))))]
+          ;; The tick is what invalidates the panel's read; without it the
+          ;; roster never arrives and every assertion below would be about
+          ;; an empty page. W0 is what proves the tick is the mechanism.
+          (tick-trace! custom-shell-frame)
+          (-> (rf.test-support/poll-until roster?
+                {:label "the roster reached the DOM under the custom shell"})
+              (.then
+                (fn [_]
+                  (let [frames (door)
+                        text   (.-textContent container)]
+                    (is (some #{custom-shell-frame} frames)
+                        (str "NON-VACUITY, AND THE DOOR HALF: the runtime "
+                             "really did seat this panel's own boundary in "
+                             "the custom shell frame, and the producer's own "
+                             "answer still carries it — so the absence below "
+                             "is a filter and not a runtime that never "
+                             "recorded the row. Door frames: " (pr-str frames)))
+                    (is (some #{app-frame} frames)
+                        "NON-VACUITY: and the application's boundary is in the
+                         door's answer too")
+
+                    (is (not (string/includes? text (str custom-shell-frame)))
+                        (str "THE COMMITTED PAGE DOES NOT NAME THE SHELL'S OWN "
+                             "FRAME. This is the assertion that reddens "
+                             "against the literal-only filter — under it the "
+                             "Mounted view committed a second row reading "
+                             "`…panels.fresco/Panel · frame "
+                             (str custom-shell-frame) " · 2 reads`. DOM: "
+                             text))
+                    (is (not (string/includes? text "panels.fresco/Panel"))
+                        (str "and it does not name the panel's own VIEW "
+                             "either — the row is gone rather than merely "
+                             "printing a different frame. DOM: " text))
+                    (is (string/includes? text (str "frame " app-frame))
+                        (str "and the APPLICATION's boundary is on the page, "
+                             "so the drop is the tool's own frame and not a "
+                             "roster that emptied. DOM: " text)))))
+              (.catch (fn [e]
+                        (is false (str "W4 poll timed out: " (.-message e)
+                                       " DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_] (finish)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -654,55 +654,72 @@
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
-        (let [release   (mount-boundary!)
-              {:keys [container root]} (mount-panel! custom-shell-frame)
-              finish    (fn []
-                          (release)
-                          (teardown! root container)
-                          (done))
-              roster?   (fn [] (seq (boundary-rows container)))
-              door      (fn [] (mapv :frame
-                                     (:boundaries
-                                       (rf.fresco.tool/read-mounted-boundaries))))]
-          ;; The tick is what invalidates the panel's read; without it the
-          ;; roster never arrives and every assertion below would be about
-          ;; an empty page. W0 is what proves the tick is the mechanism.
-          (tick-trace! custom-shell-frame)
-          (-> (rf.test-support/poll-until roster?
-                {:label "the roster reached the DOM under the custom shell"})
+        (let [{:keys [container root]} (mount-panel! custom-shell-frame)
+              release (volatile! nil)
+              finish  (fn []
+                        (when-some [r @release] (r))
+                        (teardown! root container)
+                        (done))
+              roster? (fn [] (seq (boundary-rows container)))
+              door    (fn [] (mapv :frame
+                                   (:boundaries
+                                     (rf.fresco.tool/read-mounted-boundaries))))
+              seated? (fn [] (some #{custom-shell-frame} (door)))]
+          ;; THE PANEL'S OWN BOUNDARY REACHES THE CENSUS ASYNCHRONOUSLY, AND
+          ;; WAITING FOR IT IS WHAT MAKES THIS ROW BITE. Measured: with the
+          ;; app boundary mounted first and the tick fired in the same turn as
+          ;; the panel's mount, the page committed ONE row under a
+          ;; DELIBERATELY SABOTAGED filter — not because the drop worked, but
+          ;; because the panel's own boundary was not yet in the collector's
+          ;; entry table when the sub recomputed, and nothing invalidates the
+          ;; read a second time. A green sabotage run, from a race rather than
+          ;; from the behaviour. So the census is polled for the panel's own
+          ;; boundary FIRST, and only then does the application's boundary
+          ;; mount and the tick fire.
+          (-> (rf.test-support/poll-until seated?
+                {:label "the panel's own boundary reached the census"})
               (.then
                 (fn [_]
-                  (let [frames (door)
+                  (vreset! release (mount-boundary!))
+                  (tick-trace! custom-shell-frame)
+                  (rf.test-support/poll-until roster?
+                    {:label "the roster reached the DOM under the custom shell"})))
+              (.then
+                (fn [_]
+                  (let [rows   (boundary-rows container)
+                        frames (door)
                         text   (.-textContent container)]
                     (is (some #{custom-shell-frame} frames)
-                        (str "NON-VACUITY, AND THE DOOR HALF: the runtime "
-                             "really did seat this panel's own boundary in "
-                             "the custom shell frame, and the producer's own "
-                             "answer still carries it — so the absence below "
-                             "is a filter and not a runtime that never "
-                             "recorded the row. Door frames: " (pr-str frames)))
+                        (str "THE DOOR HALF: the producer's own answer still "
+                             "carries the panel's own boundary, seated in the "
+                             "custom shell frame — so the absences below are a "
+                             "filter and not a runtime that never recorded the "
+                             "row. Door frames: " (pr-str frames)))
                     (is (some #{app-frame} frames)
                         "NON-VACUITY: and the application's boundary is in the
                          door's answer too")
 
+                    (is (= 1 (count rows))
+                        (str "ONE row committed. Under the literal-only filter "
+                             "this reads TWO: the census carries the panel's "
+                             "own boundary (asserted above) and a filter that "
+                             "knows only `:rf/xray` cannot see a shell mounted "
+                             "under any other id. DOM: " text))
                     (is (not (string/includes? text (str custom-shell-frame)))
-                        (str "THE COMMITTED PAGE DOES NOT NAME THE SHELL'S OWN "
-                             "FRAME. This is the assertion that reddens "
-                             "against the literal-only filter — under it the "
-                             "Mounted view committed a second row reading "
-                             "`…panels.fresco/Panel · frame "
-                             (str custom-shell-frame) " · 2 reads`. DOM: "
-                             text))
+                        (str "and the committed page does not NAME the shell's "
+                             "own frame — `…panels.fresco/Panel · frame "
+                             custom-shell-frame " · 2 reads` is the row "
+                             "that appeared before rf2-bgol. DOM: " text))
                     (is (not (string/includes? text "panels.fresco/Panel"))
-                        (str "and it does not name the panel's own VIEW "
-                             "either — the row is gone rather than merely "
-                             "printing a different frame. DOM: " text))
+                        (str "nor its own VIEW — the row is gone rather than "
+                             "merely printing a different frame. DOM: " text))
                     (is (string/includes? text (str "frame " app-frame))
-                        (str "and the APPLICATION's boundary is on the page, "
-                             "so the drop is the tool's own frame and not a "
-                             "roster that emptied. DOM: " text)))))
+                        (str "and the APPLICATION's boundary IS on the page, so "
+                             "the drop is the tool's own frame and not a roster "
+                             "that emptied. DOM: " text)))))
               (.catch (fn [e]
                         (is false (str "W4 poll timed out: " (.-message e)
-                                       " DOM: " (.-textContent container)))
+                                       " DOM: " (.-textContent container)
+                                       " door: " (pr-str (door))))
                         nil))
               (.then (fn [_] (finish)))))))))


### PR DESCRIPTION
Closes rf2-bgol (filed by the merged-PR audit of #9652).

## What was wrong

#9652 gave the Fresco tab a self-exclusion filter, because the migration had
made the tab report ITSELF: with one application boundary mounted, the Mounted
view committed two rows, the second naming `…panels.fresco/Panel` in frame
`:rf/xray`. The filter decided own-ness with `(= :rf/xray frame)`.

That is right for the production singleton and blind to every other shell the
embedding contract permits. `tools/xray/spec/008-Embedding-Contract.md`
§Parameterized shell frame-id makes the shell frame a `:frame-id` OPT — "the
shell frame is **parameterized**, not a hard singleton" — `ensure-xray-frame!`
takes one, and a testbed mounting N shells side by side gives each cell a
distinct id. Under such a shell the tab's own boundary, its two reads and its
explanation are seated in a frame the filter does not know, survive all four
rosters, and Mounted, Reads, Why, Advisor and Causal present the tool as
application evidence again.

**The premise held, and it is now reproduced end to end rather than in
isolation.** The item's evidence was a Babashka run over the landed helper
blob. Sabotaging this change back to the literal-only form and running the real
browser lane commits exactly the row the item predicts:

```
day8.re-frame2-xray.panels.fresco/Panel
[:rf.xray.fresco/data :…/fresco-live-custom-shell] + [:rf.xray.fresco/view]
1 instance · frame :…/fresco-live-custom-shell · 2 reads
```

## The fix

`fresco-helpers/own-frames` is a SET now, not a literal:

* `:rf/xray` unconditionally. It is RESERVED — Conventions' `:rf/*` single root
  is the framework's, and Xray's own L1 picker already refuses it as a frame a
  user may inspect — so a row seated there is the tool whichever shell is doing
  the looking. Keeping it is not the defect; being the only member was.
* **plus the shell this panel is actually inside**, which is the member the
  literal form could never have.

That id is the `:rf.xray.fresco/data` query's argument, read by `Panel` with
`rf/current-frame-id` in its own render. **The render is the only honest place
to read it.** A subscription COMPUTATION runs under no frame scope at all:
`re-frame.subs.memo` invokes the body inside `rf.trace/with-handler-scope` and
nothing else, `live-frame/call-with-frame-resolution` binds
`rf.registrar/*generation*` and not `*current-frame*`, and no binder of
`*current-frame*` exists anywhere in `subs.cljc`, `subs/memo.cljc` or
`derivation/**`. A filter reading the frame inside the sub would be right on
the first build and wrong on every recompute — the intermittent kind of wrong.

### What deliberately did NOT change

* **The producer's door and the read seam still answer verbatim bytes.** This is
  a presentation filter, one layer above the seam, exactly where #9652 put it,
  and `the-seam-reshapes-nothing` is untouched. The byte-claim row 027 describes
  is pinned by an unmodified witness.
* **`:unknown` frames stay on screen with their chip.** An unresolved frame is
  not a tool frame, and silently dropping a stated absence is the failure this
  tab exists to prevent.
* **A MIXED intent survives.** An intent is dropped only when EVERY frame it
  touched is one of the tool's.
* **Ownership is NOT inferred from `:rf.trace/frame-no-emit?`.**
  `image-reads/seat-xray-frame!` does set that flag on every shell frame, which
  makes a tempting proxy and the wrong one: an application frame may disable
  trace emission for its own reasons, and reading that as Xray-ownership would
  silently swallow the user's evidence — worse than the defect being repaired.
  `a-shell-does-not-drop-ANOTHER-application-frames-rows` is the row that holds
  this.
* **No new configuration surface and no tracing rewrite.** The set is derived,
  and the pure `.cljc` helper takes it as DATA — the same shape
  `palette/sources` already uses for `frame-switcher/internal-frames`, and for
  the same reason.

## Witnesses

* **Pure (`fresco_helpers_cljs_test.cljc`, node + JVM).** Every self-exclusion
  row now runs TWICE, once for `:rf/xray` and once for a non-default shell
  frame; `own-frames` itself is pinned (nil, the singleton, a custom shell, and
  the negative that an application frame never joins); and a new row proves the
  set that grew did not grow onto the application.
* **Node runtime (`fresco_cljs_test.cljs`).**
  `the-subscription-drops-a-NON-DEFAULT-shells-own-boundaries-too` mounts a real
  boundary under a custom shell frame and reads the subscription, beside the
  existing singleton row.
* **Browser (`fresco_live_panel_dom_cljs_test.cljs`, new W4).** The REGISTERED
  panel — the `:panel` value the L4 registry holds, the bridge `shell/detail-panel`
  actually mounts — into a real `reagent.dom.client` root inside
  `[frame-provider {:frame <custom shell>}]`, beside a live application
  boundary. Asserts the committed DOM carries ONE row, names neither the
  shell's frame nor `panels.fresco/Panel`, and DOES name the application's
  frame, while the producer's door still carries both boundaries.

**W4's first cut was a green sabotage run, and the fix is part of this change.**
It mounted the app boundary, mounted the panel and ticked in one turn, and under
the sabotage it committed one row and passed. The cause was a race, not the
behaviour: the panel's own boundary reaches the collector's process-global entry
table asynchronously, so the sub recomputed before the census carried it and
nothing invalidates that read again. W4 now polls the census for the panel's own
boundary FIRST, and only then mounts the application boundary and fires the tick.
Re-run against the same sabotage it reddens on three assertions.

## Docs

`tools/xray/spec/027-Fresco-Evidence.md` said the filter "drops every row seated
in `:rf/xray`", and that an intent is dropped only when every frame it touched is
`:rf/xray`. Both were made wrong by this change and are corrected, with a new
section stating which frames the tool owns, why the id comes from the render, and
the two things the derivation deliberately is not. The test-coverage table rows
for the three suites are updated.

One correction that is not mine but is in the file I touched: the DOM witness's
ns docstring mapped criterion 5 to W3 and criterion 6 to W4. Both halves were
wrong — W3 is the teardown row and there was no W4 at all, criterion 5 living
inside W0's third phase. Corrected, and W4 now exists.

## Quality gates

Every number below is the runner's own captured exit code, from a run on THIS
branch's final base (`origin/main` at `f90eaff227`), after the rebase.

| Gate | Command | Exit | Result |
|---|---|---|---|
| CLJS node (`cljs-node-test`) | `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | compiled |
| CLJS node (`cljs-node-test`) | `node out/node-test.js` | 0 | 11674 tests / 58528 assertions, 0 failures, 0 errors |
| CLJS browser (`cljs-browser`) | `shadow-cljs compile browser-test` | 0 | compiled |
| CLJS browser (`cljs-browser`) | `node scripts/serve-and-run-browser-tests.cjs` | 0 | 938 tests / 5192 assertions, 0 failures, 0 errors |
| JVM tools (`jvm-tools`) | `clojure -M:test` in `tools/xray` | 0 | 1280 tests / 6145 assertions, 0 failures, 0 errors |
| Doc links/anchors | `python scripts/check_doc_slugs.py` | 0 | pass (`tools/*/spec` is in its roots, so 027 is graded) |
| clj-kondo | `clj-kondo --parallel --fail-level error --lint tools/xray` | 0 | 0 errors; no finding in any file this PR touches |
| Splint | `clojure -M:splint --fail-on-errors ../tools/xray` | 0 | style warnings only, none new in kind |
| Ratchets | `check_require_alias_dialect`, `check_retired_spellings`, `check_retired_composition_vocab`, `check_retired_image_keys`, `check_test_lane_bijection`, `check_jvm_lane_rosters`, `check_skill_xray_tab_inventory_drift`, `check_readme_inventories`, `check_view_lifetime_residue`, `check_ambient_durable_reads`, `check_flattened_lists`, `check_escaped_continuations` | 0 each | pass |
| Portability | `sh scripts/check-no-hardcoded-paths.sh` | 0 | pass |

**Which lane graded which half.** The node lane grades the pure `.cljc` helper
and the node-runtime subscription row. It does **not** grade the DOM witness:
`w4_a_non_default_shell` appears in the compiled `out/browser-test` bundle and
is **absent from `out/node-test.js` entirely** — so, contrary to that file's own
ns docstring, the `:node-test` build does not load it at all, and a green node
lane says nothing whatever about W4. The browser lane (`cljs-browser`) is W4's
only lane. The JVM lane grades the `.cljc` helper suite a second time.

**Both nominated lanes were proved to read this worktree, by planted fault
rather than by a printed path.** Reverting `own-frames` to the singleton-only
form and re-running:

* node lane exit **1**, **7 failures**, every one in a row this PR adds or
  extends — `the-subscription-drops-a-NON-DEFAULT-shells-own-boundaries-too`
  (×2), `the-own-frame-set-is-the-singleton-PLUS-the-shell-being-looked-from`,
  `xray-own-frame-rows-are-dropped-from-every-roster` (×4, the custom-frame arm);
* browser lane exit **1**, **3 failures**, all in `w4-…`, the messages carrying
  the two-row DOM quoted above.

Restoring was verified by blob hash, not by reading a diff: `git rev-parse
HEAD:<path>` and `git hash-object <path>` agree at `24b30367da559620f29e134f96e59931360d85a8`
(this file is `i/lf`, so the default form is the one that reproduces the blob),
and `git diff --quiet HEAD -- <path>` exits 0. The browser lane also prints its
serving root, and it named this worktree.

**Gates NOT run, with reasons.**

* `npm run test:xray-feature-gate` — **no scenario covers this, so nominating it
  would be a green that inspected nothing.** Measured rather than assumed:
  `tools/xray/testbeds/feature_matrix/scenarios.cjs` carries 16 scenarios, 5 of
  them `smoke: true`. The only Fresco touch is the `['fresco', 'rf-xray-fresco']`
  entry in `PANEL_HANDOFFS`, and that file's own comment says the counter testbed
  is not a Fresco application, so the panel renders its `rf-xray-fresco-absent`
  state there. Nothing in the roster mounts a Fresco application, and nothing
  mounts an Xray shell under a non-default `:frame-id`.
* The rest of the required matrix. The surface classifier
  (`.github/scripts/report-changed-surfaces.sh`) reads this diff as
  `cljs_node_test=true cljs_browser=true tools_jvm=true examples_compile=true
  mcp_conformance=true story_xray_browser=true`; the first three are run above,
  and the remainder are CI's. The authoritative required set is
  `.github/workflows/test.yml`'s job list, not any list here.

## Two findings this change does not act on

1. **`self-noise/xray-internal-event?` carries the same literal**, `(= :rf/xray
   (rf.trace/trace-event-frame event))`, so the TRACE surface has the identical
   blind spot for a custom-frame shell that the evidence rosters had. It is
   outside this item's scope (`fresco_helpers`, `fresco`, their tests, one DOM
   witness, 027) and wants its own item — the frame gate at the emit site
   (`set-frame-no-emit!`) does cover a seated custom shell, so this predicate is
   the residual belt-and-braces arm rather than the primary drop.
2. **A row filtered from shell A still shows shell B's boundaries** when two
   shells with distinct ids are mounted at once. `own-frames` is what each
   panel can know from its own render without a new registry, and the item asks
   for exactly that. Closing it would need a runtime roster of seated Xray
   frames, which is a mechanism, and the item says no new mechanism.
