### PR TITLE
xray: the Epoch and Machine-Inspector panels become Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -4024,15 +4024,20 @@
   Suppressed for machine handlers — per design §Section 3 §DB DIFF
   the snapshot IS the db change (at `[:rf.runtime/machines :snapshots <id>]` in runtime-db) so the
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
-  standalone slot."
-  [db-post-handler db-write?]
-  ;; rf2-k97c.3 — `rf.fresco/sub`, a plain call the collector records an
-  ;; edge for, DONATED UPWARD into `Panel`'s window (this helper is called,
-  ;; never headed, so it has no boundary of its own). HD-016: a
-  ;; helper-donated read is settled rather than contingent. The frame comes
-  ;; from React context, so the read needs no `{:frame …}` option.
-  (let [record    (rf.fresco/sub [:rf.xray/selected-epoch-record])
-        db-before (:db-before record)
+  standalone slot.
+
+  rf2-k97c.3 — `record` ARRIVES AS AN ARGUMENT; it used to be read here
+  with `@(rf/subscribe [:rf.xray/selected-epoch-record])`. [[Panel]] is
+  now a Fresco boundary and reads it there, threading it down the `ctx`
+  map. HD-016 would have allowed the read to stay and DONATE upward into
+  the boundary's window, and that would have been correct in production —
+  but it would make this helper callable only inside a React render
+  window, and its diff algebra is ordinary data → data that the fast node
+  lane is the right place to test. Every migrated panel in this tree made
+  the same call. `nil` renders as `db-before` absent, which is what a
+  direct caller passing no `ctx` means."
+  [db-post-handler db-write? record]
+  (let [db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
         ;; HANDLER `:db`; fall back to the record's post-flow `:db-after`
         ;; only when the runtime stamped no t1 — but ONLY when the handler
@@ -4103,9 +4108,17 @@
 
   Either, both, or neither may render — sections are
   `seq`-conditioned. The `:db` part stays in its own dedicated
-  block (the [diff][full][full+diff] toggle) above."
-  [{:keys [flavour event-id db-post-handler db-write? fx-vec other-effects
-           machine errors] :as _row}]
+  block (the [diff][full][full+diff] toggle) above.
+
+  rf2-k97c.3 — the optional `ctx` is the cascade-level map [[Panel]]
+  threads down; the only key read here is `:selected-epoch-record`, which
+  [[handler-db-diff-block]] needs for `:db-before`. The 1-arity keeps
+  every direct caller that has no cascade context working: no record
+  means no `:db-before`, which renders as an absent pre-image."
+  ([row] (handler-body row {}))
+  ([{:keys [flavour event-id db-post-handler db-write? fx-vec other-effects
+            machine errors] :as _row}
+    ctx]
   (let [machine? (= :reg-machine flavour)
         ;; rf2-wnvid — the handler threw iff a `:rf.error/handler-exception`
         ;; attached to this step (`:errors`). Tunes the no-`:db` placeholder
@@ -4127,7 +4140,8 @@
      ;; inline 'Exception Thrown' card below is the signal). The slot
      ;; stays present for a clean handler that simply returned no `:db`.
      (when (and (not machine?) (not threw?))
-       (handler-db-diff-block db-post-handler db-write?))
+       (handler-db-diff-block db-post-handler db-write?
+                              (:selected-epoch-record ctx)))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -4155,7 +4169,7 @@
             :opts     {:site-id                [:rf.xray.epoch/handler-other event-id]
                        :card?                  false
                        :zoomable?              true
-                       :default-expanded-depth 16}}]]))]))
+                       :default-expanded-depth 16}}]]))])))
 
 (defn render-handler-step
   "Render the HANDLER step (always present). Per Mike pair-debug
@@ -4170,9 +4184,15 @@
   FX step's :db row (the implicit commit fx). HANDLER step's
   `:violations` slot still renders generically — currently empty
   for HANDLER in practice — but the call site stays in case future
-  violation kinds attach here."
-  [{:keys [flavour event-id duration-ms step-number violations errors]
-    :as step}]
+  violation kinds attach here.
+
+  rf2-k97c.3 — the optional `ctx` is threaded straight to
+  [[handler-body]], which uses its `:selected-epoch-record` for the `:db`
+  diff's pre-image. The 1-arity keeps every direct caller working."
+  ([step] (render-handler-step step {}))
+  ([{:keys [flavour event-id duration-ms step-number violations errors]
+     :as step}
+    ctx]
   (let [status   (proj/step-status step)
         skipped? (= :skipped status)]
     [:div {:data-testid "rf-xray-epoch-step-handler"
@@ -4196,7 +4216,7 @@
        ;; "— no :db (handler returned no :db)" which was WRONG: the handler
        ;; body returns a :db (via `bump`), it just never executed.
        (skipped-body "rf-xray-epoch-handler" "The handler")
-       (handler-body step))
+       (handler-body step ctx))
      ;; rf2-ahhgn — a handler EXCEPTION attaches here as an inline error
      ;; card (button-16). Rendered BELOW the handler body so the operator
      ;; reads what the handler tried to do, then the failure that aborted
@@ -4204,7 +4224,7 @@
      ;; steps per rf2-yz57h, so this slot carries only genuine handler
      ;; throws.)
      (error-blocks :handler errors)
-     (violation-blocks :handler violations)]))
+     (violation-blocks :handler violations)])))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -4971,16 +4991,21 @@
   writes + reads hit THIS instance's Xray app-db (N isolated shells
   stay independent), not the `:rf/xray` singleton.
 
-  rf2-k97c.3 — the read is now `rf.fresco/sub`, donated upward into
-  `Panel`'s collector window. The anchor is UNCHANGED in effect and
-  simpler in spelling: `rf.fresco/sub` takes no frame option because it
-  resolves the frame off the same React context `rf/current-frame-id`
-  reads, so the read and the click still name ONE frame. `frame` stays
-  bound for the CLICK, which fires after the render extent has unwound
-  and so must have captured it during render."
-  [{:keys [rows disposed-rows step-number violations]}]
+  rf2-k97c.3 — THE MODE ARRIVES IN `ctx`; it used to be read here with
+  `@(rf/subscribe [:rf.xray.epoch/subs-filter-mode] {:frame frame})`.
+  [[Panel]] is now a Fresco boundary and reads it there, so this fn is a
+  pure function of its arguments and stays drivable from the fast node
+  lane. The ANCHOR is unchanged in effect: the boundary resolves the read
+  against the same React-context frame `rf/current-frame-id` answers
+  here, so the read and the click still name ONE frame — and `frame`
+  stays bound for the CLICK, which fires after the render extent has
+  unwound and so must have captured it during render. The 1-arity means
+  no mode, which the `case` below already treats as the `:changed`
+  default."
+  ([step] (render-subscriptions-step step {}))
+  ([{:keys [rows disposed-rows step-number violations]} ctx]
   (let [frame         (rf/current-frame-id)
-        mode          (rf.fresco/sub [:rf.xray.epoch/subs-filter-mode])
+        mode          (:subs-filter-mode ctx)
         visible-rows  (case mode
                         :all       rows
                         :unchanged (filterv (complement :changed?) rows)
@@ -5025,7 +5050,7 @@
      ;; pooled at the foot of the step). Step-level violations
      ;; (indirect recomputes that don't surface a row) continue to
      ;; ride at the foot.
-     (violation-blocks :subscriptions violations)]))
+     (violation-blocks :subscriptions violations)])))
 
 ;; ---- VIEWS step ----------------------------------------------------------
 
@@ -5741,8 +5766,11 @@
   APP-DB-DIFF steps were retired by rf2-zkiu5).
 
   `ctx` carries the cascade-level pieces a row may need (the rf2-5qp4g
-  DISPATCH `:fx-dispatch` parent-epoch link resolution index). Most
-  steps ignore it."
+  DISPATCH `:fx-dispatch` parent-epoch link resolution index, and since
+  rf2-k97c.3 the two VALUES the HANDLER and SUBSCRIPTIONS rows used to
+  read from the substrate themselves — `:selected-epoch-record` and
+  `:subs-filter-mode`, both now read once in [[Panel]]'s boundary body).
+  Most steps ignore it."
   [step ctx]
   (case (:step step)
     :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
@@ -5750,10 +5778,10 @@
     :coeffect          (render-coeffect-step step)
     :interceptors      (render-interceptors-step step)
     :interceptor       (render-interceptor-step step)
-    :handler           (render-handler-step step)
+    :handler           (render-handler-step step ctx)
     :flow              (render-flow-step step)
     :side-effects      (render-side-effects-step step)
-    :subscriptions     (render-subscriptions-step step)
+    :subscriptions     (render-subscriptions-step step ctx)
     :views             (render-views-step step)
     nil))
 
@@ -5793,24 +5821,31 @@
             :aria-hidden true
             :style pipeline-rail-style}]
      ;; Steps — `doall` forces the lazy `for` to realise INSIDE the
-     ;; render pass (rf2-atqkg), and rf2-k97c.3 did NOT retire the
-     ;; reason: it re-founded it on the collector. `render-step`
-     ;; returns hiccup whose descendants (`handler-db-diff-block`,
-     ;; `render-subscriptions-step`) read the substrate themselves.
+     ;; render pass (rf2-atqkg). READ THE REASON AS HISTORY NOW, not as a
+     ;; live hazard, and keep the `doall` anyway.
      ;;
-     ;; Pre-migration those were `@(rf/subscribe …)` and the tracker was
-     ;; Reagent's reactive context: derefs firing after the render pass
-     ;; landed outside it, so a sub-value change triggered no re-render
-     ;; (symptom: the operator clicks `[diff][all]`, the sub flips in
-     ;; app-db, the cascade reads the new value, and the panel hiccup
-     ;; stays stale). They are now `rf.fresco/sub` and the tracker is
-     ;; Fresco's collector, which records an edge WHERE THE READ HAPPENS
-     ;; — so a read that happens after this body has returned is recorded
-     ;; into no window at all and the same staleness returns by the same
-     ;; route. The `doall` is what keeps every donated read inside
-     ;; `Panel`'s window; it is load-bearing under BOTH observers, which
-     ;; is why it survives the migration unchanged. See spec/006
-     ;; §Lazy-seq deref tracking.
+     ;; The original reason: `render-step`'s descendants
+     ;; (`handler-db-diff-block`, `render-subscriptions-step`) read the
+     ;; substrate THEMSELVES via `@(rf/subscribe …)`, and Reagent tracks
+     ;; only derefs that fire while the parent reg-view's reactive scope
+     ;; is live. A lazy seq realised after the render pass left those
+     ;; derefs outside it, so a sub-value change triggered no re-render —
+     ;; the operator clicked `[diff][all]`, the sub flipped in app-db, and
+     ;; the panel hiccup stayed stale.
+     ;;
+     ;; rf2-k97c.3 REMOVED THE HAZARD AT ITS SOURCE: those two reads were
+     ;; hoisted into `Panel`'s boundary body and now arrive as VALUES in
+     ;; `ctx`, so nothing below this line reads the substrate at all and
+     ;; there is no read left to strand. Had they instead been left to
+     ;; donate upward, the hazard would have survived the migration
+     ;; unchanged — Fresco's collector records an edge WHERE THE READ
+     ;; HAPPENS, so a read fired after this body returns is recorded into
+     ;; no window at all, which is the same staleness by the same route.
+     ;;
+     ;; The `doall` stays because it is free, because the shape it
+     ;; protects is one edit away from returning, and because
+     ;; `pipeline-view-realises-step-seq-rf2-atqkg-test` pins it. See
+     ;; spec/006 §Lazy-seq deref tracking.
      (doall
        (for [[i step] (map-indexed vector steps)]
          [:div {:key (str "step-" (:step step) "-" i)
@@ -5873,11 +5908,31 @@
   The READS are `rf.fresco/sub` — plain calls the shipped collector
   records an edge for, with no deref and no reaction owned by the
   INSTALLED adapter. That is coupling (3), and it is the one a
-  first-paint smoke test cannot see. Three sites read, not one: this
-  body's pipeline read, plus `db-diff-slot`'s selected-epoch record and
-  `step-subscriptions`' filter mode, both of which donate their read
-  upward into this boundary's collector window from an inlined helper
-  (HD-016 — helper-donated reads are settled rather than contingent).
+  first-paint smoke test cannot see.
+
+  ALL THREE OF THE PANEL'S READS ARE IN THIS BODY, and that is a choice
+  worth naming because HD-016 permits the other one. Before rf2-k97c.3
+  two of them lived in helpers deep in the cascade —
+  `handler-db-diff-block`'s selected-epoch record and
+  `render-subscriptions-step`'s filter mode. Inlining those helpers would
+  have let their reads DONATE upward into this window, which HD-016 calls
+  settled rather than contingent and which would have been correct in
+  production. They were hoisted anyway, for a reason that is about
+  TESTING rather than about correctness: a `rf.fresco/sub` raises
+  `:rf.error/fresco-sub-outside-render` when it runs outside a collector
+  window, so a helper that performs one is callable only inside a real
+  React commit — and the cascade's step-rendering algebra is ordinary
+  data → data with 2,600 lines of fast node-lane coverage over it. The
+  two values now ride the `ctx` map [[pipeline-view]] already threaded,
+  and the helpers kept a 1-arity so a direct caller needs no cascade
+  context. Every migrated panel in this tree made the same call.
+
+  The cost is one lost conditional: both slots are now read on every
+  panel render rather than only when their step happens to be present.
+  Neither widens invalidation in practice — the selected-epoch record
+  moves with the same focus the pipeline read already depends on, and the
+  filter mode can only change from a control that renders inside the
+  SUBSCRIPTIONS step itself.
 
   The FRAME each read resolves against comes from React context, which
   the enclosing frame boundary writes: `rf/frame-provider` and
@@ -5917,7 +5972,16 @@
            ;; epoch-history scan per render).
            (pipeline-view steps
                           {:dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
-                                                    epoch-history)})]
+                                                    epoch-history)
+                           ;; rf2-k97c.3 — the two reads the HANDLER and
+                           ;; SUBSCRIPTIONS rows used to perform
+                           ;; THEMSELVES, hoisted here and threaded down
+                           ;; as values. See this view's docstring for
+                           ;; why they are not left to donate upward.
+                           :selected-epoch-record
+                           (rf.fresco/sub [:rf.xray/selected-epoch-record])
+                           :subs-filter-mode
+                           (rf.fresco/sub [:rf.xray.epoch/subs-filter-mode])})]
           (empty-state-view :no-events))
 
         :else

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -60,14 +60,33 @@
   for the follow-on rich-expansion pass (see the §expansion state
   helpers comment below); until then it is registered-but-unused.
 
-  ## Pure hiccup
+  ## Hiccup, and who renders it (rf2-k97c.3)
 
