### PR TITLE
fix(xray): call the filter-chrome helpers instead of heading them (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -20,9 +20,11 @@
 
   ## What does NOT live here
 
-  - The ribbon pill cluster is in `filters/pills.cljs`; the shell's
-    `ribbon-filter-pills` reg-view in `shell.cljs` delegates to it
-    so the cluster carries the ribbon's frame-context.
+  - The ribbon pill cluster is in `filters/pills.cljs`; `shell.cljs`'s
+    `ribbon-filter-pills` delegates to it so the cluster carries the
+    ribbon's frame-context. Since rf2-k97c.3 that delegate is a plain
+    fn CALLED from the `events-ribbon` Fresco boundary, not a
+    `reg-view`.
   - Pattern matching is in `filters/matcher.cljc` (JVM-portable).
   - localStorage round-trip is in `filters/persistence.cljs`."
   (:require [re-frame.core :as rf]
@@ -63,7 +65,26 @@
 
   Threads the reg-view-injected frame-aware `dispatch`
   into `popup-view` so deferred `:on-*` handlers land on the
-  surrounding instance frame, not a `{:frame :rf/xray}` literal."
+  surrounding instance frame, not a `{:frame :rf/xray}` literal.
+
+  ## rf2-k97c.3 — STILL AN `rf/reg-view`, AND THAT IS THE DECISION
+
+  Not an oversight, and not a half-done migration. This is one of the
+  seven shell-root modals `shell-view` mounts, and `shell-view` is
+  still an `rf/reg-view` — a Reagent tree — because severing Xray's
+  paint from the installed adapter's `:render` is the parent epic's
+  coupling (1) and a LATER slice. A `defview` mints a React function
+  component, which is not a legal hiccup head in a Reagent tree, so
+  migrating this Modal today would mean either an `as-component` bridge
+  with nothing above it to justify one, or an edit to `shell.cljs` that
+  the four sibling chrome satellites would each need too.
+
+  The later slice owns the choice and has two live options on record —
+  migrate these modals, or island them behind `as-child`. Whichever it
+  picks, the subtree below here is already ready: `popup-view` is
+  CALLED rather than headed, and every plain-fn head inside it has been
+  inlined, so nothing under this Modal is a `:invalid` head waiting to
+  fire."
   []
   (when @(rf/subscribe [:rf.xray/edit-popup-open?])
     (edit-popup/popup-view dispatch)))

--- a/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
@@ -217,7 +217,23 @@
   `dispatch` is the frame-aware dispatcher injected by the
   `filters/Modal` `reg-view` body — every deferred handler routes
   through it so the edit lands on the surrounding instance frame, not
-  a `{:frame :rf/xray}` literal."
+  a `{:frame :rf/xray}` literal.
+
+  ## rf2-k97c.3 — the three reads are STILL AMBIENT, deliberately
+
+  `filters/Modal` above is still an `rf/reg-view` mounted from
+  `shell-view`, which is itself still an `rf/reg-view` — a Reagent
+  tree — so the reads below are `@(rf/subscribe …)` resolving through
+  the React-context tier, exactly as they always have been. They do NOT
+  become `rf.fresco/sub`: that call is legal only inside a `defview`
+  body and would raise `:rf.error/fresco-sub-outside-render` here, and
+  it would also break the two suites that drive this fn directly
+  (`modals_aria_cljs_test`, `filters/edit_popup_cljs_test`).
+
+  What DID change is the head shape: every plain-fn head inside this
+  subtree is now a call, so whichever way the later slice resolves
+  `filters/Modal` — migrated to a boundary, or islanded behind
+  `as-child` — this file needs no further repair."
   [dispatch]
   (let [trigger     @(rf/subscribe [:rf.xray/edit-popup-trigger])
         draft       @(rf/subscribe [:rf.xray/edit-popup-draft])
@@ -265,9 +281,16 @@
 
       [:div {:style (section-style)}
        [:label {:style (label-style)} "Action"]
+       ;; rf2-k97c.3 — `mode-radio` is CALLED, not headed. It answers
+       ;; hiccup, its subtree is head-free (`[:label …]` over
+       ;; `[:input …]`), and it reads nothing, so the ruled HD-016
+       ;; repair is to inline it. It costs nothing today — `filters/
+       ;; Modal` above is still an `rf/reg-view`, where a plain-fn head
+       ;; is legal — and it is what lets that Modal become a boundary
+       ;; later without this file being re-opened. See [[popup-view]].
        [:div {:style (radio-row-style)}
-        [mode-radio dispatch {:mode :in :current-mode mode}]
-        [mode-radio dispatch {:mode :out :current-mode mode}]]]
+        (mode-radio dispatch {:mode :in :current-mode mode})
+        (mode-radio dispatch {:mode :out :current-mode mode})]]
 
       [:div {:style (section-style)}
        [:label {:style (label-style) :for "rf-xray-edit-popup-pattern"}

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -34,8 +34,11 @@
   ## Pure hiccup
 
   Same posture as the rest of Xray's view code: pure
-  hiccup, no per-substrate switches. Mount is via `reg-view` from the
-  caller (`shell.cljs`'s `ribbon-filter-pills`)."
+  hiccup, no per-substrate switches. Every fn here is CALLED by its
+  caller rather than headed — `shell.cljs`'s `ribbon-filter-pills`,
+  `ribbon` and `events-ribbon` reach them that way — and since
+  rf2-k97c.3 those callers are `rf.fresco/defview` BOUNDARIES, where a
+  plain function in head position is a loud `:invalid` refusal."
   (:require [day8.re-frame2-xray.filters.typed-predicates :as typed]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
@@ -102,7 +105,7 @@
                remove-filter event payload)
 
   `dispatch` is the frame-aware dispatcher captured by the
-  caller's `reg-view` body so the edit / remove clicks land on the
+  caller's Fresco boundary body so the edit / remove clicks land on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal."
   [dispatch {:keys [mode pill idx]}]
   (let [tone        (pill-tone mode)
@@ -196,7 +199,7 @@
   chrome ribbon's left cluster.
 
   `dispatch` is the frame-aware dispatcher captured by the
-  caller's `reg-view` body."
+  caller's Fresco boundary body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add"
             :on-click    #(dispatch
@@ -233,7 +236,7 @@
   near-black ribbon.
 
   `dispatch` is the frame-aware dispatcher captured by the
-  caller's `reg-view` body."
+  caller's Fresco boundary body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add"
             :on-click    #(dispatch
@@ -262,7 +265,7 @@
   band).
 
   `dispatch` is the frame-aware dispatcher captured by the
-  caller's `reg-view` body."
+  caller's Fresco boundary body."
   [dispatch]
   [:button {:data-testid "rf-xray-filter-add-events"
             :on-click    #(dispatch
@@ -303,8 +306,9 @@
 (defn pills-view
   "The committed filter pills cluster — green-bordered IN pills, then
   red-bordered OUT pills. Reads `:rf.xray/active-filters`
-  via the caller; the caller is expected to be inside a `reg-view` so
-  subscribes resolve to `:rf/xray`.
+  via the caller; this fn itself reads NOTHING, which is what lets
+  `filters/pills_cljs_test` drive it straight from the node lane with
+  no render window around it.
 
   The add(+) affordance is not part of this
   cluster: per the authoritative reference the committed pills live on
@@ -314,7 +318,7 @@
   events ribbon.
 
   `dispatch` is the frame-aware dispatcher captured by the
-  caller's `reg-view` body, threaded to each `pill`."
+  caller's Fresco boundary body, threaded to each `pill`."
   [dispatch {:keys [filters]}]
   [:div {:data-testid "rf-xray-ribbon-filters"
          :title (counts-tooltip filters)
@@ -330,9 +334,25 @@
    ;; would shift its arguments — `[:<> {:key …} …]` carries the key on a
    ;; head BOTH substrates honour and leaves the call untouched (the same
    ;; shape `views/edn_inspector` uses under rf2-k97c.3).
+   ;;
+   ;; rf2-k97c.3 — `pill` is CALLED, not headed. This cluster renders
+   ;; inside the `shell/events-ribbon` Fresco BOUNDARY (reached through
+   ;; `shell/ribbon-filter-pills`, which calls [[pills-view]]), and there
+   ;; a plain function in head position grades `:invalid` — a loud
+   ;; refusal, never a silent embedding. `pill` answers hiccup and its
+   ;; subtree is head-free all the way down (`pill-tone` / `pill-kind` /
+   ;; `pill-display` all return values, not hiccup), so the ruled HD-016
+   ;; repair applies: inline it. No boundary of its own, and no read to
+   ;; donate upward — `pill` touches the substrate nowhere, which is also
+   ;; what keeps it callable from OUTSIDE a render window, as
+   ;; `filters/pills_cljs_test` does directly.
+   ;;
+   ;; The keyed fragment is what makes that inline free of structural
+   ;; cost: it still carries the list key without adding a DOM node, so
+   ;; `pill` stays the presentational helper it has always been.
    (for [[idx p] (map-indexed vector (:in filters))]
      [:<> {:key (str "in-" idx)}
-      [pill dispatch {:mode :in :pill p :idx idx}]])
+      (pill dispatch {:mode :in :pill p :idx idx})])
    (for [[idx p] (map-indexed vector (:out filters))]
      [:<> {:key (str "out-" idx)}
-      [pill dispatch {:mode :out :pill p :idx idx}]])])
+      (pill dispatch {:mode :out :pill p :idx idx})])])


### PR DESCRIPTION
Slice B2 of the Xray Fresco migration — the **filters** chrome satellite.
Surface: `filters.cljs`, `filters/edit_popup.cljs`, `filters/pills.cljs`.

## What changed

Four plain-fn hiccup heads become calls. That is T1 in the bead's settled
taxonomy — the ruled HD-016 repair — applied at every site my three files carry.

| site | file | was |
| --- | --- | --- |
| `pills-view` IN bucket | `filters/pills.cljs` | `[pill dispatch {...}]` |
| `pills-view` OUT bucket | `filters/pills.cljs` | `[pill dispatch {...}]` |
| `popup-view` radio row | `filters/edit_popup.cljs` | `[mode-radio dispatch {...}]` |
| `popup-view` radio row | `filters/edit_popup.cljs` | `[mode-radio dispatch {...}]` |

`filters.cljs` carries no hiccup heads at all — its `Modal` body already
*called* `popup-view`.

## Two of the four were a live defect, not prophylaxis

`pills-view`'s two `[pill ...]` heads render inside `shell/events-ribbon`,
which became an `rf.fresco/defview` **boundary** in #9653. A plain function in
head position grades `:invalid` there — a loud refusal, never a silent
embedding. It has not fired only because the events ribbon renders no pills
while the filter set is empty, and `shell_fresco_boundary_dom_cljs_test`'s w1
asserts the ribbon commits **without ever seeding a filter**. So the head was
live and unwitnessed. The reach is
`events-ribbon` (boundary) → `events-ribbon-tree` → `ribbon-filter-pills`
(call) → `pills-view` (call) → `[pill ...]` (head).

The other two sit under `filters/Modal`, still an `rf/reg-view`, where a
plain-fn head is legal today. Inlined anyway — it costs nothing and spares
this file a second pass whichever way the later slice resolves the modal.

## Q1 and Q2

**Q1 holds at all four sites.** Each helper answers hiccup and its subtree is
head-free all the way down. Followed out of the files per Q1's second half:
`pill-tone` / `pill-kind` / `pill-display` return values rather than hiccup;
`typed/pill-label` and `typed/pill-glyph` return strings; and
`theme/modal-chrome/modal-chrome`, which `popup-view` calls, returns
`[:div ... [:div ...]]` with keyword heads only.

**Q2 is inert on this surface.** Neither `pill` nor `mode-radio` reads the
substrate, so no read donates upward and no helper is narrowed to
inside-a-render. Measured: `filters/pills.cljs` contains zero reads of any
kind; the only reads in the slice are `filters.cljs:68` and
`edit_popup.cljs:222-224`, all inside functions I did not inline. That
read-free property is load-bearing rather than incidental —
`filters/pills_cljs_test` drives `pills-view` and `add-pill` directly from the
node lane with no render window around them, and a `rf.fresco/sub` inlined
into either would raise `:rf.error/fresco-sub-outside-render` on that path.

The keyed fragments stay, and are what makes the inline structurally free: the
list key rides `[:<> {:key ...}]`, a head both substrates honour, so `pill`
keeps its positional `dispatch` argument (rf2-a38l).

## `filters/Modal` deliberately stays an `rf/reg-view`

Not an oversight. It is one of the seven shell-root modals `shell-view` mounts,
and `shell-view` is still an `rf/reg-view` — a Reagent tree — until the epic's
coupling (1) is severed. A `defview` mints a React function component, which is
not a legal hiccup head there, so migrating it today would mean either an
`as-component` bridge with nothing above it to justify one, or a `shell.cljs`
edit that the four sibling chrome satellites would each need too. The later
slice owns that choice and has two live options on record (migrate, or island
behind `as-child`); the subtree below the modal is now ready for either.
Recorded in the `Modal` docstring so the next reader does not score it a miss.

## Docstring prose corrected

#9653 falsified seven statements in these files, all left standing: five
claiming the caller captures `dispatch` in a `reg-view` body (those callers are
Fresco boundaries using `(:dispatch (rf/capture-frame))` now) and two
describing the mount itself as a `reg-view`. Corrected in place. The statements
that are still *true* — `filters/Modal` is a `reg-view`, and `popup-view`'s
reads are ambient because of it — were left alone and are now explained.

## Quality gates

Every number below is the exit code captured from the runner itself on its own
command line, not one reported about the run by anything else.

### Node lane — `test:cljs`, split into its two phases

Split deliberately: `test:cljs` chains a compile to a run, and a failed compile
leaves the previous `out/node-test.js` in place for the run to pass against.
Each phase was run separately and the run was gated on the compile's captured exit.

| phase | captured exit | result |
| --- | --- | --- |
| compile `node-test` | **0** | 1951 files, 1950 compiled, 0 warnings |
| run `out/node-test.js` | **0** | 11686 tests, 58559 assertions, **0 failures, 0 errors** |

### Sabotage — the gate was shown to go red on this surface

The quiet reporter prints nothing for passing namespaces, so a clean log is no
evidence the suite reached these files. Planted a single-line fault in `pill`'s
testid (anchor match count read as exactly 1 before the run):

| phase | captured exit | result |
| --- | --- | --- |
| compile with plant | **0** | 253 files recompiled |
| run with plant | **1** | **26 failures**, `0 errors` |

The failures named `filters.pills-cljs-test` (17), `filters.hidden-indicator-cljs-test`
and `shell-cljs-test`. The fault existed only in this branch's working tree, so a
run that had wandered into another checkout would have come back green — that red
is what identifies the tree the gate read. The compile log also names this
worktree's `shadow-cljs.edn` directly.

Restore verified against the committed object rather than by reading a diff:
`git hash-object` (default filtered form — the file is `i/lf w/crlf`) returned
`7916529872cd719d65d17d648a4f00bbf091277c`, equal to `git rev-parse HEAD:<path>`,
and `git diff --quiet HEAD -- <path>` exited 0 as a second instrument.

### Ratchets grading these paths

Nine run, all captured **exit 0**: `check_retired_spellings`,
`check_view_lifetime_residue`, `check_ambient_durable_reads`,
`check_retired_composition_vocab`, `check_require_alias_dialect`,
`check_flattened_lists`, `check_thrown_error_messages`,
`check-no-hardcoded-paths`, `check-ai-tracking-ratchet`.

A zero is not a check that passed, so the highest-risk one — rule (g) of
`check_retired_spellings.py`, the zero-tolerance product-name ratchet, which is
the one most exposed by the volume of new prose in this diff — was exercised in
both directions on one of these very files: **exit 1** with the retired spelling
planted, **exit 0** restored, restore hash-verified as above.

### Declared not run, with reasons

**`npm run test:xray-feature-gate` — it does not cover this diff, so running it
would be a green that verified nothing.** Searched the whole repo for
`rf-xray-filter-pill|rf-xray-ribbon-filters|rf-xray-filter-add`: six files, and
every one is either a source file here or a node-lane `*_cljs_test.cljs`. No
browser scenario and no `*_dom_cljs_test.cljs` renders a filter pill at all.
That absence is also the reason the `:invalid` head this PR removes has never
fired. Flagged in the report rather than fixed here — a browser witness for the
events-ribbon's pill path belongs with that boundary's own DOM suite, which is
not this slice's surface.

**Adapter smokes** — no adapter surface is touched.

### One limit of the node lane, stated rather than glossed

`re-frame.test-helpers/expand-tree` invokes a function head with its args, so
`[pill …]` and `(pill …)` expand to identical trees. The node lane therefore
cannot see the head-versus-call distinction at all. What its green proves is
**behavioural equivalence** — that the inline renders exactly what the head did,
which is the property a wrong inline would break, and which the 26-failure
sabotage shows it is genuinely grading. Head legality itself is a codec fact:
`codec/boundary-head?` reads one own property, `frescoBoundary`, set only by
`rf.fresco/defview`.

The merge decision is CI's. The required set this local run omits is derived
from the canonical matrix in `TESTING.md` rather than re-listed here.
