### PR TITLE
fix(gate): roster the uix README on ADAPTER_READMES (rf2-poxh)

### DIFF
--- a/scripts/check_skill_migration_contract_drift.py
+++ b/scripts/check_skill_migration_contract_drift.py
@@ -250,8 +250,24 @@ for _stream in (sys.stdout, sys.stderr):
 
 SKILL_DIR = REPO_ROOT / "skills" / "re-frame-migration"
 MIGRATION_MD = REPO_ROOT / "migration" / "from-re-frame-v1" / "README.md"
+# The READMEs of the adapters that SHIP — the three rostered under
+# `implementation/adapters/README.md` §"Adapters that ship today", in that
+# table's order. Each carries the same lifecycle-frame contract the migration
+# corpus does, so each is a stale-claim scan surface. uix was added under
+# rf2-poxh: it had been off this roster while shipping, and the gap was found
+# by measurement rather than audit — the stale `:rf/default` claim rf2-mhpo
+# repaired (PR #9659) outlived its already-corrected siblings' copies
+# precisely because no rule here ever read the uix file.
+#
+# This is a ROSTER and deliberately not a glob over
+# `implementation/adapters/*/README.md`: `adapters/test-react/` is
+# local-test-only, has no Maven coordinate and is deliberately unsmoked (see
+# `implementation/adapters/README.md` §"Local-test-only adapter"), so a glob
+# would scan it today and would silently acquire any future local-test-only
+# adapter tomorrow. A new SHIPPING adapter is added here by hand.
 ADAPTER_READMES = (
     REPO_ROOT / "implementation" / "adapters" / "reagent" / "README.md",
+    REPO_ROOT / "implementation" / "adapters" / "uix" / "README.md",
     REPO_ROOT / "implementation" / "adapters" / "reagent-slim" / "README.md",
 )
 # The reagent-slim Form-3 adopter owner (rf2-aalo4n). FORM-3.md is the
@@ -266,7 +282,7 @@ FORM3_MD = REPO_ROOT / "implementation" / "adapters" / "reagent-slim" / "FORM-3.
 def _scanned_files() -> list[Path]:
     """User-facing migration-skill leaves (SKILL.md + references/*.md), globbed so
     a new reference leaf is covered automatically, plus the migration corpus the
-    skill treats as source of truth, the two Reagent adapter READMEs, and the
+    skill treats as source of truth, the shipped adapter READMEs, and the
     reagent-slim Form-3 adopter owner (FORM-3.md — rf2-aalo4n). The skill's spec/
     meta-docs are excluded (re-authoring material, not loaded during normal
     operation)."""


### PR DESCRIPTION
Closes rf2-poxh.

`scripts/check_skill_migration_contract_drift.py` scanned an `ADAPTER_READMES`
roster holding **two** of the **three** adapters that ship. UIx was missing, so
one shipped adapter's copy of the lifecycle-frame contract had never been read
by any rule in this gate.

## Why this is a measured escape, not a coverage opinion

