### PR TITLE
xray: migrate the Trace panel onto a Fresco boundary (rf2-fcy5 slice 3, rf2-bqzk trace half)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -85,6 +85,7 @@
   cross-panel consumers + tests; the flat panel no longer renders them.)"
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             [day8.re-frame2-xray.panels.cancellation-cascade-helpers
@@ -373,30 +374,51 @@
 ;; expanded simultaneously each keep an independent expansion tree.
 ;;
 ;; Per rf2-hhtbl (rf2-oqa60 phase 2) this call site invokes
-;; `[ei/edn-inspector value opts]` directly — no facade hop through
+;; `[ei/edn-inspector-view {…}]` directly — no facade hop through
 ;; `edn/browse`. The per-row `panel-id` qualifier embeds the row id so
-;; two simultaneously-expanded rows can't collide on expansion state
-;; even if their mount-ids alias (and the auto-id guarantees they
-;; won't — this is belt-and-braces).
+;; two simultaneously-expanded rows can't collide on expansion state.
+;;
+;; rf2-fcy5 — THE HEAD IS `edn-inspector-view`, NOT `edn-inspector`, and
+;; the swap is downstream of this panel's own mount becoming a boundary,
+;; never ahead of it. `ei/edn-inspector` is an `rf/reg-view` head, which
+;; `codec/head-kind` grades `:invalid` down the identical arm it grades a
+;; plain `defn` — `views/edn_inspector.cljs` says so in terms, "Only
+;; `edn-inspector-view` is a head in a Fresco body". The reverse is just as
+;; loud, so this line could not move until `Panel` below was a `defview`.
+;;
+;; `:mount-id` IS REQUIRED and is PER ROW, which is the node-key question
+;; slice 2 had to repair in `managed_fx_template` and which this file
+;; already answers. `edn-inspector-view` qualifies the id by its frame and
+;; hands the result to `container-ref-for`, which MEMOISES the ref callback
+;; on it — so two mounts sharing an id share a ResizeObserver entry and a
+;; measured-width slot. The row id is this panel's own per-record identity
+;; (it is the trace event's `:id`, the same value `:panel-id` and `:site-id`
+;; below already qualify with), so all three now derive from one source.
+;; The remaining case — TWO Trace panels in ONE frame — is rf2-5ykm's, and
+;; is not reachable from anything this file can name.
 
 (defn- render-payload
   "Per-row payload renderer — the raw `:operation` · `:tags` · timing ·
   `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), rendered via
-  the first-class edn-inspector widget."
+  the first-class edn-inspector widget's FRESCO boundary."
   [{:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-xray-trace-row-" id "-payload")
          :style       payload-container-style}
-   [ei/edn-inspector raw
-    {:panel-id (keyword "rf.xray.trace" (str "row-" id))
-     ;; rf2-pvsxs — trace rows survive tab leave-and-return because
-     ;; the trace event-id is itself stable; the `:site-id` reuses it
-     ;; so the operator's expansion choices persist across tab churn.
-     :site-id  [:rf.xray.trace/row id]
-     :default-expanded-depth 1
-     ;; rf2-l4625 — trace rows expand within the row's narrow column;
-     ;; tags + payload maps are routinely cramped. Popup gives the
-     ;; operator a full-modal inspection surface.
-     :popup-affordance? true}]])
+   [ei/edn-inspector-view
+    {:mount-id (str "rf-xray-trace-row-" id)
+     :value    raw
+     :opts     {:panel-id (keyword "rf.xray.trace" (str "row-" id))
+                ;; rf2-pvsxs — trace rows survive tab leave-and-return
+                ;; because the trace event-id is itself stable; the
+                ;; `:site-id` reuses it so the operator's expansion
+                ;; choices persist across tab churn.
+                :site-id  [:rf.xray.trace/row id]
+                :default-expanded-depth 1
+                ;; rf2-l4625 — trace rows expand within the row's narrow
+                ;; column; tags + payload maps are routinely cramped.
+                ;; Popup gives the operator a full-modal inspection
+                ;; surface.
+                :popup-affordance? true}}]])
 
 ;; ---- per-path db-changed diff rows (spec/023 §APP-DB CHANGES) -----------
 ;;
@@ -456,7 +478,20 @@
       - [:stale]
 
   Indented under the parent op row so the diff reads as a sub-list of
-  the db-changed event."
+  the db-changed event.
+
+  ## The React key rides the ATTRIBUTE MAP (rf2-bqzk · RULING 2)
+
+  `db-diff-rows` below used to wrap this fn's RETURN VALUE in
+  `(with-meta … {:key (pr-str path)})`. That is not the dead
+  metadata-on-a-call-form shape — the metadata genuinely attached and the
+  key genuinely reached React under Reagent, which is why it worked and
+  why its failure is invisible: Fresco's codec reads a literal `:key` off
+  a native tag's attrs and reads Clojure metadata NOWHERE, so faithfully
+  preserving that spelling through this panel's migration would have
+  preserved a NO-OP and every diff row in every changed-path list would
+  have silently lost its identity. The key expression is unchanged; only
+  its carrier moved, to the one place BOTH substrates read."
   [parent-row-id {:keys [op path before after] :as _triple}]
   (let [suffix     (path-suffix path)
         glyph      (get diff-op->glyph op "?")
@@ -464,7 +499,8 @@
         path-label (f/format-edn (vec path))
         row-test-id (str "rf-xray-trace-row-" parent-row-id
                          "-db-diff-row-" suffix)]
-    [:div {:data-testid row-test-id
+    [:div {:key         (pr-str path)
+           :data-testid row-test-id
            :data-op     (name op)
            :on-click    (fn [e] (.stopPropagation e))
            :style       db-diff-row-container-style}
@@ -496,14 +532,16 @@
   treats the empty diff section as the no-changes case (spec/023
   §APP-DB CHANGES). The container carries the testid
   `rf-xray-trace-row-<id>-db-diff` so tests can target the section
-  regardless of contents."
+  regardless of contents.
+
+  rf2-bqzk — the per-row `:key` is `db-diff-row`'s own now (see there);
+  this fn no longer wraps the returned vector in `with-meta`."
   [parent-row-id triples]
   (when (seq triples)
     (into [:div {:data-testid (str "rf-xray-trace-row-" parent-row-id "-db-diff")
                  :style       db-diff-rows-container-style}]
-          (for [{:keys [path] :as triple} triples]
-            (with-meta (db-diff-row parent-row-id triple)
-                       {:key (pr-str path)})))))
+          (map #(db-diff-row parent-row-id %))
+          triples)))
 
 ;; ---- one op row (spec/023 §3) -------------------------------------------
 ;;
@@ -699,12 +737,20 @@
 
 (defn- flat-row-list
   "Render the focused epoch's whole trace as a SINGLE flat list of op
-  rows (rf2-aqusw). Rows mount through `rt/resizable-table` with
+  rows (rf2-aqusw). Rows mount through `rt/resizable-table-view` with
   `:header? false` (the header lives once at the top of the panel) so
   the list shares the `:rf.xray.trace/ops` column-widths slot — a drag
-  on the panel header re-aligns every row live."
+  on the panel header re-aligns every row live.
+
+  rf2-fcy5 — the head is `resizable-table-VIEW`, the widget's Fresco
+  boundary, because `Panel` below is a `defview` and the `rf/reg-view`
+  head `resizable-table` is one `codec/head-kind` grades `:invalid`.
+  Identical props and identical rendering — both heads hand the same map
+  to the widget's own `render-table` and differ only in how they resolve
+  the column-widths read and the drag dispatcher. It needs no instance
+  key: its state is keyed by the `:table-id` this panel supplies."
   [rows expanded-row-ids]
-  [rt/resizable-table
+  [rt/resizable-table-view
    ;; rf2-hxfy — the React key lives in this props map rather than as
    ;; `^{:key "rows"}` reader meta on the `(flat-row-list …)` call in
    ;; `Panel` below. Reader meta on a CALL form attaches to the source
@@ -781,26 +827,24 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view Panel
-  "The Trace panel's root view — the focused epoch's whole trace as a
-  FLAT list (spec/023-Trace-Panel.md · rf2-aqusw). Subscribes to
-  `:rf.xray/trace-feed` (the epoch-scoped feed) and renders the focused
-  epoch's `:rows` as a single oldest-first list of op rows: each row
-  carries a STAGE column + colour-coded left edge (the Epoch pipeline
-  step, via `panels.epoch.badge`). Clicking a row opens the edn-inspector
-  on its raw trace MAP inline. No bands, no envelope, no hierarchy. No
-  mock data — fed by real trace data throughout."
-  []
-  (let [{:keys [rows empty-kind] :as _data}
-        @(rf/subscribe [:rf.xray/trace-feed])
-        ;; rf2-wcfsy — focused-event-bundle is a layer-3 composite over
-        ;; `:rf.xray/event-bundles` + `:rf.xray/focus`, NOT an inline scan in
-        ;; the render body. The composite memoises on its two input
-        ;; signals so the scan only re-runs when event-bundles / focus
-        ;; actually change (rather than every Panel render).
-        focus           @(rf/subscribe [:rf.xray/focus])
-        focused-event-bundle @(rf/subscribe [:rf.xray.trace/focused-event-bundle])
-        expanded-ids    @(rf/subscribe [:rf.xray/trace-expanded-row-ids])]
+(defn panel-tree
+  "The Trace panel's BODY, as a pure function of the four values the
+  boundary below reads. Same markup, same testids; it simply takes its
+  inputs as an argument instead of subscribing for them.
+
+  rf2-k97c.3 — split out of the view when `Panel` became a Fresco
+  boundary, so the panel's whole render contract stays drivable from the
+  node lane without a React commit. A Fresco boundary is a real React
+  function component: CALLING it outside a render extent would run
+  `rf.fresco/sub` with no collector in flight, so the ~30 pure-hiccup
+  rows in `trace_view_cljs_test` call THIS instead and supply the four
+  reads themselves.
+
+  `feed` is the whole `:rf.xray/trace-feed` map — only `:rows` and
+  `:empty-kind` are rendered (the `:envelope` / `:bands` / `:outcome`
+  slots are retained for cross-panel consumers, per `install!` below)."
+  [{:keys [feed focus focused-event-bundle expanded-ids]}]
+  (let [{:keys [rows empty-kind]} feed]
     [:section {:data-testid "rf-xray-trace"
                :style       panel-root-style}
      (when focused-event-bundle
@@ -834,7 +878,8 @@
          ;; the one place BOTH substrates read, which is why the sibling
          ;; below already keys there. `resizable-table` destructures named
          ;; opts and never spreads them, so `:key` is inert for its body.
-         [rt/resizable-table
+         ;; rf2-fcy5 — head is the Fresco boundary, as in `flat-row-list`.
+         [rt/resizable-table-view
           {:key             "ops-header"
            :table-id        trace-ops-table-id
            :columns         trace-op-columns
@@ -850,35 +895,105 @@
          ;; attach to the list and never reach React.
          (flat-row-list rows expanded-ids)])]]))
 
+(rf.fresco/defview Panel
+  "The Trace panel's root view — the focused epoch's whole trace as a
+  FLAT list (spec/023-Trace-Panel.md · rf2-aqusw). Reads
+  `:rf.xray/trace-feed` (the epoch-scoped feed) and renders the focused
+  epoch's `:rows` as a single oldest-first list of op rows: each row
+  carries a STAGE column + colour-coded left edge (the Epoch pipeline
+  step, via `panels.epoch.badge`). Clicking a row opens the edn-inspector
+  on its raw trace MAP inline. No bands, no envelope, no hierarchy. No
+  mock data — fed by real trace data throughout.
+
+  ## THE READS (rf2-k97c.3 · rf2-fcy5, slice 3 of 3)
+
+  Four `rf.fresco/sub`s in place of four `@(rf/subscribe …)`. Each returns
+  the VALUE rather than a reaction, and the edge is recorded by Fresco's
+  own collector WHERE THE READ HAPPENS — which is the coupling this
+  migration exists to sever: a `reg-view` body's reads are tracked only by
+  whichever reaction machinery the installed adapter happens to ship.
+
+  ## THE DISPATCHES DID NOT MOVE, AND THAT IS THE MEASURED ANSWER
+
+  This panel never used `reg-view`'s lexically injected bare `dispatch` /
+  `subscribe` — the only name a `defview` body does not bind. Its row and
+  cell handlers already capture the frame at render time (rf2-nesy9) and
+  dispatch `{:frame frame}` explicitly, which is exactly right under a
+  boundary: `intent/with-frame`'s refusal tier deletes the ambient FIND
+  and not the CARRYING, and `rf/current-frame-id` answers the declared
+  frame while reading and dispatching nothing. So `op-row-attrs` and
+  `op-row-cells` carry over verbatim.
+
+  ## THE THREE HEADS INSIDE THE BODY MOVED WITH IT
+
+  A `reg-view` head grades `:invalid` to `codec/head-kind` down the
+  IDENTICAL arm a plain `defn` does, so migrating the mount without
+  migrating them would be the same HD-016 throw one level down — and with
+  no error boundary above this render path it presents as a tab that never
+  appears rather than as an error. The three are the two
+  `rt/resizable-table` heads (`flat-row-list` and the ops header) and
+  `ei/edn-inspector` in `render-payload`; each has a shipped Fresco
+  sibling and now uses it. Every OTHER helper in this file is CALLED, so
+  Fresco's plain-fn-in-head-position rule never meets one.
+
+  The argument is the ordinary one-props-map vector every `defview` takes.
+  This panel reads nothing from props — neither the L4 registry nor the
+  `mount-trace!` facade passes any — so it is destructured away."
+  [_props]
+  (panel-tree
+    {:feed  (rf.fresco/sub [:rf.xray/trace-feed])
+     :focus (rf.fresco/sub [:rf.xray/focus])
+     ;; rf2-wcfsy — focused-event-bundle is a layer-3 composite over
+     ;; `:rf.xray/event-bundles` + `:rf.xray/focus`, NOT an inline scan in
+     ;; the render body. The composite memoises on its two input signals
+     ;; so the scan only re-runs when event-bundles / focus actually
+     ;; change (rather than every Panel render).
+     :focused-event-bundle (rf.fresco/sub [:rf.xray.trace/focused-event-bundle])
+     :expanded-ids         (rf.fresco/sub [:rf.xray/trace-expanded-row-ids])}))
+
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;
 ;; `panels/mount-trace!` mounts this panel BY NAME, and RULING 1's
 ;; surviving spelling puts the Fresco boundary on the natural name with a
 ;; PUBLIC bridge passed by the caller — the shape `resources/Panel-bridge`
-;; already ships. Pointing the mount facade at the bridge name NOW, while
-;; it is still a plain alias, is what lets this panel's migration happen
-;; entirely INSIDE THIS FILE: `Panel` becomes the `defview` boundary and
-;; this def becomes the real `rf.fresco/as-component` bridge, with
-;; `panels.cljs` never touched again. It adopts RULING 1 early rather than
-;; bending it.
+;; already ships. `mount-trace!` was pointed at the bridge name while it
+;; was still a plain alias (PR #9654), which is what let this panel's
+;; migration happen entirely INSIDE THIS FILE: `panels.cljs` is untouched.
 ;;
-;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
-;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
-;; SAME OBJECT — nothing downstream can tell the two names apart. And
-;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
-;; head position is the only position either name is used in, and the hazard
-;; `render-panel!`'s docstring warns about is not reached: what is unsafe
-;; there is CALLING the view, because that fn runs outside any React render
-;; and an ambient subscribe with no in-flight component resolves to nil and
-;; RAISES `:rf.error/no-frame-context` (there is no `:rf/default` fallback —
-;; Spec 006 §Plain-fn footgun).
-(def Panel-bridge
-  "The name `panels/mount-trace!` mounts this panel through — a plain
-  alias of `Panel` until this panel migrates to Fresco, when it becomes
-  the `as-component` bridge without the mount facade moving. Scaffolding
-  with a defined end: it is deleted with every other `*-bridge` when the
-  shell itself becomes a Fresco tree. See the comment above."
-  Panel)
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter. `shell/detail-panel` mounts the active tab as the hiccup head
+;; `[(:panel tab)]`, `panel-registry/reg-l4-tab!`'s `:pre` requires
+;; `:panel` to be CALLABLE, and `render-panel!` builds the component VECTOR
+;; `[panel-view]` — none of which a React component is (it IS `fn?`, but
+;; calling it outside a render extent is the plain-fn footgun, not a
+;; render). `rf.fresco/as-component` is Fresco's own outward door for
+;; exactly this: it answers a real React component a React parent mounts
+;; UNDER THE FRAME IT IS ALREADY IN, taking the frame from React context
+;; rather than from a second root. No second root, no adapter-kind branch,
+;; no props ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When the shell is itself a
+;; Fresco tree, `reg-l4-tab!` and `mount-trace!` take `Panel` directly,
+;; `[:>]` goes, and both defs below are deleted.
+
+(def ^:private Panel-component
+  "The React component `Panel` presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the panel on each parent render."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable `panels/mount-trace!` and the L4 tab registry mount this
+  panel through. Returns Reagent-shaped hiccup interoping to the React
+  component above; the enclosing `rf/frame-provider` is what puts the
+  frame in React context for it.
+
+  PUBLIC, because this panel is in `panel_enum` with a `mount-trace!`
+  facade and `panels/render-panel!` takes the view to mount as an
+  ARGUMENT — so the embedding contract needs a name it can pass."
+  []
+  [:> Panel-component {}])
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -985,4 +1100,8 @@
      :mnem  "t"
      :modes #{:dynamic}
      :order 3
-     :panel Panel}))
+     ;; rf2-fcy5 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary) and the shell mounts `:panel` as a
+     ;; Reagent hiccup head; the bridge is the one line between them and
+     ;; goes when the shell is a Fresco tree.
+     :panel Panel-bridge}))

--- a/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
@@ -65,6 +65,43 @@
 (defn- find-by-testid-prefix [tree prefix]
   (first (rf.test-helpers/find-by-testid-prefix tree prefix)))
 
+;; ---- the Trace panel's status bar --------------------------------------
+;;
+;; rf2-fcy5 — the three Trace rows below used to call `trace/Panel` and hand
+;; the result to the walkers above. Neither half works now.
+;;
+;; `trace/Panel` is an `rf.fresco/defview`: a real React function component
+;; whose body reads through Fresco's collector, which refuses a read outside
+;; a render extent by name (`:rf.error/fresco-sub-outside-render`).
+;; `trace/panel-tree` is the same body as a pure fn of the four values the
+;; boundary reads, so the reads move here.
+;;
+;; And the scan has to be NON-EXPANDING. The panel's body carries two
+;; `rt/resizable-table-view` heads — boundaries too — which
+;; `rf.test-helpers/expand-tree` would invoke and which would refuse for the
+;; same reason. The status bar is a CALLED helper returning a native div and
+;; sits above the table, so a plain depth-first scan reaches it. The Trace
+;; panel's own suite (`panels/trace_view_cljs_test`) owns the walking of the
+;; table's interior; these rows only need the bar.
+
+(defn- trace-status-bar
+  "The Trace panel's event-bundle status-bar node whose `:data-testid`
+  satisfies `match?`, or nil."
+  [match?]
+  (let [tree (trace/panel-tree
+               {:feed                 @(rf/subscribe [:rf.xray/trace-feed])
+                :focus                @(rf/subscribe [:rf.xray/focus])
+                :focused-event-bundle @(rf/subscribe [:rf.xray.trace/focused-event-bundle])
+                :expanded-ids         @(rf/subscribe [:rf.xray/trace-expanded-row-ids])})]
+    (some (fn [node]
+            (when (and (vector? node)
+                       (map? (second node))
+                       (some-> (:data-testid (second node)) match?))
+              node))
+          (tree-seq (some-fn vector? seq?) seq tree))))
+
+(def ^:private status-bar-prefix "rf-xray-trace-event-bundle-status-bar-")
+
 ;; ---- fixture builders --------------------------------------------------
 
 (defn- xray-setup! []
@@ -141,9 +178,7 @@
     (trace-collector/seed-trace-for-test! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/select-dispatch-id 1])
-      (let [tree (trace/Panel)
-            bar  (find-by-testid-prefix tree
-                                        "rf-xray-trace-event-bundle-status-bar-")]
+      (let [bar (trace-status-bar #(.startsWith ^String % status-bar-prefix))]
         (is (some? bar)
             "event-bundle-status bar renders when a cascade is in focus")
         (let [attrs (second bar)
@@ -162,9 +197,7 @@
     (trace-collector/seed-trace-for-test! (handler-exception-ev 99 1))
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/select-dispatch-id 1])
-      (let [tree (trace/Panel)
-            bar  (find-by-testid tree
-                                 "rf-xray-trace-event-bundle-status-bar-settled-error")]
+      (let [bar (trace-status-bar #(= % (str status-bar-prefix "settled-error")))]
         (is (some? bar))
         (is (= (:red tokens/tokens)
                (get-in (second bar) [:style :background])))))))
@@ -181,10 +214,8 @@
     (trace-collector/seed-trace-for-test! (handler-exception-ev 99 1))
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/select-dispatch-id 1])
-      (let [trace-tree   (trace/Panel)
-            trace-bar    (find-by-testid-prefix
-                           trace-tree
-                           "rf-xray-trace-event-bundle-status-bar-")
+      (let [trace-bar    (trace-status-bar
+                           #(.startsWith ^String % status-bar-prefix))
             trace-status (:data-rf-xray-status (second trace-bar))]
         (is (= "settled-error" trace-status)
             (str "the trace bar rides the canonical vocabulary — "

--- a/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event/event_status_colour_view_cljs_test.cljs
@@ -55,15 +55,14 @@
     {:post-reset (fn [] (config/reset-suppressed-count!))}))
 
 ;; ---- hiccup walker ------------------------------------------------------
-;; Thin aliases over re-frame.test-helpers. The local
-;; `find-by-testid-prefix` returns the FIRST match (vs the framework's
-;; `find-by-testid-prefix` which returns a vector of matches); the
-;; thin wrapper here preserves the existing call-site contract.
+;; A thin alias over re-frame.test-helpers.
+;;
+;; rf2-fcy5 — the local first-match `find-by-testid-prefix` wrapper that
+;; used to sit here went with its last caller: the three Trace rows below
+;; are the only things that ever took a prefix, and they now scan through
+;; [[trace-status-bar]] for the reason given there.
 
 (def ^:private find-by-testid rf.test-helpers/find-by-testid)
-
-(defn- find-by-testid-prefix [tree prefix]
-  (first (rf.test-helpers/find-by-testid-prefix tree prefix)))
 
 ;; ---- the Trace panel's status bar --------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,390 @@
+(ns day8.re-frame2-xray.panels.trace-fresco-boundary-dom-cljs-test
+  "THE TRACE TAB RE-AUTHORED IN THE RE-FRAME-NATIVE VIEW LAYER, read off a
+  real React commit (rf2-fcy5, slice 3 of 3).
+
+  `trace/Panel` is now an `rf.fresco/defview` reading through Fresco's
+  shipped collector rather than an `rf/reg-view` reading through whatever
+  view build the installed substrate adapter supplies. This file is the
+  behavioural evidence for that swap. It is the merged
+  `resources_fresco_boundary_dom_cljs_test` template, trimmed to the three
+  rows this panel's migration can actually be wrong about.
+
+  ## Why a DOM row at all, when `trace_view_cljs_test` has thirty
+
+  Because every one of those thirty drives `trace/panel-tree`, the pure
+  body — which is right for what they assert and blind to the one thing
+  this slice could break outright. A NAIVE MIGRATION SHIPS A TAB THAT
+  RENDERS NOTHING while the node lane stays green, because the node lane
+  never asks React to mount the boundary through the bridge the registry
+  holds. That is the failure this file exists to catch, and it caught
+  nothing else the unit rows already cover.
+
+  ## Which row answers what
+
+    1 FIRST DISPLAY               — W1, through `panel-registry`'s entry
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    2 UPDATES ON A REAL CHANGE    — W2, with the deaf control that makes
+                                    the update mean liveness
+    6 CLEAN TEARDOWN              — W3
+
+  Criteria 3 and 5 have no row here. Criterion 3 (Xray's own interactions)
+  is covered structurally by `trace_view_cljs_test`'s row-click rows
+  against `op-row-attrs`; criterion 5 (tool activity never masquerading as
+  application evidence) is a property of the boundary rather than of this
+  panel, and `resources_fresco_boundary_dom_cljs_test`'s W3 already proves
+  it in both directions for the same mechanism.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell/detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id` rather than naming the var — so the bridge the
+  registry actually holds is the thing under test. Nothing below calls the
+  panel a second time; every assertion after the mount reads
+  `container.querySelector…`, the DOM React committed on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports —
+  because the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing exactly as it is in the template:
+  the fixture's default ambient `:rf/default` scope would otherwise SHADOW
+  the React-context tier W1 is about, and the frame-targeting row would
+  pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`, whose `:source-paths` already carry
+  `tools/xray/test`. The `:node-test` build's `cljs-test$` regex also
+  matches, so it LOADS under Node — where every row short-circuits through
+  [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. W1 reads it as
+  the negative half of the frame-targeting claim."
+  ::app)
+
+(def ^:private feed-q
+  "The panel's principal read. Named once because three rows key off it —
+  the sub-cache is keyed by the query vector itself
+  (`re-frame.subs/cache-key` is identity), so this value IS the cache key."
+  [:rf.xray/trace-feed])
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn- mk-trace [id operation time dispatch-id]
+  {:id        id
+   :time      time
+   :op-type   :rf.event
+   :operation operation
+   :tags      {:rf.trace/dispatch-id dispatch-id}})
+
+(defn- mk-epoch
+  "A minimal `:rf/epoch-record` carrying `trace-events`, shaped exactly as
+  `trace_view_cljs_test`'s seeding builds one."
+  [epoch-id dispatch-id trace-events]
+  {:epoch-id      epoch-id
+   :dispatch-id   dispatch-id
+   :event-id      :test/event
+   :trigger-event [:test/event]
+   :db-before     {}
+   :db-after      {}
+   :renders       []
+   :sub-runs      []
+   :committed-at  (* 1000 epoch-id)
+   :trace-events  (vec trace-events)})
+
+(def ^:private one-row-epoch
+  (mk-epoch 1 11 [(mk-trace 101 :rf.event/dispatched 100 11)]))
+
+(def ^:private two-row-epoch
+  "W2's second state: the SAME epoch with a second op appended, so the
+  invalidation is a real value change on a declared input of the feed."
+  (mk-epoch 1 11 [(mk-trace 101 :rf.event/dispatched 100 11)
+                  (mk-trace 202 :rf.event/handler-ran 200 11)]))
+
+(rf/reg-sub ::n (fn [db _] (::n db)))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2 and W3 are `async` rows, and `cljs.test`
+     ;; refuses a FUNCTION fixture in any namespace that carries one.
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W3's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission — the template records it and it cost that worker a red row.
+;; A Fresco boundary is NOT in Reagent's render queue: its update is
+;; scheduled by the collector through React, so draining Reagent's queue
+;; commits nothing of this panel's and a row written that way reads a DOM
+;; that has not moved and reports a LIVE panel as dead. Mount is committed
+;; with `flushSync` (React's own door) and everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after a change is
+  a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- seed!
+  "Seed the per-frame epoch ring and pin focus at its cascade. A dispatch,
+  so it IS a real invalidation of the feed composite."
+  [record]
+  (rf/dispatch-sync [:rf.xray/sync-epoch-history [record]] {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/focus-event (:dispatch-id record) nil]
+                    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Trace tab the way `shell/detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and the first assertion would read an empty container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :trace)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the next
+  line reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid-sel [testid] (str "[data-testid=\"" testid "\"]"))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means
+  the frame is not live, which is a defect in the row's own setup and
+  should throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the
+  entry is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+;; ===========================================================================
+;; W1 — first display, and the read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-read-lands-in-the-named-frame
+  (testing "rf2-fcy5 — the migrated Trace panel commits real DOM through the
+            registry entry the shell mounts, and its `rf.fresco/sub` reads
+            resolve against the frame the enclosing `frame-provider` named
+            rather than the ambient one. Epic criteria 1 and 4.
+
+            THE ROW ALSO GRADES THE THREE INTERIOR HEADS, without naming
+            them: `rf-xray-trace-row-101` is emitted by `op-row-attrs`,
+            which only runs if `rt/resizable-table-view` rendered. A
+            `reg-view` head left behind would raise HD-016 inside the
+            boundary with no error boundary above it, and the panel would
+            paint nothing at all."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            _ (seed! one-row-epoch)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [::n] {:frame app-frame})
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (q container (testid-sel "rf-xray-trace")))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (some? (q container (testid-sel "rf-xray-trace-feed")))
+              "and the feed container rendered, so the body ran rather than
+               short-circuiting to an empty state")
+          (is (some? (q container (testid-sel "rf-xray-trace-rows")))
+              "the flat row list's own container is there — so
+               `resizable-table-view` rendered rather than throwing")
+          (is (some? (q container (testid-sel "rf-xray-trace-row-101")))
+              "with a real row from the seeded epoch — the read reached the
+               panel rather than the panel painting an empty shell")
+
+          ;; ---- criterion 4: the read is where the tree said it would be ----
+          (is (pos? (ref-count-of :rf/xray feed-q))
+              (str "the panel's read holds a reference in :rf/xray's sub-cache "
+                   "— the frame the enclosing frame-provider named. Cache keys: "
+                   (pr-str (keys (cache-of :rf/xray)))))
+          (is (zero? (ref-count-of app-frame feed-q))
+              "and NOT in the application frame's — a foreign root that
+               inherited the ambient scope instead of reading React context
+               would put it here")
+          (is (pos? (ref-count-of app-frame [::n]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zero
+               above is an absence and not a broken reader")
+          (finally
+            ;; Release the imperative probe explicitly: `unsubscribe`'s own
+            ;; docstring says a Reagent view auto-disposes via the reaction
+            ;; lifecycle and an imperative subscriber must not rely on that.
+            (rf/unsubscribe [::n] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-fcy5 — the mounted panel re-renders itself and commits new DOM
+            when its read's value really changes, and does NOT when nothing it
+            watches moved. Epic criterion 2, with the control that makes the
+            update mean liveness rather than a commit that simply had not
+            happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed! one-row-epoch)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (q container (testid-sel "rf-xray-trace"))
+              row?    (fn [] (some? (q container (testid-sel "rf-xray-trace-row-202"))))]
+          (is (not (row?))
+              "NON-VACUITY: the op this row drives on is NOT on screen before
+               the epoch carrying it is synced")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          ;; `:rf.xray/trace-feed` declares `[:rf.xray/focus]` and
+          ;; `[:rf.xray/epoch-history]` as its inputs and reads NOTHING else.
+          ;; The expanded-row set is a different sub entirely, so toggling a
+          ;; row that does not exist changes app-db while invalidating nothing
+          ;; the feed watches.
+          (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 999]
+                            {:frame :rf/xray})
+          (is (contains? (rf/subscribe-once [:rf.xray/trace-expanded-row-ids]
+                                            {:frame :rf/xray})
+                         999)
+              "PRECONDITION: app-db really moved — so a missing row below is
+               the panel failing to re-render and not the dispatch failing")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (row?))
+                      "CONTROL: given a full settling window, the committed DOM
+                       still does NOT carry the row. A panel that re-rendered
+                       here would make phase 3 pass for a reason that is not
+                       liveness")
+                  ;; ---- phase 3: a declared input moves, the read re-runs ---
+                  (rf/dispatch-sync [:rf.xray/sync-epoch-history [two-row-epoch]]
+                                    {:frame :rf/xray})
+                  (rf.test-support/poll-until row?
+                    {:label "the panel committed the new op's row"})))
+              (.then
+                (fn [_]
+                  (is (row?)
+                      (str "the panel re-rendered on a real invalidation of its "
+                           "own read and committed the new op's row"))
+                  (is (identical? section
+                                  (q container (testid-sel "rf-xray-trace")))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the row did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — teardown releases what the mount acquired
+;; ===========================================================================
+
+(deftest w3-unmount-releases-the-boundarys-reads
+  (testing "rf2-fcy5 — unmounting the panel releases every reference its
+            boundary took in the frame's sub-cache. Epic criterion 6, and the
+            number the spike measured the REJECTED design against: there the
+            ref-count climbed across renders and never fell on unmount
+            (22 → 25 → 32)."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed! one-row-epoch)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              mounted (ref-count-of :rf/xray feed-q)]
+          (is (pos? mounted)
+              "NON-VACUITY: the mount took a reference, so the zero below is
+               a release and not an entry that was never there")
+          ;; A second value change, so the release is measured after the
+          ;; boundary has re-wired its read at least once rather than only
+          ;; on its first pass.
+          (rf/dispatch-sync [:rf.xray/sync-epoch-history [two-row-epoch]]
+                            {:frame :rf/xray})
+          (-> (rf.test-support/poll-until
+                (fn [] (some? (q container (testid-sel "rf-xray-trace-row-202"))))
+                {:label "the panel committed the second op's row"})
+              (.then
+                (fn [_]
+                  (is (>= mounted (ref-count-of :rf/xray feed-q))
+                      "the re-render did not ACCUMULATE references — the
+                       count is no higher than it was on first paint")
+                  (teardown! root container)
+                  (is (zero? (ref-count-of :rf/xray feed-q))
+                      (str "unmount released the boundary's read. Cache keys "
+                           "after teardown: "
+                           (pr-str (keys (cache-of :rf/xray)))))))
+              (.catch (fn [e]
+                        (is false (str "W3 never settled: " (.-message e)))
+                        (teardown! root container)
+                        nil))
+              (.then (fn [_] (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_fresco_boundary_dom_cljs_test.cljs
@@ -346,45 +346,80 @@
                        (done)))))))))
 
 ;; ===========================================================================
-;; W3 — teardown releases what the mount acquired
+;; W3 — teardown releases what the mount acquired, and a reopen does not grow it
 ;; ===========================================================================
 
-(deftest w3-unmount-releases-the-boundarys-reads
-  (testing "rf2-fcy5 — unmounting the panel releases every reference its
-            boundary took in the frame's sub-cache. Epic criterion 6, and the
-            number the spike measured the REJECTED design against: there the
-            ref-count climbed across renders and never fell on unmount
-            (22 → 25 → 32)."
+(defn- released? [] (zero? (ref-count-of :rf/xray feed-q)))
+
+(deftest w3-unmount-releases-the-read-and-reopen-does-not-grow-it
+  (testing "rf2-fcy5 — unmounting the panel releases its subscription
+            reference completely, and mounting it again returns to the SAME
+            count rather than a higher one. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed 22 → 25 → 32 across
+            renders and never fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once. `impl.collector`'s `cell-reapers` gives a cell
+            whose last reader unmounts ONE MACROTASK OF GRACE, so that a keyed
+            reorder which unmounts and remounts a row within a single turn
+            reuses the reaction instead of rebuilding it. A synchronous read
+            straight after `flushSync(root.unmount)` returns 1 and the same
+            read one macrotask later returns 0 — measured here on the first
+            draft of this row, which duly reported a LEAK against a collector
+            behaving exactly as documented."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
         (seed! one-row-epoch)
-        (let [{:keys [container root]} (mount-panel! :rf/xray)
-              mounted (ref-count-of :rf/xray feed-q)]
-          (is (pos? mounted)
-              "NON-VACUITY: the mount took a reference, so the zero below is
-               a release and not an entry that was never there")
-          ;; A second value change, so the release is measured after the
-          ;; boundary has re-wired its read at least once rather than only
-          ;; on its first pass.
-          (rf/dispatch-sync [:rf.xray/sync-epoch-history [two-row-epoch]]
-                            {:frame :rf/xray})
-          (-> (rf.test-support/poll-until
-                (fn [] (some? (q container (testid-sel "rf-xray-trace-row-202"))))
-                {:label "the panel committed the second op's row"})
-              (.then
-                (fn [_]
-                  (is (>= mounted (ref-count-of :rf/xray feed-q))
-                      "the re-render did not ACCUMULATE references — the
-                       count is no higher than it was on first paint")
-                  (teardown! root container)
-                  (is (zero? (ref-count-of :rf/xray feed-q))
-                      (str "unmount released the boundary's read. Cache keys "
-                           "after teardown: "
-                           (pr-str (keys (cache-of :rf/xray)))))))
-              (.catch (fn [e]
-                        (is false (str "W3 never settled: " (.-message e)))
-                        (teardown! root container)
-                        nil))
-              (.then (fn [_] (done)))))))))
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (ref-count-of :rf/xray feed-q)]
+                  (is (pos? mounted)
+                      "the mount took a reference — otherwise the release
+                       below is vacuous")
+                  ;; A real value change first, so the release is measured
+                  ;; after the boundary has re-wired its read at least once
+                  ;; rather than only on its first pass.
+                  (rf/dispatch-sync [:rf.xray/sync-epoch-history [two-row-epoch]]
+                                    {:frame :rf/xray})
+                  (-> (rf.test-support/poll-until
+                        (fn [] (some? (q container
+                                         (testid-sel "rf-xray-trace-row-202"))))
+                        {:label "the panel committed the second op's row"})
+                      (.then
+                        (fn [_]
+                          (is (= mounted (ref-count-of :rf/xray feed-q))
+                              "the re-render did not ACCUMULATE references")
+                          (teardown! root container)
+                          (rf.test-support/poll-until released?
+                            {:label "the first unmount released the read"})))
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released it COMPLETELY, within "
+                                   "the collector's grace macrotask. Cache: "
+                                   (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same count, not a higher one ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (ref-count-of :rf/xray feed-q)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "count (" mounted ") rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got: " remounted))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released it too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases it too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -1175,14 +1175,21 @@
             [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                         :time 102 :dispatch-id 1})])])
       (focus! 1)
-      (let [rows (db-diff-row-nodes (rendered-tree) 2)
-            ks   (mapv #(:key (second %)) rows)]
+      (let [rows     (db-diff-row-nodes (rendered-tree) 2)
+            ;; The LITERAL every door below is compared against. Comparing
+            ;; the two renderers to the attrs map instead would be hollow in
+            ;; the one direction that matters: under a revert to `with-meta`
+            ;; the attrs read and the codec read are BOTH nil, so they agree
+            ;; and the row goes green on a defect. Measured — the first draft
+            ;; did exactly that.
+            expected ["[:counter]" "[:flag]" "[:stale]"]
+            ks       (mapv #(:key (second %)) rows)]
         ;; Non-vacuity first: an empty `rows` would make every assertion
         ;; below trivially true.
         (is (= 3 (count rows)) "three changed paths render three diff rows")
         ;; `(pr-str path)` of the whole path VECTOR — the expression the
         ;; `with-meta` wrapper carried, unchanged.
-        (is (= ["[:counter]" "[:flag]" "[:stale]"] (sort ks))
+        (is (= expected (sort ks))
             "each diff row carries the unchanged `(pr-str path)` key in attrs")
         (is (= 3 (count (distinct ks))) "sibling keys are distinct")
         ;; THE GATE. `subvec` for the same reason the sibling panels take it:
@@ -1190,17 +1197,21 @@
         ;; HD-016 the moment anything below a diff row stopped being native,
         ;; and that exception would hide the key answer behind it. Dropping
         ;; the subtree cannot change the answer — the key is read off the
-        ;; attribute map. RED under a revert to `with-meta`: `[nil nil nil]`.
-        (is (= (sort ks)
+        ;; attribute map. RED under a revert to `with-meta`: `[nil nil nil]`,
+        ;; measured.
+        (is (= expected
                (sort (mapv #(.-key (rf.fresco.impl.codec/as-element
                                      (subvec % 0 2)))
                            rows)))
             "Fresco's codec commits the same key for every diff row")
-        ;; The Reagent door, kept beside it and labelled: it is HOLLOW for
-        ;; this sub-case and passes under the revert. It is here to show that
-        ;; ONE attribute satisfies both substrates rather than trading one
-        ;; for the other.
-        (is (= (sort ks)
+        ;; The Reagent door, kept beside it and labelled: `r/as-element` on
+        ;; the WHOLE node is HOLLOW for this sub-case, because Reagent reads
+        ;; meta AND props and answers the same key either way. It is
+        ;; `subvec`'d here too, which drops the metadata before Reagent sees
+        ;; it — so this row reads the ATTRIBUTE and is a compatibility check
+        ;; rather than a second gate: it shows ONE attribute satisfies both
+        ;; substrates rather than trading one for the other.
+        (is (= expected
                (sort (mapv #(.-key (r/as-element (subvec % 0 2))) rows)))
             "and Reagent commits it too")
         ;; Guard the guard: no row depends on reader metadata any more.

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -48,6 +48,9 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
+            [day8.re-frame2-xray.views.resizable-table :as rt]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [reagent.core :as r]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
@@ -77,15 +80,120 @@
   ;; stays required for the `seed-trace-for-test!` seeding below.)
   (xray-test-support/make-xray-runtime-fixture))
 
-;; ---- hiccup walkers ----------------------------------------------------
+;; ---- the panel's body, and the two walkers over it ----------------------
+;;
+;; rf2-fcy5 (slice 3) — `trace/Panel` IS A FRESCO BOUNDARY NOW, so the rows
+;; below no longer call it. A boundary is a real React function component:
+;; its body reads through Fresco's collector, which refuses a read outside a
+;; render extent by name (`:rf.error/fresco-sub-outside-render`). The panel's
+;; body was split out as `trace/panel-tree`, a pure fn of the four values the
+;; boundary reads, and [[panel-tree]] below supplies them.
 
+(defn- panel-tree
+  "The Trace panel's body, driven from the ambient frame's own subs.
+
+  THIS USED TO BE A DIRECT CALL TO `trace/Panel`. Everything downstream of
+  it is unchanged — same markup, same testids — so the rows below read
+  exactly what they read before the migration."
+  []
+  (trace/panel-tree
+    {:feed                 @(rf/subscribe [:rf.xray/trace-feed])
+     :focus                @(rf/subscribe [:rf.xray/focus])
+     :focused-event-bundle @(rf/subscribe [:rf.xray.trace/focused-event-bundle])
+     :expanded-ids         @(rf/subscribe [:rf.xray/trace-expanded-row-ids])}))
+
+(defn- lower-head
+  "One hiccup node with a FRESCO BOUNDARY head swapped for the Reagent
+  `reg-view` sibling of the SAME widget, or `node` unchanged. `lower`
+  selects which of the two widgets to lower — `:table`, `:inspector`.
+
+  Both widgets ship both heads on purpose, and both hand the same values
+  to ONE renderer — `views/resizable_table.cljs`'s `render-table` and
+  `views/edn_inspector.cljs`'s `render-inspector` — differing only in HOW
+  each resolves the two things the renderer cannot resolve for itself (the
+  read and the dispatcher). So the swap changes the resolution route and
+  not the rendering, which is what makes it honest for the structural
+  assertions in this file.
+
+  It is a LOWERING and never a claim about which head the panel ships:
+  [[panel-heads-are-the-ones-the-codec-accepts]] grades that with the
+  codec's own classifier over the UNLOWERED tree, so a revert of any of
+  the three heads reds that row whatever this walker does."
+  [lower node]
+  (let [head (first node)]
+    (cond
+      (and (lower :table) (identical? head rt/resizable-table-view))
+      (assoc node 0 rt/resizable-table)
+
+      (and (lower :inspector) (identical? head ei/edn-inspector-view))
+      (let [{:keys [value opts]} (second node)]
+        [ei/edn-inspector value opts])
+
+      :else node)))
+
+(defn- expand-tree*
+  "`rf.test-helpers/expand-tree`, with [[lower-head]] applied ON THE WAY
+  DOWN.
+
+  A pre-pass will not do, and that is the whole reason this exists rather
+  than a `postwalk` over the finished tree: the panel's boundary heads are
+  not all present at the start. Expanding the table invokes the
+  `:row-extras` callback, and an expanded row's payload is a FRESH
+  `[ei/edn-inspector-view …]` node minted during that expansion — which
+  the framework walker would reach, call, and throw on.
+
+  A BOUNDARY HEAD IS NEVER INVOKED, lowered or not — that is what makes
+  [[inspector-heads-tree]] possible and what stops a boundary this walker
+  does not know about from throwing `:rf.error/fresco-sub-outside-render`
+  half way down someone else's row. An un-lowered boundary node is left
+  standing, which the head-grading row reads and the structural rows do
+  not reach past.
+
+  Mirrors the framework walker's two component shapes (plain fn, and the
+  Form-2 fn-returning-a-fn `edn-inspector` uses). It does NOT mirror the
+  Form-3 reagent-class arm: this panel's tree contains no class
+  components, and a class head here would fall through to the `mapv` and
+  be left un-expanded rather than silently mis-rendered."
+  [lower node]
+  (cond
+    (vector? node)
+    (let [n    (lower-head lower node)
+          head (first n)]
+      (if (and (fn? head) (not (rf.fresco.impl.codec/boundary-head? head)))
+        (let [out (apply head (rest n))]
+          (expand-tree* lower (if (fn? out) (apply out (rest n)) out)))
+        ;; METADATA IS CARRIED ACROSS THE REBUILD, which the framework
+        ;; walker does not do. Without this the key rows below could not
+        ;; tell a repaired `:key`-in-attrs from a reverted `with-meta`:
+        ;; `mapv` would have stripped the metadata before the assertion
+        ;; read it, and the metadata negative would pass vacuously.
+        (with-meta (mapv #(expand-tree* lower %) n) (meta n))))
+
+    (seq? node) (map #(expand-tree* lower %) node)
+    :else       node))
+
+(defn- rendered-tree
+  "The panel's tree, fully expanded — what the rows below walk."
+  []
+  (expand-tree* #{:table :inspector} (panel-tree)))
+
+(defn- inspector-heads-tree
+  "The panel's tree with the TABLE lowered and expanded but the payload
+  inspector left as the boundary head the panel wrote — so the head
+  grading row below can read a head that only exists once the table's
+  `:row-extras` callback has run."
+  []
+  (expand-tree* #{:table} (panel-tree)))
+
+;; The framework finder is unchanged and is applied to an ALREADY-EXPANDED
+;; tree: its own `expand-tree` pass is then a no-op rebuild, because
+;; `expand-tree*` left no fn in head position for it to invoke.
 (def ^:private find-by-testid rf.test-helpers/find-by-testid)
 
 (defn- hiccup-seq
-  "Expands fn components via the framework walker, then yields
-  depth-first nodes."
+  "Depth-first nodes of an already-expanded tree."
   [tree]
-  (tree-seq (some-fn vector? seq?) seq (rf.test-helpers/expand-tree tree)))
+  (tree-seq (some-fn vector? seq?) seq tree))
 
 (defn- node-attrs
   "The attribute map of the rendered node with the given data-testid."
@@ -222,7 +330,7 @@
   (testing "the panel renders its root container regardless of focus state"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace"))
             "panel container present")))))
 
@@ -235,7 +343,7 @@
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 42 :source :ui})])])
       (focus! 42)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (nil? (find-by-testid tree "rf-xray-trace-counts")))
         (is (nil? (find-by-testid tree "rf-xray-trace-epoch-indicator")))
         (is (nil? (find-by-testid tree "rf-xray-trace-film-strip")))
@@ -260,7 +368,7 @@
                     (mk-trace {:id 8 :op-type :rf.epoch :operation :rf.epoch/outcome
                                :time 121 :tags {:rf.epoch/outcome :ok}})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-feed")) "feed container present")
         (is (some? (find-by-testid tree "rf-xray-trace-rows"))
             "the flat row list container renders")
@@ -295,7 +403,7 @@
                                    :time 1002})
                         (assoc-in [:tags :elapsed-ms] 0.4))])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (= "+0.0" (last (find-by-testid tree "rf-xray-trace-row-1-time")))
             "Δt column reads +0.0 relative to the epoch origin")
         (is (= "DISPATCH" (last (find-by-testid tree "rf-xray-trace-row-1-stage")))
@@ -328,7 +436,7 @@
                                :dispatch-id 1})
                     (mk-trace {:id 4 :op-type :rf.sub :operation :rf.sub/run})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (= "event" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-1"))))
         (is (= "db" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-2"))))
         (is (= "fx" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-3"))))
@@ -360,7 +468,7 @@
                     (mk-trace {:id 2 :op-type :error :operation :rf.error/fx-handler-exception
                                :time 105 :reason "boom"})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
             "the error row renders inline (not hidden)")
         (is (= "error" (:data-rf-xray-severity (node-attrs tree "rf-xray-trace-row-2")))
@@ -409,7 +517,7 @@
              (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                         :time 102 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-2-db-diff"))
             "the db-diff section renders beneath the db-changed row")
         (let [row (db-diff-row-by-suffix tree 2 ":counter")]
@@ -430,7 +538,7 @@
             [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                         :time 102 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree    (trace/Panel)
+      (let [tree    (rendered-tree)
             added   (db-diff-row-by-suffix tree 2 ":flag")
             removed (db-diff-row-by-suffix tree 2 ":stale")]
         (is (some? added) "the [:flag] added row renders")
@@ -453,7 +561,7 @@
             [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                         :time 102 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (db-diff-row-by-suffix tree 2 ":counter"))
             "top-level [:counter] row renders")
         (is (some? (db-diff-row-by-suffix tree 2 ":user_:age"))
@@ -472,7 +580,7 @@
             [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                         :time 102 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
             "the db-changed row itself still renders")
         (is (nil? (find-by-testid tree "rf-xray-trace-row-2-db-diff"))
@@ -492,7 +600,7 @@
              (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
                         :time 105 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (nil? (find-by-testid tree "rf-xray-trace-row-1-db-diff"))
             "the dispatch row carries no diff section")
         (is (nil? (find-by-testid tree "rf-xray-trace-row-3-db-diff"))
@@ -508,7 +616,7 @@
     (rf/with-frame :rf/xray
       (seed-history! [(mk-epoch 1 11 [])])
       (focus! 11)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-empty-no-events")))
         (is (nil? (find-by-testid tree "rf-xray-trace-feed"))
             "no arc when focused epoch carries no events")))))
@@ -517,7 +625,7 @@
   (testing "with no focus + no history → :no-focus empty-state"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-empty-no-focus")))
         (is (nil? (find-by-testid tree "rf-xray-trace-feed")))))))
 
@@ -530,7 +638,7 @@
       (rf/dispatch-sync
         [:day8.re-frame2-xray.panels.trace-view-cljs-test/seed-evicted-focus])
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])
-            tree (trace/Panel)]
+            tree (rendered-tree)]
         (is (= :epoch-evicted (:empty-kind feed)))
         (is (some? (find-by-testid tree "rf-xray-trace-empty-epoch-evicted")))
         (is (nil? (find-by-testid tree "rf-xray-trace-feed")))))))
@@ -658,7 +766,7 @@
         (with-redefs [rf/dispatch-impl (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
+          (let [tree    (rendered-tree)
                 row     (find-by-testid tree "rf-xray-trace-row-7")
                 handler (:on-click (second row))]
             (is (some? row) "row node present")
@@ -696,11 +804,11 @@
                    [(mk-trace {:id 13 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 1 :source :ui :origin :app})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (nil? (find-by-testid tree "rf-xray-trace-row-13-payload"))
             "payload absent when row not expanded"))
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 13])
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-13-payload"))
             "payload renders when row expanded")
         ;; rf2-hhtbl phase 2 — the per-row payload renders the widget
@@ -737,7 +845,7 @@
       ;; Expand both rows at once.
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 41])
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 42])
-      (let [tree         (trace/Panel)
+      (let [tree         (rendered-tree)
             dd-testids   (->> (hiccup-seq tree)
                               (keep (fn [n]
                                       (when (and (vector? n) (map? (second n)))
@@ -773,7 +881,7 @@
                                :dispatch-id 1 :source :ui :origin :app})])])
       (focus! 1)
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 51])
-      (let [tree     (trace/Panel)
+      (let [tree     (rendered-tree)
             payload  (find-by-testid tree "rf-xray-trace-row-51-payload")
             ;; Walk the payload subtree (which is itself the result of
             ;; `expand-tree`-ing) and find the edn-inspector widget's
@@ -806,7 +914,7 @@
         (with-redefs [rf/dispatch-impl (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
+          (let [tree    (rendered-tree)
                 node    (find-by-testid tree "rf-xray-trace-row-9-source-coord")
                 handler (:on-click (second node))]
             (is (some? node) "source-coord ↗ rendered")
@@ -836,7 +944,7 @@
                     (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
                                :time 120 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)]
+      (let [tree (rendered-tree)]
         ;; no band chrome at all (rf2-aqusw)
         (is (nil? (find-by-testid tree "rf-xray-trace-band-effects")))
         (is (nil? (find-by-testid tree "rf-xray-trace-band-count-effects")))
@@ -902,7 +1010,7 @@
                     (mk-trace {:id 33 :op-type :rf.event :operation :rf.event/db-changed
                                :time 300 :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)
+      (let [tree (rendered-tree)
             k11  (:key (second (row-node-by-id tree 11)))
             k22  (:key (second (row-node-by-id tree 22)))
             k33  (:key (second (row-node-by-id tree 33)))]
@@ -945,7 +1053,7 @@
                    [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
                                :time 100 :dispatch-id 1})])])
       (focus! 1)
-      (let [kids (feed-children (trace/Panel))
+      (let [kids (feed-children (panel-tree))
             ks   (mapv #(.-key (r/as-element %)) kids)]
         (is (= 2 (count kids)))
         (is (= ["ops-header" "rows"] ks))
@@ -972,9 +1080,14 @@
             it reads nil at a repaired site precisely because the key is in
             props — so metadata appears here only as the negative below.
 
-            Not a Fresco DOM row: `rt/resizable-table` is a `reg-view`, a
-            head Fresco's codec refuses, so neither child can be handed to
-            `codec/as-element` until that widget grows a boundary."
+            rf2-fcy5 — THE CODEC DOOR IS OPEN NOW and is asserted below.
+            This row used to close with \"not a Fresco DOM row:
+            `rt/resizable-table` is a `reg-view`, a head Fresco's codec
+            refuses, so neither child can be handed to `codec/as-element`
+            until that widget grows a boundary.\" Slice 1b grew it and this
+            slice adopted it, so both children are boundary-headed and the
+            codec answers about them directly — which is the only door that
+            can tell an attrs key from a metadata one."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -982,7 +1095,7 @@
                    [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
                                :time 100 :dispatch-id 1})])])
       (focus! 1)
-      (let [kids  (feed-children (trace/Panel))
+      (let [kids  (feed-children (panel-tree))
             props (mapv second kids)]
         (is (= 2 (count kids)))
         ;; The Fresco-side read. RED before the repair: `[nil "rows"]`.
@@ -995,5 +1108,158 @@
         ;; Guard the guard: neither key is also in metadata, so the
         ;; assertion above cannot be passing on a shape Fresco can't see.
         (is (every? nil? (mapv #(:key (meta %)) kids))
-            "no feed child depends on reader metadata")))))
+            "no feed child depends on reader metadata")
+        ;; rf2-fcy5 — and now the CODEC's own answer, which is the door the
+        ;; children actually cross once this panel is a boundary. The
+        ;; props-map assertion above is the authoring shape; this is the
+        ;; renderer's reading of it.
+        (is (= ["ops-header" "rows"]
+               (mapv #(.-key (rf.fresco.impl.codec/as-element %)) kids))
+            "Fresco's codec commits both feed keys")))))
+
+;; ---- RULING 2: the db-diff rows key through the ATTRIBUTE MAP ------------
+;;
+;; rf2-bqzk — `db-diff-rows` used to wrap each row in
+;; `(with-meta (db-diff-row …) {:key (pr-str path)})`. That is NOT the dead
+;; metadata-on-a-call-form shape rf2-hxfy repaired one file over: `with-meta`
+;; applied to the RETURN VALUE genuinely attaches, and the key genuinely
+;; reached React under Reagent. Which is exactly why it is dangerous —
+;; Fresco's codec reads a literal `:key` off a native tag's attrs and reads
+;; Clojure metadata NOWHERE, so a faithful migration of that spelling would
+;; have preserved a NO-OP and every diff row in every changed-path list would
+;; have lost its identity with nothing on screen to say so. The key
+;; expression `(pr-str path)` is unchanged; only its carrier moved.
+;;
+;; THE OBVIOUS INSTRUMENT IS HOLLOW HERE. `(.-key (r/as-element node))` is
+;; exactly right for the call-form defect and BLIND to this one, because
+;; Reagent reads meta AND props and answers the same key either way. Under a
+;; revert the Reagent assertion below PASSES and the Fresco one fails; both
+;; are kept, and which is the gate is said out loud.
+
+(defn- node-by-testid
+  "The first node in an ALREADY-EXPANDED tree carrying `testid`, found
+  without a rebuild. Deliberately NOT `rf.test-helpers/find-by-testid`,
+  which runs its own `expand-tree` pass and rebuilds nested vectors with
+  `mapv` — that would substitute its own vectors for the ones under test
+  and strip the very metadata the negative below asserts is absent."
+  [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- db-diff-row-nodes
+  "The per-path diff rows under the db-changed row with id `parent-row-id`.
+  `db-diff-rows` is CALLED by `op-row-extras`, so the rows exist as soon as
+  the table has been expanded and need no inspector lowering."
+  [tree parent-row-id]
+  (vec (drop 2 (node-by-testid tree (str "rf-xray-trace-row-" parent-row-id
+                                         "-db-diff")))))
+
+(def ^:private diff-seed
+  "Three changed paths in one db-changed row — modified, added, removed —
+  so the sibling-distinctness assertion has something to say."
+  {:before {:counter 1 :stale :x}
+   :after  {:counter 2 :flag true}})
+
+(deftest db-diff-row-keys-reach-the-renderer-through-attrs
+  (testing "rf2-bqzk — the trace half of the metadata-key sweep. The key
+            rides `db-diff-row`'s own `:div` attrs map now, which is the one
+            place BOTH substrates read."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 (:before diff-seed) (:after diff-seed)
+            [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (let [rows (db-diff-row-nodes (rendered-tree) 2)
+            ks   (mapv #(:key (second %)) rows)]
+        ;; Non-vacuity first: an empty `rows` would make every assertion
+        ;; below trivially true.
+        (is (= 3 (count rows)) "three changed paths render three diff rows")
+        (is (= [":counter" ":flag" ":stale"] (sort ks))
+            "each diff row carries the unchanged `(pr-str path)` key in attrs")
+        (is (= 3 (count (distinct ks))) "sibling keys are distinct")
+        ;; THE GATE. `subvec` for the same reason the sibling panels take it:
+        ;; the codec lowers children eagerly, so a whole-node call would raise
+        ;; HD-016 the moment anything below a diff row stopped being native,
+        ;; and that exception would hide the key answer behind it. Dropping
+        ;; the subtree cannot change the answer — the key is read off the
+        ;; attribute map. RED under a revert to `with-meta`: `[nil nil nil]`.
+        (is (= (sort ks)
+               (sort (mapv #(.-key (rf.fresco.impl.codec/as-element
+                                     (subvec % 0 2)))
+                           rows)))
+            "Fresco's codec commits the same key for every diff row")
+        ;; The Reagent door, kept beside it and labelled: it is HOLLOW for
+        ;; this sub-case and passes under the revert. It is here to show that
+        ;; ONE attribute satisfies both substrates rather than trading one
+        ;; for the other.
+        (is (= (sort ks)
+               (sort (mapv #(.-key (r/as-element (subvec % 0 2))) rows)))
+            "and Reagent commits it too")
+        ;; Guard the guard: no row depends on reader metadata any more.
+        (is (every? nil? (mapv #(:key (meta %)) rows))
+            "no diff row depends on vector metadata")))))
+
+;; ---- the three heads are the ones Fresco accepts (rf2-fcy5) --------------
+
+(deftest panel-heads-are-the-ones-the-codec-accepts
+  (testing "rf2-fcy5 slice 3 — `Panel` is an `rf.fresco/defview`, so every
+            hiccup head inside its body has to be one the codec accepts. A
+            `reg-view` head grades `:invalid` down the IDENTICAL arm a plain
+            `defn` does, and with no error boundary above this render path
+            an HD-016 throw presents as a tab that never appears rather than
+            as an error. The three heads are the two `rt/resizable-table`
+            sites and `ei/edn-inspector` in `render-payload`.
+
+            THE INSTRUMENT IS THE CODEC'S OWN CLASSIFIER, and neither
+            obvious shape works: a boundary IS a fn, so an `fn?` filter is
+            wrong permissively; a boundary carries no Clojure metadata, so a
+            `(some? (meta head))` discriminator is wrong strictly.
+
+            Read over the UNLOWERED tree, so `lower-head` cannot launder a
+            revert into a pass."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 (:before diff-seed) (:after diff-seed)
+            [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                        :time 100 :dispatch-id 1})
+             (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 1])
+      ;; Controls, in both directions, so `:invalid` below is an answer
+      ;; rather than a default.
+      (is (= :tag (rf.fresco.impl.codec/head-kind :div)))
+      (is (= :invalid (rf.fresco.impl.codec/head-kind rt/resizable-table))
+          "the Reagent `reg-view` head these sites used to carry is :invalid")
+      (is (= :invalid (rf.fresco.impl.codec/head-kind ei/edn-inspector))
+          "…and so is the inspector's")
+      (is (= :boundary (rf.fresco.impl.codec/head-kind rt/resizable-table-view)))
+      (is (= :boundary (rf.fresco.impl.codec/head-kind ei/edn-inspector-view)))
+      ;; The panel's own body: the two table heads, unexpanded and unlowered.
+      (let [heads (map first (filter vector? (hiccup-seq (panel-tree))))
+            kinds (frequencies (map rf.fresco.impl.codec/head-kind heads))]
+        (is (< 5 (count heads))
+            "the walk reached a populated tree, so the zero below is absence")
+        (is (= 2 (get kinds :boundary 0))
+            "both `resizable-table` sites are boundary heads")
+        (is (zero? (get kinds :invalid 0))
+            (str "every head the panel body writes is one Fresco accepts — "
+                 kinds)))
+      ;; And the payload inspector, which only exists once the table's
+      ;; `:row-extras` callback has run.
+      (let [heads (map first (filter vector? (hiccup-seq (inspector-heads-tree))))
+            kinds (frequencies (map rf.fresco.impl.codec/head-kind heads))]
+        (is (pos? (get kinds :boundary 0))
+            "the expanded row's inspector head is in the tree")
+        (is (some #(identical? ei/edn-inspector-view %) heads)
+            "…and it is `edn-inspector-view`, the boundary, not `edn-inspector`")
+        (is (zero? (get kinds :invalid 0))
+            (str "no invalid head anywhere below the table — " kinds))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -1180,7 +1180,9 @@
         ;; Non-vacuity first: an empty `rows` would make every assertion
         ;; below trivially true.
         (is (= 3 (count rows)) "three changed paths render three diff rows")
-        (is (= [":counter" ":flag" ":stale"] (sort ks))
+        ;; `(pr-str path)` of the whole path VECTOR — the expression the
+        ;; `with-meta` wrapper carried, unchanged.
+        (is (= ["[:counter]" "[:flag]" "[:stale]"] (sort ks))
             "each diff row carries the unchanged `(pr-str path)` key in attrs")
         (is (= 3 (count (distinct ks))) "sibling keys are distinct")
         ;; THE GATE. `subvec` for the same reason the sibling panels take it:
@@ -1245,7 +1247,12 @@
       ;; The panel's own body: the two table heads, unexpanded and unlowered.
       (let [heads (map first (filter vector? (hiccup-seq (panel-tree))))
             kinds (frequencies (map rf.fresco.impl.codec/head-kind heads))]
-        (is (< 5 (count heads))
+        ;; The panel's own body is SHALLOW — `:section`, the scroll `:div`,
+        ;; the feed `:div` and the two table heads is all of it, because
+        ;; every other helper is CALLED and the depth lives inside the
+        ;; widget. So the non-vacuity floor is 5, measured rather than
+        ;; guessed at.
+        (is (<= 5 (count heads))
             "the walk reached a populated tree, so the zero below is absence")
         (is (= 2 (get kinds :boundary 0))
             "both `resizable-table` sites are boundary heads")

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/event_status_colour_cross_site_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/event_status_colour_cross_site_e2e_cljs_test.cljs
@@ -82,13 +82,32 @@
   "Render the L4 Trace panel under `:rf/xray` and return the cascade-
   status bar's `:data-rf-xray-status` (or nil when absent). Post rf2-pjjwh
   the Trace bar is the single status-colour render site (the L2 row stripe
-  was retired). Reads only — no state mutation."
+  was retired). Reads only — no state mutation.
+
+  rf2-fcy5 — `trace/Panel` is an `rf.fresco/defview` now, a real React
+  function component whose body refuses a read outside a render extent
+  (`:rf.error/fresco-sub-outside-render`); `trace/panel-tree` is the same
+  body as a pure fn of the four values the boundary reads. And the scan is
+  non-expanding for the matching reason: the body carries two
+  `rt/resizable-table-view` boundary heads that an expanding walker would
+  invoke. The status bar is a CALLED helper returning a native div above
+  the table, so a plain depth-first scan reaches it."
   [_dispatch-id]
   (rf/with-frame :rf/xray
-    (let [trace-tree (trace/Panel)
-          trace-bar  (first (rf.test-helpers/find-by-attr-prefix
-                              trace-tree :data-testid
-                              "rf-xray-trace-event-bundle-status-bar-"))]
+    (let [trace-tree (trace/panel-tree
+                       {:feed  @(rf/subscribe [:rf.xray/trace-feed])
+                        :focus @(rf/subscribe [:rf.xray/focus])
+                        :focused-event-bundle
+                        @(rf/subscribe [:rf.xray.trace/focused-event-bundle])
+                        :expanded-ids
+                        @(rf/subscribe [:rf.xray/trace-expanded-row-ids])})
+          trace-bar  (some (fn [node]
+                             (when (and (vector? node)
+                                        (map? (second node))
+                                        (some-> ^String (:data-testid (second node))
+                                                (.startsWith "rf-xray-trace-event-bundle-status-bar-")))
+                               node))
+                           (tree-seq (some-fn vector? seq?) seq trace-tree))]
       (get (rf.test-helpers/attrs trace-bar) :data-rf-xray-status))))
 
 ;; ---- tests --------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -938,7 +938,9 @@
    ;; ruled on 2026-09-10; step 3 converges both onto this spelling).
    :app-db          app-db-diff/Panel-bridge
    :views           reactive-panel/Panel-bridge
-   :trace           trace/Panel
+   ;; rf2-fcy5 slice 3 — the Trace panel's root is a Fresco boundary now
+   ;; too, so `reg-l4-tab!` stores its `as-component` bridge.
+   :trace           trace/Panel-bridge
    :machines        machine-inspector/Panel
    :routing         routing/Panel})
 

--- a/tools/xray/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/xray/testbeds/panel_gallery/panel_views.cljs
@@ -142,7 +142,13 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-trace-card"}
-   [trace/Panel]])
+   ;; rf2-fcy5 — `Panel-bridge`, for the reason spelled out on the
+   ;; Reactive card above: this gallery cell is a Reagent tree and
+   ;; `trace/Panel` is now a Fresco boundary, which may not be mounted as
+   ;; a Reagent hiccup head. The bridge is Fresco's `as-component` door and
+   ;; takes the frame from React context, which the variant
+   ;; `frame-provider` above already wrote.
+   [trace/Panel-bridge]])
 
 (defn- machines-tab-panel
   "Embedded mount of the Machines tab body — the machine-inspector


### PR DESCRIPTION
Slice 3 of 3 of **rf2-fcy5**, and the trace half of **rf2-bqzk** — the last remaining piece of each.

## What changed

`trace/Panel` becomes an `rf.fresco/defview` behind the public `Panel-bridge` that `panels/mount-trace!` already names (PR #9654 pointed the facade at it while it was still a plain alias), so **`panels.cljs` is untouched**. RULING 1's surviving spelling: boundary on the natural name, public bridge passed by the caller.

The body is split out as `trace/panel-tree`, a pure fn of the four values the boundary reads — the `resources` shape — which keeps the panel's whole render contract drivable from the node lane without a React commit.

**The three interior heads moved with the mount.** A `reg-view` head grades `:invalid` to `codec/head-kind` down the identical arm a plain `defn` does, and there is no error boundary above this render path, so leaving one is a tab that never appears rather than an error:

| site | before | after |
|---|---|---|
| `flat-row-list` | `rt/resizable-table` | `rt/resizable-table-view` |
| ops-header in `panel-tree` | `rt/resizable-table` | `rt/resizable-table-view` |
| `render-payload` | `ei/edn-inspector` | `ei/edn-inspector-view` + `:mount-id` |

The dispatches did **not** move. This panel never used `reg-view`'s lexically injected bare `dispatch`/`subscribe` (measured: zero sites, against a live tree-wide control that finds them elsewhere); its handlers already capture the frame at render time per rf2-nesy9 and carry `{:frame frame}` explicitly, which is exactly right under a boundary.

`edn-inspector-view`'s `:mount-id` is **per row** — it is qualified by frame and memoises `container-ref-for` on the result, so a shared id shares a ResizeObserver entry and a width slot. The row id is this panel's own per-record identity, the same value `:panel-id` and `:site-id` already used, so all three now derive from one source. That is the slice-2 defect asked of this file; the remaining case (two Trace panels in one frame) is rf2-5ykm's.

## rf2-bqzk — the trace key

`db-diff-rows` wrapped each row in `(with-meta (db-diff-row …) {:key (pr-str path)})`. Not the dead metadata-on-a-call-form shape: `with-meta` on the **return value** genuinely attaches and the key genuinely reached React under Reagent, which is what makes it dangerous — Fresco's codec reads a literal `:key` off a native tag's attrs and reads Clojure metadata nowhere, so carrying that spelling faithfully through the migration would have carried a no-op. The key expression `(pr-str path)` is unchanged; only its carrier moved, into `db-diff-row`'s own `:div` attrs map.

## Re-measured counts, including the zeros

Head census with an s-expression reader that tracks lexical scope, controlled against the hand-written census in `static/routes/panel.cljs` (nine in-file sites across the four `static/routes/*.cljs` files — the instrument reads exactly nine, and finds the end-of-line `search-box/search-box` head that a first pass missed).

* `panels/trace.cljs` before: **0** plain-`defn` heads, **3** `reg-view` heads. Exactly as briefed.
* After: **3** heads, all `:boundary`.

Key census in `panels/trace.cljs`: **1** real `with-meta` site (`:505-506`), **0** real `^{:key …}` sites — the two `^{:key` grep hits are comment lines documenting the hazard, which is the prose-contaminates-a-census trap rf2-bqzk's own notes predicted. Live tree-wide control over `tools/xray/src` at this base: **33** `^{:key` across **22** files, **19** `with-meta` — so the instrument bites and the zero is absence.

## The registry took the bridge

`reg-l4-tab!`'s `:pre` requires `:panel` to be callable and `shell/detail-panel` mounts it as a Reagent hiccup head, so `:panel` is `Panel-bridge` (a `defn` returning `[:> Panel-component {}]`), exactly as `resources` already ships. No refusal; the registry needed no change.

## Test-surface consequence, stated because it is the real work of the slice

Every pure-hiccup row in `trace_view_cljs_test` used to reach the row testids by letting `rf.test-helpers/expand-tree` descend through the `reg-view` table head. It cannot descend through a boundary: `rf.fresco/sub` outside a render extent refuses by name. So the suite gets a `panel-tree` driver and a local `expand-tree*` that lowers each Fresco head to its **Reagent sibling of the same widget** on the way down — both heads hand the same map to one renderer, so the swap changes the resolution route and not the rendering. It is a lowering and never a claim about which head the panel ships: a new row grades that with `codec/head-kind` over the **unlowered** tree, so a revert reds it whatever the walker does. `expand-tree*` also carries metadata across its rebuild, which the framework walker does not — without that the key rows could not tell a repaired attrs key from a reverted `with-meta`.

## Other call sites that had to follow

`shell_cljs_test.cljs` (the tab-to-Panel map), `panel_gallery/panel_views.cljs` (a Reagent gallery cell mounting the panel by name — the mirror failure if left), `event_status_colour_view_cljs_test.cljs` and the cross-site e2e test (both scan for the status bar without expanding).

## Quality gates

Every number below is the runner's own captured exit code, re-run on the final rebased base (`origin/main` at 10e8e417a8).

| gate | result |
|---|---|
| `compile-node-test.cjs node-test` | exit **0** |
| `node out/node-test.js` | exit **0** — 11691 tests, 58586 assertions, 0 failures, 0 errors |
| `shadow-cljs compile browser-test` | exit **0** |
| `serve-and-run-browser-tests.cjs` | exit **0** — 948 tests, 5258 assertions, 0 failures, 0 errors |
| `tools/xray` `clojure -M:test` | exit **0** — 1280 tests, 6145 assertions, 0 failures |
| `check-examples-compile.cjs` | exit **0** — all 58 builds, zero warnings |
| `test:xray-feature-gate` (FULL) | exit **0** — 16 scenarios, 0 failures, 13 matrix rows |
| `check_require_alias_dialect.py --self-test` | exit **0** — 79 passed |
| `check_require_alias_dialect.py --verbose` | exit **0** — 2852 files, 11240 edges, 0 non-canonical |
| `clj-kondo --fail-level error --lint tools/xray` | exit **0** — errors 0, warnings 140 (141 before: one I introduced, removed) |
| `clojure -M:splint --fail-on-errors ../tools` | exit **0** |
| `check-ai-tracking-ratchet.sh` | exit **0** |
| `check_retired_spellings.py` | exit **0** |
| `check-beads-pr-boundary.sh origin/main` | exit **0** |
| `check-commit-attribution.sh origin/main` | exit **0** |

The feature gate's Trace witnesses are **`deterministic exceptions and inline/trace surfacing`** (the one Trace scenario in the smoke tier — of the 16 scenarios, 5 carry `smoke: true`) and **`1000-event trace row-budget plus 20-dispatch re-check`**, which is full-sweep only. Both click the Trace tab in the real shell and count `[data-testid^="rf-xray-trace-row-"]`, so they grade the mount through `shell/detail-panel` rather than through the registry alone.

### Sabotage, both lanes

The gates were shown red from planted faults, then the source restored and the bytes verified against the committed blob (`git rev-parse HEAD:<path>` equals `git hash-object <path>`; `git diff --quiet HEAD` clean as a second instrument).

Two faults planted at once — the key reverted into a `with-meta` wrapper, and the ops-header head reverted to `rt/resizable-table`:

* node lane: exit **1**, 5 failures + 1 error, **test totals identical** at 11675/58534. `db-diff-row-keys-reach-the-renderer-through-attrs` reported the codec reading `(nil nil nil)` — the `[nil nil nil]` signature rf2-bqzk predicted; `panel-heads-are-the-ones-the-codec-accepts` reported the `:invalid` head; and `trace-feed-children-keys-live-in-the-attribute-map` errored, because `codec/as-element` refuses the `reg-view` head outright.
* browser lane: exit **1**, 8 failures, test totals identical at 940. W1, W2 and W3 of the new DOM witness all red — the panel painted nothing, which is the failure mode this file exists for.

**That sabotage found a hollow assertion of mine and it is fixed here**: the codec door was originally compared to the attrs read rather than to the expected key, and under the revert both are `nil`, so they agreed and the gate went green on the defect. Each door is now compared to the literal key vector.

## New DOM witness

`panels/trace_fresco_boundary_dom_cljs_test` — the merged boundary template trimmed to the three rows this slice can be wrong about: first display through the registry's bridge (criteria 1 and 4), liveness on a real invalidation with a deaf control (2), and teardown release plus a reopen that does not grow the count (6). Criterion 3 is covered structurally by the existing row-click rows; criterion 5 is a property of the boundary that `resources_fresco_boundary_dom_cljs_test` already proves in both directions.

Its first draft read the ref-count synchronously after `flushSync(root.unmount)` and reported a leak: the collector's `cell-reapers` gives a cell one macrotask of grace, so the row polls, as the template's own prose already said it must.

## What I did not touch

`panels.cljs`, and every other fenced file. One stale line for a later slice, reported rather than reached: `panels.cljs`'s `render-panel!` docstring still says that `[trace/Panel {…}]` is an arity error, which was true of the `reg-view` and is not true of the boundary.

Closes the third slice of rf2-fcy5 and the trace half of rf2-bqzk. I have not closed either bead.