-  The panel emits hiccup; the substrate adapter installed via
-  `rf/init!` handles rendering. Each step body is a body-returning
-  helper composed into the numbered cascade by `pipeline-view`."
+  The panel still emits hiccup, but [[Panel]] is a `rf.fresco/defview`
+  boundary rather than an `rf/reg-view`, so FRESCO renders it — not the
+  substrate adapter installed via `rf/init!`. Each step body is still a
+  body-returning helper composed into the numbered cascade by
+  `pipeline-view`, and every one of them is CALLED rather than used as a
+  hiccup head, which is what keeps this whole file under one boundary.
+
+  Two consequences worth knowing before editing a helper here:
+
+    * A PLAIN FN IN HEAD POSITION IS A LOUD ERROR under a boundary —
+      Fresco's codec grades it `:invalid` — and it is the wrong shape
+      anyway: a plain fn carries no `:contextType`, so an ambient read
+      inside one resolves its frame to nil and raises
+      `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun; there is
+      no `:rf/default` fallback). CALL the helper. Only a `defview` — the
+      widget siblings `ei/edn-inspector-view` and `rt/resizable-table-view`
+      — belongs in head position.
+    * `^{:key …}` METADATA REACHES REACT NOWHERE under Fresco: the codec
+      takes a literal `:key` from an ATTRIBUTE MAP and reads Clojure
+      metadata not at all. Every sibling key in this file rides the
+      attribute map; keep it that way."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.flows :as rf.flows]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.schemas :as rf.schemas]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
@@ -2013,9 +2032,12 @@
   (when (vector? event)
     [:div {:data-testid "rf-xray-epoch-dispatch-event"}
      [:div {:style dispatch-body-style}
-      [ei/edn-inspector event {:site-id "epoch-dispatch-event"
-                               :card?   false
-                               :zoomable? true}]]]))
+      [ei/edn-inspector-view
+       {:mount-id "epoch/dispatch-event"
+        :value    event
+        :opts     {:site-id "epoch-dispatch-event"
+                   :card?   false
+                   :zoomable? true}}]]]))
 
 (defn- dispatch-source-label
   "Render the dispatch source label — `<source>` text. When the
@@ -2398,7 +2420,7 @@
         [:span {:style coeffect-body-arrow-style} "→"]
         [:span {:style coeffect-body-path-style} "arg"]
         [:span {:style coeffect-body-value-style}
-         [ei/mini input 80]]])
+         (ei/mini input 80)]])
      (if no-value?
        [:div {:data-testid (str "rf-xray-epoch-coeffect-failed-" (name id))
               :style coeffect-body-style}
@@ -2410,7 +2432,7 @@
         [:span {:style coeffect-body-path-style}
          (str "[" (fmt/ns-keyword id) "]")]
         [:span {:style coeffect-body-value-style}
-         [ei/mini value 80]]])
+         (ei/mini value 80)]])
      ;; rf2-yz57h — a coeffect-injection EXCEPTION attaches here as the
      ;; shared inline 'Exception Thrown' card (button-19), under the
      ;; COEFFECT step where it occurred (no longer collapsed onto HANDLER).
@@ -3193,11 +3215,13 @@
       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-" step)
              :style cascade-row-source-style}
        [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-delta-" step)}
-        [ei/edn-inspector after-ls
-         (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-transition-delta step]
-                  :card?                  false
-                  :default-expanded-depth 3}
-           (some? before-ls) (assoc :before before-ls))]]])))
+        [ei/edn-inspector-view
+         {:mount-id (str "epoch/machine-cascade-transition-delta/" step)
+          :value    after-ls
+          :opts     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-transition-delta step]
+                             :card?                  false
+                             :default-expanded-depth 3}
+                      (some? before-ls) (assoc :before before-ls))}]]])))
 
 ;; ---- structured transition cascade render (rf2-52u5n) -------------------
 ;;
@@ -3271,10 +3295,12 @@
     [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-" step)
            :style cascade-row-source-style}
      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-start-data-" step)}
-      [ei/edn-inspector data
-       {:site-id                [:rf.xray.epoch/machine-cascade-start-data step]
-        :card?                  false
-        :default-expanded-depth 3}]]]))
+      [ei/edn-inspector-view
+       {:mount-id (str "epoch/machine-cascade-start-data/" step)
+        :value    data
+        :opts     {:site-id                [:rf.xray.epoch/machine-cascade-start-data step]
+                   :card?                  false
+                   :default-expanded-depth 3}}]]]))
 
 (defn- cascade-row-source-body
   "Render the source code body for a cascade row (rf2-u69j7 baseline +
@@ -3377,11 +3403,13 @@
          :style cascade-detail-row-style}
    [:span {:style cascade-detail-data-arrow-style} "↳"]
    [:span {:style cascade-detail-value-style}
-    [ei/edn-inspector data-write
-     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-data step]
-              :card?                  false
-              :default-expanded-depth 3}
-       (some? data-before) (assoc :before data-before))]]])
+    [ei/edn-inspector-view
+     {:mount-id (str "epoch/machine-cascade-data/" step)
+      :value    data-write
+      :opts     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-data step]
+                         :card?                  false
+                         :default-expanded-depth 3}
+                  (some? data-before) (assoc :before data-before))}]]])
 
 (defn- cascade-row-action-outcome-details
   "Render the per-action outcome details for an `:action` cascade row
@@ -3998,7 +4026,12 @@
   slot folds into SNAPSHOT DIFF rather than carrying a redundant
   standalone slot."
   [db-post-handler db-write?]
-  (let [record    @(rf/subscribe [:rf.xray/selected-epoch-record])
+  ;; rf2-k97c.3 — `rf.fresco/sub`, a plain call the collector records an
+  ;; edge for, DONATED UPWARD into `Panel`'s window (this helper is called,
+  ;; never headed, so it has no boundary of its own). HD-016: a
+  ;; helper-donated read is settled rather than contingent. The frame comes
+  ;; from React context, so the read needs no `{:frame …}` option.
+  (let [record    (rf.fresco/sub [:rf.xray/selected-epoch-record])
         db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
         ;; HANDLER `:db`; fall back to the record's post-flow `:db-after`
@@ -4028,10 +4061,12 @@
        (some? db-after)
        [:div {:data-testid "rf-xray-epoch-handler-db-full-with-diff"
               :style handler-db-all-style}
-        [ei/edn-inspector db-after
-         {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
-          :before db-before
-          :default-expanded-depth 3}]]
+        [ei/edn-inspector-view
+         {:mount-id (str "epoch/handler-db-full-with-diff/" (:epoch-id record))
+          :value    db-after
+          :opts     {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
+                     :before db-before
+                     :default-expanded-depth 3}}]]
 
        :else
        [:span {:data-testid "rf-xray-epoch-handler-db-full-with-diff-missing"
@@ -4101,22 +4136,26 @@
        (let [n (count fx-vec)]
          [:div {:data-testid "rf-xray-epoch-handler-fx"}
           (sub-header ":fx" (str n " entr" (if (= 1 n) "y" "ies")))
-          [ei/edn-inspector fx-vec
-           {:site-id                [:rf.xray.epoch/handler-fx event-id]
-            :card?                  false
-            :zoomable?              true
-            :default-expanded-depth 16}]]))
+          [ei/edn-inspector-view
+           {:mount-id (str "epoch/handler-fx/" event-id)
+            :value    fx-vec
+            :opts     {:site-id                [:rf.xray.epoch/handler-fx event-id]
+                       :card?                  false
+                       :zoomable?              true
+                       :default-expanded-depth 16}}]]))
      ;; other — return map minus :db and :fx, FULL via edn-inspector.
      ;; rf2-5t8y8 — entry-count chip on the sub-header (parallel to :fx).
      (when (seq other-effects)
        (let [n (count other-effects)]
          [:div {:data-testid "rf-xray-epoch-handler-other"}
           (sub-header "other" (str n " entr" (if (= 1 n) "y" "ies")))
-          [ei/edn-inspector other-effects
-           {:site-id                [:rf.xray.epoch/handler-other event-id]
-            :card?                  false
-            :zoomable?              true
-            :default-expanded-depth 16}]]))]))
+          [ei/edn-inspector-view
+           {:mount-id (str "epoch/handler-other/" event-id)
+            :value    other-effects
+            :opts     {:site-id                [:rf.xray.epoch/handler-other event-id]
+                       :card?                  false
+                       :zoomable?              true
+                       :default-expanded-depth 16}}]]))]))
 
 (defn render-handler-step
   "Render the HANDLER step (always present). Per Mike pair-debug
@@ -4258,10 +4297,12 @@
        [:div {:data-testid (str "rf-xray-epoch-flow-db-diff-" (name flow-id))
               :style handler-db-all-style}
         (sub-header ":db" (fmt/path-display path))
-        [ei/edn-inspector diff-after
-         {:site-id [:rf.xray.epoch/flow-db-diff flow-id]
-          :before  diff-before
-          :default-expanded-depth 3}]]
+        [ei/edn-inspector-view
+         {:mount-id (str "epoch/flow-db-diff/" flow-id)
+          :value    diff-after
+          :opts     {:site-id [:rf.xray.epoch/flow-db-diff flow-id]
+                     :before  diff-before
+                     :default-expanded-depth 3}}]]
        ;; Fallback — `[path] before → after` scalar line, left-aligned
        ;; with the badge (no extra indent). Mirrors the COEFFECT step's
        ;; body layout (pair-debug 2026-05-26).
@@ -4273,11 +4314,11 @@
           [:span {:style coeffect-body-path-style}
            (fmt/path-display path)]
           (when (some? before)
-            [:span {:style diff-before-style} [ei/mini before 30]])
+            [:span {:style diff-before-style} (ei/mini before 30)])
           (when (and (some? before) (some? after))
             [:span {:style coeffect-body-path-style} "→"])
           (when (some? after)
-            [:span {:style coeffect-body-value-style} [ei/mini after 30]])]))
+            [:span {:style coeffect-body-value-style} (ei/mini after 30)])]))
      ;; rf2-ahhgn — a flow-eval exception (the flow's compute fn threw,
      ;; aborting the cascade pre-commit) attaches here as an inline card.
      (error-blocks :flow errors)]))
@@ -4393,11 +4434,13 @@
      (cond
        db-row?         (db-destination-marker idx)
        (some? payload) [:span {:style fx-row-args-style}
-                        [ei/edn-inspector payload
-                         {:site-id [:rf.xray.epoch/fx-row-args fx-id idx]
-                          :card? false
-                          :zoomable? true
-                          :default-expanded-depth 1}]])
+                        [ei/edn-inspector-view
+                         {:mount-id (str "epoch/fx-row-args/" fx-id "/" idx)
+                          :value    payload
+                          :opts     {:site-id [:rf.xray.epoch/fx-row-args fx-id idx]
+                                     :card? false
+                                     :zoomable? true
+                                     :default-expanded-depth 1}}]])
      (when (number? duration-ms)
        [:span {:style fx-row-duration-style}
         (fmt/format-duration-ms duration-ms)])
@@ -4603,7 +4646,7 @@
       [:div {:data-rf-xray-subs-leaf "unchanged"
              :data-testid            (str "rf-xray-epoch-subs-leaf-unchanged-" idx)
              :style                  subs-leaf-row-style}
-       [:span [ei/mini after 40]]]
+       [:span (ei/mini after 40)]]
       ;; first-cache-entry → :added chrome, no "was" annotation.
       first-run?
       [:div {:data-rf-xray-subs-leaf  "added"
@@ -4611,7 +4654,7 @@
              :data-testid             (str "rf-xray-epoch-subs-leaf-added-" idx)
              :style                   subs-leaf-added-row-style}
        [:span {:style subs-leaf-added-glyph-style} "+"]
-       [:span [ei/mini after 40]]]
+       [:span (ei/mini after 40)]]
       ;; value change → :modified chrome + value + inline ← was <prev>.
       :else
       [:div {:data-rf-xray-subs-leaf  "changed"
@@ -4619,12 +4662,12 @@
              :data-testid             (str "rf-xray-epoch-subs-leaf-changed-" idx)
              :style                   subs-leaf-modified-row-style}
        [:span {:style subs-leaf-modified-glyph-style} "~"]
-       [:span [ei/mini after 40]]
+       [:span (ei/mini after 40)]
        [:span {:data-rf-diff-annotation "subs-was"
                :style                   subs-leaf-was-style}
         "← was "
         [:span {:data-rf-xray-subs-leaf-was "1"}
-         [ei/mini before 40]]]])
+         (ei/mini before 40)]]])
     ;; rf2-kp7bw — a CONTAINER-valued sub return. On a first run
     ;; (`first-run?`, no prior cache entry) the inspector renders the
     ;; whole subtree as `:added` via the `:added?` opt (edn-inspector
@@ -4639,12 +4682,14 @@
     ;; container (`changed? false`) mounts plain — current value, no
     ;; diff opts (rf2-o77z4).
     [:div {:style subs-value-cell-fill-style}
-     [ei/edn-inspector after
-      (cond-> {:panel-id :rf.xray.epoch/subs-value
-               :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
-               :default-expanded-depth 3}
-        (and changed? (some? before))           (assoc :before before)
-        (and changed? first-run? (nil? before)) (assoc :added? true))]]))
+     [ei/edn-inspector-view
+      {:mount-id (str "epoch/subs-value/" sub-id "/" idx)
+       :value    after
+       :opts     (cond-> {:panel-id :rf.xray.epoch/subs-value
+                          :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
+                          :default-expanded-depth 3}
+                   (and changed? (some? before))           (assoc :before before)
+                   (and changed? first-run? (nil? before)) (assoc :added? true))}]]))
 
 (defn- sub-coord
   "Pull the registered sub's source coord off
@@ -4728,7 +4773,7 @@
   (let [columns [{:id :sub    :label "sub"    :default-flex "1fr"}
                  {:id :inputs :label "inputs" :default-flex "1fr"}
                  {:id :value  :label "value"  :default-flex "1fr"}]]
-    [rt/resizable-table
+    [rt/resizable-table-view
      {:table-id        :rf.xray.epoch/subscriptions
       :container-attrs {:data-testid              "rf-xray-epoch-subscriptions-table"
                         :data-rf-xray-diff-mode   "full+diff"
@@ -4752,8 +4797,8 @@
           ;; fallback keeps the keyword-token chrome via `mini` too.
           [:span {:style subs-cell-id-span-style}
            (if (vector? sub-vec)
-             [ei/mini sub-vec 40]
-             [ei/mini sub-id 40])
+             (ei/mini sub-vec 40)
+             (ei/mini sub-id 40))
            ;; rf2-aesni — functional click-to-source via the shared
            ;; `coord-chip`, exact parity with the disposed-subs (~3167)
            ;; + views (~3311 / ~3380) rows. Pre-fix this was a bare
@@ -4779,7 +4824,7 @@
                    :data-testid (str "rf-xray-epoch-sub-row-cause-event-id-" i)
                    :style subs-cell-cause-event-style}
              [:span "caused by"]
-             [ei/mini cause-event-id 40]])]
+             (ei/mini cause-event-id 40)])]
          ;; inputs cell
          [:div {:data-rf-xray-resizable-col "inputs"
                 :style subs-cell-inputs-style}
@@ -4799,7 +4844,7 @@
             (cond
               (seq input-ids)
               (into [:div {:style subs-inputs-list-style}]
-                    (map (fn [i] [:div [ei/mini i 40]]) input-ids))
+                    (map (fn [i] [:div (ei/mini i 40)]) input-ids))
               ;; rf2-87c8a fallback: a runtime with no captured meta but
               ;; a cascade-attributed `:inputs` slot still paints that
               ;; upstream sub (preserves the pre-fix shape for traces
@@ -4814,8 +4859,8 @@
               ;; and :a1 into two.
               (vector? inputs)
               (into [:div {:style subs-inputs-list-style}]
-                    (map (fn [i] [:div [ei/mini i 40]]) inputs))
-              (some? inputs) [ei/mini inputs 40]
+                    (map (fn [i] [:div (ei/mini i 40)]) inputs))
+              (some? inputs) (ei/mini inputs 40)
               :else          "app-db"))]
          ;; value cell
          [:div {:data-rf-xray-resizable-col "value"
@@ -4858,7 +4903,7 @@
   (let [columns [{:id :glyph    :label ""             :default-flex "24px"}
                  {:id :disposed :label "disposed sub" :default-flex "1.5fr"}
                  {:id :reason   :label "reason"       :default-flex "1fr"}]]
-    [rt/resizable-table
+    [rt/resizable-table-view
      {:table-id        :rf.xray.epoch/subscriptions-disposed
       :container-attrs {:data-testid "rf-xray-epoch-subscriptions-disposed-table"
                         :style       disposed-subs-table-style}
@@ -4886,8 +4931,8 @@
           [:span {:data-testid (str "rf-xray-epoch-sub-disposed-row-id-" i)
                   :style disposed-id-span-style}
            (cond
-             (vector? query) [ei/mini query 40]
-             (some? sub-id)  [ei/mini sub-id 40]
+             (vector? query) (ei/mini query 40)
+             (some? sub-id)  (ei/mini sub-id 40)
              :else           [:span {:style disposed-anonymous-style}
                               "<anonymous sub>"])
            ;; rf2-d2akf — click-to-source affordance for the reg-sub,
@@ -4924,11 +4969,18 @@
   SURROUNDING instance frame captured at render time, and the button-
   bar's click dispatches into that same captured frame — so toggle
   writes + reads hit THIS instance's Xray app-db (N isolated shells
-  stay independent), not the `:rf/xray` singleton."
+  stay independent), not the `:rf/xray` singleton.
+
+  rf2-k97c.3 — the read is now `rf.fresco/sub`, donated upward into
+  `Panel`'s collector window. The anchor is UNCHANGED in effect and
+  simpler in spelling: `rf.fresco/sub` takes no frame option because it
+  resolves the frame off the same React context `rf/current-frame-id`
+  reads, so the read and the click still name ONE frame. `frame` stays
+  bound for the CLICK, which fires after the render extent has unwound
+  and so must have captured it during render."
   [{:keys [rows disposed-rows step-number violations]}]
   (let [frame         (rf/current-frame-id)
-        mode          @(rf/subscribe [:rf.xray.epoch/subs-filter-mode]
-                                     {:frame frame})
+        mode          (rf.fresco/sub [:rf.xray.epoch/subs-filter-mode])
         visible-rows  (case mode
                         :all       rows
                         :unchanged (filterv (complement :changed?) rows)
@@ -5069,17 +5121,19 @@
     (if (some? render-args)
       [:div {:style                  views-render-args-fill-style
              :data-rf-render-args-diff (if (some? prev-render-args) "diff" "plain")}
-       [ei/edn-inspector render-args
-        (cond-> {:panel-id :rf.xray.epoch/view-render-args
-                 :site-id  [:rf.xray.epoch/view-render-args view-id idx]
-                 :default-expanded-depth 2}
-          ;; same `:before` diff-mode the App-db / subs value cells use —
-          ;; reused, not reinvented (rf2-u3lii). Threaded ONLY when the
-          ;; instance had a previous render this cascade; first render =>
-          ;; plain mount (no `:before`), args shown without a delta. The
-          ;; prev value is size-guarded too (rf2-yi0nr).
-          (some? prev-render-args)
-          (assoc :before (fmt/elide-large-render-args prev-render-args)))]]
+       [ei/edn-inspector-view
+        {:mount-id (str "epoch/view-render-args/" view-id "/" idx)
+         :value    render-args
+         :opts     (cond-> {:panel-id :rf.xray.epoch/view-render-args
+                            :site-id  [:rf.xray.epoch/view-render-args view-id idx]
+                            :default-expanded-depth 2}
+                     ;; same `:before` diff-mode the App-db / subs value cells use —
+                     ;; reused, not reinvented (rf2-u3lii). Threaded ONLY when the
+                     ;; instance had a previous render this cascade; first render =>
+                     ;; plain mount (no `:before`), args shown without a delta. The
+                     ;; prev value is size-guarded too (rf2-yi0nr).
+                     (some? prev-render-args)
+                     (assoc :before (fmt/elide-large-render-args prev-render-args)))}]]
       [:span {:data-rf-render-args-diff "none"
               :style views-render-args-none-style}
        "(no args)"])]))
@@ -5108,11 +5162,11 @@
                  :let [status (get sub-status s)]]
              [:div {:data-rf-sub-status (name (or status :unchanged))
                     :style (views-sub-status-style status)}
-              [ei/mini s 60]]))
+              (ei/mini s 60)]))
      (some? subs-read)
      [:span {:data-rf-sub-status (name (or (get sub-status subs-read) :unchanged))
              :style (views-sub-status-style (get sub-status subs-read))}
-      [ei/mini subs-read 60]]
+      (ei/mini subs-read 60)]
      :else
      [:span {:style italic-style} "(none)"])])
 
@@ -5149,7 +5203,7 @@
                  ;; rf2-u3lii — col-2 render-args DIFF, between view + subs.
                  {:id :render-args :label "render-args" :default-flex "1fr"}
                  {:id :subs :label "subs" :default-flex "1fr"}]]
-    [rt/resizable-table
+    [rt/resizable-table-view
      {:table-id        :rf.xray.epoch/views
       :container-attrs {:data-testid "rf-xray-epoch-views-table"
                         :style       views-table-style}
@@ -5184,7 +5238,7 @@
            ;; `ei/mini` so the row reads as an inspectable data entity,
            ;; same syntax-token chrome the App-db / subs value cells use.
            (if (some? view-id)
-             [ei/mini view-id 60]
+             (ei/mini view-id 60)
              [:span {:style views-anonymous-style}
               "<anonymous view>"])
            ;; rf2-3b9w4 — go-to-source coord-chip stays on EVERY row,
@@ -5433,13 +5487,13 @@
           "expected:"]
          [:span {:data-testid (str testid-base "-expected")
                  :style schema-violation-line-value-style}
-          [ei/mini (:expected decoded) 80]]]
+          (ei/mini (:expected decoded) 80)]]
         [:div {:style schema-violation-line-style}
          [:span {:style schema-violation-line-label-style}
           "got:"]
          [:span {:data-testid (str testid-base "-got")
                  :style schema-violation-line-value-style}
-          [ei/mini (:got decoded) 80]]]
+          (ei/mini (:got decoded) 80)]]
         (when (pos? (:more-errors decoded))
           [:div {:data-testid (str testid-base "-more-errors")
                  :style schema-violation-sensitive-style}
@@ -5456,9 +5510,11 @@
      (when (some? humanized-shown)
        [:div {:data-testid (str testid-base "-explain")
               :style schema-violation-explain-body-style}
-        [ei/edn-inspector humanized-shown
-         {:site-id [:rf.xray.epoch/violation-explain step-key idx]
-          :default-expanded-depth 16}]])
+        [ei/edn-inspector-view
+         {:mount-id (str "epoch/violation-explain/" step-key "/" idx)
+          :value    humanized-shown
+          :opts     {:site-id [:rf.xray.epoch/violation-explain step-key idx]
+                     :default-expanded-depth 16}}]])
      ;; Sensitive marker — keep as compact tail when applicable so
      ;; operators reading the humanized output know the value was
      ;; redacted at the substrate emit site (not a humanizer artifact).
@@ -5548,10 +5604,12 @@
        (when (seq ex-data*)
          [:div {:data-testid (str testid-base "-ex-data")}
           [:div {:style error-block-data-label-style} "ex-data"]
-          [ei/edn-inspector ex-data*
-           {:site-id [:rf.xray.epoch/error-ex-data testid-base]
-            :card?   false
-            :default-expanded-depth 1}]])
+          [ei/edn-inspector-view
+           {:mount-id (str "epoch/error-ex-data/" testid-base)
+            :value    ex-data*
+            :opts     {:site-id [:rf.xray.epoch/error-ex-data testid-base]
+                       :card?   false
+                       :default-expanded-depth 1}}]])
        (when stack
          [:div {:data-testid (str testid-base "-stack")}
           [:div {:style error-block-data-label-style} "stack"]
@@ -5735,18 +5793,23 @@
             :aria-hidden true
             :style pipeline-rail-style}]
      ;; Steps — `doall` forces the lazy `for` to realise INSIDE the
-     ;; reg-view's render scope (rf2-atqkg). `render-step` returns
-     ;; hiccup whose descendants (e.g. `handler-db-diff-block`,
-     ;; `render-subscriptions-step`) deref subs directly via
-     ;; `@(rf/subscribe …)`. Reagent only tracks derefs that fire
-     ;; while the parent reg-view's reactive context is live; a
-     ;; lazy seq realised AFTER the render pass leaves those derefs
-     ;; outside the scope, so sub-value changes don't trigger a
-     ;; re-render (symptom: the operator clicks `[diff][all]`, the
-     ;; sub flips in app-db, the cascade reads the new value, but
-     ;; the panel hiccup stays stale). `doall` plus the `(for …)`
-     ;; preserves the original code shape; the realised seq lets
-     ;; Reagent see every nested deref at render time. See spec/006
+     ;; render pass (rf2-atqkg), and rf2-k97c.3 did NOT retire the
+     ;; reason: it re-founded it on the collector. `render-step`
+     ;; returns hiccup whose descendants (`handler-db-diff-block`,
+     ;; `render-subscriptions-step`) read the substrate themselves.
+     ;;
+     ;; Pre-migration those were `@(rf/subscribe …)` and the tracker was
+     ;; Reagent's reactive context: derefs firing after the render pass
+     ;; landed outside it, so a sub-value change triggered no re-render
+     ;; (symptom: the operator clicks `[diff][all]`, the sub flips in
+     ;; app-db, the cascade reads the new value, and the panel hiccup
+     ;; stays stale). They are now `rf.fresco/sub` and the tracker is
+     ;; Fresco's collector, which records an edge WHERE THE READ HAPPENS
+     ;; — so a read that happens after this body has returned is recorded
+     ;; into no window at all and the same staleness returns by the same
+     ;; route. The `doall` is what keeps every donated read inside
+     ;; `Panel`'s window; it is load-bearing under BOTH observers, which
+     ;; is why it survives the migration unchanged. See spec/006
      ;; §Lazy-seq deref tracking.
      (doall
        (for [[i step] (map-indexed vector steps)]
@@ -5790,22 +5853,55 @@
 
 ;; ---- public Panel --------------------------------------------------------
 
-(rf/reg-view Panel
-  "Epoch panel root view. Subscribes to `:rf.xray/epoch-pipeline` —
-  a composite that resolves the focused epoch off the spine and
-  projects its `:trace-events` into the pipeline-step rows. Renders
-  the numbered cascade when steps are present; an empty-state when
-  the focus carries no record or the record carries no trace events.
+(rf.fresco/defview Panel
+  "Epoch panel root view. Reads `:rf.xray/epoch-pipeline` — a composite
+  that resolves the focused epoch off the spine and projects its
+  `:trace-events` into the pipeline-step rows. Renders the numbered
+  cascade when steps are present; an empty-state when the focus carries
+  no record or the record carries no trace events.
 
   rf2-ahhgn / rf2-wnvid / rf2-9wq0v — when the cascade failed
   (`:outcome :error`) the failure surfaces INLINE: the failing step's
   'Exception Thrown' card sits under it (the per-stage ✗ glyph retired
   in rf2-9wq0v). The panel root stamps `data-rf-xray-outcome` for tools /
   e2e; the pre-rf2-wnvid top banner is retired (it merely restated the
-  inline signal)."
-  []
+  inline signal).
+
+  A FRESCO BOUNDARY (rf2-k97c.3), not an `rf/reg-view`, and the two
+  differences that matter are the epic's couplings rather than spelling.
+
+  The READS are `rf.fresco/sub` — plain calls the shipped collector
+  records an edge for, with no deref and no reaction owned by the
+  INSTALLED adapter. That is coupling (3), and it is the one a
+  first-paint smoke test cannot see. Three sites read, not one: this
+  body's pipeline read, plus `db-diff-slot`'s selected-epoch record and
+  `step-subscriptions`' filter mode, both of which donate their read
+  upward into this boundary's collector window from an inlined helper
+  (HD-016 — helper-donated reads are settled rather than contingent).
+
+  The FRAME each read resolves against comes from React context, which
+  the enclosing frame boundary writes: `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context, so this boundary
+  resolves `:rf/xray` identically under today's Reagent-rendered shell
+  and under the Fresco root Xray will own. It never consults
+  `:adapter/current-component`, the hook a foreign root cannot answer.
+
+  ## Why there is no second boundary below this one
+
+  Boundary count tracks reads and head-position use, not file size. At
+  5.9k lines this panel has exactly the three reads above and — since
+  rf2-k97c.3 — no plain-fn head at all: `ei/mini`'s 21 head uses are now
+  CALLS, and the widget heads are the shipped Fresco siblings
+  (`ei/edn-inspector-view` ×13, `rt/resizable-table-view` ×3), each a
+  boundary in its own right. So nothing in the interior wants a
+  component of its own.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — neither the L4 registry
+  nor the standalone embed passes any — so it is destructured away."
+  [_props]
   (let [{:keys [status steps epoch-history outcome]}
-        @(rf/subscribe [:rf.xray/epoch-pipeline])]
+        (rf.fresco/sub [:rf.xray/epoch-pipeline])]
     [:section {:data-testid "rf-xray-epoch-panel"
                :data-rf-xray-outcome (when outcome (name outcome))
                :style panel-root-style}
@@ -5833,31 +5929,45 @@
 ;; through `panels.epoch-panel`'s re-export), and RULING 1's surviving
 ;; spelling puts the Fresco boundary on the natural name with a PUBLIC
 ;; bridge passed by the caller — the shape `resources/Panel-bridge` already
-;; ships. Pointing the mount facade at the bridge name NOW, while it is
-;; still a plain alias, is what lets this panel's migration happen entirely
-;; INSIDE THIS FILE: `Panel` becomes the `defview` boundary and this def
-;; becomes the real `rf.fresco/as-component` bridge, with `panels.cljs`
-;; never touched again (`epoch-panel`'s re-export is a `def` of whatever
-;; this is, so it is correct in both eras). It adopts RULING 1 early rather
-;; than bending it.
+;; ships, and the funnel that pointed the mount facade here (PR #9654)
+;; is what let this panel's migration happen ENTIRELY INSIDE THIS FILE and
+;; `epoch_panel.cljs`'s one re-export line: `panels.cljs` was never touched.
 ;;
-;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
-;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
-;; SAME OBJECT — nothing downstream can tell the two names apart, which is
-;; exactly what `epoch-panel`'s existing `(def Panel view/Panel)` has been
-;; demonstrating in production. And `render-panel!` always builds the
-;; component VECTOR `[panel-view]`, so head position is the only position
-;; either name is used in, and the hazard `render-panel!`'s docstring warns
-;; about is not reached: what is unsafe there is CALLING the view, because
-;; that fn runs outside any React render and an ambient subscribe with no
-;; in-flight component resolves to nil and RAISES
-;; `:rf.error/no-frame-context` (there is no `:rf/default` fallback — Spec
-;; 006 §Plain-fn footgun).
-(def Panel-bridge
-  "The name `panels/mount-epoch-panel!` mounts this panel through, via
-  `panels.epoch-panel`'s re-export — a plain alias of `Panel` until this
-  panel migrates to Fresco, when it becomes the `as-component` bridge
-  without the mount facade moving. Scaffolding with a defined end: it is
-  deleted with every other `*-bridge` when the shell itself becomes a
-  Fresco tree. See the comment above."
-  Panel)
+;; IT IS NO LONGER A NO-OP. Until this commit `Panel-bridge` was a `def`
+;; aliasing the `reg-view` value, and nothing downstream could tell the two
+;; names apart. `Panel` is now a Fresco boundary — a React function
+;; component — and Xray's shell is still a `reg-view` tree rendered by the
+;; installed adapter, which mounts the active tab as the hiccup head
+;; `[(:panel tab)]` with `panel-registry/reg-l4-tab!`'s `:pre` requiring
+;; `:panel` to be CALLABLE. A React component is neither.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI — and the `[rf/frame-provider {:frame :rf/xray}]` the shell already
+;; wraps the panel in is what puts `:rf/xray` in that context.
+;;
+;; STILL SCAFFOLDING WITH A DEFINED END: when the shell is itself a Fresco
+;; tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and both defs
+;; below are deleted with every other `*-bridge`.
+(def ^:private Panel-component
+  "The React component [[Panel]] presents as, for a non-Fresco parent.
+  Declared ONCE at top level beside the view, as `rf.fresco/as-component`'s
+  own contract requires — deriving it per render would mint a fresh
+  component type every pass and remount the whole panel, taking every
+  `edn-inspector-view` expansion and every table width with it."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable `panels/mount-epoch-panel!` mounts this panel through, via
+  `panels.epoch-panel`'s re-export. Returns Reagent-shaped hiccup
+  interoping to the React component above.
+
+  PUBLIC, because this panel carries a `mount-epoch-panel!` facade and
+  `panels/render-panel!` takes the view to mount as an ARGUMENT — so the
+  embedding contract needs a name it can pass. Deleted with the component
+  above when the shell itself becomes a Fresco tree."
+  []
+  [:> Panel-component {}])

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs
@@ -139,16 +139,24 @@
 ;; ---- public Panel surface ------------------------------------------------
 
 ;; Re-export the view-side `Panel` so the spine + panel-registry
-;; resolve a single name. `mount-fns` (panels.cljs) reach through this
-;; ns when added to the per-panel mount inventory.
+;; resolve a single name.
+;;
+;; rf2-k97c.3 — `Panel` is now a FRESCO BOUNDARY (a React function
+;; component), not an `rf/reg-view`, so this name is no longer callable
+;; and no longer what anything MOUNTS. It is kept because it is still the
+;; canonical name for the panel's root view, which prose and the shell's
+;; routing table refer to; everything that mounts goes through
+;; `Panel-bridge` below.
 (def Panel view/Panel)
 
 ;; rf2-k97c.3 — the same re-export for the migration bridge name, which is
-;; what `panels/mount-epoch-panel!` now mounts through. A `def` of whatever
-;; `view/Panel-bridge` is, so this line is correct both while the bridge is
-;; a plain alias of the `reg-view` and after the panel migrates and it
-;; becomes a real `as-component` bridge — the migration stays inside
-;; `panels/epoch/view.cljs`, which is the whole point of the bridge name.
+;; what `panels/mount-epoch-panel!` AND the L4 tab registration below both
+;; mount through. This line predates the migration and needed no change
+;; when it landed: it is a `def` of whatever `view/Panel-bridge` is, which
+;; was a plain alias of the `reg-view` and is now the real
+;; `rf.fresco/as-component` bridge. That is the whole point of the bridge
+;; name — the migration stayed inside `panels/epoch/view.cljs` and this
+;; file's one registration line, and `panels.cljs` was never touched.
 (def Panel-bridge view/Panel-bridge)
 
 ;; ---- registration --------------------------------------------------------
@@ -315,4 +323,10 @@
      ;; pair-debug call 2026-05-26: the event-bundle pipeline view is the
      ;; primary "what just happened" surface; it belongs first.
      :order -1
-     :panel Panel}))
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary); `reg-l4-tab!`'s `:pre` requires
+     ;; `:panel` to be CALLABLE and `shell/detail-panel` mounts it as a
+     ;; Reagent hiccup head `[(:panel tab)]`, neither of which a React
+     ;; component satisfies. The bridge is the one line between them and
+     ;; goes when the shell itself is a Fresco tree.
+     :panel Panel-bridge}))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -314,12 +314,20 @@
   surface), so migrating it is that slice's to make, not this one's.
   ELEMENT 2 needs no island — every head reachable through
   `epoch-view/machine-cascade-mini-pipeline` was repaired in the same
-  commit, so that whole subtree is head-free."
+  commit, so that whole subtree is head-free.
+
+  `fit-signal` ARRIVES AS AN ARGUMENT; it used to be read here with
+  `@(rf/subscribe [:rf.xray/machine-tab-fit-signal])`. [[Panel]] reads it
+  now. HD-016 would have allowed the read to stay and donate upward, but
+  a `rf.fresco/sub` raises outside a collector window, which would make
+  this fn callable only inside a real React commit — and its markup is
+  ordinary data → data that the node lane drives."
   [cascade
    {:keys [machine-id from-state to-state definition fired-edge-ids
            guard-blocked-edge-ids start? no-op?]
     :as _record}
-   as-child]
+   as-child
+   fit-signal]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance is GONE; xyflow + elkjs own positioning end-to-end
   ;; inside `MachineChart`. The panel only computes the from/to node-ids
@@ -335,16 +343,13 @@
                      (chart-layout/highlight-id from-state))
         to-id      (when (and to-state (not no-op?))
                      (chart-layout/highlight-id to-state))
-        engine     "xyflow+elkjs"
-        ;; rf2-6tw7t — fit-on-entry nonce. Bumped by `:rf.xray/select-tab
-        ;; :machines`; forwarded to the chart's `:fit-signal` so the
-        ;; topology re-frames whenever the operator (re-)enters the
-        ;; Machine tab, even when the focused machine (hence the chart's
-        ;; layout-key) is unchanged.
-        ;; rf2-k97c.3 — `rf.fresco/sub`, donated upward into [[Panel]]'s
-        ;; collector window: this helper is CALLED, never headed, so it has
-        ;; no boundary of its own and the read belongs to the panel's.
-        fit-signal (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])]
+        ;; rf2-6tw7t — fit-on-entry nonce (arrives as an argument since
+        ;; rf2-k97c.3). Bumped by `:rf.xray/select-tab :machines`;
+        ;; forwarded to the chart's `:fit-signal` so the topology
+        ;; re-frames whenever the operator (re-)enters the Machine tab,
+        ;; even when the focused machine (hence the chart's layout-key)
+        ;; is unchanged.
+        engine     "xyflow+elkjs"]
     [:section
      {:data-testid (str "rf-xray-machine-focused-event-section-"
                         (when machine-id
@@ -548,23 +553,23 @@
   rf2-alsnz — `records` flows in as an arg so the panel reads the
   composite once per render instead of twice.
 
-  rf2-k97c.3 — `as-child` is threaded straight through to
-  [[focused-event-section]], which is the only place it is used; see that
-  fn's docstring for what it islands and why."
-  [records cascade as-child]
+  rf2-k97c.3 — `as-child` and `fit-signal` are threaded straight through
+  to [[focused-event-section]], the only place either is used; see that
+  fn's docstring for what the island covers and why the nonce is an
+  argument now. `target-frame` likewise ARRIVES AS AN ARGUMENT rather
+  than being read here, for the same reason: a `rf.fresco/sub` raises
+  outside a collector window, and this fn is node-lane-driven."
+  [records cascade as-child fit-signal target-frame]
   (let [;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
         ;; sorts cascade-document-order, so `first` is the tiebreaker.
-        record (h/pick-focused-transition records)
-        ;; rf2-un3gfo — the inspected frame id. Part of the STRUCTURAL
-        ;; section key below so the L1 frame picker (which re-seeds the
-        ;; panel against a different runtime) gets a clean section
-        ;; instance, while ordinary Prev/Next within one frame+machine
-        ;; preserves it.
-        ;; rf2-k97c.3 — `rf.fresco/sub`, donated upward into [[Panel]]'s
-        ;; collector window (this helper is called, never headed).
-        target-frame (rf.fresco/sub [:rf.xray/target-frame])]
+        ;; rf2-un3gfo — `target-frame` (an argument since rf2-k97c.3) is
+        ;; the inspected frame id. Part of the STRUCTURAL section key
+        ;; below so the L1 frame picker (which re-seeds the panel against
+        ;; a different runtime) gets a clean section instance, while
+        ;; ordinary Prev/Next within one frame+machine preserves it.
+        record (h/pick-focused-transition records)]
     (when record
       [:div {:data-testid "rf-xray-machine-focused-event"
              ;; The host carries the count of records the cascade
@@ -595,7 +600,7 @@
        ;; `focused-event-section` answers hiccup whose own attribute map
        ;; is not ours to write into, so the key rides the fragment.
        [:<> {:key (h/focused-event-section-key target-frame record)}
-        (focused-event-section cascade record as-child)]])))
+        (focused-event-section cascade record as-child fit-signal)]])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
@@ -679,12 +684,15 @@
   [[focused-event-section]] and used nowhere else: `identity` for a
   hiccup caller, `reagent.core/as-element` under the boundary.
 
-  NOT PURE in one respect worth naming: the two helpers it calls —
-  [[focused-event-view]] and [[focused-event-section]] — each perform one
-  `rf.fresco/sub`, which DONATES upward into the calling boundary's
-  collector window (HD-016). Under the node lane they are ordinary reads
-  against whatever frame the test binds."
-  [{:keys [empty-kind]} records cascade as-child]
+  PURE: every helper it calls is a plain fn of its arguments. Two values
+  that used to be read deep in the tree — [[focused-event-view]]'s
+  target-frame and [[focused-event-section]]'s fit-signal — are arguments
+  now and read once in [[Panel]]. HD-016 would have let them donate
+  upward instead, and that would have been correct in production; they
+  were hoisted because a `rf.fresco/sub` raises outside a collector
+  window, which would have made this whole tree callable only inside a
+  real React commit."
+  [{:keys [empty-kind]} records cascade as-child fit-signal target-frame]
   (let [;; The first record's machine-id drives the prev/next nav (a
         ;; cascade may touch multiple machines; the nav's "this machine"
         ;; is the head section's machine).
@@ -717,7 +725,7 @@
        ;; does not duplicate-subscribe the same composite handle.
        [:div {:data-testid "rf-xray-machine-inspector-focused-event-host"
               :style focused-event-host-style}
-        (focused-event-view records cascade as-child)]
+        (focused-event-view records cascade as-child fit-signal target-frame)]
 
        :else
        (blank-state))]))
@@ -730,10 +738,20 @@
   The READS are `rf.fresco/sub` — plain calls the shipped collector
   records an edge for, with no deref and no reaction owned by the
   INSTALLED adapter. That is the third of the epic's three couplings and
-  the one a first-paint smoke test cannot see. Two more reads donate
-  upward into this boundary's window from inlined helpers
-  ([[focused-event-view]]'s target-frame and [[focused-event-section]]'s
-  fit-signal), which HD-016 makes settled rather than contingent.
+  the one a first-paint smoke test cannot see.
+
+  ALL FIVE OF THE PANEL'S READS ARE IN THIS BODY. Two of them used to sit
+  deep in the tree ([[focused-event-view]]'s target-frame and
+  [[focused-event-section]]'s fit-signal) and HD-016 would have let them
+  DONATE upward into this window, which is settled rather than contingent
+  and would have been correct. They were hoisted for a reason about
+  TESTING rather than correctness: a `rf.fresco/sub` raises
+  `:rf.error/fresco-sub-outside-render` outside a collector window, so a
+  helper performing one is callable only inside a real React commit — and
+  this panel's markup is ordinary data → data with a large fast node-lane
+  suite over it. The cost is that both are now read on every panel render
+  rather than only when a focused-event section happens to render; neither
+  widens invalidation in practice.
 
   The FRAME they resolve against comes from React context, which the
   enclosing frame boundary writes — `rf/frame-provider` and
@@ -758,7 +776,9 @@
               ;; same focused epoch Prev/Next drives, so the mini-pipeline
               ;; and the chart move together.
               (:cascade (rf.fresco/sub [:rf.xray/machine-focused-epoch-cascade]))
-              r/as-element))
+              r/as-element
+              (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])
+              (rf.fresco/sub [:rf.xray/target-frame])))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -37,11 +37,22 @@
     - `:after` countdown rings overlay (when armed timers exist).
     - prev/next nav (per-machine epoch walking).
 
-  ## Pure hiccup
+  ## Hiccup, and who renders it (rf2-k97c.3)
 
-  Same contract as every other Xray panel — the view is pure hiccup,
-  no Reagent / UIx references. Frame isolation comes from the
-  enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`."
+  The markup is still pure hiccup, but [[Panel]] is a `rf.fresco/defview`
+  boundary rather than an `rf/reg-view`, so FRESCO renders it — not the
+  substrate adapter installed via `rf/init!`. [[panel-tree]] holds the
+  markup as a pure fn so the node lane can still drive it.
+
+  `reagent.core` IS referenced now, and only as a migration seam: one
+  `as-element` island for the topology chart, which is still an
+  `rf/reg-view` and shared with the Static surface. Every other helper in
+  this file answers hiccup and is CALLED, never used as a hiccup head —
+  the standard HD-016 repair, and what keeps this file to one boundary.
+
+  Frame isolation is unchanged and comes from the same place: the
+  enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`,
+  which writes the React context a boundary reads its frame from."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             ;; rf2-kq8nac (EP-0005) — the snapshot-egress chokepoint. The
@@ -55,6 +66,13 @@
             ;; `[:schemas :data]` slot lands as `:rf/redacted` / the size
             ;; marker before any panel surface reads it — never raw.
             [re-frame.classification :as rf.classification]
+            [re-frame.fresco :as rf.fresco]
+            ;; rf2-k97c.3 — `reagent.core/as-element` is the `as-child`
+            ;; spelling [[Panel]] hands down for the ONE island this panel
+            ;; still needs (the topology chart; see [[panel-tree]]). The
+            ;; markup stays pure hiccup — Reagent appears here as a
+            ;; migration seam, not as an authoring dependency.
+            [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             ;; rf2-g2axio — the SHARED EVENT HANDLER machine-cascade
@@ -282,11 +300,26 @@
   chart-collapse toggle + summary, the snapshot drill-in, and the
   inline cancellation-cascade block — all subsumed by the shared
   mini-pipeline above the chart, or relocated to the chart's own
-  toolbar."
+  toolbar.
+
+  rf2-k97c.3 — `as-child` is the island spelling [[panel-tree]] threads
+  down: `identity` for a hiccup caller (the node lane), and
+  `reagent.core/as-element` under the boundary. It wraps ELEMENT 3 only.
+  `machine-canvas/Chart` is still an `rf/reg-view`, and a `reg-view` head
+  grades `:invalid` under Fresco's codec down the IDENTICAL arm a plain
+  `defn` does — the codec reads one own property, `frescoBoundary`, which
+  only `rf.fresco/defview` sets. Islanding rather than migrating `Chart`
+  is a SCHEDULING call and a deliberate one: `Chart` has a second consumer
+  outside this panel (`panels/machines/topology_view.cljs`, on the Static
+  surface), so migrating it is that slice's to make, not this one's.
+  ELEMENT 2 needs no island — every head reachable through
+  `epoch-view/machine-cascade-mini-pipeline` was repaired in the same
+  commit, so that whole subtree is head-free."
   [cascade
    {:keys [machine-id from-state to-state definition fired-edge-ids
            guard-blocked-edge-ids start? no-op?]
-    :as _record}]
+    :as _record}
+   as-child]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance is GONE; xyflow + elkjs own positioning end-to-end
   ;; inside `MachineChart`. The panel only computes the from/to node-ids