The stale `:rf/default` claim repaired under rf2-mhpo (#9659) survived in
`implementation/adapters/uix/README.md` precisely because this gate never read
that file — its siblings' copies of the same claim had been caught and
corrected *by this gate* earlier. The gap is why the stale copy outlived them.

## The roster grows by one entry, deliberately not a glob

`implementation/adapters/README.md` §"Adapters that ship today" rosters three
(Reagent, UIx, reagent-slim); the entry is inserted in that table's order.

This is intentionally **not** a glob over `implementation/adapters/*/README.md`.
`adapters/test-react/` is local-test-only, has no Maven coordinate and is
deliberately unsmoked — it sits in that README's separate "Local-test-only
adapter" section. A glob would scan it today and would silently acquire any
future local-test-only adapter tomorrow, trading a known gap for an unknown
one. The reasoning is recorded in a comment beside the tuple so the next reader
does not "simplify" it into a glob.

Also corrects the `_scanned_files` docstring, which said "the two Reagent
adapter READMEs" and is now false.

## Effect on the scan surface

| | files | lines |
|---|---|---|
| before | 28 | 8297 |
| after | 29 | 8394 |

The +97 lines is exactly the uix README's length.

## The newly-rostered file came back clean — so here is the positive control

Running every existing rule against a file no rule had ever read produced **no
new hits**. A silent green on a newly-rostered file is indistinguishable from
the roster edit not having taken effect, so it was not taken on trust:

1. The scanned counts above move by exactly one file / 97 lines, so the file is
   demonstrably being read.
2. A known-offending line was planted in that README — the gate's own
   `--self-test` A7 fixture, the "README fall-through variant" of the M-11
   `:rf/default` stale claim, which is the same rule class as the escape that
   motivated this change. The gate went **red (exit 1)**, naming
   `implementation/adapters/uix/README.md:99`, rule `M11-RFDEFAULT-PIN`, and
   quoting the planted text back.
3. The plant was removed and the file verified restored by content hash against
   the committed object (blob hash identical to pre-plant), with
   `git diff --quiet HEAD` exit 0 as a second independent instrument.

That red is also what proves the run read *this* checkout: the planted line
existed in no other tree, so a run that had wandered into a sibling worktree
would have come back green.

So the honest finding is: the uix README is clean **today** — #9659 having
already corrected the one claim that was known — and it is now gated, where
before it was not.

## Second unrostered surface — recorded, not fixed

`implementation/adapters/reagent-slim/IMPL-SPEC.md` and
`DESIGN-RATIONALE.md` are also unrostered and do mention the frame-provider
surface (4 and 2 mentions; IMPL-SPEC carries one `:rf/default`). They are
plausibly excluded on purpose — the gate's own docstring excludes "spec/
meta-docs (re-authoring material, not loaded during normal operation)", and
both read as that class rather than as adopter-facing migration guidance.
Recorded here and deliberately left alone: that is a roster-shape decision,
not a detail to settle in passing.

## Quality gates

Gate: `python scripts/check_skill_migration_contract_drift.py`, run directly.

CI job by path: `.github/workflows/test.yml`, job key `verify-skill-mcp-drift`,
steps `check_skill_migration_contract_drift_selftest` and
`check_skill_migration_contract_drift`. Those steps carry
`continue-on-error: true`, but the job is **not** advisory — its final
`Report every failing invariant check` step decides the verdict from
`outcome == 'failure'` across every step that declared an id. The job carries no
`if:` surface guard, so it runs on every PR.

**12 passed, 0 unexpected failures, 1 deliberate red (the positive control).**

| gate | exit |
|---|---|
| contract-drift `--verbose --ci` (baseline, pre-edit) | 0 |
| contract-drift `--verbose --ci` (post-edit) | 0 |
| contract-drift `--verbose --ci` (planted fault) | **1 — expected red, positive control** |
| contract-drift `--verbose --ci` (post-restore) | 0 |
| contract-drift `--self-test` | 0 |
| `check_retired_spellings.py` | 0 |
| `check_retired_composition_vocab.py` | 0 |
| `check-no-hardcoded-paths.sh` | 0 |
| `check_ci_reproduce_commands.py` | 0 |
| `check_gate_scheduling.py` | 0 |
| `check_fast_pr_gap.py` | 0 |
| `check-beads-pr-boundary.sh` | 0 |
| `check-commit-attribution.sh` | 0 |

Every number above is the runner's own captured exit code.

`check_retired_spellings.py` is included because it is a zero-permitted
retired-vocabulary ratchet that landed in 281d9a00a3 and grades the paths a
change touches rather than the change it makes; this diff adds comment prose,
which is exactly what such a ratchet reads.

**Skipped, with reasons.** `scripts/test-fast-pr.sh` was not run: it is the
heavyweight spine and duplicates CI, and the only two steps in it that cover
this diff are the `--self-test` and `--verbose --ci` invocations already run
directly above. No other local gate was run because
`.github/scripts/report-changed-surfaces.sh` classifies this diff as arming
**no** tiered surface (all false) — an all-false reading that was itself
controlled by handing the classifier paths it should flag, which returned 16
surfaces true. The required set this local run does not reproduce is derived
from `.github/workflows/test.yml`; the merge decision is CI's.
