### PR TITLE
docs: a deferred handler's bare dispatch raises, it does not leak to :rf/default (rf2-mhpo)

### DIFF
--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -91,7 +91,7 @@ Compose `use-effect` with the standard outer/inner split: the outer `defui` read
 
 ### Cross-references
 
-- Views MUST NOT attach native DOM event listeners from render bodies, and MUST NOT own imperative library lifecycles directly — bare `addEventListener` in a render body leaks listeners and silently routes dispatches to `:rf/default`; library lifecycles belong in `use-effect`.
+- Views MUST NOT attach native DOM event listeners from render bodies, and MUST NOT own imperative library lifecycles directly — bare `addEventListener` in a render body leaks listeners, and the listener fires with no carried frame, so a bare `dispatch` in its callback raises `:rf.error/no-frame-context` (under EP-0002 there is no `:rf/default` to fall open to). Carry the frame with the `use-frame` hook at render time; library lifecycles belong in `use-effect`.
 - [Spec 002 §Dispatches issued from inside a handler body](../../../spec/002-Frames.md#dispatches-issued-from-inside-a-handler-body) — async callbacks escape the dynamic frame binding; call the `use-frame` hook at render-time (capture-frame in hook position) to carry the frame into the callback.
 - Outer/inner Pattern (Pattern-OuterInner) — the canonical home for wrapping stateful JS components (D3, Mapbox, animation libraries); the worked example above is one instance.
 - [UIx 2.x docs — `use-effect`](https://github.com/pitch-io/uix) — the underlying hook's signature, deps-vector semantics, and stale-closure considerations.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -3209,8 +3209,10 @@
       handler routes to the handler's own frame (not `:rf/default`).
       Without this binding, the handler body would see the same
       `*current-frame*` value the original dispatcher saw — typically
-      `nil` for app-level dispatches — and child dispatches would
-      slide to `:rf/default`, silently breaking multi-frame isolation.
+      `nil` for app-level dispatches — and every child dispatch would
+      raise `:rf.error/no-frame-context`: EP-0002 leaves no
+      `:rf/default` floor for them to slide onto, so the cascade fails
+      loudly instead of silently breaking multi-frame isolation.
 
       The binding does NOT survive async escapes (setTimeout,
       Promise.then, requestAnimationFrame): the JS callback fires on

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -2018,7 +2018,7 @@ After (mechanical):
                     (rf/dispatch (conj (if ok? on-success on-failure) response)))}))))
 ```
 
-The simple ignore-`m` rewrite preserves v1 sync semantics — the handler runs and any dispatches it issues default to `:rf/default`. For multi-frame correctness in async callbacks, follow up with the frame-bound handle pattern:
+The simple ignore-`m` rewrite preserves v1 **sync** semantics — the handler runs, and dispatches it issues on the synchronous path resolve through whatever scope is in effect. It does **not** make the `:handler` callback above correct: that callback fires after the scope has unwound, so its bare `rf/dispatch` resolves no frame and raises `:rf.error/no-frame-context` (EP-0002 leaves no `:rf/default` floor to absorb it — the same loud failure the **Why** note above describes). Any async-dispatching fx therefore needs the frame-bound handle pattern:
 
 ```clojure
 (rf/reg-fx :http-xhrio
@@ -2030,7 +2030,7 @@ The simple ignore-`m` rewrite preserves v1 sync semantics — the handler runs a
                     (dispatch (conj (if ok? on-success on-failure) response)))}))))
 ```
 
-The handle-capture step is needed only for async-dispatching fx that target multi-frame use; sync-only handlers are correct after the mechanical `_`-prepend.
+The handle-capture step is needed for every async-dispatching fx, not only those targeting multi-frame use — a bare dispatch from the callback raises whatever the app's frame topology is; sync-only handlers are correct after the mechanical `_`-prepend.
 
 **What to look for.** Greps for `reg-fx` followed by a one-arg `fn` literal:
 

--- a/tools/xray/spec/027-Fresco-Evidence.md
+++ b/tools/xray/spec/027-Fresco-Evidence.md
@@ -38,7 +38,9 @@ The sub-view is panel-local app-db state (`:rf.xray.fresco/set-view` /
 id lands on a view that exists. The strip dispatches through a frame-bound
 `dispatch` threaded down from the `Panel` body: the click fires after render
 unwinds, when the ambient frame is gone, so a bare global `rf/dispatch` would
-leak to `:rf/default` and switch some other shell's sub-view (rf2-1w07r;
+resolve no frame and raise `:rf.error/no-frame-context` — EP-0002 leaves no
+`:rf/default` floor beneath the ambient read — and the sub-view would never
+switch at all (rf2-1w07r;
 `frame_singleton_guard_test` holds it, and the browser row below drives the
 click end to end). Under rf2-k97c.3's migration that dispatcher is built from
 `rf/current-frame-id` rather than injected by `reg-view`, which binds no name

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
@@ -43,8 +43,10 @@
   Sister fix to rf2-smvvz (Settings popup) + rf2-w8lxg (Causality
   popover). Subscribes resolve through the React-context tier at
   render time; dispatches from `:on-click` / `:on-key-down` fire AFTER
-  React pops the context, so the dispatch would otherwise land on
-  `:rf/default` and the close handler would silently no-op. Carrying
+  React pops the context, so a bare dispatch would otherwise resolve no
+  frame at all and RAISE `:rf.error/no-frame-context` — there is no
+  `:rf/default` floor under EP-0002 — and the close handler would fail
+  rather than close. Carrying
   the `{:frame :rf/xray}` opt at call time pins the envelope to
   Xray's frame regardless of click-time React context."
   (:require [re-frame.core :as rf]

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -190,8 +190,9 @@
 
 ;; `dispatch` (rf2-1w07r) is the frame-bound dispatcher threaded down from
 ;; the `Panel` body, so the deferred `:on-click` lands on the surrounding
-;; `:rf/xray` instance frame (not a bare global `rf/dispatch` that leaks to
-;; `:rf/default` once render unwinds and the ambient frame is gone).
+;; `:rf/xray` instance frame (a bare global `rf/dispatch` would instead
+;; raise `:rf.error/no-frame-context` once render unwinds and the ambient
+;; frame is gone — EP-0002 leaves no `:rf/default` floor beneath it).
 ;; Read-only panel: the only dispatch is the maintainer's mode toggle.
 ;; rf2-k97c.3 — since `Panel` became a Fresco boundary this is
 ;; `(:dispatch (rf/capture-frame))` rather than a `reg-view`-injected name;
@@ -433,8 +434,10 @@
   which answers this boundary's declared frame inside a body. It replaces
   the `reg-view`-injected bare `dispatch` (rf2-1w07r) that `defview` binds
   no name for, and it keeps the mode toggle's deferred `:on-click` landing
-  on the surrounding `:rf/xray` instance frame rather than leaking to
-  `:rf/default` once render scope has unwound.
+  on the surrounding `:rf/xray` instance frame once render scope has
+  unwound — where a bare global `rf/dispatch` would raise
+  `:rf.error/no-frame-context`, EP-0002 having removed the `:rf/default`
+  floor that would once have absorbed it.
 
   The argument is the ordinary one-props-map vector every `defview` takes.
   This panel reads nothing from props — it is an L4-registry surface with

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs
@@ -72,8 +72,10 @@
   which answers the boundary's declared frame inside a body. It replaces
   the `reg-view`-injected bare `dispatch` (rf2-16y3x), which `defview`
   binds no name for; the disclosure toggle's deferred `:on-click` still
-  lands on THIS Xray instance's frame after render scope unwinds rather
-  than leaking to `:rf/default`.
+  lands on THIS Xray instance's frame after render scope unwinds. A bare
+  global `rf/dispatch` in its place would resolve no frame once that
+  scope is gone and RAISE `:rf.error/no-frame-context` — there is no
+  `:rf/default` floor under EP-0002 to absorb it.
 
   The argument is the ordinary one-props-map vector every `defview`
   takes. This panel reads nothing from props — the L4 registry and the

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -630,8 +630,9 @@
   `dispatch` (rf2-16y3x) is the facade-injected frame-aware dispatcher: the
   toggle's deferred `:on-click` calls IT, not a bare global `rf/dispatch`,
   so the flip lands on the surrounding Xray instance's frame after render
-  scope unwinds (a bare dispatch would leak to `:rf/default` / emit
-  `:rf.error/no-frame-context` and leave the disclosure state untouched)."
+  scope unwinds (a bare dispatch would resolve no frame and raise
+  `:rf.error/no-frame-context` — EP-0002 leaves no `:rf/default` floor —
+  leaving the disclosure state untouched)."
   [dispatch data]
   (let [rows  (:subs-skipped data)
         n     (count rows)
@@ -742,8 +743,9 @@
   (rf/capture-frame))` inside the boundary — threaded down so the
   panel-local unchanged-subs disclosure toggle's deferred `:on-click`
   lands on the surrounding instance frame after render scope unwinds,