@@ -308,7 +341,10 @@
         ;; topology re-frames whenever the operator (re-)enters the
         ;; Machine tab, even when the focused machine (hence the chart's
         ;; layout-key) is unchanged.
-        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])]
+        ;; rf2-k97c.3 — `rf.fresco/sub`, donated upward into [[Panel]]'s
+        ;; collector window: this helper is CALLED, never headed, so it has
+        ;; no boundary of its own and the read belongs to the panel's.
+        fit-signal (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])]
     [:section
      {:data-testid (str "rf-xray-machine-focused-event-section-"
                         (when machine-id
@@ -396,54 +432,55 @@
          ;; rf2-y3l8z — the chart wraps an interactive viewport adapter
          ;; (zoom/pan/fit + controls toolbar) and owns the after-rings
          ;; overlay so they stay co-located with the canvas.
-         [machine-canvas/Chart
-          {:definition         definition
-           :machine-id         machine-id
-           ;; rf2-kq8nac (EP-0005) — surface the AUTHORITATIVE declared
-           ;; Context shape (keys + type captions) in the focused-event
-           ;; chart's root Context band, with the declared-vs-inferred
-           ;; indicator. When the machine declares a `[:schemas :data]` schema the
-           ;; shape is read off the schema and `:context-band-inferred?`
-           ;; is FALSE (the chart drops the `inferred from :data` badge and
-           ;; shows `declared` — consistent with the Static Topology view
-           ;; from rf2-3q4k5b); absent a schema it falls back to the
-           ;; one-sample inference (rf2-5tz9p's badge stays). This is the
-           ;; SHAPE, not live `:data` VALUES — the live runtime `:data`
-           ;; surfaces (egress-redacted) through the SHARED mini-pipeline's
-           ;; cascade rows above, never raw here.
-           :context-band       (topology-view/static-context-shape definition)
-           :context-band-inferred? (topology-view/static-context-inferred? definition)
-           ;; rf2-skmc7 — a NO-OP has no from→to edge; suppress the
-           ;; from/to highlight grammar and surface the CURRENT state via
-           ;; `:current-state` instead.
-           :from-highlight     (when-not no-op? from-state)
-           :to-highlight       (when-not no-op? to-state)
-           ;; rf2-eldze / rf2-skmc7 — a BIRTH's initial state and a
-           ;; NO-OP's unchanged current state both ride `:current-state`
-           ;; so the chart highlights the one resting node.
-           :current-state      (cond
-                                 start? to-state
-                                 no-op? to-state
-                                 :else  nil)
-           ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
-           ;; treatment on the live chart.
-           :fired-edge-ids     fired-edge-ids
-           ;; rf2-fzrzlw — the attempted-and-rejected edges (guard-blocked
-           ;; no-op, e.g. door :door/close blocked by :may-close?) paint
-           ;; the PINK guard-blocked treatment on the live chart so the
-           ;; operator sees which edge the event hit + that a guard
-           ;; rejected it (no transition fired, so the fired set is empty).
-           :guard-blocked-edge-ids guard-blocked-edge-ids
-           ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
-           ;; tab re-frames the topology.
-           :fit-signal         fit-signal
-           :on-state-click     (fn [path]
-                                 (rf/dispatch
-                                   [:rf.xray/machine-state-clicked
-                                    {:machine-id machine-id
-                                     :path       path}]
-                                   {:frame frame}))
-           :show-after-rings?  true}]]])]))
+         (as-child
+           [machine-canvas/Chart
+            {:definition         definition
+             :machine-id         machine-id
+             ;; rf2-kq8nac (EP-0005) — surface the AUTHORITATIVE declared
+             ;; Context shape (keys + type captions) in the focused-event
+             ;; chart's root Context band, with the declared-vs-inferred
+             ;; indicator. When the machine declares a `[:schemas :data]` schema the
+             ;; shape is read off the schema and `:context-band-inferred?`
+             ;; is FALSE (the chart drops the `inferred from :data` badge and
+             ;; shows `declared` — consistent with the Static Topology view
+             ;; from rf2-3q4k5b); absent a schema it falls back to the
+             ;; one-sample inference (rf2-5tz9p's badge stays). This is the
+             ;; SHAPE, not live `:data` VALUES — the live runtime `:data`
+             ;; surfaces (egress-redacted) through the SHARED mini-pipeline's
+             ;; cascade rows above, never raw here.
+             :context-band       (topology-view/static-context-shape definition)
+             :context-band-inferred? (topology-view/static-context-inferred? definition)
+             ;; rf2-skmc7 — a NO-OP has no from→to edge; suppress the
+             ;; from/to highlight grammar and surface the CURRENT state via
+             ;; `:current-state` instead.
+             :from-highlight     (when-not no-op? from-state)
+             :to-highlight       (when-not no-op? to-state)
+             ;; rf2-eldze / rf2-skmc7 — a BIRTH's initial state and a
+             ;; NO-OP's unchanged current state both ride `:current-state`
+             ;; so the chart highlights the one resting node.
+             :current-state      (cond
+                                   start? to-state
+                                   no-op? to-state
+                                   :else  nil)
+             ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
+             ;; treatment on the live chart.
+             :fired-edge-ids     fired-edge-ids
+             ;; rf2-fzrzlw — the attempted-and-rejected edges (guard-blocked
+             ;; no-op, e.g. door :door/close blocked by :may-close?) paint
+             ;; the PINK guard-blocked treatment on the live chart so the
+             ;; operator sees which edge the event hit + that a guard
+             ;; rejected it (no transition fired, so the fired set is empty).
+             :guard-blocked-edge-ids guard-blocked-edge-ids
+             ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
+             ;; tab re-frames the topology.
+             :fit-signal         fit-signal
+             :on-state-click     (fn [path]
+                                   (rf/dispatch
+                                     [:rf.xray/machine-state-clicked
+                                      {:machine-id machine-id
+                                       :path       path}]
+                                     {:frame frame}))
+             :show-after-rings?  true}])]])]))
 
 ;; ---- prev/next nav (per-machine epoch walking) -------------------------
 
@@ -508,9 +545,13 @@
   no machine transitioned in the focused event's cascade — the panel
   renders the empty-state placeholder in that case (see `blank-state`).
 
-  rf2-alsnz — `records` flows in as an arg so the panel makes one
-  Reaction handle per render instead of two."
-  [records cascade]
+  rf2-alsnz — `records` flows in as an arg so the panel reads the
+  composite once per render instead of twice.
+
+  rf2-k97c.3 — `as-child` is threaded straight through to
+  [[focused-event-section]], which is the only place it is used; see that
+  fn's docstring for what it islands and why."
+  [records cascade as-child]
   (let [;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
@@ -521,7 +562,9 @@
         ;; panel against a different runtime) gets a clean section
         ;; instance, while ordinary Prev/Next within one frame+machine
         ;; preserves it.
-        target-frame @(rf/subscribe [:rf.xray/target-frame])]
+        ;; rf2-k97c.3 — `rf.fresco/sub`, donated upward into [[Panel]]'s
+        ;; collector window (this helper is called, never headed).
+        target-frame (rf.fresco/sub [:rf.xray/target-frame])]
     (when record
       [:div {:data-testid "rf-xray-machine-focused-event"
              ;; The host carries the count of records the cascade
@@ -552,7 +595,7 @@
        ;; `focused-event-section` answers hiccup whose own attribute map
        ;; is not ours to write into, so the key rides the fragment.
        [:<> {:key (h/focused-event-section-key target-frame record)}
-        (focused-event-section cascade record)]])))
+        (focused-event-section cascade record as-child)]])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
@@ -606,9 +649,10 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view Panel
-  "The Machine Inspector (Machine tab) root view (rf2-g2axio). Shows
-  EXACTLY THREE elements when the focused event targets a machine:
+(defn panel-tree
+  "The Machine Inspector's markup, as a pure fn of the three values
+  [[Panel]] reads plus the island spelling. Shows EXACTLY THREE elements
+  when the focused event targets a machine:
 
     1. the Prev/Next epoch nav (header — per-machine epoch walker),
     2. the SHARED EVENT HANDLER mini-pipeline (the SAME numbered
@@ -618,16 +662,30 @@
 
   Event-driven: BLANK when the focused event has no machine activity.
   Prev/Next moves the spine focus, which re-feeds the mini-pipeline AND
-  the chart highlights together (both read the focused epoch)."
-  []
-  (let [{:keys [empty-kind]} @(rf/subscribe [:rf.xray/machine-inspector-data])
-        records @(rf/subscribe [:rf.xray/machine-transitions-for-focused-event])
-        ;; rf2-g2axio — the focused epoch's projected machine-cascade rows
-        ;; for the SHARED mini-pipeline (element 2). Reads the same focused
-        ;; epoch Prev/Next drives, so the mini-pipeline + chart move
-        ;; together.
-        {:keys [cascade]} @(rf/subscribe [:rf.xray/machine-focused-epoch-cascade])
-        ;; The first record's machine-id drives the prev/next nav (a
+  the chart highlights together (both read the focused epoch).
+
+  SPLIT OUT OF [[Panel]] BY rf2-k97c.3, and the split is `defview`'s own
+  documented extract-a-helper spelling rather than an invention. A
+  boundary's body may only run inside a React render window, so `(Panel)`
+  is no longer a callable that answers hiccup — while this panel's
+  section algebra is ordinary data → data and is worth testing in the
+  fast node lane rather than behind a real React commit.
+  `machine_inspector_view_cljs_test` drives THIS fn with the values it
+  takes from the subs directly; the boundary's own behaviour — first
+  paint, liveness, frame targeting and teardown — is
+  `machine_inspector_fresco_boundary_dom_cljs_test`'s subject.
+
+  `as-child` is the island spelling, threaded down to
+  [[focused-event-section]] and used nowhere else: `identity` for a
+  hiccup caller, `reagent.core/as-element` under the boundary.
+
+  NOT PURE in one respect worth naming: the two helpers it calls —
+  [[focused-event-view]] and [[focused-event-section]] — each perform one
+  `rf.fresco/sub`, which DONATES upward into the calling boundary's
+  collector window (HD-016). Under the node lane they are ordinary reads
+  against whatever frame the test binds."
+  [{:keys [empty-kind]} records cascade as-child]
+  (let [;; The first record's machine-id drives the prev/next nav (a
         ;; cascade may touch multiple machines; the nav's "this machine"
         ;; is the head section's machine).
         scope-machine-id (some-> records first :machine-id)]
@@ -659,45 +717,103 @@
        ;; does not duplicate-subscribe the same composite handle.
        [:div {:data-testid "rf-xray-machine-inspector-focused-event-host"
               :style focused-event-host-style}
-        (focused-event-view records cascade)]
+        (focused-event-view records cascade as-child)]
 
        :else
        (blank-state))]))
+
+(rf.fresco/defview Panel
+  "The Machine Inspector (Machine tab) root — a FRESCO BOUNDARY
+  (rf2-k97c.3), not an `rf/reg-view`. The THREE READS, and
+  [[panel-tree]] for everything below them.
+
+  The READS are `rf.fresco/sub` — plain calls the shipped collector
+  records an edge for, with no deref and no reaction owned by the
+  INSTALLED adapter. That is the third of the epic's three couplings and
+  the one a first-paint smoke test cannot see. Two more reads donate
+  upward into this boundary's window from inlined helpers
+  ([[focused-event-view]]'s target-frame and [[focused-event-section]]'s
+  fit-signal), which HD-016 makes settled rather than contingent.
+
+  The FRAME they resolve against comes from React context, which the
+  enclosing frame boundary writes — `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context — so this boundary
+  resolves `:rf/xray` identically under today's Reagent-rendered shell
+  and under the Fresco root Xray will own.
+
+  ONE ISLAND SURVIVES, and it is scheduling rather than residue:
+  `r/as-element` is handed down for the topology chart, because
+  `machine-canvas/Chart` is still an `rf/reg-view` and has a second
+  consumer on the Static surface. [[focused-event-section]] records the
+  condition that retires it.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. This panel reads nothing from props — neither the L4 registry
+  nor the standalone embed passes any — so it is destructured away."
+  [_props]
+  (panel-tree (rf.fresco/sub [:rf.xray/machine-inspector-data])
+              (rf.fresco/sub [:rf.xray/machine-transitions-for-focused-event])
+              ;; rf2-g2axio — the focused epoch's projected machine-cascade
+              ;; rows for the SHARED mini-pipeline (element 2). Reads the
+              ;; same focused epoch Prev/Next drives, so the mini-pipeline
+              ;; and the chart move together.
+              (:cascade (rf.fresco/sub [:rf.xray/machine-focused-epoch-cascade]))
+              r/as-element))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;
 ;; `panels/mount-machine-inspector!` mounts this panel BY NAME, and
 ;; RULING 1's surviving spelling puts the Fresco boundary on the natural
 ;; name with a PUBLIC bridge passed by the caller — the shape
-;; `resources/Panel-bridge` already ships. Pointing the mount facade at the
-;; bridge name NOW, while it is still a plain alias, is what lets this
-;; panel's migration happen entirely INSIDE THIS FILE: `Panel` becomes the
-;; `defview` boundary and this def becomes the real
-;; `rf.fresco/as-component` bridge, with `panels.cljs` never touched again.
-;; It adopts RULING 1 early rather than bending it.
+;; `resources/Panel-bridge` already ships, and the funnel that pointed the
+;; mount facade here (PR #9654) is what let this panel's migration happen
+;; ENTIRELY INSIDE THIS FILE: `panels.cljs` was never touched.
 ;;
-;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Panel
-;; (re-frame.core/view :id))`, so `Panel` is a VALUE and this def binds the
-;; SAME OBJECT — nothing downstream can tell the two names apart. And
-;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
-;; head position is the only position either name is used in, and the hazard
-;; `render-panel!`'s docstring warns about is not reached: what is unsafe
-;; there is CALLING the view, because that fn runs outside any React render
-;; and an ambient subscribe with no in-flight component resolves to nil and
-;; RAISES `:rf.error/no-frame-context` (there is no `:rf/default` fallback —
-;; Spec 006 §Plain-fn footgun).
+;; IT IS NO LONGER A NO-OP. Until this commit `Panel-bridge` was a `def`
+;; aliasing the `reg-view` value, and nothing downstream could tell the two
+;; names apart. `Panel` is now a Fresco boundary — a React function
+;; component — and Xray's shell is still a `reg-view` tree rendered by the
+;; installed adapter, which mounts the active tab as the hiccup head
+;; `[(:panel tab)]` with `panel-registry/reg-l4-tab!`'s `:pre` requiring
+;; `:panel` to be CALLABLE. A React component is neither.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch, and no props
+;; ABI — and the `[rf/frame-provider {:frame :rf/xray}]` the shell already
+;; wraps the panel in is what puts `:rf/xray` in that context.
 ;;
 ;; The Tier 4 sub-components (after-rings overlay, arc/cluster overlays,
 ;; scrubber strip, sim side-rail) render UNDER `Panel` and are not
-;; independently mountable, so they need no bridge of their own.
-(def Panel-bridge
-  "The name `panels/mount-machine-inspector!` mounts this panel through —
-  a plain alias of `Panel` until this panel migrates to Fresco, when it
-  becomes the `as-component` bridge without the mount facade moving.
-  Scaffolding with a defined end: it is deleted with every other
-  `*-bridge` when the shell itself becomes a Fresco tree. See the comment
-  above."
-  Panel)
+;; independently mountable, so they need no bridge of their own. The
+;; after-rings overlay is the ONE exception and already carries its own
+;; (`machine_after_rings/AfterRingsOverlay-bridge`), because it is mounted
+;; from `machine-canvas/Chart`, which is still Reagent.
+;;
+;; STILL SCAFFOLDING WITH A DEFINED END: when the shell is itself a Fresco
+;; tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and both defs
+;; below are deleted with every other `*-bridge`.
+(def ^:private Panel-component
+  "The React component [[Panel]] presents as, for a non-Fresco parent.
+  Declared ONCE at top level beside the view, as `rf.fresco/as-component`'s
+  own contract requires — deriving it per render would mint a fresh
+  component type every pass and remount the panel, taking the xyflow
+  chart's measured layout with it."
+  (rf.fresco/as-component Panel))
+
+(defn Panel-bridge
+  "The callable `panels/mount-machine-inspector!` and the L4 tab
+  registration both mount this panel through. Returns Reagent-shaped
+  hiccup interoping to the React component above; the enclosing
+  `rf/frame-provider` is what puts the frame in React context for it.
+
+  PUBLIC, because this panel carries a `mount-machine-inspector!` facade
+  and `panels/render-panel!` takes the view to mount as an ARGUMENT, so
+  the embedding contract needs a name it can pass."
+  []
+  [:> Panel-component {}])
 
 ;; ---- production value sources --------------------------------------------
 ;;
@@ -1096,7 +1212,13 @@
      :mnem  "m"
      :modes #{:dynamic}
      :order 4
-     :panel Panel}))
+     ;; rf2-k97c.3 — `Panel-bridge`, not `Panel`. `Panel` is now a React
+     ;; component (a Fresco boundary); `reg-l4-tab!`'s `:pre` requires
+     ;; `:panel` to be CALLABLE and `shell/detail-panel` mounts it as a
+     ;; Reagent hiccup head `[(:panel tab)]`, neither of which a React
+     ;; component satisfies. The bridge is the one line between them and
+     ;; goes when the shell itself is a Fresco tree.
+     :panel Panel-bridge}))
 
 ;; ---- test-only override seam (rf2-e8330v / xxo3zz F3) ---------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -73,6 +73,25 @@
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
+;; ---- hiccup walker (rf2-k97c.3) -----------------------------------------
+;;
+;; PLAIN DESCENT — nothing is CALLED. This row used the walker in
+;; `re-frame.test-helpers`, which EXPANDS function components as it walks. The Epoch view's EDN-widget heads are now `[ei/edn-inspector-view …]`
+;; — Fresco boundaries whose bodies may only run inside a React render window
+;; — so applying one runs `rf.fresco/sub` outside the collector and raises.
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-nodes tree)))
+
+
 ;; ============================================================================
 ;; The hard machine — a self-contained copy of the testbed's :hvac/controller.
 ;; ============================================================================
@@ -352,20 +371,20 @@
                         :fx [] :machine {:cascade rows
                                          :transition nil :guards []
                                          :lifecycle [] :timers []}}))]
-        (is (nil? (rf.test-helpers/find-by-testid tree sp))
+        (is (nil? (find-by-testid tree sp))
             "rf2-akvfe — the up/down structured-cascade block no longer renders")
         ;; rf2-2hj0h item 2 — the akvfe nested-pipeline RAIL is REMOVED; the
         ;; rows render as a flat numbered stack (the ordinal chips carry the
         ;; pipeline reading). The rows host + the orientation line remain.
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
             "the nested-pipeline rail is removed (rf2-2hj0h)")
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
             "the flat rows host still renders")
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
             "the EVENT HANDLER orientation line renders")
         ;; No-info-loss: the per-EMIT exit/entry action rows survive and carry
         ;; their action verbs (the cascade the removed block restated).
-        (is (some? (rf.test-helpers/find-by-testid tree (str "rf-xray-epoch-machine-cascade-row-"
+        (is (some? (find-by-testid tree (str "rf-xray-epoch-machine-cascade-row-"
                                                  (:step tx-row))))
             "the transition row survives in the pipeline")))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/hard_machine_fidelity_cljs_test.cljs
@@ -61,7 +61,6 @@
             [re-frame.frame :as rf.frame]
             [re-frame.machines :as rf.machines]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
-            [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.diff.engine :as diff]
             [day8.re-frame2-xray.panels.epoch.format :as fmt]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -52,6 +52,17 @@
 (defn- hiccup-nodes [tree]
   (tree-seq (some-fn vector? seq?) seq tree))
 
+(defn- text-content
+  "String leaves under `node`, joined. Shadows the one in
+  `re-frame.test-helpers`, which collects its leaves off a walk that
+  EXPANDS function components — unsafe now the Epoch view emits
+  `[ei/edn-inspector-view …]` Fresco boundaries."
+  [node]
+  (->> (hiccup-nodes node)
+       (filter (some-fn string? number?))
+       (map str)
+       (string/join)))
+
 (defn- find-by-testid [tree testid]
   (some (fn [node]
           (when (and (vector? node)
@@ -123,7 +134,7 @@
                                              (find-by-testid
                                                (str "rf-xray-epoch-machine-cascade-source-body-"
                                                     (:step r)))
-                                             rf.test-helpers/text-content)))
+                                             text-content)))
                              (string/join "\n"))]
       (is (seq action-rows)
           "the macrostep produced at least one :action cascade row")

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -34,7 +34,6 @@
             [re-frame.frame :as rf.frame]
             [re-frame.machines]  ;; loaded for its late-bind hooks (`rf/reg-machine`)
             [re-frame.adapter.reagent :as rf.adapter.reagent]
-            [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.preload :as preload]

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -42,6 +42,25 @@
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
+;; ---- hiccup walker (rf2-k97c.3) -----------------------------------------
+;;
+;; PLAIN DESCENT — nothing is CALLED. This row used the walker in
+;; `re-frame.test-helpers`, which EXPANDS function components as it walks. The Epoch view's EDN-widget heads are now `[ei/edn-inspector-view …]`
+;; — Fresco boundaries whose bodies may only run inside a React render window
+;; — so applying one runs `rf.fresco/sub` outside the collector and raises.
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-nodes tree)))
+
+
 (use-fixtures :each
   ;; `make-xray-runtime-fixture` (rf2-vj80u8) replaces the bespoke
   ;; `xray-init!` (preload/registry/trace three-liner): the `:all` reset
@@ -101,7 +120,7 @@
           source-bodies (->> action-rows
                              (keep (fn [r]
                                      (some-> tree
-                                             (rf.test-helpers/find-by-testid
+                                             (find-by-testid
                                                (str "rf-xray-epoch-machine-cascade-source-body-"
                                                     (:step r)))
                                              rf.test-helpers/text-content)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs
@@ -54,7 +54,9 @@
             [clojure.string :as string]
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
+            [reagent.core :as r]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.registry :as registry]
@@ -124,9 +126,54 @@
     (react-dom/flushSync (fn [] (rdc/render root component)))
     {:container container :root root}))
 
+;; ---- rendering the subject the way PRODUCTION renders it (rf2-k97c.3) ----
+;;
+;; Both rows below used to mount their subject straight into a REAGENT tree.
+;; That stopped being representative when the Epoch panel migrated: the shared
+;; mini-pipeline's EDN-widget heads are `[ei/edn-inspector-view …]` now, and a
+;; FRESCO BOUNDARY IS NOT A REAGENT RENDER FN. Reagent sees a fn in head
+;; position, mints its own component for it and CALLS it during Reagent's
+;; render — which is not a React function-component render, so the boundary's
+;; first hook throws `Invalid hook call`, React swallows the render throw, and
+;; the whole cascade subtree silently commits nothing. The rows then read 0
+;; rows and blame the projection. (`machine_after_rings` records the same fact
+;; from the other side: crossing INTO React from Reagent needs
+;; `rf.fresco/as-component`.)
+;;
+;; So the subject is hosted in a real boundary, which is where it renders in
+;; production — under `epoch/view`'s `Panel` or `machine-inspector`'s. It is
+;; handed over through an atom rather than through props deliberately: the
+;; crossing below is `[:>]` from a Reagent parent, and only an EMPTY props map
+;; survives that intact (the after-rings bridge measured a payload does not).
+
+(defonce ^:private !subject
+  (atom nil))
+
+(rf.fresco/defview SubjectHost
+  "Renders whatever [[mount-in-boundary!]] parked in `!subject`, inside a
+  Fresco boundary. Takes the ordinary one-props-map argument every `defview`
+  takes and reads nothing from it."
+  [_props]
+  (when-let [render @!subject]
+    (render)))
+
+(def ^:private SubjectHost-component
+  "The React component [[SubjectHost]] presents as, for the Reagent root
+  below. Declared ONCE at top level as `rf.fresco/as-component` requires."
+  (rf.fresco/as-component SubjectHost))
+
+(defn- mount-in-boundary!
+  "Mount `render` (a 0-arg fn answering hiccup) inside a Fresco boundary, in
+  turn inside the `frame-provider` the real shell wraps every panel in."
+  [render]
+  (reset! !subject render)
+  (mount! [rf/frame-provider {:frame :rf/default}
+           [:> SubjectHost-component {}]]))
+
 (defn- cleanup! [{:keys [container root]}]
   (try (.unmount root) (catch :default _ nil))
-  (.remove container))
+  (.remove container)
+  (reset! !subject nil))
 
 (defn- q-all [container sel] (vec (js/Array.from (.querySelectorAll container sel))))
 
@@ -155,7 +202,13 @@
       (is true ":node — the :browser-test runner drives the real DOM mount")
       (let [trace-events (drive-real-round!)
             cascade      (proj/machine-cascade-rows trace-events)
-            mounted      (mount! [epoch-view/machine-cascade-mini-pipeline cascade machine-id])
+            ;; rf2-k97c.3 — hosted in a real Fresco boundary; see
+            ;; [[mount-in-boundary!]] for why a Reagent mount stopped being
+            ;; representative and what it silently reads instead.
+            mounted      (mount-in-boundary!
+                           (fn []
+                             (epoch-view/machine-cascade-mini-pipeline
+                               cascade machine-id)))
             container    (:container mounted)]
         (try
           (let [micro-rows    (q-all container
@@ -206,9 +259,15 @@
                           :definition     parallel-round-machine
                           :fired-edge-ids fired
                           :no-op?         false}
-            mounted      (mount! [rf/frame-provider {:frame :rf/default}
-                                  [(fn [] (#'machine-inspector/focused-event-section
-                                            cascade record))]])
+            ;; rf2-k97c.3 — hosted in a real Fresco boundary, which is what
+            ;; the Machine tab is now, so `r/as-element` is the `as-child`
+            ;; spelling: `machine-canvas/Chart` is still an `rf/reg-view` and
+            ;; the island is what gets it onto the page under a boundary. The
+            ;; fit-signal nonce is nil because nothing here asserts on it.
+            mounted      (mount-in-boundary!
+                           (fn []
+                             (#'machine-inspector/focused-event-section
+                               cascade record r/as-element nil)))
             container    (:container mounted)]
         (try
           (is (every? string? [a-go b-go a-always b-always])

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -58,14 +58,18 @@
 ;; `panels/app_db_diff_cljs_test` and `static/flows/panel_cljs_test` already
 ;; settled for the same reason.
 ;;
-;; The rows that USED to assert on markup inside the EDN widget now assert on
-;; the boundary vector the panel emits — see `inspector-view-forms`.
+;; THE TWO WIDGET BOUNDARIES ARE EXPANDED THROUGH THEIR REAGENT SIBLINGS
+;; instead, by `expand-widgets` below, and that is a considered choice rather
+;; than a shortcut. The panel hands each widget the content it asserts on —
+;; the table's columns, row-attrs and CELLS; the inspector's value and opts —
+;; and some forty rows here are about EPOCH's contribution, not the widget's.
+;; Each widget ships BOTH heads over one private renderer, so expanding the
+;; Reagent one reaches the same markup without entering a boundary body.
 ;;
-;; THE TABLE IS THE OTHER WAY ROUND, and `expand-widgets` below says why. Its
-;; interior is not the widget's private business the way the inspector's is:
-;; the panel hands `resizable-table-view` the columns, the row-attrs and the
-;; CELLS, and roughly thirty rows here assert on that content. Those rows are
-;; about EPOCH's contribution, not the widget's, so they keep their spelling.
+;; The cost is that the expanded tree cannot say WHICH head the panel emits,
+;; so `panel-emits-the-fresco-widget-heads-test` pins that separately, off the
+;; unexpanded tree. That claim is the HD-016 repair itself and is the one
+;; thing the old spelling could not state.
 
 (defn- expand-widgets
   "Expand `[rt/resizable-table-view props]` into the grid the widget renders,
@@ -79,15 +83,25 @@
   The Reagent head resolves them the way this suite always drove it, with a
   documented nil-safe path for a test that registered no handlers.
 
-  `[ei/edn-inspector-view …]` is deliberately left a LEAF. Applying it would
-  run `rf.fresco/sub` outside the collector and raise
-  `:rf.error/fresco-sub-outside-render`; its interior belongs to the widget's
-  own suite and to the DOM lane. It falls out of the plain `vector?` branch
-  below — its fn head is not the table's, so nothing invokes it."
+  `[ei/edn-inspector-view {:mount-id … :value v :opts o}]` is expanded the
+  same way and for the same reason, through `[ei/edn-inspector v o]`. Its two
+  heads also share one private `render-inspector`, and differ only in how
+  each resolves the expansion / zoom / width slots and its per-mount
+  identity — none of which any row here asserts on. The props RESHAPE is the
+  whole of the difference at the call site: the Reagent head takes the value
+  and opts positionally, the boundary takes one map.
+
+  WHAT THIS DELIBERATELY DOES NOT GRADE is which head the panel emits, since
+  it erases exactly that. `panel-emits-the-fresco-widget-heads-test` pins it
+  directly instead, off `inspector-view-forms` and the unexpanded tree."
   [tree]
   (cond
     (and (vector? tree) (= rt/resizable-table-view (first tree)))
     (expand-widgets (apply rt/resizable-table (rest tree)))
+
+    (and (vector? tree) (= ei/edn-inspector-view (first tree)))
+    (let [{:keys [value opts]} (second tree)]
+      (expand-widgets (rf.test-helpers/expand-tree [ei/edn-inspector value opts])))
 
     (vector? tree) (mapv expand-widgets tree)
     (seq? tree)    (map expand-widgets tree)
@@ -119,27 +133,90 @@
                      (.startsWith prefix)))
            (hiccup-nodes tree)))
 
-(defn- inspector-view-forms
-  "Every `[ei/edn-inspector-view {…}]` form in the tree — the EDN widget's
-  FRESCO head, and one of the only two fn-headed vectors this panel still
-  emits.
+(defn- text-content
+  "String leaves under `node`, joined. Shadows the one in
+  `re-frame.test-helpers` for the same reason the finders above shadow
+  theirs: that one collects its leaves off `hiccup-seq`, which
+  EXPANDS function components, so calling it on any node carrying an
+  `[ei/edn-inspector-view …]` descendant raises inside the boundary."
+  [node]
+  (->> (hiccup-nodes node)
+       (filter (some-fn string? number?))
+       (map str)
+       (string/join)))
 
-  No expansion of any kind, and the leaf must STAY a leaf: applying a
-  boundary here would run `rf.fresco/sub` outside the collector."
+(defn- raw-nodes
+  "Every node in the tree AS THE PANEL EMITS IT — no expansion of any kind,
+  so a widget head is whatever the panel actually wrote there. The
+  boundary-head rows below need this rather than `hiccup-nodes`, which
+  substitutes the Reagent siblings and so erases the very thing they grade."
   [tree]
-  (filterv #(and (vector? %) (= ei/edn-inspector-view (first %)))
-           (hiccup-nodes tree)))
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- head-counts
+  "How many times each of the four widget heads appears in the UNEXPANDED
+  tree, as `{:inspector-fresco n :inspector-reagent n :table-fresco n
+  :table-reagent n}`."
+  [tree]
+  (let [heads (keep #(when (and (vector? %) (seq %)) (first %)) (raw-nodes tree))
+        n     (fn [h] (count (filter #(= h %) heads)))]
+    {:inspector-fresco  (n ei/edn-inspector-view)
+     :inspector-reagent (n ei/edn-inspector)
+     :table-fresco      (n rt/resizable-table-view)
+     :table-reagent     (n rt/resizable-table)}))
 
 ;; ---- helpers -----------------------------------------------------------
 
 (defn- text-of
   [tree testid]
-  (some-> tree (find-by-testid testid) rf.test-helpers/text-content))
+  (some-> tree (find-by-testid testid) text-content))
 
 (defn- style-of
   "The inline `:style` map of the node carrying `testid` under `tree`."
   [tree testid]
   (some-> tree (find-by-testid testid) rf.test-helpers/attrs :style))
+
+;; ---- rf2-k97c.3 — the panel emits the FRESCO widget heads ---------------
+
+(deftest panel-emits-the-fresco-widget-heads-test
+  (testing "rf2-k97c.3 — every widget this panel heads with is a FRESCO
+            BOUNDARY, never the widget's Reagent head.
+
+            This is the HD-016 repair itself, and it is the one claim the
+            pre-migration spelling could not make. `Panel` is an
+            `rf.fresco/defview` now, and Fresco's codec grades a head by
+            ONE own property, `frescoBoundary`, which only
+            `rf.fresco/defview` sets — so an `rf/reg-view` head grades
+            `:invalid` down the IDENTICAL arm a plain `defn` does. Leaving
+            either Reagent head in place would break the panel at runtime
+            while every other row in this file stayed green, because
+            `expand-widgets` substitutes those very heads to reach the
+            markup. So this row reads the UNEXPANDED tree.
+
+            The Reagent heads must read ZERO, and a zero is only evidence
+            when the instrument bites — so the Fresco counts are asserted
+            POSITIVE on the same tree, which is the control."
+    (epoch-orchestrator/install!)
+    (rf/make-frame {:id :rf/xray})
+    (rf/with-frame :rf/xray
+      (let [steps [{:step :dispatch :badge :DISPATCH :step-number 1
+                    :event [:counter/inc 7] :source :ui :coord nil}
+                   {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                    :rows [{:sub-id :a :sub-vec [:a] :changed? true
+                            :before 1 :after 2}]
+                    :changed 1 :unchanged 0}]
+            counts (head-counts (view/pipeline-view steps))]
+        (is (pos? (:inspector-fresco counts))
+            "the DISPATCH step heads the EDN widget's Fresco boundary
+             (control: a zero here would mean the probe found no widget
+             at all, not that the migration held)")
+        (is (pos? (:table-fresco counts))
+            "the SUBSCRIPTIONS step heads the table widget's Fresco
+             boundary (control, as above)")
+        (is (zero? (:inspector-reagent counts))
+            "no `ei/edn-inspector` Reagent head survives")
+        (is (zero? (:table-reagent counts))
+            "no `rt/resizable-table` Reagent head survives")))))
 
 ;; ---- rf2-9jvx1 — text-duplication audit --------------------------------
 
@@ -200,9 +277,9 @@
                   :event [:counter/inc 7] :source :ui :coord nil})
           body (find-by-testid tree "rf-xray-epoch-dispatch-event")]
       (is (some? body) "the body's event-vector slot is present")
-      (is (string/includes? (rf.test-helpers/text-content body) ":counter/inc")
+      (is (string/includes? (text-content body) ":counter/inc")
           "event-id is visible in the body")
-      (is (string/includes? (rf.test-helpers/text-content body) "7")
+      (is (string/includes? (text-content body) "7")
           "the event args are visible too"))))
 
 (deftest dispatch-body-omits-event-when-absent-test
@@ -599,6 +676,23 @@
   [tree prefix]
   (count (find-by-testid-prefix tree prefix)))
 
+(defn- subscriptions-step
+  "`render-subscriptions-step` with the cascade context `Panel` supplies.
+
+  rf2-k97c.3 — the filter mode used to be read INSIDE the step renderer.
+  `Panel` is a Fresco boundary now and reads it there, threading the VALUE
+  down the `ctx` map, so the renderer is a pure fn of its arguments and
+  stays drivable here. This helper reads the slot exactly as the boundary
+  does; the rows that exercise mode-switching keep grading the read and
+  the dispatch against ONE frame, which is what they were always about.
+
+  Rows that only want the DEFAULT mode go on calling the 1-arity
+  directly — no mode is the `:changed` default the `case` already has."
+  [step]
+  (view/render-subscriptions-step
+    step
+    {:subs-filter-mode @(rf/subscribe [:rf.xray.epoch/subs-filter-mode])}))
+
 (deftest sub-row-renders-sub-id-test
   (testing "rf2-kfh1v — SUBSCRIPTIONS row leads with the sub-id /
             sub-vec (operator can tell WHICH sub recomputed)"
@@ -612,7 +706,7 @@
             tree (view/render-subscriptions-step step)
             row  (find-by-testid tree "rf-xray-epoch-sub-row-0")]
         (is (some? row) "the sub row renders")
-        (let [txt (rf.test-helpers/text-content row)]
+        (let [txt (text-content row)]
           (is (string/includes? txt ":counter/total")
               "sub-id is visible as the leading element"))))))
 
@@ -684,12 +778,12 @@
               "default mode `:changed` renders only the changed row"))
         ;; switch to `:all`
         (rf/dispatch-sync [:rf.xray.epoch/set-subs-filter-mode :all])
-        (let [tree (view/render-subscriptions-step step)]
+        (let [tree (subscriptions-step step)]
           (is (= 3 (count-prefix tree "rf-xray-epoch-sub-row-"))
               "`:all` mode renders every row"))
         ;; switch to `:unchanged`
         (rf/dispatch-sync [:rf.xray.epoch/set-subs-filter-mode :unchanged])
-        (let [tree (view/render-subscriptions-step step)]
+        (let [tree (subscriptions-step step)]
           (is (= 2 (count-prefix tree "rf-xray-epoch-sub-row-"))
               "`:unchanged` mode renders only the unchanged rows"))))))
 
@@ -718,7 +812,7 @@
       (rf/with-frame :rf/xray
         (rf/dispatch-sync [:rf.xray.epoch/set-subs-filter-mode :all]))
       (rf/with-frame :rf/xray
-        (let [tree (view/render-subscriptions-step step)]
+        (let [tree (subscriptions-step step)]
           (is (= 2 (count-prefix tree "rf-xray-epoch-sub-row-"))
               "frame-anchored dispatch flips the :rf/xray slot the 2-arity sub reads"))))))
 
@@ -1365,7 +1459,7 @@
             marker (find-by-testid tree "rf-xray-epoch-fx-row-db-destination-0")]
         (is (some? marker) "the :db row carries the destination marker")
         (is (= :button (first marker)) "marker is a clickable <button>")
-        (is (string/includes? (rf.test-helpers/text-content marker) "→ app-db"))
+        (is (string/includes? (text-content marker) "→ app-db"))
         (is (fn? (:on-click (second marker)))
             "marker carries an on-click that jumps to the App-db panel")))))
 
@@ -1378,9 +1472,9 @@
                    [{:fx-id :clipboard/write :status :skipped}]))
           row  (find-by-testid tree "rf-xray-epoch-fx-row-0")]
       (is (some? row))
-      (is (string/includes? (rf.test-helpers/text-content row) badge/skipped-glyph)
+      (is (string/includes? (text-content row) badge/skipped-glyph)
           "the skipped row leads with the en-dash glyph")
-      (is (not (string/includes? (rf.test-helpers/text-content row) "·"))
+      (is (not (string/includes? (text-content row) "·"))
           "NOT the :cancelled middle-dot"))))
 
 (deftest side-effects-fx-row-shows-attribution-chip-test
@@ -1393,7 +1487,7 @@
           tree (view/render-side-effects-step step)
           chip (find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
       (is (some? chip) "the attribution chip is present")
-      (is (string/includes? (rf.test-helpers/text-content chip) ":open-socket")
+      (is (string/includes? (text-content chip) ":open-socket")
           "the action-id rides the chip"))))
 
 (deftest side-effects-fx-row-omits-attribution-chip-when-none-test
@@ -1491,6 +1585,25 @@
 ;; because its key lives in props. Hence the raw walk below and `r/as-element`,
 ;; which grades what the RENDERER receives rather than how it is spelled.
 
+(defn- call-widget-head
+  "Invoke a hiccup vector's fn head, substituting each widget's REAGENT
+  sibling for its Fresco boundary.
+
+  rf2-k97c.3 — the same swap `expand-widgets` makes and for the same reason,
+  written separately because this walker must not rebuild (see
+  [[raw-children]]). Applying a boundary here calls a React function
+  component outside any render, which raises on the first hook."
+  [node]
+  (cond
+    (= rt/resizable-table-view (first node))
+    (apply rt/resizable-table (rest node))
+
+    (= ei/edn-inspector-view (first node))
+    (let [{:keys [value opts]} (second node)]
+      (ei/edn-inspector value opts))
+
+    :else (apply (first node) (rest node))))
+
 (defn- raw-children
   "Children of a hiccup node WITHOUT rebuilding it. `expand-tree` would
   `mapv` fresh vectors and strip reader metadata, so this gate could not see
@@ -1498,7 +1611,7 @@
   nil and fail for the wrong reason."
   [node]
   (cond
-    (and (vector? node) (fn? (first node))) [(apply (first node) (rest node))]
+    (and (vector? node) (fn? (first node))) [(call-widget-head node)]
     (vector? node)                          (if (map? (second node)) (drop 2 node) (rest node))
     (seq? node)                             node
     :else                                   nil))
@@ -1858,10 +1971,10 @@
         (is (some #(and (vector? %) (= "↳" (last %)))
                   (tree-seq vector? seq data-write-node))
             "rf2-32kyr — the `↳` arrow is KEPT")
-        (is (not (string/includes? (or (rf.test-helpers/text-content data-write-node) "") "data Δ"))
+        (is (not (string/includes? (or (text-content data-write-node) "") "data Δ"))
             "rf2-32kyr — the redundant `data Δ` caption text is REMOVED")
         ;; The edn-inspector value still renders (the written `:opened-count`).
-        (is (string/includes? (or (rf.test-helpers/text-content data-write-node) "") "opened-count")
+        (is (string/includes? (or (text-content data-write-node) "") "opened-count")
             "rf2-32kyr — the edn-inspector value is KEPT (arrow → value, no caption)")))
     ;; A no-op exit action whose :data is unchanged still surfaces the
     ;; slot (the inspector renders the value with no delta).
@@ -2457,9 +2570,9 @@
       ;; rf2-5t8y8 — sub-header carries an at-a-glance entry-count chip
       ;; on both `:fx` and `other` (was lost during the rf2-p2zy0
       ;; edn-inspector migration).
-      (is (string/includes? (rf.test-helpers/text-content fx-sec) "2 entries")
+      (is (string/includes? (text-content fx-sec) "2 entries")
           "the :fx sub-header carries the entry-count chip")
-      (is (string/includes? (rf.test-helpers/text-content oth-sec) "1 entry")
+      (is (string/includes? (text-content oth-sec) "1 entry")
           "the other sub-header carries the singular entry chip"))))
 
 (deftest side-effects-fx-args-route-through-edn-inspector-test
@@ -2673,7 +2786,7 @@
             (is (string/includes? (str (:border-left style))
                                   (:diff-modified-stripe tokens/tokens))
                 "changed leaf stripe reads through the diff-modified-stripe token"))
-          (let [txt (rf.test-helpers/text-content leaf)]
+          (let [txt (text-content leaf)]
             (is (string/includes? txt "~")
                 "leading `~` glyph paints (parity with the inspector's
                  R1 `:modified` leaf shape)")
@@ -2692,7 +2805,7 @@
               tree (view/render-subscriptions-step step)
               leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
           (is (some? leaf))
-          (let [txt (rf.test-helpers/text-content leaf)]
+          (let [txt (text-content leaf)]
             (is (string/includes? txt "← was"))
             (is (string/includes? txt "odd"))
             (is (string/includes? txt "even")))))
@@ -2709,7 +2822,7 @@
               "nil-prev leaf still mounts the leaf-changed wrapper (the
                `:first-run? false` discriminator is the gate, NOT
                `(some? before)`)")
-          (let [txt (rf.test-helpers/text-content leaf)]
+          (let [txt (text-content leaf)]
             (is (string/includes? txt "← was"))
             (is (string/includes? txt "1779972561856"))
             (is (string/includes? txt "nil")
@@ -2734,7 +2847,7 @@
                           :inputs nil :changed? false :first-run? false
                           :before 7 :after 7}]
                   :changed 0 :unchanged 1}
-            tree (view/render-subscriptions-step step)
+            tree (subscriptions-step step)
             leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-unchanged-0")]
         (is (some? leaf)
             "unchanged leaf mounts the leaf-unchanged wrapper")
@@ -2749,7 +2862,7 @@
               "unchanged leaf paints no wash (no diff chrome)")
           (is (nil? (:border-left style))
               "unchanged leaf paints no stripe (no diff chrome)"))
-        (let [txt (rf.test-helpers/text-content leaf)]
+        (let [txt (text-content leaf)]
           (is (string/includes? txt "7")
               "the current value renders")
           (is (not (string/includes? txt "~"))
@@ -2783,7 +2896,7 @@
         (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
             "the changed-wrapper is NOT mounted (mutually exclusive
              with leaf-added)")
-        (let [txt (rf.test-helpers/text-content added)]
+        (let [txt (text-content added)]
           (is (string/includes? txt "+")
               "leading `+` glyph paints (parity with the inspector's
                R1 `:added` shape)")
@@ -2865,7 +2978,7 @@
             chrome (find-by-testid tree "rf-xray-epoch-sub-row-cause-event-id-0")]
         (is (some? chrome)
             "the cause-event-id chrome mounts when the row carries it")
-        (let [txt (rf.test-helpers/text-content chrome)]
+        (let [txt (text-content chrome)]
           (is (string/includes? txt "caused by")
               "chrome carries the `caused by` prose label")
           (is (string/includes? txt ":counter/inc")
@@ -2914,7 +3027,7 @@
           "the view-id span renders")
       (is (pos? (count (mini-mounts id-cell)))
           "the view-id cell mounts at least one ei/mini widget (no longer plain text)")
-      (is (string/includes? (rf.test-helpers/text-content id-cell) ":app.counter/Counter")
+      (is (string/includes? (text-content id-cell) ":app.counter/Counter")
           "the keyword text is still present (mini renders the colon + ns + name)"))))
 
 (deftest unmounted-views-row-view-id-routes-through-mini-test
@@ -3082,10 +3195,10 @@
             l1-row       (find-by-testid tree "rf-xray-epoch-sub-row-1")
             param-inputs (some-> (find-by-attr
                                    param-row :data-rf-xray-resizable-col "inputs")
-                                 rf.test-helpers/text-content)
+                                 text-content)
             l1-inputs    (some-> (find-by-attr
                                    l1-row :data-rf-xray-resizable-col "inputs")
-                                 rf.test-helpers/text-content)]
+                                 text-content)]
         (is (some? param-row) "the parameterized sub row renders")
         (is (some? l1-row) "the L1 root row renders")
         (is (string/includes? param-inputs "chain-root")
@@ -3146,7 +3259,7 @@
              was iterated element-wise into TWO mini tokens")
         (is (contains? titles "[:article/by-id :a1]")
             "the single input is the WHOLE query-vector `[:article/by-id :a1]`")
-        (is (not (string/includes? (rf.test-helpers/text-content cell) "app-db"))
+        (is (not (string/includes? (text-content cell) "app-db"))
             "not the Level-1 `app-db` fallback — a cascade-attributed input"))))
   (testing "rf2-nlraqq — a multi-edge `:rf.sub/inputs` set (NOT cause-sub;
             already a vector OF query-vectors) still renders one mini per

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -17,6 +17,16 @@
             [day8.re-frame2-xray.theme.tokens :as tokens]
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            ;; rf2-k97c.3 — the EDN widget's FRESCO head, identity-compared
+            ;; by `inspector-view-forms` below so the rows that used to
+            ;; assert on the widget's EXPANDED markup can assert on the
+            ;; boundary the panel emits instead.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]
+            ;; rf2-k97c.3 — both heads of the resizable-table widget:
+            ;; `expand-widgets` swaps the Fresco one the panel now emits for
+            ;; the Reagent one, which shares its renderer, so the cell rows
+            ;; below keep working outside a React render window.
+            [day8.re-frame2-xray.views.resizable-table :as rt]
             [day8.re-frame2-xray.panels.epoch.view :as view]
             [day8.re-frame2-xray.panels.resources-helpers :as rh]
             [day8.re-frame2-xray.panels.epoch-panel :as epoch-orchestrator]))
@@ -29,16 +39,107 @@
   ;; plain-atom adapter + the default `:all` reset tier.
   (xray-test-support/make-xray-runtime-fixture))
 
+;; ---- hiccup walkers ------------------------------------------------------
+;;
+;; PLAIN DESCENT — nothing is CALLED. These rows used
+;; `find-by-testid` and friends, which EXPAND function
+;; components as they walk.
+;;
+;; rf2-k97c.3 made that expansion UNSAFE. `ei/mini`'s 21 head uses are now
+;; CALLS, so that markup is already realized in the tree and a shallow walk
+;; reaches it exactly as the expanding walk did — but the fn-headed vectors
+;; that REMAIN are `[ei/edn-inspector-view …]` and
+;; `[rt/resizable-table-view …]`, both FRESCO BOUNDARIES: React function
+;; components whose bodies may only run inside a React render window.
+;; Applying one here runs `rf.fresco/sub` outside the collector, which
+;; raises `:rf.error/fresco-sub-outside-render` — and because the expanding
+;; walker applies every fn head it meets, that raise took out rows asserting
+;; on nodes nowhere near the widget. So the widgets stay LEAVES, exactly as
+;; `panels/app_db_diff_cljs_test` and `static/flows/panel_cljs_test` already
+;; settled for the same reason.
+;;
+;; The rows that USED to assert on markup inside the EDN widget now assert on
+;; the boundary vector the panel emits — see `inspector-view-forms`.
+;;
+;; THE TABLE IS THE OTHER WAY ROUND, and `expand-widgets` below says why. Its
+;; interior is not the widget's private business the way the inspector's is:
+;; the panel hands `resizable-table-view` the columns, the row-attrs and the
+;; CELLS, and roughly thirty rows here assert on that content. Those rows are
+;; about EPOCH's contribution, not the widget's, so they keep their spelling.
+
+(defn- expand-widgets
+  "Expand `[rt/resizable-table-view props]` into the grid the widget renders,
+  so the rows below can go on asserting on the cells the PANEL supplies.
+
+  It expands through the widget's REAGENT head, `rt/resizable-table`, and
+  that substitution is sound rather than convenient: the widget's own
+  docstrings state that both heads hand the SAME props map to one private
+  `render-table`, and differ only in how each resolves the column-width
+  overrides and the dispatcher — neither of which any row here asserts on.
+  The Reagent head resolves them the way this suite always drove it, with a
+  documented nil-safe path for a test that registered no handlers.
+
+  `[ei/edn-inspector-view …]` is deliberately left a LEAF. Applying it would
+  run `rf.fresco/sub` outside the collector and raise
+  `:rf.error/fresco-sub-outside-render`; its interior belongs to the widget's
+  own suite and to the DOM lane. It falls out of the plain `vector?` branch
+  below — its fn head is not the table's, so nothing invokes it."
+  [tree]
+  (cond
+    (and (vector? tree) (= rt/resizable-table-view (first tree)))
+    (expand-widgets (apply rt/resizable-table (rest tree)))
+
+    (vector? tree) (mapv expand-widgets tree)
+    (seq? tree)    (map expand-widgets tree)
+    :else          tree))
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-widgets tree)))
+
+(defn- node-attrs [node]
+  (when (and (vector? node) (map? (second node)))
+    (second node)))
+
+(defn- find-by-attr [tree attr val]
+  (some (fn [node]
+          (when (= val (get (node-attrs node) attr))
+            node))
+        (hiccup-nodes tree)))
+
+(defn- find-all-by-attr [tree attr val]
+  (filterv (fn [node] (= val (get (node-attrs node) attr)))
+           (hiccup-nodes tree)))
+
+(defn- find-by-testid [tree testid]
+  (find-by-attr tree :data-testid testid))
+
+(defn- find-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (some-> (:data-testid (node-attrs node))
+                     (.startsWith prefix)))
+           (hiccup-nodes tree)))
+
+(defn- inspector-view-forms
+  "Every `[ei/edn-inspector-view {…}]` form in the tree — the EDN widget's
+  FRESCO head, and one of the only two fn-headed vectors this panel still
+  emits.
+
+  No expansion of any kind, and the leaf must STAY a leaf: applying a
+  boundary here would run `rf.fresco/sub` outside the collector."
+  [tree]
+  (filterv #(and (vector? %) (= ei/edn-inspector-view (first %)))
+           (hiccup-nodes tree)))
+
 ;; ---- helpers -----------------------------------------------------------
 
 (defn- text-of
   [tree testid]
-  (some-> tree (rf.test-helpers/find-by-testid testid) rf.test-helpers/text-content))
+  (some-> tree (find-by-testid testid) rf.test-helpers/text-content))
 
 (defn- style-of
   "The inline `:style` map of the node carrying `testid` under `tree`."
   [tree testid]
-  (some-> tree (rf.test-helpers/find-by-testid testid) rf.test-helpers/attrs :style))
+  (some-> tree (find-by-testid testid) rf.test-helpers/attrs :style))
 
 ;; ---- rf2-9jvx1 — text-duplication audit --------------------------------
 
@@ -48,9 +149,9 @@
     (let [tree (view/render-dispatch-step
                  {:step :dispatch :badge :DISPATCH :step-number 1
                   :event [:counter/inc] :source :ui :coord nil})]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-event"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-event"))
           "dispatch event vector renders in the body")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-dispatch-source"))
           "the body MUST NOT carry a duplicate `from <source>` row")
       (let [header-text (text-of tree "rf-xray-epoch-dispatch-header")]
         (is (string/includes? header-text "from"))
@@ -79,7 +180,7 @@
       (is (string/includes? header-text "reg-event"))
       ;; The body's first slot is now the source block — never a
       ;; duplicate flavour pill.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-source"))
           "the body leads with the source block (rf2-66wis)")
       ;; Confirm the body never carries a redundant flavour-only span.
       ;; The body text for an unknown handler resolves to the
@@ -97,7 +198,7 @@
     (let [tree (view/render-dispatch-step
                  {:step :dispatch :badge :DISPATCH :step-number 1
                   :event [:counter/inc 7] :source :ui :coord nil})
-          body (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-event")]
+          body (find-by-testid tree "rf-xray-epoch-dispatch-event")]
       (is (some? body) "the body's event-vector slot is present")
       (is (string/includes? (rf.test-helpers/text-content body) ":counter/inc")
           "event-id is visible in the body")
@@ -110,7 +211,7 @@
     (let [tree (view/render-dispatch-step
                  {:step :dispatch :badge :DISPATCH :step-number 1
                   :event nil :source :ui :coord nil})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-event"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-dispatch-event"))
           "no body row when no event vector was captured"))))
 
 (deftest dispatch-source-label-is-clickable-button-when-coord-present-test
@@ -123,7 +224,7 @@
           tree  (view/render-dispatch-step
                   {:step :dispatch :badge :DISPATCH :step-number 1
                    :event [:counter/inc] :source :ui :coord coord})
-          label (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+          label (find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
       (is (some? label) "the dispatch source-label slot is present")
       (is (= :button (first label))
           "with a coord, the label renders as a real button (clickable)")
@@ -141,7 +242,7 @@
     (let [tree (view/render-dispatch-step
                  {:step :dispatch :badge :DISPATCH :step-number 1
                   :event [:counter/inc] :source :ui :coord nil})
-          label (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+          label (find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
       (is (some? label) "the source-label slot is still rendered")
       (is (= :span (first label))
           "no coord → plain span (no broken button)")
@@ -169,17 +270,17 @@
                                     :source-state-path [:active :authenticating]}}
           tree (view/render-dispatch-step step)
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
           "the dispatch source-label slot is present")
       (is (string/includes? (or header-text "") "from :after timer")
           "the kind label reads 'from :after timer'")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-after-timer-delay"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-after-timer-delay"))
           "the delay chip slot renders when delay-ms is present")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-dispatch-after-timer-delay") "")
             "250ms")
           "the delay chip shows the timer's delay in ms")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-after-timer-state-path"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-after-timer-state-path"))
           "the source-state-path slot renders")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-dispatch-after-timer-state-path") "")
@@ -228,7 +329,7 @@
                                       :delay-ms          250
                                       :source-state-path [:active :authenticating]}}
             tree (view/render-dispatch-step step)
-            chip (rf.test-helpers/find-by-testid
+            chip (find-by-testid
                    tree "rf-xray-epoch-dispatch-after-timer-state-path")]
         (is (some? chip) "the state-path chip slot renders")
         (is (= :button (first chip))
@@ -255,7 +356,7 @@
                                       :delay-ms          250
                                       :source-state-path [:active :authenticating]}}
             tree (view/render-dispatch-step step)
-            chip (rf.test-helpers/find-by-testid
+            chip (find-by-testid
                    tree "rf-xray-epoch-dispatch-after-timer-state-path")]
         (is (some? chip) "the state-path chip slot still renders")
         (is (= :span (first chip))
@@ -271,11 +372,11 @@
                 :source-enrichment {:spawned-actor-id :checkout/worker}}
           tree (view/render-dispatch-step step)
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-source-label"))
           "the source-label slot is present")
       (is (string/includes? (or header-text "") "from machine spawn")
           "the kind label reads 'from machine spawn'")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-machine-spawn-actor"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-machine-spawn-actor"))
           "the spawned-actor-id chip renders")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-dispatch-machine-spawn-actor") "")
@@ -297,7 +398,7 @@
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
       (is (string/includes? (or header-text "") "from fx :dispatch")
           "the kind label reads 'from fx :dispatch'")
-      (let [link (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link")]
+      (let [link (find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link")]
         (is (some? link) "the parent-epoch-link slot is present")
         (is (= :button (first link))
             "with a resolved parent-epoch-id, the chip renders as a clickable button")
@@ -321,13 +422,13 @@
           header-text (text-of tree "rf-xray-epoch-dispatch-header")]
       (is (string/includes? (or header-text "") "from fx :dispatch-later")
           "the kind label reads 'from fx :dispatch-later'")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-fx-later-delay"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-fx-later-delay"))
           "the delay chip renders when delay-ms is present")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-dispatch-fx-later-delay") "")
             "500ms")
           "the delay chip shows the original scheduled delay")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
           "the parent-epoch-link slot is also present"))))
 
 (deftest dispatch-source-fx-dispatch-unresolved-parent-test
@@ -343,9 +444,9 @@
                 :source-enrichment {:parent-dispatch-id 99999}}
           index {9001 42}
           tree (view/render-dispatch-step step index)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
           "no clickable link when the parent epoch isn't in the buffer")
-      (let [unresolved (rf.test-helpers/find-by-testid
+      (let [unresolved (find-by-testid
                          tree "rf-xray-epoch-dispatch-parent-epoch-unresolved")]
         (is (some? unresolved) "the unresolved-parent chip is rendered")
         (is (= :span (first unresolved))
@@ -362,9 +463,9 @@
                 :coord nil
                 :source-enrichment {:parent-dispatch-id 9001}}
           tree (view/render-dispatch-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-dispatch-parent-epoch-link"))
           "no clickable link without dispatch-id->epoch-id threaded")
-      (is (some? (rf.test-helpers/find-by-testid
+      (is (some? (find-by-testid
                    tree "rf-xray-epoch-dispatch-parent-epoch-unresolved"))
           "the unresolved-parent chip carries the parent-dispatch-id"))))
 
@@ -379,7 +480,7 @@
                   :event [:some/other]
                   :source :after-timer
                   :coord nil})
-          label (rf.test-helpers/find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
+          label (find-by-testid tree "rf-xray-epoch-dispatch-source-label")]
       (is (some? label) "the source-label slot still renders"))))
 
 (deftest dispatch-source-always-renders-kind-label-test
@@ -412,7 +513,7 @@
           tree (view/render-coeffect-step step)
           id-text    (text-of tree "rf-xray-epoch-coeffect-id-session")
           value-text (text-of tree "rf-xray-epoch-coeffect-value-session")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-step-coeffect-session"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-step-coeffect-session"))
           "the per-cofx step wrapper renders with the cofx-id in its testid")
       (is (string/includes? (or id-text "") ":session")
           "the cofx-id is surfaced in the header")