-  never on a bare global `rf/dispatch` that would leak to `:rf/default`.
-  nil is legal for a mount that never clicks the toggle."
+  never on a bare global `rf/dispatch`, which would resolve no frame at
+  all and raise `:rf.error/no-frame-context` (EP-0002 — no `:rf/default`
+  floor). nil is legal for a mount that never clicks the toggle."
   [dispatch data]
   [:section {:data-testid "rf-xray-reactive"
              :style {:height "100%"

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -17,13 +17,13 @@
 
   Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire
   LATER — after render commits and React has POPPED `_currentValue`
-  back to the context's default (`:rf/default`). At click time the
-  3-tier frame resolution chain (dynamic var → React-context tier →
-  `:rf/default`) falls all the way through, the dispatch lands on
-  `:rf/default`'s router, and the `:rf.xray/settings-*` handler
-  reduces `:rf/default`'s db — leaving Xray's `:settings-open?` flag
-  untouched. Symptom: X button does nothing, tabs do not switch, Esc
-  does not close — the modal is stuck.
+  back to the context's no-provider sentinel. At click time the frame
+  resolution chain (dynamic var → React-context tier) bottoms out at
+  NIL: there is no `:rf/default` floor under EP-0002, so a bare
+  `rf/dispatch` RAISES `:rf.error/no-frame-context` and nothing lands
+  anywhere — Xray's `:settings-open?` flag is left untouched. Symptom:
+  X button does nothing, tabs do not switch, Esc does not close — the
+  modal is stuck.
 
   An EARLIER fix pinned every deferred handler to a `{:frame :rf/xray}`
   literal — correct for the singleton shell, but it entrenched the

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -346,8 +346,9 @@
   the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
   same guarantee, one call, and it is the spelling every migrated panel
   now uses. The search box's keystroke dispatch therefore still lands on
-  THIS Xray instance's frame after render scope unwinds rather than
-  leaking to `:rf/default`.
+  THIS Xray instance's frame after render scope unwinds; a bare global
+  `rf/dispatch` would there resolve no frame and raise
+  `:rf.error/no-frame-context`, EP-0002 leaving no `:rf/default` floor.
 
   ONE read and ONE boundary. Boundary count tracks reads and
   head-position use, not file size: `catalogue-panel`, `catalogue-row`,

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -397,8 +397,9 @@
   the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
   same guarantee, one call, and it is the spelling every migrated panel
   now uses. The search box's keystroke dispatch therefore still lands on
-  THIS Xray instance's frame after render scope unwinds rather than
-  leaking to `:rf/default`.
+  THIS Xray instance's frame after render scope unwinds; a bare global
+  `rf/dispatch` would there resolve no frame and raise
+  `:rf.error/no-frame-context`, EP-0002 leaving no `:rf/default` floor.
 
   ONE read and ONE boundary. Boundary count tracks reads and
   head-position use, not file size: `catalogue-panel`, `catalogue-row`,

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -404,8 +404,9 @@
   the render-time `(rf/current-frame-id)` capture the `reg-view` body did:
   same guarantee, one call, and it is the spelling every migrated panel
   now uses. The search box's keystroke dispatch therefore still lands on
-  THIS Xray instance's frame after render scope unwinds rather than
-  leaking to `:rf/default`.
+  THIS Xray instance's frame after render scope unwinds; a bare global
+  `rf/dispatch` would there resolve no frame and raise
+  `:rf.error/no-frame-context`, EP-0002 leaving no `:rf/default` floor.
 
   ONE read and ONE boundary. Boundary count tracks reads and
   head-position use, not file size: `catalogue-panel`, `catalogue-row`,

--- a/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shared/search_box.cljs
@@ -28,11 +28,15 @@
 
   The input's keystroke dispatch is an OUT-OF-RENDER affordance: it
   fires after render unwinds, when the ambient frame is gone, so a bare
-  global `rf/dispatch` would leak to `:rf/default` and two Xray shells
-  on one page would collide. This component therefore takes a
-  caller-supplied frame-aware `:dispatch` fn and NEVER reaches a bare
-  `{:frame :rf/xray}` literal or a global `rf/dispatch`. Each call-site
-  supplies the dispatcher its own way:
+  global `rf/dispatch` would resolve no frame and RAISE
+  `:rf.error/no-frame-context` — EP-0002 leaves no `:rf/default` floor
+  to absorb it — and every keystroke would die there. A hard-coded
+  `{:frame :rf/xray}` literal fails the other way: it resolves, but
+  pins the shell to one frame, so two Xray shells on one page collide.
+  This component therefore takes a caller-supplied frame-aware
+  `:dispatch` fn and NEVER reaches a bare `{:frame :rf/xray}` literal
+  or a global `rf/dispatch`. Each call-site supplies the dispatcher its
+  own way:
 
     - Flows / Interceptors / Schemas — these `search-box` call-sites
       render INSIDE a `reg-view` body, so they render-capture


### PR DESCRIPTION
Prose across the tree said that a bare `rf/dispatch` called from a DEFERRED HANDLER — an `:on-click`, an `:on-change`, a timeout callback — "leaks to `:rf/default`".

It does not. There is no `:rf/default` floor under EP-0002: the ambient read bottoms out at NIL and the operation raises `:rf.error/no-frame-context`.

Verified at source rather than taken on trust:

- `spec/006-ReactiveSubstrate.md` — the `:adapter/current-frame` impl "MUST return **nil** (not `:rf/default`) when no scope names a frame, so a public frame-scoped op raises `:rf.error/no-frame-context` rather than synthesising a default"; both impls "bottom out at **nil** (no `:rf/default` tier)".
- `implementation/core/src/re_frame/views/provider.cljs` — `current-frame` "Returns the scope frame, or **nil** when no scope is established — it never synthesises `:rf/default`", with a trailing nil in the body.
- `implementation/core/src/re_frame/frame.cljc` — `require-current-frame!` emits then throws `:rf.error/no-frame-context` on a nil read.

What is TRUE is kept throughout: a deferred handler really does run outside the React render window, really has no in-flight component, and really will fail. Only the destination changes — it raises rather than routing anywhere — and the remedy already in the code (capture the dispatcher during render and close over it) is unchanged.

## A second error, in the same passages

The `settings` / `palette`-shaped passages named the React context's default value as `:rf/default`. It is the **no-provider sentinel**. `re-frame.adapter.context`'s own docstring reads "The React-context default value — the **no-provider sentinel**, NOT `:rf/default`", and `coerce-context-value` maps it to nil. Corrected alongside, because the two errors compose into one false story: a "3-tier chain" whose bottom tier is a default frame. There is no third tier.

## Scope

13 files, prose only — no behaviour change, no test change, no migration.

Nine in `tools/xray/src`, plus `tools/xray/spec/027-Fresco-Evidence.md`, `implementation/core/src/re_frame/router.cljc`, `implementation/adapters/uix/README.md`, and `migration/from-re-frame-v1/README.md`.

The last two are the ones with reach beyond Xray:

- The **uix README** said a render-body `addEventListener` "silently routes dispatches to `:rf/default`". Its already-corrected twin is one sentence in `skills/re-frame2/patterns/stateful-components.md`, whose wording this now mirrors. That README is **not** on `check_skill_migration_contract_drift.py`'s `ADAPTER_READMES` roster (reagent + reagent-slim only), which is why the stale copy survived the sweep that corrected its siblings.
- The **migration guide** (M-51) told a v1 migrator that the mechanical ignore-`m` rewrite leaves ajax-callback dispatches defaulting to `:rf/default`. They raise. The section's own **Why** paragraph already said so, so the stale sentence contradicted its own section four paragraphs down. The dependent clause is corrected with it: handle-capture is needed for *every* async-dispatching fx, not only multi-frame ones.

Deliberately **not** generalised into the plain-fn-head case, which runs the opposite way (heading is the footgun, inlining the ruled repair, HD-016) and is tracked on rf2-k97c.3 / rf2-78wg.

## Census

Run three ways over every git-tracked file, keyed on the *claim* rather than the bare `:rf/default` token (the token alone reads 5837 occurrences across 919 files — it is the ordinary default frame id).

| pass | files | candidate occurrences |
|---|---|---|
| line-oriented | 6 | 8 |
| whitespace-collapsed | 52 | 105 |
| comment-markers stripped, then collapsed | 52 | 107 |

**46 of the 52 candidate files are invisible to a line-oriented probe.** `tools/xray/spec/027-Fresco-Evidence.md` is one of them: its claim breaks as `would` / `leak to :rf/default` across a line boundary. Pass 3 added two occurrences over pass 2 but no new files.

Every zero was controlled against a positive of the same shape. After the edits, the 13 changed files read **0** wrong-destination matches and each carries the corrected `:rf.error/no-frame-context` wording; the same pattern reads **1** against the pre-edit `settings/view.cljs` taken from `origin/main`, and **2** against EP-0002's motivation section, so the instrument is live and the zero is absence rather than breakage.

## Not corrected, deliberately

- `docs/EP/EP-0002-frame-target-resolution.md` — its **Motivation** section describes the pre-EP world this EP removed. Correcting it would destroy the EP's own argument.
- `docs/tools/playground/**` — the playground's SCI wrappers inject `{:frame app-frame}` where `app-frame` *is* `:rf/default`, so "targets `:rf/default`" is true there.
- `views/resizable_table.cljs` — says only where dispatches *don't* go, which is accurate; it makes no affirmative false claim.
- Test files. The bead bounds this to prose with no test change, so the stale claims in `frame_singleton_guard_test.clj`, `dispatch_frame_capture_cljs_test.cljs`, `runtime_cljs_test.cljs` and four routing tests are left for a follow-up; several sit inside `is`/`testing` message strings rather than comments. Listed on the bead.

## Quality gates

| gate | exit | notes |
|---|---|---|
| `compile-node-test.cjs node-test` (compile phase) | **0** | 1950 files, 1026 compiled, 0 warnings. Log names this worktree's `shadow-cljs.edn`. |
| `node out/node-test.js` (run phase) | **0** | 11680 tests, 58536 assertions, 0 failures, 0 errors. Gated on the compile's captured 0. |
| `check_skill_migration_contract_drift.py` | **0** | Covers `migration/from-re-frame-v1/README.md`. Baselined green before editing, re-run after. |
| `check_doc_slugs.py` | **0** | Covers `tools/*/spec` and `migration/`. |
| `check_readme_links.py --ci` | **0** | Covers `implementation/adapters/uix/README.md`. |
| `check_retired_spellings.py` | **0** | The retired-product-name ratchet — rule (g) grades file content, and comments are this whole diff. |
| `check_ambient_durable_reads.py` | **0** | |
| `check_thrown_error_messages.py` | **0** | |
| `check_retired_composition_vocab.py` | **0** | |
| `check_keyword_catalogue_drift.py` | **0** | |

All ten re-run on the post-rebase base; the table reports those runs.

**Sabotage check.** `npm run test:cljs`'s compile phase prints its root but not a per-file verdict, so it was proved red rather than assumed: a malformed docstring planted at a line already being edited in `static/shared/search_box.cljs` produced **exit 1** naming `search_box.cljs`. Restore verified by hash — `git hash-object` reproduced the committed blob id `645235fe…` and `git diff --quiet HEAD` exited 0.

**Browser lanes not run, deliberately.** This diff is comments and docstrings only; no runtime behaviour, no markup, no test. The adapter smokes and the feature-matrix gate have nothing to say about it, and four peers were in heavyweight browser gates concurrently. CI covers them on this PR.

**Not gated by anything here:** nothing validates markdown prose, tables or rendering — the two link gates check targets and anchors only, and neither looks inside fenced code blocks. No fenced block was edited in this change; the two markdown edits (`027-Fresco-Evidence.md`, the uix README, the migration guide) are all prose outside fences, and their surrounding links and anchors were left untouched.