@@ -430,7 +531,7 @@
           tree (view/render-coeffect-step step)
           input-text (text-of tree "rf-xray-epoch-coeffect-input-session")
           value-text (text-of tree "rf-xray-epoch-coeffect-value-session")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-coeffect-input-session"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-coeffect-input-session"))
           "the parameterized request arg renders on its own line")
       (is (string/includes? (or input-text "") ":auth-token")
           "the request arg value renders distinctly")
@@ -445,7 +546,7 @@
     (let [step {:step :coeffect :badge :COEFFECT :step-number 2
                 :id :now :value #inst "2026-01-01"}
           tree (view/render-coeffect-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-coeffect-input-now"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-coeffect-input-now"))
           "no :input on the step → no request-arg line rendered"))))
 
 ;; ---- rf2-9fyn40 · EP-0017 §9 — RECORDABLE COEFFECTS step ----------------
@@ -456,7 +557,7 @@
     (let [step {:step :recordable-cofx :badge :RECORDABLE-COFX :step-number 2
                 :time-ms 1781078400123}
           tree (view/render-recordable-cofx-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-step-recordable-cofx"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-step-recordable-cofx"))
           "the RECORDABLE COEFFECTS step wrapper renders")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-recordable-cofx-time-ms-value") "")
@@ -473,7 +574,7 @@
           tree (view/render-recordable-cofx-step step)
           key-text (text-of tree "rf-xray-epoch-recordable-cofx-key-delta")
           val-text (text-of tree "rf-xray-epoch-recordable-cofx-value-delta")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-recordable-cofx-row-delta"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-recordable-cofx-row-delta"))
           "the value-bearing leaf row renders")
       (is (string/includes? (or key-text "") "counter/delta")
           "the leaf id rides verbatim (owner-qualified vocabulary)")
@@ -496,7 +597,7 @@
 
 (defn- count-prefix
   [tree prefix]
-  (count (rf.test-helpers/find-by-testid-prefix tree prefix)))
+  (count (find-by-testid-prefix tree prefix)))
 
 (deftest sub-row-renders-sub-id-test
   (testing "rf2-kfh1v — SUBSCRIPTIONS row leads with the sub-id /
@@ -509,7 +610,7 @@
                           :inputs nil :changed? true :before 5 :after 6}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+            row  (find-by-testid tree "rf-xray-epoch-sub-row-0")]
         (is (some? row) "the sub row renders")
         (let [txt (rf.test-helpers/text-content row)]
           (is (string/includes? txt ":counter/total")
@@ -531,11 +632,11 @@
             tree (view/render-subscriptions-step step)]
         (is (= 1 (count-prefix tree "rf-xray-epoch-sub-row-"))
             "only the one changed row renders in the default `:changed` mode")
-        (is (some? (rf.test-helpers/find-by-testid
+        (is (some? (find-by-testid
                      tree "rf-xray-epoch-subscriptions-filter-mode"))
             "the new `[all][changed][unchanged]` button-bar is present")
         (doseq [m ["all" "changed" "unchanged"]]
-          (is (some? (rf.test-helpers/find-by-testid
+          (is (some? (find-by-testid
                        tree (str "rf-xray-epoch-subscriptions-filter-" m)))
               (str "the " m " button is in the bar")))))))
 
@@ -553,7 +654,7 @@
                   :changed 1 :unchanged 1}
             tree (view/render-subscriptions-step step)
             header (text-of tree "rf-xray-epoch-subscriptions-header")]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subscriptions-toggle"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subscriptions-toggle"))
             "the prior `Show unchanged` toggle is gone")
         (is (not (string/includes? header "recomputed"))
             "the badge-adjacent `N recomputed (...)` summary text is gone")
@@ -608,7 +709,7 @@
       (rf/with-frame :rf/xray
         (let [tree (view/render-subscriptions-step step)]
           (doseq [m ["all" "changed" "unchanged"]]
-            (let [btn (rf.test-helpers/find-by-testid
+            (let [btn (find-by-testid
                         tree (str "rf-xray-epoch-subscriptions-filter-" m))]
               (is (some? btn) (str m " button rendered"))
               (is (fn? (:on-click (second btn)))
@@ -643,8 +744,8 @@
                                    :frame  :rf/default}]}
             tree (view/render-subscriptions-step step)
             header (text-of tree "rf-xray-epoch-subscriptions-header")
-            disposed-tbl (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table")
-            row0   (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-disposed-row-0")
+            disposed-tbl (find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table")
+            row0   (find-by-testid tree "rf-xray-epoch-sub-disposed-row-0")
             id0    (text-of tree "rf-xray-epoch-sub-disposed-row-id-0")
             reason0 (text-of tree "rf-xray-epoch-sub-disposed-row-reason-0")]
         (is (some? disposed-tbl)
@@ -670,7 +771,7 @@
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
             header (text-of tree "rf-xray-epoch-subscriptions-header")]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table"))
             "no DISPOSED table renders when disposed-rows is absent")
         (is (not (string/includes? header "disposed"))
             "header omits the disposed clause")))))
@@ -691,9 +792,9 @@
                                    :frame  :rf/default}]}
             tree (view/render-subscriptions-step step)
             header (text-of tree "rf-xray-epoch-subscriptions-header")]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subscriptions-table"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subscriptions-table"))
             "the recompute table is omitted when no recompute rows fired")
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-subscriptions-disposed-table"))
             "the DISPOSED table renders")
         (is (string/includes? header "1 disposed")
             "header reads the dispose-only shape")))))
@@ -720,7 +821,7 @@
                      {:step :handler :badge :HANDLER :step-number 3
                       :flavour :db-only :event-id :nop
                       :fx [] :machine nil}))
-            slot (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+            slot (find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             ":db diff sub-section is always present even when empty")
         (is (= "full+diff"
@@ -733,7 +834,7 @@
                       :flavour :db-only :event-id :counter/inc
                       :db-post-handler {:counter {:value 6}} :db-write? true
                       :fx [] :machine nil}))
-            slot (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+            slot (find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot))
         (is (= "true" (-> slot second :data-rf-xray-db-write))
             "a handler that wrote :db reports db-write? true")))
@@ -744,7 +845,7 @@
                       :flavour :effectful :event-id :navigate
                       :fx [{:fx-id :navigate :value "/x"}]
                       :machine nil}))
-            slot (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff")]
+            slot (find-by-testid tree "rf-xray-epoch-handler-db-diff")]
         (is (some? slot)
             "even an :effectful handler that returned no :db gets the sub-section")))))
 
@@ -766,11 +867,11 @@
                       :status :error
                       :errors [{:operation :rf.error/handler-exception
                                 :message "boom"}]}))]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
             "the no-write placeholder is OMITTED when the handler threw")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-diff"))
             "the whole :db sub-section is dropped on a throw")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
             "NO phantom full-app-db block either")))
     (testing "clean handler returning no :db → 'returned no :db' wording"
       (let [tree (rf/with-frame :rf/xray
@@ -795,7 +896,7 @@
                   :flavour :reg-machine :event-id :ws/start
                   :fx []
                   :machine {:cascade []}})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-diff"))
           "no standalone :db diff under machine handlers — folded into
            SNAPSHOT DIFF per design"))))
 
@@ -817,13 +918,13 @@
                     :path [:derived] :before 2 :after 4
                     :db-pre-flow  {:base 2 :baseline 1 :derived 2}
                     :db-post-flow {:base 2 :baseline 1 :derived 4}}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-flow-db-diff-derived"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-flow-db-diff-derived"))
           "FLOW step renders a `:db` diff sub-block when snapshots present")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-flow-value-derived"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-flow-value-derived"))
           "the legacy scalar before→after line is NOT rendered when the
            `:db` diff is shown")
       (is (= "true"
-             (-> tree (rf.test-helpers/find-by-testid "rf-xray-epoch-step-flow-derived")
+             (-> tree (find-by-testid "rf-xray-epoch-step-flow-derived")
                  second :data-rf-xray-flow-db-diff))
           "the step root flags `:db`-diff mode for tooling / e2e"))))
 
@@ -838,12 +939,12 @@
                    {:step :flow :badge :FLOW :step-number 4
                     :flow-id :total-parity
                     :path [:total] :before 5 :after 6}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-flow-value-total-parity"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-flow-value-total-parity"))
           "the scalar before→after line renders on fallback")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-flow-db-diff-total-parity"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-flow-db-diff-total-parity"))
           "no `:db` diff sub-block when snapshots are absent")
       (is (= "false"
-             (-> tree (rf.test-helpers/find-by-testid "rf-xray-epoch-step-flow-total-parity")
+             (-> tree (find-by-testid "rf-xray-epoch-step-flow-total-parity")
                  second :data-rf-xray-flow-db-diff))))))
 
 (deftest handler-body-renders-source-placeholder-test
@@ -856,9 +957,9 @@
                 :flavour :db-only :event-id :no-such/handler
                 :fx [] :machine nil}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-source"))
           "the source slot is present even on graceful-degrade")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
           "no-source state renders the placeholder")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-handler-source-placeholder") "")
@@ -875,7 +976,7 @@
                         :subs-read [[:counter/total] [:counter/threshold]]
                         :duration-ms 1.2}]}
           tree (view/render-views-step step)
-          row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-0")
+          row  (find-by-testid tree "rf-xray-epoch-view-row-0")
           id   (text-of tree "rf-xray-epoch-view-row-id-0")
           subs (text-of tree "rf-xray-epoch-view-row-subs-0")]
       (is (some? row) "the view row renders")
@@ -903,14 +1004,14 @@
                         :status :rendered
                         :cause :mount}]}
           tree  (view/render-views-step step)
-          g-re  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-glyph-0")
-          g-mnt (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-glyph-1")]
+          g-re  (find-by-testid tree "rf-xray-epoch-view-row-glyph-0")
+          g-mnt (find-by-testid tree "rf-xray-epoch-view-row-glyph-1")]
       (is (some? g-re) "re-render row renders a glyph")
       (is (= "rerender" (:data-rf-view-glyph (second g-re)))
           "a re-render (non-mount cause) reads `~` / rerender")
       (is (= "mount" (:data-rf-view-glyph (second g-mnt)))
           "a fresh mount reads `+` / mount")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-cause-0"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-view-row-cause-0"))
           "the rf2-bhi3t render-cause chip is RETIRED"))))
 
 (deftest views-row-colour-codes-subs-test
@@ -927,7 +1028,7 @@
                         :status :rendered
                         :cause :mount}]}
           tree (view/render-views-step step)
-          subs (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-subs-0")
+          subs (find-by-testid tree "rf-xray-epoch-view-row-subs-0")
           statuses (->> (tree-seq vector? seq subs)
                         (filter vector?)
                         (keep #(:data-rf-sub-status (second %)))
@@ -966,9 +1067,9 @@
                         :status :rendered
                         :cause :mount}]}
           tree   (view/render-views-step step)
-          c0     (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-render-args-0")
-          c1     (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-render-args-1")
-          c2     (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-render-args-2")
+          c0     (find-by-testid tree "rf-xray-epoch-view-row-render-args-0")
+          c1     (find-by-testid tree "rf-xray-epoch-view-row-render-args-1")
+          c2     (find-by-testid tree "rf-xray-epoch-view-row-render-args-2")
           diff-attr (fn [cell]
                       (->> (tree-seq vector? seq cell)
                            (filter vector?)
@@ -1013,8 +1114,8 @@
                              (filter vector?)
                              (keep #(:data-testid (second %)))
                              (filter #(= "rf-xray-edn-inspector-large" %))))
-          c0 (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-render-args-0")
-          c1 (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-render-args-1")]
+          c0 (find-by-testid tree "rf-xray-epoch-view-row-render-args-0")
+          c1 (find-by-testid tree "rf-xray-epoch-view-row-render-args-1")]
       (is (some? c0) "small-arg cell renders")
       (is (some? c1) "fat-arg cell renders")
       (is (empty? (large-chips c0))
@@ -1047,7 +1148,7 @@
                 :rows [{:view-id :app.counter/Counter
                         :subs-read [[:counter/total]] :duration-ms 0.5}]}
           tree (view/render-views-step step)
-          row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-0")
+          row  (find-by-testid tree "rf-xray-epoch-view-row-0")
           attrs (when (vector? row) (second row))]
       (is (some? row) "the view row renders")
       (is (fn? (:on-mouse-enter attrs))
@@ -1074,12 +1175,12 @@
                 :unmounted-count 1}
           tree (view/render-views-step step)
           header (text-of tree "rf-xray-epoch-views-header")
-          rendered-row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-0")
-          unmounted-row (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-1")
-          glyph (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-glyph-1")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-views-table"))
+          rendered-row  (find-by-testid tree "rf-xray-epoch-view-row-0")
+          unmounted-row (find-by-testid tree "rf-xray-epoch-view-row-1")
+          glyph (find-by-testid tree "rf-xray-epoch-view-row-glyph-1")]
+      (is (some? (find-by-testid tree "rf-xray-epoch-views-table"))
           "there is ONE views-table; no separate unmounted table")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-views-unmounted-table"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-views-unmounted-table"))
           "the separate UNMOUNTED table is RETIRED")
       (is (= "rendered" (:data-rf-view-status (second rendered-row))))
       (is (= "unmounted" (:data-rf-view-status (second unmounted-row)))
@@ -1115,7 +1216,7 @@
                 :unmounted-count 1}
           tree (view/render-views-step step)
           header (text-of tree "rf-xray-epoch-views-header")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-views-table"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-views-table"))
           "the single views-table renders the unmount-only row")
       (is (string/includes? header "1 unmounted")
           "header reads the unmount-only shape"))))
@@ -1154,7 +1255,7 @@
                 :sensitive? false}
           tree (view/violation-block :handler 0 row)
           base "rf-xray-epoch-violation-handler-0"]
-      (is (some? (rf.test-helpers/find-by-testid tree base))
+      (is (some? (find-by-testid tree base))
           "the sub-block wrapper renders")
       (let [title       (text-of tree (str base "-title"))
             recovery    (text-of tree (str base "-recovery"))
@@ -1168,7 +1269,7 @@
             "prose sentence explains the :app-db :where outcome")
         (is (string/includes? schema-link "schema check")
             "inline 'schema check' link sits inside the prose")
-        (is (some? (rf.test-helpers/find-by-testid tree (str base "-explain")))
+        (is (some? (find-by-testid tree (str base "-explain")))
             "humanized explain map renders via `edn-inspector`")))))
 
 (deftest violation-block-recovery-chip-test
@@ -1247,10 +1348,10 @@
                    [{:fx-id :db :status :ok}
                     {:fx-id :http/post :status :ok :args {:url "/x"}}
                     {:fx-id :legacy/persist :status :skipped :value {:to :disk}}]))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-0")) ":db row at 0")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-1")) ":fx row at 1")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-2")) "other row at 2")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-side-effects-sub-db-header"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-fx-row-0")) ":db row at 0")
+      (is (some? (find-by-testid tree "rf-xray-epoch-fx-row-1")) ":fx row at 1")
+      (is (some? (find-by-testid tree "rf-xray-epoch-fx-row-2")) "other row at 2")
+      (is (nil? (find-by-testid tree "rf-xray-epoch-side-effects-sub-db-header"))
           "no :db sub-step header — the ledger is flat"))))
 
 (deftest side-effects-db-row-renders-app-db-destination-marker-test
@@ -1261,7 +1362,7 @@
     (rf/with-frame :rf/xray
       (let [tree   (view/render-side-effects-step
                      (side-effects-step [{:fx-id :db :status :ok}]))
-            marker (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-db-destination-0")]
+            marker (find-by-testid tree "rf-xray-epoch-fx-row-db-destination-0")]
         (is (some? marker) "the :db row carries the destination marker")
         (is (= :button (first marker)) "marker is a clickable <button>")
         (is (string/includes? (rf.test-helpers/text-content marker) "→ app-db"))
@@ -1275,7 +1376,7 @@
     (let [tree (view/render-side-effects-step
                  (side-effects-step
                    [{:fx-id :clipboard/write :status :skipped}]))
-          row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-0")]
+          row  (find-by-testid tree "rf-xray-epoch-fx-row-0")]
       (is (some? row))
       (is (string/includes? (rf.test-helpers/text-content row) badge/skipped-glyph)
           "the skipped row leads with the en-dash glyph")
@@ -1290,7 +1391,7 @@
                    :attributed-to {:action-id :open-socket
                                    :phase :entry}}])
           tree (view/render-side-effects-step step)
-          chip (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
+          chip (find-by-testid tree "rf-xray-epoch-fx-row-attribution-0")]
       (is (some? chip) "the attribution chip is present")
       (is (string/includes? (rf.test-helpers/text-content chip) ":open-socket")
           "the action-id rides the chip"))))
@@ -1300,7 +1401,7 @@
             the chip"
     (let [step (side-effects-step [{:fx-id :db :status :ok}])
           tree (view/render-side-effects-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-fx-row-attribution-0"))))))
 
 (deftest side-effects-fx-row-mounts-coord-chip-when-meta-resolves-test
   (testing "rf2-g1mfc — each :fx ledger row routes its fx-id through
@@ -1322,14 +1423,14 @@
             step (side-effects-step
                    [{:fx-id :rf.g1mfc-fixture/ping :status :ok}])
             tree (view/render-side-effects-step step)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-0"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-fx-row-0"))
             "the fx row itself renders")
         ;; If the test harness captured a source coord the chip mounts;
         ;; otherwise the call-site still fired but produced nil (graceful
         ;; degrade per coord-chip's contract). Either branch proves the
         ;; bug-fix is in place — pre-fix there was no chip call-site at
         ;; all on the fx row.
-        (let [chip (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-coord-0")]
+        (let [chip (find-by-testid tree "rf-xray-epoch-fx-row-coord-0")]
           (if meta-resolved?
             (do
               (is (some? chip)
@@ -1638,17 +1739,17 @@
                                      :microsteps 1}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
           "the cascade view replaces the category-grouped layout")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
           "cascade rows container is rendered")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "first cascade row is rendered")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine-data-reduction"))
           "the LEGACY DATA REDUCTION sub-section is GONE")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-snapshot-diff"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine-snapshot-diff"))
           "the LEGACY SNAPSHOT DIFF sub-section is GONE"))))
 
 (deftest machine-handler-cascade-renders-rows-in-trace-order-test
@@ -1670,10 +1771,10 @@
                                      :reason :on-exit}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-4"))))))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-2")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-3")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-4"))))))
 
 (deftest machine-handler-cascade-action-row-phase-chip-test
   (testing "rf2-u69j7 — `:action` rows render a phase chip identifying
@@ -1687,7 +1788,7 @@
                                      :phase :entry}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-phase-entry"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-phase-entry"))
           "phase chip is stamped with the row's phase keyword"))))
 
 (deftest machine-handler-cascade-action-fx-attribution-test
@@ -1706,9 +1807,9 @@
                                      :fx [[:http/get {:url "/x"}]]}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1"))
           "per-action fx attribution row is rendered")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1-0"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-fx-1-0"))
           "first emitted fx-id is rendered as a chip"))))
 
 (deftest machine-handler-cascade-action-data-diff-test
@@ -1729,15 +1830,15 @@
                                          :data-write  {:opened-count 1}}]
                               :transition nil :guards [] :lifecycle [] :timers []}}
           tree-m (view/render-handler-step mutating)]
-      (is (some? (rf.test-helpers/find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1"))
+      (is (some? (find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1"))
           "DATA Δ slot renders for a data-mutating action")
-      (is (some? (rf.test-helpers/find-by-testid tree-m "rf-xray-epoch-machine-cascade-outcome-1"))
+      (is (some? (find-by-testid tree-m "rf-xray-epoch-machine-cascade-outcome-1"))
           "the action outcome-details block is present")
       ;; rf2-fg3c4 — the `↳ data Δ` arrow reads LIGHT GREY (`:text-tertiary`),
       ;; the SAME token the NORMAL (non-machine) handler's `↳ :db diff` arrow
       ;; (`sub-header-glyph-style`) uses — NOT the prior `:success` green. The
       ;; arrow is the first `↳` span inside the data-write subtree.
-      (let [data-write-node (rf.test-helpers/find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1")
+      (let [data-write-node (find-by-testid tree-m "rf-xray-epoch-machine-cascade-data-write-1")
             arrow-colour    (some-> data-write-node
                                     (->> (tree-seq vector? seq)
                                          (filter #(and (vector? %) (= "↳" (last %))))
@@ -1774,7 +1875,7 @@
                                      :data-write  {:held-open? false}}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree-n (view/render-handler-step noop)]
-      (is (some? (rf.test-helpers/find-by-testid tree-n "rf-xray-epoch-machine-cascade-data-write-1"))
+      (is (some? (find-by-testid tree-n "rf-xray-epoch-machine-cascade-data-write-1"))
           "DATA Δ slot renders even for a no-op action (no delta shown)"))))
 
 (deftest machine-handler-cascade-step-content-aligns-to-badge-left-test
@@ -1835,16 +1936,16 @@
                                      :microsteps 1}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
       ;; The prominent verb-link IS the state change (the focal point).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-verb-link-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-verb-link-1"))
           "the prominent transition verb-link renders the state change")
       ;; The repetitive detail block is REMOVED (rf2-ge6uj ISSUE 3).
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-transition-1"))
           "the redundant transition detail block is gone")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-from-to-1"))
           "the redundant `state from → to` line is gone")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-trigger-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-trigger-1"))
           "the redundant echoed `event [...]` line is gone"))))
 
 ;; ---- rf2-yueoa — the no-op renders `[TRANSITION] [NO OP] staying in {state}` --
@@ -1870,12 +1971,12 @@
                                      :show-machine-name? false}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the no-op row renders")
       ;; rf2-yueoa — the `[TRANSITION]` badge renders exactly as a real
       ;; transition's, using the SAME kind-pill (testid + magenta hue). It is
       ;; NOT a bare `[NO OP]` kind pill any more.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-transition"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-kind-transition"))
           "the no-op row carries the `[TRANSITION]` badge a real transition uses")
       (is (= "TRANSITION"
              (text-of tree "rf-xray-epoch-machine-cascade-kind-transition"))
@@ -1886,15 +1987,15 @@
       ;; rf2-yueoa — the `[NO OP]` QUALIFIER chip follows the badge (a separate
       ;; testid from a kind pill — it is a qualifier on the transition step,
       ;; not the row's kind). The old bare `…-kind-no-op` pill is GONE.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-kind-no-op"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-kind-no-op"))
           "no bare `[NO OP]` kind pill — the qualifier carries the NO-OP marker now")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
           "the `[NO OP]` qualifier chip is present")
       (is (= "NO OP"
              (text-of tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
           "the qualifier reads `NO OP` (space, not hyphen)")
       ;; The stray leading "1" ordinal is SUPPRESSED for the no-op (rf2-iu3no).
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-ordinal-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-ordinal-1"))
           "the unexplained leading '1' ordinal is dropped for the no-op row")
       ;; The verb is the consequence only: `staying in :alarming`.
       (let [verb (text-of tree "rf-xray-epoch-machine-cascade-verb-link-1")]
@@ -1904,7 +2005,7 @@
         (is (not (string/includes? verb "received")) "no 'received [event]' echo")
         (is (not (string/includes? verb "transition")) "no ', no transition' suffix"))
       ;; NO outcome chip — the prior `ignored` chip is gone.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ignored"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ignored"))
           "no `ignored` outcome chip — the badge + qualifier + verb are the whole notice"))))
 
 (deftest machine-handler-cascade-multi-machine-no-op-keeps-name-test
@@ -1957,9 +2058,9 @@
                                          :event-id :go}]
                               :transition nil :guards [] :lifecycle [] :timers []}}
               tree (view/render-handler-step step)]
-          (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+          (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
               "inline-entry row renders")
-          (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+          (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
               "source slot is present (rf2-wwc3j inline-fn surfacing)"))))))
 
 (deftest cascade-row-renders-inline-guard-source-body-test
@@ -1985,8 +2086,8 @@
                                          :event-id :submit}]
                               :transition nil :guards [] :lifecycle [] :timers []}}
               tree (view/render-handler-step step)]
-          (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-          (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+          (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+          (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
               "inline-guard source slot is present"))))))
 
 (deftest cascade-row-source-not-captured-links-to-machine-def-test
@@ -2025,7 +2126,7 @@
                                        :event-id :go}]
                             :transition nil :guards [] :lifecycle [] :timers []}}
             tree (view/render-handler-step step)
-            link (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
+            link (find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
         (is (some? link)
             "the source-missing slot renders the machine-def link")
         ;; coord present (macro-stamped call-site) → clickable <button>,
@@ -2056,7 +2157,7 @@
                                        :event-id :go}]
                             :transition nil :guards [] :lifecycle [] :timers []}}
             tree (view/render-handler-step step)
-            link (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
+            link (find-by-testid tree "rf-xray-epoch-machine-cascade-source-missing-1")]
         (is (some? link)
             "the source-missing slot still renders the (degraded) label")
         (is (= :span (first link))
@@ -2089,10 +2190,10 @@
                                      :microsteps 1}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
           "transition source slot is present (the logical-state delta box)")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
           "the logical-state delta box renders for a state-changing transition"))))
 
 (deftest cascade-transition-row-elides-delta-on-self-transition-test
@@ -2120,11 +2221,11 @@
                                      :microsteps 0}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the transition row still renders (verb headline present)")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
           "the delta box is elided — no logical-state change")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
           "no delta box on a self/internal transition"))))
 
 (deftest cascade-transition-row-renders-parallel-state-delta-test
@@ -2151,7 +2252,7 @@
                                      :microsteps 1}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-transition-delta-1"))
           "the delta box renders the structured parallel-state diff"))))
 
 (deftest cascade-timer-row-elides-source-body-test
@@ -2175,8 +2276,8 @@
                                        :reason :on-exit}]
                             :transition nil :guards [] :lifecycle [] :timers []}}
             tree (view/render-handler-step step)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-source-1"))
             "timer rows have no inline source-body slot")))))
 
 (deftest machine-handler-cascade-empty-state-test
@@ -2190,7 +2291,7 @@
                 :machine {:cascade []
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-empty"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-empty"))
           "empty-state line renders"))))
 
 (deftest vanilla-db-only-cascade-unchanged-by-rf2-u69j7-test
@@ -2201,11 +2302,11 @@
                 :flavour :db-only :event-id :counter/inc
                 :fx [] :machine nil}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-diff"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-db-diff"))
           "the standard :db sub-section renders for non-machine handlers")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine"))
           "no machine block on a non-machine handler")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
           "no cascade view on a non-machine handler"))))
 
 (deftest duration-chip-renders-long-step-warning-test
@@ -2216,9 +2317,9 @@
                   :flavour :db-only :event-id :rf.test.epoch.view/slow-handler
                   :fx [] :machine nil
                   :duration-ms 42})]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-duration-long"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-duration-long"))
           "the long-duration testid is stamped on slow steps")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-duration"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-duration"))
           "the bare-duration testid is NOT stamped on long steps")))
 
   (testing "rf2-nqt3d — a fast step keeps the bare-duration chip"
@@ -2227,7 +2328,7 @@
                   :flavour :db-only :event-id :rf.test.epoch.view/fast-handler
                   :fx [] :machine nil
                   :duration-ms 0.1})]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-duration"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-duration"))
           "fast step keeps the standard duration testid"))))
 
 (deftest handler-body-renders-captured-source-test
@@ -2243,9 +2344,9 @@
                   :event-id :rf.test.epoch.view/srctest-handler
                   :fx [] :machine nil}
             tree (view/render-handler-step step)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-body"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-handler-source-body"))
             "the code-block widget mounts under the source slot")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
             "no placeholder when source IS captured")))))
 
 ;; ---- rf2-ehd8v — HANDLER source `file:line + [open]` ----------------
@@ -2277,9 +2378,9 @@
                   :event-id :rf.test.epoch.view/ehd8v-never-registered
                   :fx [] :machine nil}
             tree (view/render-handler-step step)]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-coord"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source-coord"))
             "no coord-row when :file meta is absent")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-open"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source-open"))
             "no [open] affordance without a coord")))))
 
 ;; Machine-handler path is exercised by the rf2-66wis tests above; the
@@ -2297,14 +2398,14 @@
   "Return every `[ei/mini ...]` hiccup mount under `tree`. Anchors on
   the `:data-rf-mini` attribute the widget stamps onto every render."
   [tree]
-  (rf.test-helpers/find-all-by-attr tree :data-rf-mini "1"))
+  (find-all-by-attr tree :data-rf-mini "1"))
 
 (defn- ei-mounts
   "Return every full-widget `[ei/edn-inspector ...]` mount under
   `tree`. Anchors on the data-testid suffix the widget stamps onto
   every render (`*-inspector` testid form)."
   [tree]
-  (rf.test-helpers/find-by-testid-prefix tree "rf-xray-edn-inspector"))
+  (find-by-testid-prefix tree "rf-xray-edn-inspector"))
 
 (deftest dispatch-event-routes-through-edn-inspector-test
   (testing "rf2-8w8er (subsumes rf2-nszcv) — DISPATCH event vector
@@ -2343,8 +2444,8 @@
                                [:http/get {:url "/x"}]]
                      :other-effects {:navigate "/home"}
                      :machine nil})
-          fx-sec  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-fx")
-          oth-sec (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-other")]
+          fx-sec  (find-by-testid tree "rf-xray-epoch-handler-fx")
+          oth-sec (find-by-testid tree "rf-xray-epoch-handler-other")]
       (is (some? fx-sec)
           "the :fx section mounts when fx-vec is non-empty")
       (is (pos? (count (ei-mounts fx-sec)))
@@ -2375,7 +2476,7 @@
     (let [tree (view/render-side-effects-step
                  (side-effects-step
                    [{:fx-id :http/get :status :ok :args {:url "/x"}}]))
-          row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-fx-row-0")]
+          row  (find-by-testid tree "rf-xray-epoch-fx-row-0")]
       (is (some? row))
       (is (pos? (count (ei-mounts row)))
           "the fx row's args mount an edn-inspector"))))
@@ -2401,7 +2502,7 @@
                           :before 5 :after 6}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+            row  (find-by-testid tree "rf-xray-epoch-sub-row-0")]
         (is (some? row))
         ;; sub-vec column + leaf-scalar `before` + leaf-scalar `after`
         ;; all mount mini; assert ≥ 3.
@@ -2417,7 +2518,7 @@
                         :subs-read [[:counter/total] [:counter/threshold]]
                         :duration-ms 1.2}]}
           tree (view/render-views-step step)
-          subs (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-subs-0")]
+          subs (find-by-testid tree "rf-xray-epoch-view-row-subs-0")]
       (is (some? subs))
       ;; 2 consumed subs → 2 mini mounts
       (is (>= (count (mini-mounts subs)) 2)
@@ -2530,7 +2631,7 @@
                           :before {:a 1} :after {:a 1 :b 2}}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            row  (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0")]
+            row  (find-by-testid tree "rf-xray-epoch-sub-row-0")]
         (is (some? row)
             "row renders cleanly under FULL+DIFF (hoisted style applied)")))))
 
@@ -2558,10 +2659,10 @@
                             :before 0 :after 1}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)
-              leaf (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
+              leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
           (is (some? leaf)
               "row mounts the leaf-changed wrapper (not the container path)")
-          (is (some? (rf.test-helpers/find-by-attr tree :data-rf-diff-annotation "subs-was"))
+          (is (some? (find-by-attr tree :data-rf-diff-annotation "subs-was"))
               "row carries the `← was <prev>` annotation chip")
           ;; rf2-o77z4 — the changed leaf now mirrors app-db's :modified
           ;; leaf chrome: yellow stripe + wash (via the reserved
@@ -2589,7 +2690,7 @@
                             :before "even" :after "odd"}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)
-              leaf (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
+              leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
           (is (some? leaf))
           (let [txt (rf.test-helpers/text-content leaf)]
             (is (string/includes? txt "← was"))
@@ -2603,7 +2704,7 @@
                             :before nil :after 1779972561856}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)
-              leaf (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
+              leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")]
           (is (some? leaf)
               "nil-prev leaf still mounts the leaf-changed wrapper (the
                `:first-run? false` discriminator is the gate, NOT
@@ -2634,14 +2735,14 @@
                           :before 7 :after 7}]
                   :changed 0 :unchanged 1}
             tree (view/render-subscriptions-step step)
-            leaf (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-unchanged-0")]
+            leaf (find-by-testid tree "rf-xray-epoch-subs-leaf-unchanged-0")]
         (is (some? leaf)
             "unchanged leaf mounts the leaf-unchanged wrapper")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
             "the changed wrapper is NOT mounted for an unchanged row")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
             "the added wrapper is NOT mounted for an unchanged row")
-        (is (nil? (rf.test-helpers/find-by-attr tree :data-rf-diff-annotation "subs-was"))
+        (is (nil? (find-by-attr tree :data-rf-diff-annotation "subs-was"))
             "unchanged row carries NO `← was <prev>` annotation")
         (let [style (-> leaf second :style)]
           (is (nil? (:background style))
@@ -2673,13 +2774,13 @@
                           :before nil :after 42}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            added (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0")]
+            added (find-by-testid tree "rf-xray-epoch-subs-leaf-added-0")]
         (is (some? added)
             "row mounts the leaf-added wrapper (`:first-run? true` branch)")
-        (is (nil? (rf.test-helpers/find-by-attr tree :data-rf-diff-annotation "subs-was"))
+        (is (nil? (find-by-attr tree :data-rf-diff-annotation "subs-was"))
             "first-run row carries NO `← was <prev>` annotation
              (no prior value to be was)")
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
             "the changed-wrapper is NOT mounted (mutually exclusive
              with leaf-added)")
         (let [txt (rf.test-helpers/text-content added)]
@@ -2706,9 +2807,9 @@
                             :before {:a 1} :after {:a 1 :b 2}}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)]
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
+          (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0"))
               "container path does NOT mount the leaf-changed wrapper")
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
+          (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
               "container path does NOT mount the leaf-added wrapper either")))
       (testing "vector sub return — container path"
         (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
@@ -2717,8 +2818,8 @@
                             :before [1 2] :after [1 2 3]}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)]
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")))
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0")))))
+          (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-changed-0")))
+          (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-added-0")))))
       (testing "first-run? on a CONTAINER → still container path
                 (the `:added` chrome only applies to leaf-scalars; the
                 inspector's own R1 paints `:added` for whole-subtree
@@ -2729,7 +2830,7 @@
                             :before nil :after [1 2 3]}]
                     :changed 1 :unchanged 0}
               tree (view/render-subscriptions-step step)]
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
+          (is (nil? (find-by-testid tree "rf-xray-epoch-subs-leaf-added-0"))
               "container first-run does NOT route through the leaf-added
                wrapper — inspector handles the whole-subtree :added at
                the row level"))))))
@@ -2761,7 +2862,7 @@
                           :cause-event-id :counter/inc}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            chrome (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-cause-event-id-0")]
+            chrome (find-by-testid tree "rf-xray-epoch-sub-row-cause-event-id-0")]
         (is (some? chrome)
             "the cause-event-id chrome mounts when the row carries it")
         (let [txt (rf.test-helpers/text-content chrome)]
@@ -2788,12 +2889,12 @@
                           :before 0 :after 1}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-cause-event-id-0"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-sub-row-cause-event-id-0"))
             "no chrome mount when `:cause-event-id` is absent
              (parity with the OMIT-vs-nil semantics on the projection)")
         ;; the sub-id span itself still renders — the absence is only
         ;; the secondary attribution line.
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-sub-row-0"))
             "the row itself still mounts; only the chrome is omitted")))))
 
 ;; ---- rf2-309cy — VIEWS row view-id keyword routes through ei/mini ------
@@ -2808,7 +2909,7 @@
                 :rows [{:view-id :app.counter/Counter
                         :subs-read [] :duration-ms nil}]}
           tree (view/render-views-step step)
-          id-cell (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-id-0")]
+          id-cell (find-by-testid tree "rf-xray-epoch-view-row-id-0")]
       (is (some? id-cell)
           "the view-id span renders")
       (is (pos? (count (mini-mounts id-cell)))
@@ -2829,7 +2930,7 @@
                         :status :unmounted :unmounted? true}]
                 :unmounted-count 1}
           tree (view/render-views-step step)
-          id-cell (rf.test-helpers/find-by-testid tree "rf-xray-epoch-view-row-id-0")]
+          id-cell (find-by-testid tree "rf-xray-epoch-view-row-id-0")]
       (is (some? id-cell)
           "the unmounted view-id span renders")
       (is (pos? (count (mini-mounts id-cell)))
@@ -2863,14 +2964,14 @@
                                    :reason :no-more-derefers
                                    :frame  :rf/default}]}
             tree (view/render-subscriptions-step step)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-disposed-row-0"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-sub-disposed-row-0"))
             "the disposed row itself renders")
         ;; If the test harness captured a source coord, the chip
         ;; mounts. Otherwise the call-site still fired but produced
         ;; nil (graceful degrade per coord-chip's contract). Either
         ;; way the bug-fix is in place — pre-fix there was no chip
         ;; call-site at all. Pin both branches.
-        (let [chip (rf.test-helpers/find-by-testid tree
+        (let [chip (find-by-testid tree
                      "rf-xray-epoch-sub-disposed-row-coord-0")]
           (if meta-resolved?
             (do
@@ -2911,9 +3012,9 @@
                           :inputs nil :changed? true :before 1 :after 2}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0"))
+        (is (some? (find-by-testid tree "rf-xray-epoch-sub-row-0"))
             "the active sub row itself renders")
-        (let [chip (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-coord-0")]
+        (let [chip (find-by-testid tree "rf-xray-epoch-sub-row-coord-0")]
           (if meta-resolved?
             (do
               (is (some? chip)
@@ -2977,12 +3078,12 @@
             ;; Search WITHIN each row's subtree so the shared `inputs`
             ;; header cell (which also stamps `data-rf-xray-resizable-col`)
             ;; doesn't shift the indexing.
-            param-row    (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0")
-            l1-row       (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-1")
-            param-inputs (some-> (rf.test-helpers/find-by-attr
+            param-row    (find-by-testid tree "rf-xray-epoch-sub-row-0")
+            l1-row       (find-by-testid tree "rf-xray-epoch-sub-row-1")
+            param-inputs (some-> (find-by-attr
                                    param-row :data-rf-xray-resizable-col "inputs")
                                  rf.test-helpers/text-content)
-            l1-inputs    (some-> (rf.test-helpers/find-by-attr
+            l1-inputs    (some-> (find-by-attr
                                    l1-row :data-rf-xray-resizable-col "inputs")
                                  rf.test-helpers/text-content)]
         (is (some? param-row) "the parameterized sub row renders")
@@ -3002,8 +3103,8 @@
   "The INPUTS cell node for sub-row `i` under `tree`."
   [tree i]
   (-> tree
-      (rf.test-helpers/find-by-testid (str "rf-xray-epoch-sub-row-" i))
-      (rf.test-helpers/find-by-attr :data-rf-xray-resizable-col "inputs")))
+      (find-by-testid (str "rf-xray-epoch-sub-row-" i))
+      (find-by-attr :data-rf-xray-resizable-col "inputs")))
 
 (deftest parametric-cause-sub-renders-as-one-query-vector-test
   (testing "rf2-nlraqq — a PARAMETERIZED cause-sub (`[:article/by-id :a1]`)
@@ -3036,7 +3137,7 @@
                   :changed 1 :unchanged 0}
             tree   (view/render-subscriptions-step step)
             cell   (inputs-cell tree 0)
-            minis  (rf.test-helpers/find-all-by-attr cell :data-rf-mini "1")
+            minis  (find-all-by-attr cell :data-rf-mini "1")
             titles (set (map #(-> % rf.test-helpers/attrs :title) minis))]
         (is (some? cell) "the parameterized sub's inputs cell renders")
         (is (= 1 (count minis))
@@ -3061,7 +3162,7 @@
                   :changed 1 :unchanged 0}
             tree  (view/render-subscriptions-step step)
             cell  (inputs-cell tree 0)
-            minis (rf.test-helpers/find-all-by-attr cell :data-rf-mini "1")]
+            minis (find-all-by-attr cell :data-rf-mini "1")]
         (is (= 2 (count minis))
             "two realized input edges → two input query-vectors rendered")))))
 
@@ -3094,9 +3195,9 @@
             ;; `data-rf-diff-op` with the classified op. `find-all-by-
             ;; attr` walks through (realizes) the form-2 component, so
             ;; the inspector's projection is actually computed.
-            added-nodes    (rf.test-helpers/find-all-by-attr tree :data-rf-diff-op "added")
-            modified-nodes (rf.test-helpers/find-all-by-attr tree :data-rf-diff-op "modified")]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-sub-row-0"))
+            added-nodes    (find-all-by-attr tree :data-rf-diff-op "added")
+            modified-nodes (find-all-by-attr tree :data-rf-diff-op "modified")]
+        (is (some? (find-by-testid tree "rf-xray-epoch-sub-row-0"))
             "the first-run container sub row renders")
         (is (pos? (count added-nodes))
             "the first-run container subtree paints `:added` chrome
@@ -3120,7 +3221,7 @@
                           :before nil :after {}}]
                   :changed 1 :unchanged 0}
             tree (view/render-subscriptions-step step)
-            added-nodes (rf.test-helpers/find-all-by-attr tree :data-rf-diff-op "added")]
+            added-nodes (find-all-by-attr tree :data-rf-diff-op "added")]
         (is (pos? (count added-nodes))
             "a first-run EMPTY container still reads `:added`")))))
 
@@ -3148,7 +3249,7 @@
             tree (view/render-subscriptions-step step)
             ;; The inline-attached block uses the step-key
             ;; `:sub-row-<sub-name>` (rf2-xgeag namer).
-            inline-block (rf.test-helpers/find-by-testid
+            inline-block (find-by-testid
                            tree "rf-xray-epoch-violations-sub-row-preview")]
         (is (some? inline-block)
             "the per-row violation sub-block renders (anchored on the
@@ -3168,7 +3269,7 @@
                   :violations [{:where :sub-return :failing-id :indirect/sub
                                 :explain-humanized {:errors ["nope"]}}]}
             tree (view/render-subscriptions-step step)
-            foot (rf.test-helpers/find-by-testid tree "rf-xray-epoch-violations-subscriptions")]
+            foot (find-by-testid tree "rf-xray-epoch-violations-subscriptions")]
         (is (some? foot)
             "step-level violations still render at the foot of the
             SUBSCRIPTIONS step (no behaviour change for non-row
@@ -3206,7 +3307,7 @@
                :sensitive? false}
           tree (view/violation-block :handler 0 row)
           base "rf-xray-epoch-violation-handler-0"]
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-decoded")))
+      (is (some? (find-by-testid tree (str base "-decoded")))
           "the decomposed sub-block renders when explain carries the Malli shape")
       (let [expected (text-of tree (str base "-expected"))
             got      (text-of tree (str base "-got"))]
@@ -3243,9 +3344,9 @@
                :explain-humanized {:errors ["something"]}}
           tree (view/violation-block :handler 0 row)
           base "rf-xray-epoch-violation-handler-0"]
-      (is (nil? (rf.test-helpers/find-by-testid tree (str base "-decoded")))
+      (is (nil? (find-by-testid tree (str base "-decoded")))
           "decoded sub-block is omitted when no Malli explain is present")
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-explain")))
+      (is (some? (find-by-testid tree (str base "-explain")))
           "the humanized explain still renders (unchanged behaviour)"))))
 
 ;; ---- rf2-ahhgn — inline exception card + per-step ✓/✗ + outcome banner ---
@@ -3265,18 +3366,18 @@
                 :db-rolled-back? true}
           tree (view/error-block :handler 0 row)
           base "rf-xray-epoch-error-handler-0"]
-      (is (some? (rf.test-helpers/find-by-testid tree base))
+      (is (some? (find-by-testid tree base))
           "the exception card wrapper renders")
       (is (string/includes? (text-of tree (str base "-title")) "Exception Thrown")
           "title reads 'Exception Thrown'")
       (is (string/includes? (text-of tree (str base "-recovery")) "Rolled back")
           ":no-recovery + db-rolled-back? → 'Rolled back' chip")
-      (is (nil? (rf.test-helpers/find-by-testid tree (str base "-headline")))
+      (is (nil? (find-by-testid tree (str base "-headline")))
           "rf2-oqi0c — the category-reason boilerplate headline is dropped")
       (is (string/includes? (text-of tree (str base "-message"))
                             "intentional")
           "the verbatim ex-info message renders")
-      (is (nil? (rf.test-helpers/find-by-testid tree (str base "-source")))
+      (is (nil? (find-by-testid tree (str base "-source")))
           "rf2-wnvid — the redundant jump-to-source link is dropped"))))
 
 (deftest error-block-styling-is-token-driven-test
@@ -3295,7 +3396,7 @@
                        :recovery  :no-recovery})
           base      "rf-xray-epoch-error-handler-0"
           card      (style-of tree base)
-          glyph     (some-> tree (rf.test-helpers/find-by-testid base)
+          glyph     (some-> tree (find-by-testid base)
                             ;; the glyph span is the first title-bar child
                             (->> (tree-seq vector? seq)
                                  (filter #(and (vector? %)
@@ -3338,7 +3439,7 @@
                   :failing-id :standard-epochs/boom
                   :recovery :no-recovery
                   :db-rolled-back? false})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-side-effects-0-recovery"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-error-side-effects-0-recovery"))
           "post-commit fx throw → no spurious 'Rolled back' chip")))
 
   (testing "rf2-wnvid / rf2-s6oqd — a pre-commit handler throw also rolls
@@ -3348,7 +3449,7 @@
                   :message "boom"
                   :recovery :no-recovery
                   :db-rolled-back? false})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-handler-0-recovery"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-error-handler-0-recovery"))
           "no rollback → no spurious 'Rolled back' chip"))))
 
 (deftest error-block-collapsible-details-test
@@ -3361,14 +3462,14 @@
                   :message "boom"
                   :exception ex})
           base "rf-xray-epoch-error-handler-0"]
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-details")))
+      (is (some? (find-by-testid tree (str base "-details")))
           "the collapsible details disclosure renders")
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-ex-data")))
+      (is (some? (find-by-testid tree (str base "-ex-data")))
           "ex-data is surfaced inside the disclosure")))
   (testing "rf2-wnvid — no exception object → no details disclosure"
     (let [tree (view/error-block :handler 0
                  {:operation :rf.error/handler-exception :message "boom"})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-handler-0-details"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-error-handler-0-details"))
           "nothing to disclose → the details element is omitted"))))
 
 (deftest error-block-drops-boilerplate-headline-test
@@ -3384,7 +3485,7 @@
                     :failing-id :http/post
                     :phase :after
                     :recovery :no-recovery})]
-        (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-fx-0-headline"))
+        (is (nil? (find-by-testid tree "rf-xray-epoch-error-fx-0-headline"))
             (str "no boilerplate headline for " op))
         (is (string/includes? (text-of tree "rf-xray-epoch-error-fx-0-message")
                               "the real ex-info message")
@@ -3409,14 +3510,14 @@
                           :failing-id :standard-epochs/throw-handler
                           :recovery :no-recovery}]}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-handler-0"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-error-handler-0"))
           "the inline exception card renders under the HANDLER step")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-handler-0-message")
             "boom in handler"))
       ;; rf2-9wq0v — the per-stage ✗ glyph retired; the inline exception
       ;; card under the step is the sole inline failure signal.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-status"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-status"))
           "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 (deftest handler-step-clean-renders-no-error-card-test
@@ -3427,9 +3528,9 @@
                 :flavour :db-only :event-id :counter/inc
                 :fx [] :machine nil}
           tree (view/render-handler-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-status"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-status"))
           "no per-stage status glyph on a clean step (retired rf2-9wq0v)")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-errors-handler"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-errors-handler"))
           "a clean step renders no error block"))))
 
 (deftest side-effects-renders-per-row-exception-test
@@ -3448,7 +3549,7 @@
                              :recovery :no-recovery}]}]
                  1)
           tree (view/render-side-effects-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-fx-row-1-0"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-error-fx-row-1-0"))
           "the throwing fx row (global index 1) carries its inline error card")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-fx-row-1-0-title")
@@ -3482,10 +3583,10 @@
                               :recovery :no-recovery}]}))]
       ;; the failed-injection body, NOT a `+ [id] value` diff line.
       ;; (testids key off `(name id)` — the namespace is stripped.)
-      (is (some? (rf.test-helpers/find-by-testid
+      (is (some? (find-by-testid
                    tree "rf-xray-epoch-coeffect-failed-throwing-cofx"))
           "renders the 'injection threw' body (no value)")
-      (is (nil? (rf.test-helpers/find-by-testid
+      (is (nil? (find-by-testid
                   tree "rf-xray-epoch-coeffect-value-throwing-cofx"))
           "no `+ [id] value` diff line — the injector threw before resolving")
       ;; the shared 'Exception Thrown' card (wnvid) is under the COEFFECT step
@@ -3496,7 +3597,7 @@
             (text-of tree "rf-xray-epoch-error-coeffect-0-message")
             "cofx threw on purpose"))
       ;; rf2-9wq0v — no per-stage glyph; the exception card is the signal.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-coeffect-throwing-cofx-status"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-coeffect-throwing-cofx-status"))
           "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 (deftest interceptor-step-renders-row-and-exception-card-test
@@ -3517,7 +3618,7 @@
                               :failing-id :standard-epochs/throwing-interceptor
                               :phase :before
                               :recovery :no-recovery}]}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-step-interceptor"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-step-interceptor"))
           "the INTERCEPTOR step renders")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-interceptor-row-0")
@@ -3531,7 +3632,7 @@
       ;; the per-row id + the inline card carry the signal. rf2-rvxem —
       ;; the INTERCEPTOR badge now leads the inline row itself (the
       ;; step-level `step-header` is gone), so no summary verb can exist.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-header-verb"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-interceptor-header-verb"))
           "no redundant 'N interceptor threw' summary verb (rf2-rvxem: no step-header)")
       ;; the shared card under the interceptor row
       (is (string/includes?
@@ -3540,7 +3641,7 @@
       (is (string/includes?
             (text-of tree "rf-xray-epoch-error-interceptor-row-0-0-message")
             "interceptor :before boom"))
-      (let [badge-pill (rf.test-helpers/find-by-testid tree "rf-xray-epoch-badge-interceptor")]
+      (let [badge-pill (find-by-testid tree "rf-xray-epoch-badge-interceptor")]
         (is (some? badge-pill) "the INTERCEPTOR badge pill renders")
         (is (= "INTERCEPTOR" (badge/label :INTERCEPTOR))))))
 
@@ -3581,12 +3682,12 @@
                     :errors [{:operation :rf.error/interceptor-exception
                               :message "before boom"
                               :failing-id :app/auth :phase :before}]}))
-          id-node (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
+          id-node (find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
       (is (= :button (first id-node))
           "a coord-bearing row renders the id as a clickable coord-link button")
       (is (fn? (:on-click (second id-node)))
           "the coord-link button carries the open-in-editor on-click")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
           "rf2-rvxem FIX 1 — NO redundant standalone coord-chip (one glyph only)")))
 
   (testing "rf2-siheh / rf2-rvxem — NO coord on the row → the id degrades to
@@ -3603,12 +3704,12 @@
                     :errors [{:operation :rf.error/interceptor-exception
                               :message "before boom"
                               :failing-id :app/auth :phase :before}]}))
-          id-node (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-row-0"))
+          id-node (find-by-testid tree "rf-xray-epoch-interceptor-id-0")]
+      (is (some? (find-by-testid tree "rf-xray-epoch-interceptor-row-0"))
           "the interceptor row still renders")
       (is (= :span (first id-node))
           "no coord → the id is a plain span (no clickable go-to-source)")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-interceptor-row-coord-0"))
           "no coord → no go-to-source glyph"))))
 
 (deftest interceptors-step-renders-authored-chain-test
@@ -3628,19 +3729,19 @@
                            {:interceptor-id :rf.interceptor/path
                             :authored [:rf.interceptor/path [:cart]]
                             :arg [:cart] :factory? true}]}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-step-interceptors"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-step-interceptors"))
           "the INTERCEPTORS step renders")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-badge-interceptors"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-badge-interceptors"))
           "the INTERCEPTORS badge pill renders")
       (is (= "INTERCEPTORS" (badge/label :INTERCEPTORS)))
       ;; row 0 — a coord-bearing keyword ref renders as a coord-link button
-      (let [id0 (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptors-id-0")]
+      (let [id0 (find-by-testid tree "rf-xray-epoch-interceptors-id-0")]
         (is (= :button (first id0))
             "a coord-bearing ref renders the id as a clickable coord-link"))
       (is (string/includes?
             (text-of tree "rf-xray-epoch-interceptors-hook-0") "before")
           "the resolved :before hook shape renders")
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptors-ref-0"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-interceptors-ref-0"))
           "a by-reference entry carries a ref badge")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-interceptors-doc-0") "Require auth")
@@ -3663,7 +3764,7 @@
                     :rows [{:interceptor-id :nope/unregistered
                             :authored :nope/unregistered
                             :missing-ref? true}]}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-interceptors-missing-0"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-interceptors-missing-0"))
           "the missing-ref badge renders for an unregistered ref")))
 
   (testing "rf2-se9a9t — :interceptors is wired into render-step (the dispatcher)"
@@ -3675,7 +3776,7 @@
                      :event-id :cart/add
                      :rows [{:interceptor-id :auth/required
                              :authored :auth/required :before? true}]}]))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-step-interceptors"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-step-interceptors"))
           "render-step dispatches :interceptors to render-interceptors-step"))))
 
 (deftest handler-skipped-renders-as-skipped-not-no-db-test
@@ -3690,11 +3791,11 @@
                     :flavour :db-only :event-id :standard-epochs/throw-interceptor
                     :db-write? true :fx [] :machine nil
                     :status :skipped}))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-skipped"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-skipped"))
           "the SKIPPED body renders")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-no-write"))
           "the 'no :db (returned no :db)' placeholder does NOT render")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-db-full-with-diff"))
           "no phantom :db block")
       (is (string/includes?
             (text-of tree "rf-xray-epoch-handler-skipped")
@@ -3702,7 +3803,7 @@
           "the body states the handler did not run")
       ;; rf2-9wq0v — the SKIPPED body itself carries the 'did not run'
       ;; signal; the per-stage ⊘ glyph retired.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-status"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-status"))
           "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 (deftest side-effects-skipped-renders-as-skipped-test
@@ -3712,10 +3813,10 @@
                  {:step :side-effects :badge :SIDE-EFFECTS :step-number 5
                   :rows [{:fx-id :db :status :ok}]
                   :status :skipped})]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-side-effects-skipped"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-side-effects-skipped"))
           "the SKIPPED body renders")
       ;; rf2-9wq0v — no per-stage glyph; the SKIPPED body is the signal.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-side-effects-status"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-side-effects-status"))
           "no per-stage status glyph (retired rf2-9wq0v)"))))
 
 ;; ============================================================================
@@ -3741,14 +3842,14 @@
                                      :threw? true}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source"))
           "NO source block wrapper for a machine handler")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-spec"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source-spec"))
           "NO machine SPEC dump under the HANDLER step")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-source-placeholder"))
           "and NOT the '<source not yet captured>' placeholder either")
       ;; The machine cascade IS the content — confirm it still renders.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade"))
           "the machine CASCADE remains the HANDLER step's content")))
   (testing "rf2-4yrr6 — an EVENT handler (non-machine) STILL renders its
             source block (only the machine case is suppressed)"
@@ -3756,7 +3857,7 @@
                 :flavour :db-only :event-id :no-such/handler
                 :fx [] :machine nil}
           tree (view/render-handler-step step)]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-source"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-source"))
           "the event handler's source block is unaffected"))))
 
 ;; ---- rf2-akvfe — EVENT HANDLER rework (supersedes the rf2-52u5n up/down block)
@@ -3804,10 +3905,10 @@
             GONE. NO `…-machine-cascade-structured-…` element renders."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-structured-2"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-structured-2"))
           "the up/down transition block no longer renders")
       ;; The transition row itself + its `{from}→{to}` verb still render.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-2"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-2"))
           "the transition row still renders")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-machine-cascade-verb-link-2") "")
@@ -3833,7 +3934,7 @@
           "the entry action :count-open survives on its own pipeline row")
       ;; The entry action's data-delta survives — the `data Δ` slot renders
       ;; the {:opened-count …} write on the :count-open row (step 3).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-data-write-3"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-data-write-3"))
           "the entry action's data Δ renders on its row")
       (is (string/includes?
             (or (text-of tree "rf-xray-epoch-machine-cascade-data-write-3") "")
@@ -3848,7 +3949,7 @@
             'Processing' word is DROPPED (rf2-2hj0h item 4)."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
           "the orientation line renders")
       ;; rf2-2hj0h item 4 — no leading "Processing" word.
       (is (not (string/includes?
@@ -3870,7 +3971,7 @@
     (let [start-rows [{:kind :start :step 1 :machine-id :door/main :cause :explicit
                        :data {:opened-count 0}}]
           tree (view/render-handler-step (machine-step-with-rows :door/main start-rows))]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-event-handler-orientation"))
           "no orientation line for a pure creation kick"))))
 
 (deftest event-handler-flat-numbered-stack-no-rail-test
@@ -3883,10 +3984,10 @@
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
       ;; item 2 — the full-height rail is GONE.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rail"))
           "the nested-pipeline vertical rail is removed")
       ;; The flat rows host still renders.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-handler-machine-cascade-rows"))
           "the flat rows host renders")
       ;; item 1 — NO `:border-bottom` horizontal line between rows.
       (is (nil? (:border-bottom (style-of tree "rf-xray-epoch-machine-cascade-row-1")))
@@ -3919,7 +4020,7 @@
           "the exit action's merged badge reads `EXIT ACTION`")
       ;; The merged badge is the SOLE phase carrier (the `…-phase-<phase>`
       ;; testid still resolves — it now rides the merged badge node).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-phase-exit"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-phase-exit"))
           "the exit phase testid still resolves (on the merged badge)")))
   (testing "rf2-2hj0h item 5 — an ENTRY-phase action reads `ENTRY ACTION`."
     (let [tree (view/render-handler-step
@@ -3965,7 +4066,7 @@
                     {:kind :action :step 2 :phase :entry :machine-id :door/main
                      :action-id :count-open :outcome :ok
                      :source-state :closed :target-state :open}]))]
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
           "the exit action renders a ` for <state> ` clause")
       (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
                             "for")
@@ -3982,7 +4083,7 @@
                  (machine-step-with-rows :door/main
                    [{:kind :action :step 1 :phase :entry :machine-id :door/main
                      :action-id :count-open :outcome :ok}]))]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
           "no ` for <state> ` clause when neither source nor target state is stamped"))))
 
 (deftest event-handler-guard-row-for-state-and-inline-outcome-test
@@ -3996,7 +4097,7 @@
                      :guard-id :may-close? :outcome :pass
                      :source-state :open :target-state :closed}]))]
       ;; B — the for-state clause carries the gated (source) state.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-for-state-1"))
           "the guard row renders a ` for <state> ` clause")
       (is (string/includes? (text-of tree "rf-xray-epoch-machine-cascade-for-state-1")
                             "for")
@@ -4013,9 +4114,9 @@
       ;; C — the pass/fail outcome chip renders INLINE in the header (a direct
       ;; sibling of the verb), NOT inside the right-aligned span. The
       ;; right-aligned span (`:margin-left auto`) must not contain it.
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-pass"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-pass"))
           "the meaningful guard pass/fail chip still renders (it decides the branch)")
-      (let [row    (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
+      (let [row    (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
             header (first (rf.test-helpers/children row))
             ;; The right-aligned span is the header child carrying margin-left:auto.
             right  (some (fn [c]
@@ -4023,9 +4124,9 @@
                          (rf.test-helpers/children header))]
         (is (some? header) "the row header renders")
         (is (some? right) "the right-aligned span (margin-left:auto) renders")
-        (is (nil? (rf.test-helpers/find-by-testid right "rf-xray-epoch-machine-cascade-outcome-pass"))
+        (is (nil? (find-by-testid right "rf-xray-epoch-machine-cascade-outcome-pass"))
             "the guard outcome chip is NOT in the right-aligned span (it moved inline)")
-        (is (some? (rf.test-helpers/find-by-testid header "rf-xray-epoch-machine-cascade-outcome-pass"))
+        (is (some? (find-by-testid header "rf-xray-epoch-machine-cascade-outcome-pass"))
             "the guard outcome chip IS in the header (inline after the verb + glyph)"))))
   (testing "rf2-h710p item C — a FAILING guard's `fail` marker also renders
             inline (the guard fail is meaningful — it blocked the transition)."
@@ -4034,9 +4135,9 @@
                    [{:kind :guard :step 1 :machine-id :door/main
                      :guard-id :may-close? :outcome :fail
                      :source-state :open :target-state :closed}]))
-          row    (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
+          row    (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1")
           header (first (rf.test-helpers/children row))]
-      (is (some? (rf.test-helpers/find-by-testid header "rf-xray-epoch-machine-cascade-outcome-fail"))
+      (is (some? (find-by-testid header "rf-xray-epoch-machine-cascade-outcome-fail"))
           "the `fail` chip renders inline in the header"))))
 
 (deftest event-handler-action-no-ok-tick-test
@@ -4046,10 +4147,10 @@
             the success tick too."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
           "no `✓ ok` outcome chip on a successful action row")
       ;; The action row + its merged badge still render (only the tick is gone).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the action row still renders"))))
 
 (deftest event-handler-exception-box-test
@@ -4067,16 +4168,16 @@
                      :exception exc
                      :source-state :ok :target-state :blown}]))
           base "rf-xray-epoch-machine-cascade-exception-1"]
-      (is (some? (rf.test-helpers/find-by-testid tree base))
+      (is (some? (find-by-testid tree base))
           "the exception box renders below the throwing action's code")
       (is (= "Exception Thrown" (text-of tree (str base "-title")))
           "the box carries the 'Exception Thrown' title (outer-card anatomy)")
       (is (= "action blew up" (text-of tree (str base "-message")))
           "the box renders the verbatim ex-info message")
       ;; The ex-data rides the collapsible details disclosure.
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-details")))
+      (is (some? (find-by-testid tree (str base "-details")))
           "the collapsible stack / ex-data disclosure renders")
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-ex-data")))
+      (is (some? (find-by-testid tree (str base "-ex-data")))
           "the ex-data renders inside the disclosure")))
   (testing "rf2-2hj0h item 8 — a THROWING guard renders the exception box too."
     (let [exc  (ex-info "guard blew up" {:guard :is-ready?})
@@ -4086,16 +4187,16 @@
                      :guard-id :is-ready? :outcome :threw
                      :exception exc :source-state :closed}]))
           base "rf-xray-epoch-machine-cascade-exception-1"]
-      (is (some? (rf.test-helpers/find-by-testid tree base))
+      (is (some? (find-by-testid tree base))
           "the exception box renders below the throwing guard's code")
       (is (= "guard blew up" (text-of tree (str base "-message")))
           "the box renders the guard's verbatim message")))
   (testing "rf2-2hj0h item 8 — a CLEAN action / guard renders NO exception box."
     (let [tree (view/render-handler-step
                  (machine-step-with-rows :door/main door-push-cascade-rows))]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
           "no exception box on a clean (non-throwing) action row")
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-3"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-exception-3"))
           "no exception box on a clean entry action row"))))
 
 ;; ---- Part 3 — a threw ACTION row shows exactly ONE threw signal -----------
@@ -4121,17 +4222,17 @@
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
       ;; (a) NO right-aligned `:threw` outcome chip.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-threw"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-threw"))
           "no duplicate `:threw` outcome chip on the threw action row")
       ;; (b) NO '✗ threw — <message>' outcome-detail line.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-threw-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-threw-1"))
           "no duplicate '✗ threw — <message>' outcome-detail line")
       ;; rf2-2hj0h item 8 — the threw signal is now the EXCEPTION BOX below
       ;; the code (the single failure signal, paired with item 7's no-tick).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
           "the throwing action's exception box renders (rf2-2hj0h item 8)")
       ;; The action row itself still renders (only the threw chrome is gone).
-      (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
+      (is (some? (find-by-testid tree "rf-xray-epoch-machine-cascade-row-1"))
           "the action row still renders")))
   (testing "rf2-2hj0h item 7 — a SUCCESSFUL `:action` row carries NO ok-tick
             (success is clean — the prior `✓ ok` chip is removed; rf2-4yrr6
@@ -4144,10 +4245,10 @@
                                      :outcome {:data {:opened-count 1}}}]
                           :transition nil :guards [] :lifecycle [] :timers []}}
           tree (view/render-handler-step step)]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-outcome-ok"))
           "a successful action carries NO `✓ ok` tick (rf2-2hj0h item 7)")
       ;; A clean action also renders NO exception box.
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-machine-cascade-exception-1"))
           "a clean action renders no exception box"))))
 
 ;; ---- Part 4 — collapsed exception-card machine attribution ----------------
@@ -4174,7 +4275,7 @@
                   :recovery      :no-recovery})
           base "rf-xray-epoch-error-handler-0"
           attr (text-of tree (str base "-machine-attribution"))]
-      (is (some? (rf.test-helpers/find-by-testid tree (str base "-machine-attribution")))
+      (is (some? (find-by-testid tree (str base "-machine-attribution")))
           "the machine-attribution line renders")
       (is (= "action :blow-fuse threw an exception" attr)
           "the attribution collapses to 'action :blow-fuse threw an exception'")
@@ -4187,7 +4288,7 @@
           "no 'in machine :fuse/box' echo (obvious from cascade context)")
       ;; `:data-via-wildcard` STILL rides the row for downstream consumers.
       (is (= "true"
-             (-> tree (rf.test-helpers/find-by-testid (str base "-machine-attribution"))
+             (-> tree (find-by-testid (str base "-machine-attribution"))
                  rf.test-helpers/attrs :data-via-wildcard))
           "the :data-via-wildcard attribute still distinguishes a wildcard throw")))
   (testing "rf2-4yrr6 — the collapsed wording reads cleanly for a NAMED-action
@@ -4204,7 +4305,7 @@
              (text-of tree (str base "-machine-attribution")))
           "named-action throw reads 'action :enter-alarm threw an exception'")
       (is (= "false"
-             (-> tree (rf.test-helpers/find-by-testid (str base "-machine-attribution"))
+             (-> tree (find-by-testid (str base "-machine-attribution"))
                  rf.test-helpers/attrs :data-via-wildcard))
           "named-transition throw stamps :data-via-wildcard false")))
   (testing "rf2-4yrr6 — a non-machine exception kind renders NO
@@ -4213,5 +4314,5 @@
                  {:operation :rf.error/handler-exception
                   :message   "boom"
                   :recovery  :no-recovery})]
-      (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-epoch-error-handler-0-machine-attribution"))
+      (is (nil? (find-by-testid tree "rf-xray-epoch-error-handler-0-machine-attribution"))
           "no machine-attribution line for a plain handler exception"))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch_panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch_panel_fresco_boundary_dom_cljs_test.cljs
@@ -296,15 +296,18 @@
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
-        ;; Mount with the history loaded but NO focus, so the panel starts on
-        ;; its empty state and the cascade's ARRIVAL is the signal.
-        (set-history! fixture-history)
+        ;; Mount with an EMPTY spine, so the panel starts on its empty state
+        ;; and the cascade's ARRIVAL is the signal. The history is the lever
+        ;; rather than the focus, and that is measured rather than chosen:
+        ;; the focus-resolver HEAD-TRACKS, so loading history with no explicit
+        ;; focus already paints the cascade and a focus-as-lever row would
+        ;; fail its own precondition.
         (let [{:keys [container root]} (mount-panel! :rf/xray)
               section (panel-node container)]
           (is (some? section)
               "PRECONDITION: the panel is on screen at all")
           (is (not (cascade? container))
-              "NON-VACUITY: with no focused epoch the cascade is NOT on screen
+              "NON-VACUITY: with an empty spine the cascade is NOT on screen
                before this row moves the world")
 
           ;; ---- phase 2: the world moves, and the panel is deaf ------------
@@ -318,7 +321,7 @@
                        commits nothing. A panel that repainted here would make
                        phase 3 pass for a reason that is not liveness")
                   ;; ---- phase 3: the read's real input moves --------------
-                  (focus-epoch! 1)
+                  (set-history! fixture-history)
                   (rf.test-support/poll-until #(cascade? container)
                     {:label "the panel committed the focused epoch's cascade"})))
               (.then

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch_panel_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch_panel_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,406 @@
+(ns day8.re-frame2-xray.panels.epoch-panel-fresco-boundary-dom-cljs-test
+  "The Epoch panel re-authored in the re-frame-native view layer, read off a
+  real React commit (rf2-k97c.3).
+
+  `panels.epoch.view/Panel` is now an `rf.fresco/defview` reading through
+  Fresco's shipped collector rather than an `rf/reg-view` reading through
+  whatever view build the installed substrate adapter supplies. This file is
+  the behavioural evidence for that swap. Nothing in the fast node lane can
+  make it: `view_cljs_test` drives the step renderers as pure functions, and
+  a boundary's body only runs inside a React render window.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes the
+                                    update mean liveness rather than a
+                                    commit that had not happened yet)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    6 CLEAN TEARDOWN              — W3
+
+  Criterion 3 (Xray's own interactions) and criterion 5 (tool activity never
+  masquerading as application evidence) have no row HERE, and in both cases
+  that is a division of labour rather than a gap. Criterion 5 is structural
+  and identical for every boundary in this migration — a Fresco boundary is
+  not a substrate view render, so there is no `:rf.view/*` op to gate — and
+  `static/flows/panel_fresco_boundary_dom_cljs_test` already carries it with
+  its positive `reg-view` control. Criterion 3's affordances here (the
+  subscriptions filter bar, the parent-epoch and app-db jump links) dispatch
+  through a frame captured at render time by `rf/current-frame-id`, which
+  this migration did not touch and which `view_cljs_test` grades directly.
+
+  ## THREE READS, AND WHY THE COUNT IS THE POINT
+
+  The boundary reads `:rf.xray/epoch-pipeline`, `:rf.xray/selected-epoch-
+  record` and `:rf.xray.epoch/subs-filter-mode`. The last two used to be
+  performed by helpers deep in the cascade; rf2-k97c.3 hoisted them into the
+  body so the helpers stay pure functions the node lane can drive. W1 and W3
+  therefore assert on ALL THREE cache entries rather than on one: a hoist
+  that half-landed would leave a read stranded in a helper, where it would
+  raise `:rf.error/fresco-sub-outside-render` on the first render — loudly,
+  which is why W1 asserting the panel painted at all is already most of that
+  claim.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell.cljs`'s `detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, and it reaches `:panel` THROUGH
+  `panel-registry/tab-by-id :dynamic :epoch` rather than naming the var — so
+  the BRIDGE the registry actually holds is the thing under test. That
+  matters more here than the phrasing suggests: `Panel` is a React component
+  now, `reg-l4-tab!`'s `:pre` requires `:panel` to be CALLABLE, and a
+  registration left pointing at `Panel` rather than `Panel-bridge` reddens
+  here rather than in a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after the
+  mount reads `container.querySelector…` — the DOM React committed on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports, because
+  the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing: the fixture's default ambient scope
+  is still in effect during a synchronous `flushSync`, and tier 1 of the
+  frame resolver is the dynamic var, so an ambient frame would SHADOW the
+  React-context tier W1's frame-targeting row is about — and that row would
+  pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test` build
+  (real DOM + React via Chromium). The `:node-test` build's regex also
+  matches, so it LOADS under Node — where every row short-circuits through
+  [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. W1 reads it as
+  the negative half of the frame-targeting claim."
+  ::app)
+
+(def ^:private pipeline-q
+  "The boundary's primary read. Named once because three rows key off it —
+  the sub-cache is keyed by the query vector itself, so this value IS the
+  cache key."
+  [:rf.xray/epoch-pipeline])
+
+(def ^:private record-q  [:rf.xray/selected-epoch-record])
+(def ^:private filter-q  [:rf.xray.epoch/subs-filter-mode])
+
+(def ^:private boundary-reads
+  "Every query the boundary issues, in the order the body issues them."
+  [pipeline-q record-q filter-q])
+
+;; W2's DEAF lever. It writes a key on Xray's own app-db that NO sub in the
+;; panel's read set consults, so the world moves and nothing the panel
+;; watches is invalidated. Without it, phase 3's repaint would be evidence
+;; that a commit happened — not that this boundary is live.
+(rf/reg-event ::write-unwatched-slot
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db ::probe n)}))
+
+(def ^:private fixture-history
+  "One epoch carrying a dispatch the projection turns into a cascade. Kept
+  minimal on purpose: these rows are about the boundary, and `view_cljs_test`
+  owns what each step renders."
+  [{:epoch-id 1
+    :dispatch-id "d-1"
+    :event [:counter/inc 7]
+    :trace-events
+    [{:id 1 :time 10 :operation :rf.event/dispatch
+      :tags {:event [:counter/inc 7] :rf.trace/dispatch-id "d-1"}}]}])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W3's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission. A Fresco boundary is NOT in Reagent's render queue — its
+;; update is scheduled by the collector through React — so draining Reagent's
+;; queue commits nothing of this panel's, and a row written that way reads a
+;; DOM that has not moved and reports a live panel as dead. Mount is
+;; committed with `flushSync` (React's own door) and everything after it is
+;; polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a real
+  chance to commit — two animation frames and a macrotask. It exists for the
+  CONTROL in W2: an absence asserted immediately after the world moves is a
+  race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which installs the epoch sub family and the
+  `:epoch` L4 tab entry the mount reads — plus the test-override seam the
+  liveness lever writes through, and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- set-history! [history]
+  (rf/dispatch-sync [:rf.xray/set-epoch-history-for-test history]
+                    {:frame :rf/xray}))
+
+(defn- focus-epoch! [epoch-id]
+  (rf/dispatch-sync [:rf.xray/set-focus-epoch-id-for-test epoch-id]
+                    {:frame :rf/xray}))
+
+(defn- mount-panel!
+  "Mount the Epoch tab the way `shell.cljs`'s `detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and the first assertion would run against an empty
+  container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :epoch)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where the
+  collector releases a boundary's reads — have RUN by the time the next line
+  reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- panel-node [container]
+  (q container "[data-testid=\"rf-xray-epoch-panel\"]"))
+
+(defn- cascade? [container]
+  (some? (q container "[data-testid=\"rf-xray-epoch-pipeline\"]")))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means the
+  frame is not live, which is a defect in the row's own setup and should
+  throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the entry
+  is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- released?
+  "True once the frame holds NO reference for any of the boundary's reads."
+  []
+  (every? #(zero? (ref-count-of :rf/xray %)) boundary-reads))
+
+;; ===========================================================================
+;; W1 — first display, and every read lands in the frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-and-its-reads-land-in-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Epoch panel commits real DOM through
+            the registry entry the Dynamic shell mounts, and each of its
+            three `rf.fresco/sub` reads resolves against the frame the
+            enclosing `frame-provider` named rather than the ambient one.
+            Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            _ (set-history! fixture-history)
+            _ (focus-epoch! 1)
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (panel-node container))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (cascade? container)
+              "and with a focused epoch in the spine it committed the numbered
+               cascade, so the body really ran through `pipeline-view` rather
+               than painting an empty shell")
+
+          ;; ---- criterion 4: the reads are where the tree said they'd be ----
+          (doseq [query-v boundary-reads]
+            (is (pos? (ref-count-of :rf/xray query-v))
+                (str "the boundary's read " (pr-str query-v) " holds a "
+                     "reference in :rf/xray's sub-cache — the frame the "
+                     "enclosing frame-provider named. Cache keys: "
+                     (pr-str (keys (cache-of :rf/xray)))))
+            (is (zero? (ref-count-of app-frame query-v))
+                (str "and NOT in the application frame's — a foreign root "
+                     "that inherited the ambient scope instead of reading "
+                     "React context would put " (pr-str query-v) " here")))
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zeros
+               above are absences and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its read's value really changes, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; Mount with the history loaded but NO focus, so the panel starts on
+        ;; its empty state and the cascade's ARRIVAL is the signal.
+        (set-history! fixture-history)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (panel-node container)]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen at all")
+          (is (not (cascade? container))
+              "NON-VACUITY: with no focused epoch the cascade is NOT on screen
+               before this row moves the world")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          (rf/dispatch-sync [::write-unwatched-slot 1] {:frame :rf/xray})
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (cascade? container))
+                      "CONTROL: given a full settling window, a write to an
+                       app-db slot the panel's read set does not consult
+                       commits nothing. A panel that repainted here would make
+                       phase 3 pass for a reason that is not liveness")
+                  ;; ---- phase 3: the read's real input moves --------------
+                  (focus-epoch! 1)
+                  (rf.test-support/poll-until #(cascade? container)
+                    {:label "the panel committed the focused epoch's cascade"})))
+              (.then
+                (fn [_]
+                  (is (cascade? container)
+                      "the panel re-rendered on a real invalidation of its own
+                       read and committed the cascade")
+                  (is (identical? section (panel-node container))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the cascade did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — unmount releases every read, and reopening does not grow the count
+;; ===========================================================================
+
+(deftest w3-unmount-releases-the-reads-and-reopen-does-not-grow-them
+  (testing "rf2-k97c.3 — unmounting the panel releases ALL THREE subscription
+            references completely, and mounting it again returns to the SAME
+            counts rather than higher ones. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (set-history! fixture-history)
+        (focus-epoch! 1)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (mapv #(ref-count-of :rf/xray %) boundary-reads)]
+                  (is (every? pos? mounted)
+                      (str "the mount took a reference for every one of the "
+                           "boundary's reads — otherwise the release below is "
+                           "vacuous. Got " (pr-str mounted) " for "
+                           (pr-str boundary-reads)))
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released every read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released them COMPLETELY, "
+                                   "within the collector's grace macrotask. "
+                                   "Cache: " (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same counts, not higher ones ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (mapv #(ref-count-of :rf/xray %)
+                                                boundary-reads)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "counts " (pr-str mounted) " rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got "
+                                     (pr-str remounted)))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released them too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases them too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,445 @@
+(ns day8.re-frame2-xray.panels.machine-inspector-fresco-boundary-dom-cljs-test
+  "The Machine Inspector panel re-authored in the re-frame-native view layer,
+  read off a real React commit (rf2-k97c.3).
+
+  `panels.machine-inspector/Panel` is now an `rf.fresco/defview` reading
+  through Fresco's shipped collector rather than an `rf/reg-view` reading
+  through whatever view build the installed substrate adapter supplies. This
+  file is the behavioural evidence for that swap. Nothing in the fast node
+  lane can make it: `machine_inspector_view_cljs_test` drives `panel-tree` as
+  a pure function, and a boundary's body only runs inside a React render
+  window.
+
+  ## What the epic asked for, and which row answers it
+
+    1 FIRST DISPLAY               — W1
+    2 UPDATES ON A REAL CHANGE    — W2 (with the deaf control that makes the
+                                    update mean liveness)
+    4 FRAME TARGETING             — W1's second half, read off the frame's
+                                    OWN sub-cache rather than off the DOM
+    6 CLEAN TEARDOWN              — W3
+
+  Criteria 3 and 5 have no row here for the reasons the Epoch panel's sibling
+  suite sets out: criterion 5 is structural and identical for every boundary
+  in this migration, and `static/flows/panel_fresco_boundary_dom_cljs_test`
+  carries it with a positive `reg-view` control; criterion 3's affordances
+  here (Prev/Next, the chart's state-click) dispatch through a frame captured
+  at render time by `rf/current-frame-id`, which this migration did not touch.
+
+  ## FIVE READS, AND THE ISLAND
+
+  The boundary reads `:rf.xray/machine-inspector-data`,
+  `:rf.xray/machine-transitions-for-focused-event`,
+  `:rf.xray/machine-focused-epoch-cascade`, `:rf.xray/machine-tab-fit-signal`
+  and `:rf.xray/target-frame`. The last two used to be performed by helpers
+  deep in the tree; rf2-k97c.3 hoisted them into the body so the helpers stay
+  pure functions the node lane can drive. W1 and W3 assert on all five.
+
+  ONE ISLAND SURVIVES and W1 has a row for it. `machine-canvas/Chart` is
+  still an `rf/reg-view` — it has a second consumer on the Static surface, so
+  migrating it belongs to that slice — and a `reg-view` head grades
+  `:invalid` under Fresco's codec down the IDENTICAL arm a plain `defn` does.
+  The boundary therefore hands `r/as-element` down as the `as-child`
+  spelling. That is not a detail a node-lane row can witness: under
+  `identity` the island is a no-op and the tree looks the same either way.
+  Here, a missing or wrong island does not paint at all.
+
+  ## The mount is the SHELL's mount, taken from the registry
+
+  `shell.cljs`'s `detail-panel` mounts the active tab as the hiccup head
+  `[(:panel tab)]` inside the shell's `[rf/frame-provider {:frame …}]`.
+  [[mount-panel!]] does exactly that, reaching `:panel` THROUGH
+  `panel-registry/tab-by-id :dynamic :machines` rather than naming the var —
+  so the BRIDGE the registry actually holds is the thing under test. `Panel`
+  is a React component now and `reg-l4-tab!`'s `:pre` requires `:panel` to be
+  CALLABLE, so a registration left pointing at `Panel` rather than
+  `Panel-bridge` reddens here rather than in a browser.
+
+  Nothing below ever calls the panel a second time. Every assertion after the
+  mount reads `container.querySelector…` — the DOM React committed on its own.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  A ratom-family adapter, which is the family Xray already supports, because
+  the claim being made is that the boundary is INDIFFERENT to it.
+  `:ambient-frame nil` is load-bearing: tier 1 of the frame resolver is the
+  dynamic var, so an ambient frame would SHADOW the React-context tier W1's
+  frame-targeting row is about, and that row would pass while measuring
+  nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test` build
+  (real DOM + React via Chromium). The `:node-test` build's regex also
+  matches, so it LOADS under Node — where every row short-circuits through
+  [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.machines]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private app-frame
+  "An ORDINARY application frame — the thing Xray inspects. W1 reads it as
+  the negative half of the frame-targeting claim."
+  ::app)
+
+(def ^:private data-q     [:rf.xray/machine-inspector-data])
+(def ^:private records-q  [:rf.xray/machine-transitions-for-focused-event])
+(def ^:private cascade-q  [:rf.xray/machine-focused-epoch-cascade])
+(def ^:private fit-q      [:rf.xray/machine-tab-fit-signal])
+(def ^:private frame-q    [:rf.xray/target-frame])
+
+(def ^:private boundary-reads
+  "Every query the boundary issues, in the order the body issues them. The
+  sub-cache is keyed by the query vector itself, so these values ARE the
+  cache keys."
+  [data-q records-q cascade-q fit-q frame-q])
+
+;; W2's DEAF lever. It writes a key on Xray's own app-db that NO sub in the
+;; panel's read set consults, so the world moves and nothing the panel
+;; watches is invalidated. Without it, phase 3's repaint would be evidence
+;; that a commit happened — not that this boundary is live.
+(rf/reg-event ::write-unwatched-slot
+  (fn [{:keys [db]} [_ n]]
+    {:db (assoc db ::probe n)}))
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(def ^:private fixture-history
+  "One epoch whose cascade transitions a machine, so the focused-event
+  section has something to render. Kept minimal on purpose: these rows are
+  about the boundary, and `machine_inspector_view_cljs_test` owns what the
+  section renders."
+  [{:epoch-id 1
+    :dispatch-id "d-1"
+    :trace-events
+    [{:id 1 :time 10 :operation :rf.machine/transition
+      :tags {:machine-id :auth/login
+             :before {:state :idle :data {}}
+             :after  {:state :authing :data {}}
+             :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make W3's release row read a residue that is not
+                      ;; this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission. A Fresco boundary is NOT in Reagent's render queue — its
+;; update is scheduled by the collector through React — so draining Reagent's
+;; queue commits nothing of this panel's, and a row written that way reads a
+;; DOM that has not moved and reports a live panel as dead.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a real
+  chance to commit — two animation frames and a macrotask. It exists for the
+  CONTROL in W2: an absence asserted immediately after the world moves is a
+  race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- setup!
+  "Register Xray's handlers — which installs the machine sub family and the
+  `:machines` L4 tab entry the mount reads — plus the test-override seam the
+  fixtures write through, and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray})
+  (rf/make-frame {:id app-frame})
+  nil)
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test machines]
+                    {:frame :rf/xray}))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test definitions]
+                    {:frame :rf/xray}))
+
+(defn- set-history! [history]
+  (rf/dispatch-sync [:rf.xray/set-epoch-history-for-test history]
+                    {:frame :rf/xray}))
+
+(defn- focus-epoch! [epoch-id]
+  (rf/dispatch-sync [:rf.xray/set-focus-epoch-id-for-test epoch-id]
+                    {:frame :rf/xray}))
+
+(defn- seed-machines!
+  "The registered machines + definitions every row needs on screen, without
+  any focused epoch. The FOCUS is W2's lever and is applied separately."
+  []
+  (override-machines!    [:auth/login])
+  (override-definitions! {:auth/login fixture-definition})
+  (set-history!          fixture-history))
+
+(defn- mount-panel!
+  "Mount the Machine tab the way `shell.cljs`'s `detail-panel` mounts it: the
+  registry's `:panel` value as a hiccup head, inside a `frame-provider`
+  scoping `frame`. Committed synchronously — React 19's `root.render` is
+  otherwise async and the first assertion would run against an empty
+  container."
+  [frame]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)
+        tab       (panel-registry/tab-by-id :dynamic :machines)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame}
+                          [(:panel tab)]])))
+    {:container container :root root :tab tab}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where the
+  collector releases a boundary's reads — have RUN by the time the next line
+  reads the sub-cache. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- panel-node [container]
+  (q container "[data-testid=\"rf-xray-machine-inspector\"]"))
+
+(defn- focused-section? [container]
+  (some? (q container "[data-testid=\"rf-xray-machine-focused-event\"]")))
+
+(defn- chart-node [container]
+  (q container "[data-testid=\"rf-xray-machine-focused-event-chart\"]"))
+
+(defn- cache-of
+  "The frame's live sub-cache map. Not `some->`-guarded: a nil here means the
+  frame is not live, which is a defect in the row's own setup and should
+  throw rather than read as an empty cache."
+  [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of
+  "The sub-cache ref-count the frame holds for `query-v`, or 0 when the entry
+  is absent."
+  [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- released?
+  "True once the frame holds NO reference for any of the boundary's reads."
+  []
+  (every? #(zero? (ref-count-of :rf/xray %)) boundary-reads))
+
+;; ===========================================================================
+;; W1 — first display, the island really mounts, and the reads land in the
+;;      frame the tree named
+;; ===========================================================================
+
+(deftest w1-panel-paints-through-its-island-and-reads-the-named-frame
+  (testing "rf2-k97c.3 — the migrated Machine Inspector commits real DOM
+            through the registry entry the Dynamic shell mounts, its
+            surviving Reagent island mounts under the boundary, and each of
+            its five `rf.fresco/sub` reads resolves against the frame the
+            enclosing `frame-provider` named rather than the ambient one.
+            Epic criteria 1 and 4."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup!)
+            ;; A live read in the OTHER frame, so the negative half of the
+            ;; targeting claim below is measured with an instrument that is
+            ;; demonstrably able to see an entry in that frame's cache.
+            _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            _ (seed-machines!)
+            _ (focus-epoch! 1)
+            {:keys [container root]} (mount-panel! :rf/xray)]
+        (try
+          (is (some? (panel-node container))
+              "the panel committed a real DOM root under React — a Fresco
+               boundary mounted through Reagent's `:>` from the registry entry")
+          (is (focused-section? container)
+              "and with a machine-transitioning epoch focused it committed the
+               focused-event surface, so the body really ran through
+               `panel-tree` rather than painting an empty shell")
+
+          ;; ---- the island, which only a real commit can witness -----------
+          (is (some? (chart-node container))
+              "THE ISLAND MOUNTED. `machine-canvas/Chart` is still an
+               `rf/reg-view`, which Fresco's codec grades `:invalid` in head
+               position down the identical arm a plain `defn` takes — so this
+               subtree reaches the DOM only because the boundary hands
+               `r/as-element` down as the `as-child` spelling. Under the node
+               lane's `identity` the island is a no-op and this claim cannot
+               be made at all.")
+
+          ;; ---- criterion 4: the reads are where the tree said they'd be ----
+          (doseq [query-v boundary-reads]
+            (is (pos? (ref-count-of :rf/xray query-v))
+                (str "the boundary's read " (pr-str query-v) " holds a "
+                     "reference in :rf/xray's sub-cache — the frame the "
+                     "enclosing frame-provider named. Cache keys: "
+                     (pr-str (keys (cache-of :rf/xray)))))
+            (is (zero? (ref-count-of app-frame query-v))
+                (str "and NOT in the application frame's — a foreign root "
+                     "that inherited the ambient scope instead of reading "
+                     "React context would put " (pr-str query-v) " here")))
+          (is (pos? (ref-count-of app-frame [:rf.xray/trace-buffer]))
+              "NON-VACUITY: the application frame's cache is readable by this
+               same instrument and does hold the probe's entry, so the zeros
+               above are absences and not a broken reader")
+          (finally
+            (rf/unsubscribe [:rf.xray/trace-buffer] {:frame app-frame})
+            (teardown! root container)))))))
+
+;; ===========================================================================
+;; W2 — it updates on a real dependency change, and the control is deaf
+;; ===========================================================================
+
+(deftest w2-panel-updates-on-a-real-dependency-change
+  (testing "rf2-k97c.3 — the mounted panel re-renders itself and commits new
+            DOM when its reads' values really change, and does NOT when
+            nothing it watches moved. Epic criterion 2, with the control that
+            makes the update mean liveness rather than a commit that simply
+            had not happened yet."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; Mount with the machines seeded but NO focused epoch, so the panel
+        ;; starts blank and the focused-event surface's ARRIVAL is the signal.
+        (seed-machines!)
+        (let [{:keys [container root]} (mount-panel! :rf/xray)
+              section (panel-node container)]
+          (is (some? section)
+              "PRECONDITION: the panel is on screen at all")
+          (is (not (focused-section? container))
+              "NON-VACUITY: with no focused epoch the focused-event surface is
+               NOT on screen before this row moves the world")
+
+          ;; ---- phase 2: the world moves, and the panel is deaf ------------
+          (rf/dispatch-sync [::write-unwatched-slot 1] {:frame :rf/xray})
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (not (focused-section? container))
+                      "CONTROL: given a full settling window, a write to an
+                       app-db slot the panel's read set does not consult
+                       commits nothing. A panel that repainted here would make
+                       phase 3 pass for a reason that is not liveness")
+                  ;; ---- phase 3: the reads' real input moves --------------
+                  (focus-epoch! 1)
+                  (rf.test-support/poll-until #(focused-section? container)
+                    {:label "the panel committed the focused-event surface"})))
+              (.then
+                (fn [_]
+                  (is (focused-section? container)
+                      "the panel re-rendered on a real invalidation of its own
+                       reads and committed the focused-event surface")
+                  (is (identical? section (panel-node container))
+                      "and it is the SAME <section> node: React reconciled the
+                       live tree in place, so the surface did not arrive by the
+                       panel being remounted from scratch, which would not be
+                       liveness")))
+              (.catch (fn [e]
+                        (is false (str "W2 never settled: " (.-message e)
+                                       " — DOM: " (.-textContent container)))
+                        nil))
+              (.then (fn [_]
+                       (teardown! root container)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W3 — unmount releases every read, and reopening does not grow the counts
+;; ===========================================================================
+
+(deftest w3-unmount-releases-the-reads-and-reopen-does-not-grow-them
+  (testing "rf2-k97c.3 — unmounting the panel releases ALL FIVE subscription
+            references completely, and mounting it again returns to the SAME
+            counts rather than higher ones. Epic criterion 6, and the number
+            the spike caught the rejected design on: with a four-call interop
+            binding the `:rf/xray` ref-count climbed across renders and never
+            fell on unmount.
+
+            THE RELEASE IS ASYNCHRONOUS BY DESIGN, and this row polls rather
+            than reading once: the collector gives a cell whose last reader
+            unmounts one macrotask of grace, so that a keyed reorder which
+            unmounts and remounts a row within a single turn reuses the
+            reaction instead of rebuilding it. A synchronous assertion would
+            report a LEAK against a collector behaving exactly as documented."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-machines!)
+        (focus-epoch! 1)
+        ;; The starting point is polled, not asserted: a neighbouring row's
+        ;; teardown grace may still be in flight when this one begins.
+        (-> (rf.test-support/poll-until released?
+              {:label "no reference held before the first mount"})
+            (.then
+              (fn [_]
+                (let [{:keys [container root]} (mount-panel! :rf/xray)
+                      mounted (mapv #(ref-count-of :rf/xray %) boundary-reads)]
+                  (is (every? pos? mounted)
+                      (str "the mount took a reference for every one of the "
+                           "boundary's reads — otherwise the release below is "
+                           "vacuous. Got " (pr-str mounted) " for "
+                           (pr-str boundary-reads)))
+                  (teardown! root container)
+                  (-> (rf.test-support/poll-until released?
+                        {:label "the first unmount released every read"})
+                      (.then
+                        (fn [_]
+                          (is (released?)
+                              (str "the unmount released them COMPLETELY, "
+                                   "within the collector's grace macrotask. "
+                                   "Cache: " (pr-str (keys (cache-of :rf/xray)))))
+                          ;; ---- reopen: the same counts, not higher ones ----
+                          (let [{c2 :container r2 :root} (mount-panel! :rf/xray)
+                                remounted (mapv #(ref-count-of :rf/xray %)
+                                                boundary-reads)]
+                            (is (= mounted remounted)
+                                (str "reopening returns to the SAME reference "
+                                     "counts " (pr-str mounted) " rather than "
+                                     "accumulating — accumulation across "
+                                     "open/close cycles is the signature of a "
+                                     "release the substrate's own reaction "
+                                     "lifecycle cannot see. Got "
+                                     (pr-str remounted)))
+                            (teardown! r2 c2)
+                            (rf.test-support/poll-until released?
+                              {:label "the second unmount released them too"}))))))))
+            (.then (fn [_] (is (released?)
+                               "and the second unmount releases them too")))
+            (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
+            (.then (fn [_] (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -200,12 +200,14 @@
                     {:frame :rf/xray}))
 
 (defn- seed-machines!
-  "The registered machines + definitions every row needs on screen, without
-  any focused epoch. The FOCUS is W2's lever and is applied separately."
+  "The registered machines + definitions every row needs, with an EMPTY
+  spine. The HISTORY is W2's lever and is applied separately — and it is the
+  lever rather than the focus because the focus-resolver HEAD-TRACKS, so
+  loading history with no explicit focus already paints the focused-event
+  surface and a focus-as-lever row would fail its own precondition."
   []
   (override-machines!    [:auth/login])
-  (override-definitions! {:auth/login fixture-definition})
-  (set-history!          fixture-history))
+  (override-definitions! {:auth/login fixture-definition}))
 
 (defn- mount-panel!
   "Mount the Machine tab the way `shell.cljs`'s `detail-panel` mounts it: the
@@ -281,6 +283,7 @@
             ;; demonstrably able to see an entry in that frame's cache.
             _probe (rf/subscribe [:rf.xray/trace-buffer] {:frame app-frame})
             _ (seed-machines!)
+            _ (set-history! fixture-history)
             _ (focus-epoch! 1)
             {:keys [container root]} (mount-panel! :rf/xray)]
         (try
@@ -335,7 +338,7 @@
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
         (setup!)
-        ;; Mount with the machines seeded but NO focused epoch, so the panel
+        ;; Mount with the machines seeded but an EMPTY spine, so the panel
         ;; starts blank and the focused-event surface's ARRIVAL is the signal.
         (seed-machines!)
         (let [{:keys [container root]} (mount-panel! :rf/xray)
@@ -343,7 +346,7 @@
           (is (some? section)
               "PRECONDITION: the panel is on screen at all")
           (is (not (focused-section? container))
-              "NON-VACUITY: with no focused epoch the focused-event surface is
+              "NON-VACUITY: with an empty spine the focused-event surface is
                NOT on screen before this row moves the world")
 
           ;; ---- phase 2: the world moves, and the panel is deaf ------------
@@ -357,7 +360,7 @@
                        commits nothing. A panel that repainted here would make
                        phase 3 pass for a reason that is not liveness")
                   ;; ---- phase 3: the reads' real input moves --------------
-                  (focus-epoch! 1)
+                  (set-history! fixture-history)
                   (rf.test-support/poll-until #(focused-section? container)
                     {:label "the panel committed the focused-event surface"})))
               (.then
@@ -401,6 +404,7 @@
       (async done
         (setup!)
         (seed-machines!)
+        (set-history! fixture-history)
         (focus-epoch! 1)
         ;; The starting point is polled, not asserted: a neighbouring row's
         ;; teardown grace may still be in flight when this one begins.

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -1301,6 +1301,18 @@
 
 (defn- meta-preserving-children [node]
   (cond
+    ;; rf2-k97c.3 — a FRESCO BOUNDARY head is a LEAF here. This walker
+    ;; invokes fn heads as it descends, and the shared mini-pipeline this
+    ;; panel renders now carries `[ei/edn-inspector-view …]`: calling a
+    ;; React function component outside any render raises on its first
+    ;; hook, which would take out the key answer below for an unrelated
+    ;; reason. `codec/boundary-head?` is the same one-own-property read
+    ;; (`frescoBoundary`) the codec itself uses to grade a head, so this
+    ;; needs no roster of widget names to keep in step.
+    (and (vector? node)
+         (rf.fresco.impl.codec/boundary-head? (first node)))
+    nil
+
     (and (vector? node) (fn? (first node)))
     [(apply (first node) (rest node))]
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -55,13 +55,77 @@
 ;; Thin aliases over re-frame.test-helpers so the local call sites read
 ;; identically to before.
 
-(def ^:private find-by-testid           rf.test-helpers/find-by-testid)
-(def ^:private find-all-by-testid-prefix rf.test-helpers/find-by-testid-prefix)
+;; rf2-k97c.3 — PLAIN DESCENT; nothing is CALLED. These were aliases of
+;; `rf.test-helpers/find-by-testid` / `…-prefix`, which EXPAND function
+;; components as they walk. That is now unsafe: the SHARED mini-pipeline this
+;; panel renders comes from `panels/epoch/view`, whose EDN-widget heads are
+;; `[ei/edn-inspector-view …]` — Fresco boundaries whose bodies may only run
+;; inside a React render window. Applying one runs `rf.fresco/sub` outside the
+;; collector and raises, and because the expanding walker applies EVERY fn head
+;; it meets, that raise took out rows asserting on nodes nowhere near a widget.
+;;
+;; The topology chart stays a leaf for the same reason it always could: the
+;; rows that care about it read its PROPS (`find-machine-chart-props` below),
+;; never its interior.
+
+(defn- hiccup-nodes [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- node-attrs [node]
+  (when (and (vector? node) (map? (second node)))
+    (second node)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (= testid (:data-testid (node-attrs node))) node))
+        (hiccup-nodes tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (some-> (:data-testid (node-attrs node)) (.startsWith prefix)))
+           (hiccup-nodes tree)))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
   (xray-test-support/install-test-overrides!)
   (rf/make-frame {:id :rf/xray}))
+
+(defn- panel-tree
+  "The panel's hiccup tree, for every row below.
+
+  THIS USED TO BE A DIRECT CALL TO THE PANEL VAR. rf2-k97c.3 made `Panel`
+  an `rf.fresco/defview` — a real React function component whose body may
+  only run inside a React render window — so it is no longer a callable
+  that answers hiccup, and every row here walks hiccup.
+
+  The panel's markup was split out as `machine-inspector/panel-tree`, a
+  pure fn of the three values the boundary reads. That is
+  `re-frame.fresco/defview`'s own documented extract-a-helper spelling,
+  and it keeps the division of labour honest: the section-rendering
+  algebra is data → data and belongs in this fast node-lane suite, while
+  the boundary's OWN behaviour — first paint, liveness on a real
+  invalidation, frame targeting and teardown — is
+  `machine_inspector_fresco_boundary_dom_cljs_test`'s subject, read off a
+  real React commit.
+
+  `identity` is the `as-child` spelling for a hiccup caller: the island
+  the boundary needs for the still-Reagent topology chart is a no-op
+  here, so the rows below walk the chart's own vector exactly as they did
+  before the migration. `r/as-element` is what the boundary passes.
+
+  The reads are spelled `@(rf/subscribe …)` rather than `rf.fresco/sub`
+  deliberately: outside a render window there is no collector edge to
+  record, and what these rows want is each sub's VALUE. That the boundary
+  reads the same three queries through the collector is the DOM suite's
+  subject, not this one's."
+  []
+  (machine-inspector/panel-tree
+    @(rf/subscribe [:rf.xray/machine-inspector-data])
+    @(rf/subscribe [:rf.xray/machine-transitions-for-focused-event])
+    (:cascade @(rf/subscribe [:rf.xray/machine-focused-epoch-cascade]))
+    identity
+    @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
+    @(rf/subscribe [:rf.xray/target-frame])))
 
 (defn- override-machines! [machines]
   (rf/dispatch-sync
@@ -149,7 +213,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines! [])
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-machine-inspector")))
         (is (some? (find-by-testid tree "rf-xray-machine-inspector-empty"))
             "empty-state container present")
@@ -180,7 +244,7 @@
       (override-machines!    [:auth/login :checkout/flow])
       (override-definitions! {:auth/login    fixture-definition
                               :checkout/flow fixture-definition})
-      (let [tree (machine-inspector/Panel)
+      (let [tree (panel-tree)
             root (find-by-testid tree "rf-xray-machine-inspector")]
         (is (= "focused-event" (:data-view-mode (second root))))
         (is (= "false" (:data-has-records (second root))))
@@ -224,7 +288,7 @@
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}
          {:epoch-id 2 :trace-events []}])
       (focus-epoch! 2)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-machine-inspector-blank"))
             "blank-state container present on the event-less focused epoch")
         (is (nil? (find-by-testid tree "rf-xray-machine-focused-event"))
@@ -253,7 +317,7 @@
                    :event      [:auth/submit]
                    :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 2)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
             "the focused-event surface mounts when the cascade has a transition")
         (is (some? (find-by-testid
@@ -289,7 +353,7 @@
                    :cause      :explicit
                    :rf.trace/dispatch-id "s-1"}}]}])
       (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
+      (let [tree    (panel-tree)
             section (find-by-testid
                       tree "rf-xray-machine-focused-event-section-door/main")
             chart   (find-by-testid
@@ -345,7 +409,7 @@
                    :event      [:door/close]
                    :rf.trace/dispatch-id "n-1"}}]}])
       (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
+      (let [tree    (panel-tree)
             section (find-by-testid
                       tree "rf-xray-machine-focused-event-section-door/main")
             chart   (find-by-testid
@@ -412,7 +476,7 @@
                    :after  {:state :authing :data {}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (nil? (find-by-testid tree "rf-xray-machine-focused-event"))
             "legacy `:machine/transition` op does NOT show the focused-
              event surface")
@@ -428,7 +492,7 @@
                    :after  {:state :authing :data {}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-2"}}]}])
       (focus-epoch! 2)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
             "migrated `:rf.machine/transition` op shows the focused-event
              surface")
@@ -452,7 +516,7 @@
                    :after      {:state :authing :data {}}
                    :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree   (machine-inspector/Panel)
+      (let [tree   (panel-tree)
             chart  (find-by-testid
                      tree "rf-xray-machine-focused-event-chart")]
         (is (some? chart))
@@ -493,7 +557,7 @@
                    :after      {:state :authing :data {}}
                    :event      [:tick] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 7)
-      (let [tree     (machine-inspector/Panel)
+      (let [tree     (panel-tree)
             host     (find-by-testid tree "rf-xray-machine-focused-event")
             sections (find-all-by-testid-prefix
                        tree "rf-xray-machine-focused-event-section-")]
@@ -541,7 +605,7 @@
                    :after      {:state :authing :data {}}
                    :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         ;; ELEMENT 1 — Prev/Next nav (in the header).
         (is (some? (find-by-testid tree "rf-xray-machine-inspector-prev"))
             "element 1: Prev nav")
@@ -594,7 +658,7 @@
                    :after      {:state :authing :data {}}
                    :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         ;; The SHARED cascade host the Epoch panel renders.
         (is (some? (find-by-testid
                      tree "rf-xray-epoch-handler-machine"))
@@ -641,7 +705,7 @@
                    :event      [:auth/ok] :rf.trace/dispatch-id "d-2"}}]}])
       ;; Focus the LATER epoch (authing → done).
       (focus-epoch! 2)
-      (let [tree  (machine-inspector/Panel)
+      (let [tree  (panel-tree)
             chart (find-by-testid tree "rf-xray-machine-focused-event-chart")]
         (is (= "authing" (:data-from-highlight-id (second chart)))
             "chart highlights the focused (later) epoch's from-state")
@@ -652,7 +716,7 @@
             "the mini-pipeline renders for the focused epoch"))
       ;; Prev → the earlier epoch (idle → authing). Both re-read the focus.
       (rf/dispatch-sync [:rf.xray/machine-focus-prev])
-      (let [tree  (machine-inspector/Panel)
+      (let [tree  (panel-tree)
             chart (find-by-testid tree "rf-xray-machine-focused-event-chart")]
         (is (= "idle" (:data-from-highlight-id (second chart)))
             "after Prev, the chart re-paints to the earlier epoch's from-state")
@@ -737,7 +801,7 @@
                    :after      {:state :authing :data {:retries 1}}
                    :event      [:start] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree  (machine-inspector/Panel)
+      (let [tree  (panel-tree)
             props (find-machine-chart-props tree)]
         (is (some? props) "the focused-event chart mounts MachineChart")
         (is (= {:retries "number" :token "string?"}
@@ -770,7 +834,7 @@
                    :after      {:state :busy :data {:hits 1 :trail []}}
                    :event      [:add] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree  (machine-inspector/Panel)
+      (let [tree  (panel-tree)
             props (find-machine-chart-props tree)]
         (is (some? props))
         (is (= {:hits "number" :trail "vector"} (:context-band props))
@@ -874,7 +938,7 @@
             "egress redacts the sensitive token (after)")
         (override-epoch-history! [{:epoch-id 1 :trace-events [egressed*]}])
         (focus-epoch! 1)
-        (let [tree     (machine-inspector/Panel)
+        (let [tree     (panel-tree)
               rendered (pr-str tree)]
           (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
               "the focused-event surface mounts for the redacted transition")
@@ -929,7 +993,7 @@
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login])
       (override-definitions! {:auth/login fixture-definition})
-      (let [tree    (machine-inspector/Panel)
+      (let [tree    (panel-tree)
             blank   (find-by-testid tree "rf-xray-machine-inspector-blank")
             message (find-by-testid tree "rf-xray-machine-inspector-blank-message")]
         (is (some? blank)  "blank-state container present")
@@ -963,7 +1027,7 @@
                    :after      {:state :authing :data {}}
                    :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid
                      tree "rf-xray-machine-inspector-prev-next-nav"))
             "prev/next nav is visible when a machine is in scope")
@@ -976,7 +1040,7 @@
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines! [:auth/login])
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         (is (some? (find-by-testid tree "rf-xray-machine-inspector-blank")))
         (is (nil? (find-by-testid
                     tree "rf-xray-machine-inspector-prev-next-nav"))
@@ -1149,7 +1213,7 @@
                    :after  {:state :authing :data {}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
+      (let [tree (panel-tree)]
         ;; The header still mounts (prev/next nav is in scope).
         (is (some? (find-by-testid tree "rf-xray-machine-inspector-header"))
             "panel header still mounts")
@@ -1311,7 +1375,7 @@
                    :after  {:state :done :data {}}
                    :event [:cart/sync] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree     (machine-inspector/Panel)
+      (let [tree     (panel-tree)
             sections (raw-find-all-by-testid-prefix
                        tree "rf-xray-machine-focused-event-section-")
             ;; The keyed sibling is the fragment the host <div> holds,
@@ -1362,7 +1426,7 @@
                    :after  {:state :authing :data {}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
+      (let [tree    (panel-tree)
             section (find-by-testid
                       tree "rf-xray-machine-focused-event-section-auth/login")
             style   (style-of section)]
@@ -1390,7 +1454,7 @@
                    :after  {:state :authing :data {}}
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
+      (let [tree    (panel-tree)
             section (find-by-testid
                       tree "rf-xray-machine-focused-event-section-auth/login")
             margin  (-> section style-of :margin)]

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -37,7 +37,6 @@
             [re-frame.schemas]
             [re-frame.schemas.malli]
             [re-frame.registrar :as rf.registrar]
-            [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]))

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -929,7 +929,7 @@
   per rf2-nrbs9 — promoted from 'lives in App-db + Trace'. The
   `:epoch` tab supersedes the retired `:event` tab post rf2-5gl5r
   (Epoch panel is the canonical 'what happened in this epoch' surface)."
-  {:epoch           epoch-panel/Panel
+  {:epoch           epoch-panel/Panel-bridge
    ;; rf2-k97c.3 — the app-db and Views panels' roots are now Fresco
    ;; boundaries (React function components); `reg-l4-tab!` stores the
    ;; `as-component` BRIDGE, which is what `detail-panel` mounts as a
@@ -941,7 +941,9 @@
    ;; rf2-fcy5 slice 3 — the Trace panel's root is a Fresco boundary now
    ;; too, so `reg-l4-tab!` stores its `as-component` bridge.
    :trace           trace/Panel-bridge
-   :machines        machine-inspector/Panel
+   ;; rf2-k97c.3 — the Epoch and Machine-inspector roots are boundaries
+   ;; now too, so `:epoch` above and `:machines` below store their bridges.
+   :machines        machine-inspector/Panel-bridge
    :routing         routing/Panel})
 
 (deftest detail-panel-routes-each-tab-to-its-view-fn


### PR DESCRIPTION
The Epoch and Machine-Inspector panels become Fresco boundaries. They are one
PR because they share render code: `machine_inspector`'s closure reaches into
`panels/epoch/view.cljs` for `machine-cascade-mini-pipeline`, and most of the
head sites it depends on are written in Epoch's file.

Both `Panel`s are `rf.fresco/defview` now, and the `Panel-bridge` aliases the
PR #9654 funnel planted become the real `rf.fresco/as-component` bridges.
`panels.cljs` is untouched, which is what the funnel bought.

## The head repairs, re-measured

A `reg-view` head grades `:invalid` down the IDENTICAL arm a plain `defn` does
— `codec/boundary-head?` reads one own property, `frescoBoundary`, which only
`defview` sets — so both kinds had to go. Measured with an s-expression reader
that tracks lexical scope and resolves ns aliases, controlled against the
hand-written census in `static/routes/panel.cljs`: it reads 9 there, with the
same symbols, before and after this change.

| site | before | after |
|---|---|---|
| `epoch/view.cljs` plain-`defn` heads (`ei/mini` ×21) | 21 | 0 — inlined to calls |
| `epoch/view.cljs` `reg-view` heads (`ei/edn-inspector` ×13, `rt/resizable-table` ×3) | 16 | 0 — adopted the shipped Fresco siblings |
| `machine_inspector.cljs` `reg-view` heads (`machine-canvas/Chart`) | 1 | 1 — islanded behind `as-child`, deliberately |
| `machine_canvas.cljs` | 2 | 2 — untouched, and neither is work |

`ei/edn-inspector-view` requires a caller-supplied stable `:mount-id`; each of
the 13 derives one from the `:site-id` that site already carried.

`machine_canvas.cljs` is untouched and that is a finding rather than an
omission. Its T5 bridge (`AfterRingsOverlay-bridge`) STAYS, because `Chart`
stays Reagent — the bridge goes when `Chart` migrates, which is the Static
Machines slice's to schedule. Its other head is inside `SnapshotDrillIn`,
which no live panel reaches.

## Why `Chart` is islanded rather than migrated

`machine-canvas/Chart` has a second consumer outside this slice —
`panels/machines/topology_view.cljs`, on the Static surface — so migrating it
is that slice's call, not this one's. The boundary hands `r/as-element` down
as the `as-child` spelling, which is the tree's T3 shape.

## The reads, and one deliberate departure from HD-016

Five reads sat in helpers the boundaries CALL rather than head. HD-016 would
have let them DONATE upward into the calling boundary's collector window, and
that would have been correct in production.

They were hoisted into the two bodies anyway, and the reason is TESTING rather
than correctness: `rf.fresco/sub` raises `:rf.error/fresco-sub-outside-render`
outside a collector window, so a helper performing one is callable only inside
a real React commit — and the cascade's step-rendering algebra is ordinary
data → data with a large fast node-lane suite over it. Every migrated panel in
this tree made the same call. Epoch's two ride the `ctx` map `pipeline-view`
already threaded, and the three helpers kept a 1-arity so a direct caller needs
no cascade context.

The cost is one lost conditional: both slots are now read on every panel render
rather than only when their step is present. Neither widens invalidation in
practice, and both docstrings say so.

Re-render granularity was considered and no boundary was split. Each panel
keeps ONE `defview`: Epoch's three reads all move with the same focus, and
Machine-inspector's five likewise. There is no `shell.cljs`-style case here
where hoisting a read would re-render an expensive sibling on an unrelated
interaction.

`pipeline-view`'s `doall` survives with its comment rewritten rather than
deleted: hoisting removed the lazy-seq deref hazard at its source, so the
comment now reads as history and says why the `doall` stays anyway.

## RULING 2 — the key sweep

Reported including zeros, with a live control so a zero is absence.

| file | `^{:key` at form position | `with-meta` at form position |
|---|---|---|
| `panels/epoch/view.cljs` | 0 | 0 |
| `panels/epoch_panel.cljs` | 0 | 0 |
| `panels/machine_inspector.cljs` | 0 | 0 |
| `panels/machine_canvas.cljs` | 0 | 0 |
| both new DOM suites | 0 | 0 |

Four textual hits exist across those files and every one is PROSE — two are the
landed rf2-wvch comments, one the rf2-a38l comment, one a new docstring here.
Two independent instruments agree: a grep whose control bites tree-wide (34
`^{:key` lines across 22 files, 18 `with-meta`), and the s-expression reader,
which reads 0 form-position meta-keys tree-wide and was exercised against a
planted fixture it correctly flagged.

Nothing was moved, because there was nothing to move — rf2-wvch and rf2-a38l
had already landed the repairs in these files. No row grading a key was added
here for the same reason; the existing ones still pass.

## Quality gates

All captured on the final rebased base, each exit code echoed by the runner on
the same command line and quoted from the `.exit` file it wrote.

| gate | result | exit |
|---|---|---|
| `test:cljs` compile phase | 1953 files, 0 warnings | `0` |
| `test:cljs` run phase | 11693 tests, 58569 assertions, 0 failures, 0 errors | `0` |
| `test:browser` compile | 1055 files, 5 warnings — all pre-existing `:infer-warning`s, none in a touched file | `0` |
| `test:browser` run — CI `cljs-browser` | 951 tests, 5282 assertions, 0 failures, 0 errors | `0` |
| `test:xray-feature-gate` — FULL, 16 scenarios / 11 surfaces | 16 scenarios, 0 failures, 13 matrix rows covered | `0` |
| `clj-kondo --fail-level error --lint tools/xray` | 0 errors (144 warnings, informational per the job's own name) | `0` |
| `clojure -M:splint --fail-on-errors ../tools/xray` | 0 errors; 418 style warnings tree-wide, and the two in a file touched here are pre-existing (`clojure.string :as string`) or the tree's PascalCase component convention | `0` |
| `scripts/check_require_alias_dialect.py` (`--self-test`, then full) | 79 self-tests passed, no findings | `0` |
| `scripts/check-beads-pr-boundary.sh origin/main` | no beads-database paths in the diff | `0` |
| `scripts/check-ai-tracking-ratchet.sh` | nothing under `ai/` tracked | `0` |
| `scripts/check-commit-attribution.sh origin/main HEAD` | no AI attribution in the 5 commits | `0` |

The FULL feature gate was run rather than `:smoke` deliberately: the two
scenarios carrying the witness for these panels — `deep machine inspector
substrate` and the `machine-epochs` multi-machine frame-isolated stepper — are
NOT in the smoke tier (5 of 16 carry `smoke: true`, counted off
`tools/xray/testbeds/feature_matrix/scenarios.cjs`). It is also the only lane
that renders the SUBSCRIPTIONS step's `resizable-table-view` inside a real
application commit.

Gates not run, with reasons: `eslint` (no JS touched), `api-manifest` (no
public name moved), `mkdocs build --strict` and the two link gates (no markdown
touched), the JVM lanes (nothing in their surfaces touched).

**Sabotage witness.** One `[ei/edn-inspector-view` head was reverted to
`[ei/edn-inspector` — a single anchored line, match count read as 1 before the
run. The node lane went RED at exit `1`, and the row that named it was
`panel-emits-the-fresco-widget-heads-test`, the row added for exactly that
claim, with two collateral rows behind it. Restored with `git checkout HEAD --`
and verified by hashing the bytes rather than by reading a diff:
`git hash-object` reproduces the committed blob `2ba1e29b43…` (this file is
`i/lf w/crlf`, so the default form is the one that matches), and
`git diff --quiet HEAD --` exits 0 as a second independent instrument.

## Test-lane consequences, which are the bulk of the diff

The node-lane walkers stop expanding function components. `rf.test-helpers`'
finders apply every fn head they meet, and the trees now carry Fresco
boundaries — so ONE raise inside a widget took out rows asserting on nodes
nowhere near it. `static/flows/panel_cljs_test` and
`panels/app_db_diff_cljs_test` had already settled this shape.

The two widget boundaries are expanded through their REAGENT siblings instead.
Each widget ships both heads over one private renderer and they differ only in
how each resolves its slots and its per-mount identity — none of which these
rows assert on — so some forty rows about EPOCH's cells, columns and row-attrs
keep their spelling.

That substitution erases which head the panel emits, so a new row pins it
separately off the UNEXPANDED tree: both Reagent heads must read ZERO, with the
Fresco counts asserted positive beside them as the control. That claim is the
HD-016 repair itself and is the one thing the pre-migration spelling could not
state — and it is the row the sabotage above reddened.

`machine_inspector/panel-tree` is split out of `Panel` — `defview`'s own
documented extract-a-helper spelling — so the node lane keeps driving the
markup without a React commit.

## The two new DOM suites

Three rows each, and none is a claim the node lane can make.

**W1** is first paint plus frame targeting, read off the frame's OWN sub-cache
rather than off the DOM: every read must hold a reference in the frame the
enclosing `frame-provider` named and NONE in the application frame, with a live
probe read in that frame as the non-vacuity control. Both mounts reach `:panel`
THROUGH the registry rather than naming the var, so a registration left
pointing at `Panel` instead of `Panel-bridge` reddens here rather than in a
browser. Machine-inspector's W1 adds a row the Epoch suite has no use for: the
surviving Reagent island really mounts — under the node lane's `identity`
spelling that island is a no-op and the tree looks the same either way.

**W2** is liveness, and the deaf control is what makes it mean liveness: a
write to an app-db slot the read set does not consult must commit NOTHING
across a full settling window before the real invalidation proves anything. It
also asserts the panel's own node is IDENTICAL across the update, so a repaint
cannot arrive by remount. The lever is the epoch HISTORY rather than the focus,
and that is measured rather than chosen — the focus-resolver head-tracks, so a
focus-as-lever row fails its own precondition.

**W3** is teardown: every read released completely within the collector's
documented grace macrotask, and a reopen returning to the SAME counts rather
than higher ones.

Criteria 3 and 5 have no rows, with the reason stated in each ns docstring
rather than left as a gap.

## One existing DOM suite needed a real repair

`machine_epochs_always_round_dom_cljs_test` mounted its subjects straight into
a Reagent tree. A FRESCO BOUNDARY IS NOT A REAGENT RENDER FN: Reagent mints its
own component for a fn head and CALLS it during Reagent's render, so the
boundary's first hook throws `Invalid hook call`, React SWALLOWS the render
throw, and the cascade subtree commits nothing — both rows then read 0 and the
failure text blames the projection. The subjects are hosted in a real boundary
now, which is where they render in production, handed over through an atom
because only an empty props map survives a `[:>]` crossing from a Reagent
parent.

## Not in this PR

This does not close rf2-k97c.3 — the L4/shell chrome remains. The bead is
neither claimed nor closed.

`tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs` is shared with the
Trace migration (#9661), which landed first. This branch is rebased onto it.
It moves only the `:epoch` and `:machines` entries of `expected-detail-fn` to
`Panel-bridge`; `:trace trace/Panel-bridge` and its comment are trunk's and are
untouched, as are `:app-db`, `:views` and `:routing`.

The interleaved per-slice comments are kept exactly as trunk has them. An
earlier revision of this branch had hoisted them into one block above the map,
and that reflow is what conflicted rather than either side's values — it is
reverted here. The two lines added above `:machines` are this slice's own
provenance, in the same interleaved style, and touch no existing line.
