### PR TITLE
refactor(xray): migrate the spine-filters chrome satellite onto Fresco (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -51,8 +51,10 @@
       ns).
     - The L1 ribbon mute-count indicator + the unmute manager modal
       mount points live in `shell.cljs` so the chrome owns its
-      placement; this ns exposes the `Modal` `reg-view` for the
-      shell to mount alongside the other modals.
+      placement; this ns exposes `Modal` for the shell to mount
+      alongside the other modals. Since rf2-k97c.3 `Modal` and
+      `RowContextMenu` are migration BRIDGES onto Fresco boundaries
+      rather than `rf/reg-view`s — see their docstrings.
 
   ## Storage shape
 
@@ -67,6 +69,7 @@
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
@@ -257,82 +260,145 @@
       s
       (str (subs s 0 25) "…"))))
 
-(defn row-context-menu
-  "Hiccup for the row's right-click context menu. Pure rendering;
-  state lives in `:rf.xray/row-context-menu`. Rendered at the
+(defn row-context-menu-tree
+  "Hiccup for the row's right-click context menu, as a pure function of
+  the RESOLVED menu state and a frame-aware `dispatch`. Rendered at the
   shell-view root so the menu floats above the L2 list's
   overflow-hidden clipping.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
-  `RowContextMenu` `reg-view` body so the menu actions land on the
-  surrounding instance frame, not a `{:frame :rf/xray}` literal."
+  SPLIT OUT OF [[row-context-menu]] BY rf2-k97c.3, and the split is about
+  WHERE THE READ SITS rather than about inlining. [[RowContextMenuView]]
+  is a Fresco boundary, and `rf.fresco/sub` is legal only inside a
+  boundary render (`:rf.error/fresco-sub-outside-render`); an ambient
+  `rf/subscribe` is refused inside one
+  (`:rf.error/ambient-frame-refused`). So the read is HOISTED into each
+  lane's own entry point and the markup below reads nothing — which is
+  what keeps it drivable from the node lane without a React commit.
+
+  `dispatch` (rf2-nesy9) is the frame-aware dispatcher its caller
+  captured, so the menu actions land on the surrounding instance frame,
+  not a `{:frame :rf/xray}` literal."
+  [dispatch menu]
+  (let [{:keys [event-id x y]} menu
+        close! (fn [] (dispatch [:rf.xray/close-row-context-menu]))]
+    [:<>
+     ;; Invisible backdrop catches outside-click → close. Sized to
+     ;; the full viewport with a z-index just below the menu so the
+     ;; menu sits on top.
+     [:div {:data-testid "rf-xray-row-context-menu-backdrop"
+            :on-click    (fn [^js e]
+                           (.stopPropagation e)
+                           (close!))
+            :on-context-menu (fn [^js e]
+                               (.preventDefault e)
+                               (close!))
+            :style       {:position "fixed"
+                          :top      0
+                          :left     0
+                          :right    0
+                          :bottom   0
+                          :z-index  2147483049
+                          :background "transparent"}}]
+     [:ul {:data-testid "rf-xray-row-context-menu"
+           :data-rf-xray-event-id (str event-id)
+           :on-click    (fn [^js e] (.stopPropagation e))
+           :on-key-down (fn [^js e]
+                          (when (= "Escape" (.-key e))
+                            (close!)))
+           :style (assoc (menu-style x y)
+                         :list-style "none"
+                         :margin 0)}
+      [:li {:style {:padding "4px 12px 6px"
+                    :color   (:text-tertiary tokens)
+                    :font-size (:caption type-scale)
+                    :border-bottom (str "1px solid " (:border-subtle tokens))
+                    :margin-bottom "4px"
+                    :font-family mono-stack
+                    :overflow "hidden"
+                    :text-overflow "ellipsis"
+                    :white-space "nowrap"}}
+       (str event-id)]
+      [:li
+       [:button {:data-testid "rf-xray-row-context-menu-mute"
+                 :on-click    (fn [_e]
+                                (dispatch [:rf.xray/mute-event-id event-id])
+                                (close!))
+                 :title       (str "Mute " event-id " — hide from spine; reversible")
+                 :style       (menu-item-style)}
+        (str "Mute " (truncate-id event-id))]]
+      [:li
+       [:button {:data-testid "rf-xray-row-context-menu-hide-event-type"
+                 :on-click    (fn [_e]
+                                (dispatch [:rf.xray/hide-event-type event-id])
+                                (close!))
+                 :title       "Open the OUT-filter popup pre-filled with this event-id"
+                 :style       (menu-item-style)}
+        "Always hide this event-type…"]]]]))
+
+(defn row-context-menu
+  "The menu's NODE-LANE DOOR — ambient read + [[row-context-menu-tree]].
+  Answers nil when no menu is open.
+
+  Signature unchanged by rf2-k97c.3 (`[dispatch]`), deliberately. This is
+  the arity a caller OUTSIDE a boundary render holds, and the reason it
+  survives the migration is that `rf.fresco/sub` would refuse there
+  (`:rf.error/fresco-sub-outside-render`) — so the Fresco lane's read
+  lives in [[RowContextMenuView]] and this one lives here, rather than
+  either lane donating its read to the other."
   [dispatch]
   (when-let [menu @(rf/subscribe [:rf.xray/row-context-menu])]
-    (let [{:keys [event-id x y]} menu
-          close! (fn [] (dispatch [:rf.xray/close-row-context-menu]))]
-      [:<>
-       ;; Invisible backdrop catches outside-click → close. Sized to
-       ;; the full viewport with a z-index just below the menu so the
-       ;; menu sits on top.
-       [:div {:data-testid "rf-xray-row-context-menu-backdrop"
-              :on-click    (fn [^js e]
-                             (.stopPropagation e)
-                             (close!))
-              :on-context-menu (fn [^js e]
-                                 (.preventDefault e)
-                                 (close!))
-              :style       {:position "fixed"
-                            :top      0
-                            :left     0
-                            :right    0
-                            :bottom   0
-                            :z-index  2147483049
-                            :background "transparent"}}]
-       [:ul {:data-testid "rf-xray-row-context-menu"
-             :data-rf-xray-event-id (str event-id)
-             :on-click    (fn [^js e] (.stopPropagation e))
-             :on-key-down (fn [^js e]
-                            (when (= "Escape" (.-key e))
-                              (close!)))
-             :style (assoc (menu-style x y)
-                           :list-style "none"
-                           :margin 0)}
-        [:li {:style {:padding "4px 12px 6px"
-                      :color   (:text-tertiary tokens)
-                      :font-size (:caption type-scale)
-                      :border-bottom (str "1px solid " (:border-subtle tokens))
-                      :margin-bottom "4px"
-                      :font-family mono-stack
-                      :overflow "hidden"
-                      :text-overflow "ellipsis"
-                      :white-space "nowrap"}}
-         (str event-id)]
-        [:li
-         [:button {:data-testid "rf-xray-row-context-menu-mute"
-                   :on-click    (fn [_e]
-                                  (dispatch [:rf.xray/mute-event-id event-id])
-                                  (close!))
-                   :title       (str "Mute " event-id " — hide from spine; reversible")
-                   :style       (menu-item-style)}
-          (str "Mute " (truncate-id event-id))]]
-        [:li
-         [:button {:data-testid "rf-xray-row-context-menu-hide-event-type"
-                   :on-click    (fn [_e]
-                                  (dispatch [:rf.xray/hide-event-type event-id])
-                                  (close!))
-                   :title       "Open the OUT-filter popup pre-filled with this event-id"
-                   :style       (menu-item-style)}
-          "Always hide this event-type…"]]]])))
+    (row-context-menu-tree dispatch menu)))
 
-(rf/reg-view RowContextMenu
-  "The row context menu — rendered at the shell-view root so the
-  popover floats above the L2 list's clipping. Per rf2-in6l2
-  `reg-view`-registered so subscribes resolve to `:rf/xray`.
+(rf.fresco/defview ^:private RowContextMenuView
+  "The row context menu — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Rendered at the shell-view root so the popover floats
+  above the L2 list's clipping.
 
-  rf2-nesy9 — threads the reg-view-injected frame-aware `dispatch` so
-  menu actions land on the surrounding instance frame."
+  CLOSED-STATE COST IS UNCHANGED — one subscription and a gate.
+  `rf.fresco/sub` records its edge where the read happens, so the
+  not-taken branch contributes no edge.
+
+  THE DISPATCH IS FRAME-CARRYING, captured here at render time
+  (rf2-nesy9). `rf/current-frame-id` answers the declared frame inside a
+  Fresco body — it neither reads nor dispatches, so the boundary's
+  refusal tier does not touch it — and an explicitly carried
+  `{:frame <id>}` still answers, because that tier deletes the ambient
+  FIND and not the CARRYING. This is what replaced `reg-view`'s
+  lexically injected bare `dispatch`, which a `defview` body does not
+  bind.
+
+  PRIVATE; [[RowContextMenu]] in front of it is the public name the
+  shell already mounts."
+  [_props]
+  (when-let [menu (rf.fresco/sub [:rf.xray/row-context-menu])]
+    (let [frame (rf/current-frame-id)]
+      (row-context-menu-tree (fn [ev] (rf/dispatch ev {:frame frame})) menu))))
+
+(def ^:private RowContextMenu-component
+  "The React component [[RowContextMenuView]] presents as, for a
+  non-Fresco parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the menu."
+  (rf.fresco/as-component RowContextMenuView))
+
+(defn RowContextMenu
+  "The row context menu's public callable — what `shell.cljs` mounts as
+  a hiccup head at the shell-view root.
+
+  Since rf2-k97c.3 it is the MIGRATION BRIDGE rather than the view:
+  Reagent-shaped hiccup interoping to the React component
+  [[RowContextMenuView]] presents as. `shell-view` is still an
+  `rf/reg-view` tree, and the enclosing `rf/frame-provider` is what puts
+  the instance frame in React context for it. The open/closed gate is
+  inside the view, so this is always mounted and renders nothing while
+  the menu is closed — the same shape a mounted `reg-view` returning nil
+  had.
+
+  SCAFFOLDING WITH A DEFINED END: when the shell is itself a Fresco
+  tree, [[RowContextMenuView]] takes this name directly and the `[:>]`
+  and the two defs above it go."
   []
-  (row-context-menu dispatch))
+  [:> RowContextMenu-component {}])
 
 ;; ---- Modal --------------------------------------------------------------
 
@@ -448,8 +514,15 @@
         ;; which Reagent honours and Fresco's codec reads nowhere. Both
         ;; of `mute-row`'s arguments are positional, so there is no props
         ;; map to hold the key and inserting one would shift them.
+        ;;
+        ;; rf2-k97c.3 — `mute-row` is CALLED rather than headed: it is a
+        ;; plain fn answering hiccup, which Fresco grades a loud error in
+        ;; head position (HD-016 — a plain function call INLINES into the
+        ;; enclosing boundary). The fragment stays exactly as rf2-a38l
+        ;; left it; it carries the key without adding a DOM node, which
+        ;; keeps `mute-row` the presentational helper it is.
         (for [id (sort-by str muted-ids)]
-          [:<> {:key (str id)} [mute-row dispatch id]])))
+          [:<> {:key (str id)} (mute-row dispatch id)])))
 
 (defn- clear-all-button
   [dispatch]
@@ -467,56 +540,114 @@
                           :margin-left   "auto"}}
    "Unmute all"])
 
-(defn dialog
+(defn dialog-tree
   "The mute manager modal — backdrop + dialog scaffold (rf2-7oxvd)
-  around the manager body. Pure hiccup.
+  around the manager body — as a pure function of its RESOLVED reads and
+  a frame-aware `dispatch`. Returns the full
+  `[:div backdrop [:div dialog …]]` tree.
 
-  Returns the full `[:div backdrop [:div dialog …]]` tree (the
+  SPLIT OUT OF [[dialog]] BY rf2-k97c.3, for the same reason
+  [[row-context-menu-tree]] was: [[ModalView]] is a Fresco boundary, and
+  the two lanes cannot share one read. `rf.fresco/sub` is legal only
+  inside a boundary render (`:rf.error/fresco-sub-outside-render`) and an
+  ambient `rf/subscribe` is refused inside one
+  (`:rf.error/ambient-frame-refused`), so each lane hoists its own read
+  and this fn reads nothing at all.
+
+  `dispatch` (rf2-nesy9) is the frame-aware dispatcher its caller
+  captured — threaded to header / rows / clear-all so unmute actions land
+  on the surrounding instance frame, not a `{:frame :rf/xray}` literal."
+  [dispatch {:keys [muted positioning]}]
+  ;; rf2-7oxvd — shared backdrop + dialog scaffold. Keeps this modal's
+  ;; own `backdrop-style` / `dialog-style`, its `tab-index "-1"` dialog
+  ;; root (the empty-state body has no focusable child, so the trap
+  ;; pins focus on the root), and its dialog-level Esc handler.
+  ;; `modal-chrome` owns the positioning attribute, the click-outside
+  ;; dismiss, `a11y/dialog-attrs` + the `a11y/dialog-ref` focus trap.
+  ;; It is CALLED, never used as a hiccup head, so Fresco's "a plain fn
+  ;; in head position is a loud error" rule never meets it, and the
+  ;; `:ref` it installs crosses Fresco's codec untouched.
+  (modal-chrome/modal-chrome
+    {:positioning        positioning
+     :backdrop-style     (backdrop-style positioning)
+     :dialog-style       (dialog-style)
+     :on-dismiss         #(dispatch [:rf.xray/close-mute-manager])
+     :labelled-by        "rf-xray-mute-manager-title"
+     :backdrop-testid    "rf-xray-mute-manager-backdrop"
+     :dialog-testid      "rf-xray-mute-manager-dialog"
+     :dialog-tab-index   "-1"
+     :on-dialog-key-down (fn [^js e]
+                           (when (= "Escape" (.-key e))
+                             (dispatch [:rf.xray/close-mute-manager])))}
+   (header dispatch)
+   (if (empty? muted)
+     (empty-state)
+     [:<>
+      (list-section dispatch muted)
+      [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+       (clear-all-button dispatch)]])))
+
+(defn dialog
+  "The modal's NODE-LANE DOOR — ambient reads + [[dialog-tree]]. Returns
+  the full `[:div backdrop [:div dialog …]]` tree; the
   `modals-aria-cljs-test` renders this fn directly and walks for the
-  dialog node). `spine-filters/Modal` gates on
-  `:rf.xray/mute-manager-open?` and calls this fn.
+  dialog node.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
-  `Modal` `reg-view` body — threaded to header / rows / clear-all so
-  unmute actions land on the surrounding instance frame, not a
-  `{:frame :rf/xray}` literal."
+  Signature unchanged by rf2-k97c.3 (`[dispatch]`), deliberately, and
+  that is load-bearing rather than incidental. This is the arity a caller
+  OUTSIDE a boundary render holds, and `rf.fresco/sub` would refuse there
+  (`:rf.error/fresco-sub-outside-render`) — so letting the reads donate
+  upward into [[ModalView]]'s window would have narrowed this fn to being
+  callable only inside a real React commit. The reads are HOISTED into
+  each lane's own entry point instead; see [[dialog-tree]].
+
+  Unlike [[ModalView]] this does NOT gate on
+  `:rf.xray/mute-manager-open?` — the open/closed gate is the caller's,
+  as it always was, so this never answers nil."
   [dispatch]
-  (let [muted       @(rf/subscribe [:rf.xray/muted-event-ids])
-        positioning @(rf/subscribe [:rf.xray/modal-positioning])]
-    ;; rf2-7oxvd — shared backdrop + dialog scaffold. Keeps this modal's
-    ;; own `backdrop-style` / `dialog-style`, its `tab-index "-1"` dialog
-    ;; root (the empty-state body has no focusable child, so the trap
-    ;; pins focus on the root), and its dialog-level Esc handler.
-    ;; `modal-chrome` owns the positioning attribute, the click-outside
-    ;; dismiss, `a11y/dialog-attrs` + the `a11y/dialog-ref` focus trap.
-    (modal-chrome/modal-chrome
-      {:positioning        positioning
-       :backdrop-style     (backdrop-style positioning)
-       :dialog-style       (dialog-style)
-       :on-dismiss         #(dispatch [:rf.xray/close-mute-manager])
-       :labelled-by        "rf-xray-mute-manager-title"
-       :backdrop-testid    "rf-xray-mute-manager-backdrop"
-       :dialog-testid      "rf-xray-mute-manager-dialog"
-       :dialog-tab-index   "-1"
-       :on-dialog-key-down (fn [^js e]
-                             (when (= "Escape" (.-key e))
-                               (dispatch [:rf.xray/close-mute-manager])))}
-     (header dispatch)
-     (if (empty? muted)
-       (empty-state)
-       [:<>
-        (list-section dispatch muted)
-        [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-         (clear-all-button dispatch)]]))))
+  (dialog-tree dispatch
+               {:muted       @(rf/subscribe [:rf.xray/muted-event-ids])
+                :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))
 
-(rf/reg-view Modal
-  "The mute manager modal. Renders only when
-  `:rf.xray/mute-manager-open?` is true; closed-state is one
-  subscribe + a `when`. Per rf2-in6l2 `reg-view`-registered so the
-  body's subscribes resolve through React-context to `:rf/xray`."
+(rf.fresco/defview ^:private ModalView
+  "The mute manager modal — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Renders only when `:rf.xray/mute-manager-open?` is true.
+
+  CLOSED-STATE COST IS UNCHANGED — one subscription and a gate. The other
+  two reads sit inside the `when`, and `rf.fresco/sub` records its edge
+  where the read happens, so a branch not taken contributes no edge. That
+  is Fresco's documented behaviour rather than an accident, and it is why
+  the short-circuit survived the migration intact.
+
+  THE DISPATCH IS FRAME-CARRYING, captured here at render time
+  (rf2-nesy9) — see [[RowContextMenuView]], which says the same thing at
+  more length.
+
+  PRIVATE; [[Modal]] in front of it is the public name the shell already
+  mounts."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/mute-manager-open?])
+    (let [frame (rf/current-frame-id)]
+      (dialog-tree (fn [ev] (rf/dispatch ev {:frame frame}))
+                   {:muted       (rf.fresco/sub [:rf.xray/muted-event-ids])
+                    :positioning (rf.fresco/sub [:rf.xray/modal-positioning])}))))
+
+(def ^:private Modal-component
+  "The React component [[ModalView]] presents as, for a non-Fresco
+  parent. Declared once at top level, for the same reason as
+  [[RowContextMenu-component]]."
+  (rf.fresco/as-component ModalView))
+
+(defn Modal
+  "The mute manager modal's public callable — what `shell.cljs` mounts as
+  a hiccup head at the shell-view root.
+
+  Since rf2-k97c.3 it is the MIGRATION BRIDGE rather than the view; see
+  [[RowContextMenu]], which says the same thing at more length. The
+  open/closed gate is inside [[ModalView]], so this is always mounted and
+  renders nothing while the manager is closed."
   []
-  (when @(rf/subscribe [:rf.xray/mute-manager-open?])
-    (dialog dispatch)))
+  [:> Modal-component {}])
 
 ;; ---- ribbon indicator (mounted from shell.cljs) -------------------------
 
@@ -528,8 +659,10 @@
   Mounted inline in the L1 ribbon next to the REDACTED indicator —
   surfaces the mute state without claiming a permanent ribbon slot.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher captured by the
-  caller's `reg-view` body."
+  `dispatch` (rf2-nesy9) is the frame-aware dispatcher its caller
+  captured. CALLED rather than headed — it is a plain fn answering
+  hiccup, which Fresco grades a loud error in head position — and
+  `shell.cljs` has always called it."
   [dispatch muted-count]
   (when (pos? muted-count)
     [:button {:data-testid "rf-xray-ribbon-mute-indicator"

--- a/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine_filters.cljs
@@ -266,14 +266,17 @@
   shell-view root so the menu floats above the L2 list's
   overflow-hidden clipping.
 
-  SPLIT OUT OF [[row-context-menu]] BY rf2-k97c.3, and the split is about
-  WHERE THE READ SITS rather than about inlining. [[RowContextMenuView]]
-  is a Fresco boundary, and `rf.fresco/sub` is legal only inside a
-  boundary render (`:rf.error/fresco-sub-outside-render`); an ambient
-  `rf/subscribe` is refused inside one
-  (`:rf.error/ambient-frame-refused`). So the read is HOISTED into each
-  lane's own entry point and the markup below reads nothing — which is
-  what keeps it drivable from the node lane without a React commit.
+  THIS REPLACED THE READING `row-context-menu` AT rf2-k97c.3, and the
+  change is about WHERE THE READ SITS rather than about inlining.
+  [[RowContextMenuView]] is a Fresco boundary, and `rf.fresco/sub` is
+  legal only inside a boundary render
+  (`:rf.error/fresco-sub-outside-render`) while an ambient `rf/subscribe`
+  is refused inside one (`:rf.error/ambient-frame-refused`) — so one read
+  cannot serve both lanes. The read is HOISTED into the boundary and this
+  fn is PURE OF ITS ARGUMENTS, which is what keeps it drivable from the
+  node lane without a React commit. A node-lane caller reproduces the
+  boundary's gate and read on its own side rather than finding a reading
+  arity here.
 
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher its caller
   captured, so the menu actions land on the surrounding instance frame,
@@ -334,20 +337,6 @@
                  :title       "Open the OUT-filter popup pre-filled with this event-id"
                  :style       (menu-item-style)}
         "Always hide this event-type…"]]]]))
-
-(defn row-context-menu
-  "The menu's NODE-LANE DOOR — ambient read + [[row-context-menu-tree]].
-  Answers nil when no menu is open.
-
-  Signature unchanged by rf2-k97c.3 (`[dispatch]`), deliberately. This is
-  the arity a caller OUTSIDE a boundary render holds, and the reason it
-  survives the migration is that `rf.fresco/sub` would refuse there
-  (`:rf.error/fresco-sub-outside-render`) — so the Fresco lane's read
-  lives in [[RowContextMenuView]] and this one lives here, rather than
-  either lane donating its read to the other."
-  [dispatch]
-  (when-let [menu @(rf/subscribe [:rf.xray/row-context-menu])]
-    (row-context-menu-tree dispatch menu)))
 
 (rf.fresco/defview ^:private RowContextMenuView
   "The row context menu — a FRESCO BOUNDARY (rf2-k97c.3), not an
@@ -546,13 +535,21 @@
   a frame-aware `dispatch`. Returns the full
   `[:div backdrop [:div dialog …]]` tree.
 
-  SPLIT OUT OF [[dialog]] BY rf2-k97c.3, for the same reason
-  [[row-context-menu-tree]] was: [[ModalView]] is a Fresco boundary, and
-  the two lanes cannot share one read. `rf.fresco/sub` is legal only
-  inside a boundary render (`:rf.error/fresco-sub-outside-render`) and an
-  ambient `rf/subscribe` is refused inside one
-  (`:rf.error/ambient-frame-refused`), so each lane hoists its own read
-  and this fn reads nothing at all.
+  THIS REPLACED THE READING `dialog` AT rf2-k97c.3, for the same reason
+  [[row-context-menu-tree]] replaced `row-context-menu`: [[ModalView]] is
+  a Fresco boundary, and the two lanes cannot share one read.
+  `rf.fresco/sub` is legal only inside a boundary render
+  (`:rf.error/fresco-sub-outside-render`) and an ambient `rf/subscribe`
+  is refused inside one (`:rf.error/ambient-frame-refused`), so the read
+  is hoisted into the boundary and this fn is PURE OF ITS ARGUMENTS and
+  reads nothing at all.
+
+  IT DOES NOT GATE on `:rf.xray/mute-manager-open?` — that gate is
+  [[ModalView]]'s, exactly as it was the caller's before rf2-k97c.3 — so
+  this always answers a tree. `modals-aria-cljs-test` drives it through a
+  file-local door of its own that reproduces the boundary's reads, the
+  same way that file already drives
+  `panels.cancellation-cascade/popover-tree`.
 
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher its caller
   captured — threaded to header / rows / clear-all so unmute actions land
@@ -586,28 +583,6 @@
       (list-section dispatch muted)
       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
        (clear-all-button dispatch)]])))
-
-(defn dialog
-  "The modal's NODE-LANE DOOR — ambient reads + [[dialog-tree]]. Returns
-  the full `[:div backdrop [:div dialog …]]` tree; the
-  `modals-aria-cljs-test` renders this fn directly and walks for the
-  dialog node.
-
-  Signature unchanged by rf2-k97c.3 (`[dispatch]`), deliberately, and
-  that is load-bearing rather than incidental. This is the arity a caller
-  OUTSIDE a boundary render holds, and `rf.fresco/sub` would refuse there
-  (`:rf.error/fresco-sub-outside-render`) — so letting the reads donate
-  upward into [[ModalView]]'s window would have narrowed this fn to being
-  callable only inside a real React commit. The reads are HOISTED into
-  each lane's own entry point instead; see [[dialog-tree]].
-
-  Unlike [[ModalView]] this does NOT gate on
-  `:rf.xray/mute-manager-open?` — the open/closed gate is the caller's,
-  as it always was, so this never answers nil."
-  [dispatch]
-  (dialog-tree dispatch
-               {:muted       @(rf/subscribe [:rf.xray/muted-event-ids])
-                :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))
 
 (rf.fresco/defview ^:private ModalView
   "The mute manager modal — a FRESCO BOUNDARY (rf2-k97c.3), not an

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -19,7 +19,7 @@
   ## Surfaces under test
 
     1. Settings popup  (`settings/view/popup-view`)
-    2. Mute manager    (`spine-filters/dialog`)
+    2. Mute manager    (`spine-filters/dialog-tree`)
     3. Filter edit-popup (`filters/edit-popup/popup-view`)
     4. Cancellation-cascade popover — exercised via the Popover
        reg-view's body (it renders a [:div {:role \"dialog\" ...}])
@@ -134,10 +134,33 @@
 ;; -------------------------------------------------------------------------
 ;; (2) Mute manager
 ;; -------------------------------------------------------------------------
+;;
+;; Since rf2-k97c.3 the mute manager is a FRESCO BOUNDARY behind an
+;; `as-component` bridge: `spine-filters/Modal` answers an interop vector,
+;; not a tree to walk, and the boundary's body may only run inside a React
+;; render window. The shipped markup is `spine-filters/dialog-tree`, which
+;; is PURE OF ITS ARGUMENTS; the door below reproduces `ModalView`'s reads
+;; exactly — same query vectors, same order — so both rows below assert on
+;; the same hiccup they did before. Same shape as
+;; `cancellation-cascade-popover-tree` further down this file.
+
+(defn- mute-manager-dialog-tree
+  "The mute manager's dialog markup for the current state. Mirrors
+  `spine-filters/ModalView`'s reads.
+
+  It does NOT mirror the boundary's `:rf.xray/mute-manager-open?` gate,
+  deliberately: these two rows are about the dialog's ARIA markup, and
+  the `spine-filters/dialog` they used to call did not gate either. So
+  this always answers a tree, exactly as that call did."
+  []
+  (spine-filters/dialog-tree
+    rf/dispatch
+    {:muted       @(rf/subscribe [:rf.xray/muted-event-ids])
+     :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))
 
 (deftest mute-manager-carries-dialog-contract
   (xray-setup!)
-  (let [tree (rf/with-frame :rf/xray (spine-filters/dialog rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (mute-manager-dialog-tree))]
     (assert-dialog-contract! tree "rf-xray-mute-manager-dialog"
                              "Mute manager")))
 
@@ -234,7 +257,7 @@
 
 (deftest mute-manager-attaches-focus-ref
   (xray-setup!)
-  (let [tree (rf/with-frame :rf/xray (spine-filters/dialog rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (mute-manager-dialog-tree))]
     (assert-dialog-focus-ref! tree "rf-xray-mute-manager-dialog"
                               "Mute manager")))
 

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -245,6 +245,41 @@
 ;; -------------------------------------------------------------------------
 ;; (7) Row context menu open / close state
 ;; -------------------------------------------------------------------------
+;;
+;; THE TWO NODE-LANE DOORS (rf2-k97c.3). Since the migration the row
+;; context menu and the mute manager are FRESCO BOUNDARIES behind
+;; `as-component` bridges, so `spine-filters/RowContextMenu` and
+;; `/Modal` answer interop vectors rather than trees to walk, and
+;; `dynamic-shell-tree/shell-view-tree` — which composes the shell's
+;; hiccup — necessarily stops at them. The shipped markup is the pair of
+;; PURE `*-tree` fns; each door below reproduces its boundary's gate and
+;; reads exactly, same query vectors in the same order, so every row
+;; asserts on the hiccup the boundary itself would build.
+;;
+;; This is the same substitution `modals-aria-cljs-test` already makes
+;; for `panels.cancellation-cascade/popover-tree`, which crossed to a
+;; boundary earlier in this bead. Rows that assert on the SHELL (the L2
+;; event rows, the L1 ribbon indicator) still walk the shell tree — the
+;; ribbon indicator is a plain fn the ribbon CALLS, so it never left.
+
+(defn- row-context-menu-tree
+  "The row context menu's markup for the current state: nil while
+  closed, the menu otherwise. Mirrors
+  `spine-filters/RowContextMenuView`'s gate and read."
+  []
+  (when-let [menu @(rf/subscribe [:rf.xray/row-context-menu])]
+    (spine-filters/row-context-menu-tree rf/dispatch menu)))
+
+(defn- mute-manager-tree
+  "The mute manager's markup for the current state: nil while closed,
+  the dialog otherwise. Mirrors `spine-filters/ModalView`'s gate and
+  reads."
+  []
+  (when @(rf/subscribe [:rf.xray/mute-manager-open?])
+    (spine-filters/dialog-tree
+      rf/dispatch
+      {:muted       @(rf/subscribe [:rf.xray/muted-event-ids])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])})))
 
 (deftest open-row-context-menu-event-writes-slot
   (xray-setup!)
@@ -273,7 +308,7 @@
   (frame-dispatch [:rf.xray/open-row-context-menu
                    {:event-id :user/mouse-move :x 100 :y 200}])
   (rf/with-frame :rf/xray
-    (let [tree (dynamic-shell-tree/shell-view-tree)
+    (let [tree (row-context-menu-tree)
           menu (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu")
           mute (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-mute")
           hide (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-hide-event-type")]
@@ -302,7 +337,7 @@
   (frame-dispatch [:rf.xray/mute-event-id :b/y])
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
-    (let [tree (dynamic-shell-tree/shell-view-tree)
+    (let [tree (mute-manager-tree)
           dialog (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-dialog")
           list   (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-list")
           row-a  (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-row-:a/x")
@@ -316,7 +351,7 @@
   (xray-setup!)
   (frame-dispatch [:rf.xray/open-mute-manager])
   (rf/with-frame :rf/xray
-    (let [tree  (dynamic-shell-tree/shell-view-tree)
+    (let [tree  (mute-manager-tree)
           empty (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-empty")
           list  (rf.test-helpers/find-by-testid tree "rf-xray-mute-manager-list")]
       (is (some? empty) "empty-state copy mounts when no ids muted")
@@ -370,7 +405,7 @@
         (with-redefs [rf/dispatch-impl (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree     (dynamic-shell-tree/shell-view-tree)
+          (let [tree     (row-context-menu-tree)
                 mute-btn (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu-mute")
                 handler  (:on-click (second mute-btn))]
             (is (fn? handler) "'Mute' button has on-click handler")
@@ -393,9 +428,13 @@
         (let [tree (dynamic-shell-tree/shell-view-tree)]
           (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-1")))
           (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-event-row-2"))
-              "muted row dropped from L2")
-          (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-row-context-menu"))
-              "menu closed after click"))
+              "muted row dropped from L2"))
+        ;; rf2-k97c.3 — asserted through the door rather than the shell
+        ;; tree. The boundary's own gate is what answers nil here, so this
+        ;; row grades the close; looked for in the shell tree it would be
+        ;; absent whatever the slot held, and pass vacuously.
+        (is (nil? (row-context-menu-tree))
+            "menu closed after click")
         (let [tree (dynamic-shell-tree/shell-view-tree)
               ind  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-mute-indicator")]
           (is (some? ind) "ribbon mute indicator visible"))))))

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -262,13 +262,32 @@
 ;; event rows, the L1 ribbon indicator) still walk the shell tree — the
 ;; ribbon indicator is a plain fn the ribbon CALLS, so it never left.
 
+;; THE DISPATCH THE DOORS PASS IS A WRAPPING FN, NOT THE BARE `rf/dispatch`,
+;; and that is load-bearing for `end-to-end-mute-from-context-menu`.
+;; `rf/dispatch` is a MACRO (core.cljc), so it expands to the `^:no-doc`
+;; `rf/dispatch-impl` seam AT ITS CALL SITE. Handing the bare symbol to a
+;; helper passes something that never expands, so the `with-redefs` on
+;; `dispatch-impl` below cannot see the handler's dispatches and the
+;; capture atom stays empty. Calling it inside a fn puts the expansion
+;; where the boundary puts it — `RowContextMenuView` and `ModalView` both
+;; build `(fn [ev] (rf/dispatch ev {:frame frame}))` — so these doors
+;; reproduce the dispatch path as well as the reads.
+
+(defn- door-dispatch
+  "The frame-aware dispatcher the boundaries capture at render time,
+  reproduced for the node lane. The ambient frame stands in for the
+  boundary's `rf/current-frame-id`, which is why every door call below
+  sits inside `(rf/with-frame :rf/xray …)`."
+  [ev]
+  (rf/dispatch ev))
+
 (defn- row-context-menu-tree
   "The row context menu's markup for the current state: nil while
   closed, the menu otherwise. Mirrors
   `spine-filters/RowContextMenuView`'s gate and read."
   []
   (when-let [menu @(rf/subscribe [:rf.xray/row-context-menu])]
-    (spine-filters/row-context-menu-tree rf/dispatch menu)))
+    (spine-filters/row-context-menu-tree door-dispatch menu)))
 
 (defn- mute-manager-tree
   "The mute manager's markup for the current state: nil while closed,
@@ -277,7 +296,7 @@
   []
   (when @(rf/subscribe [:rf.xray/mute-manager-open?])
     (spine-filters/dialog-tree
-      rf/dispatch
+      door-dispatch
       {:muted       @(rf/subscribe [:rf.xray/muted-event-ids])
        :positioning @(rf/subscribe [:rf.xray/modal-positioning])})))
 


### PR DESCRIPTION
Slice B4 of the rf2-k97c.3 step-2 chrome-satellite split. One production file,
`tools/xray/src/day8/re_frame2_xray/spine_filters.cljs`, plus the two test files that
drive it. No mount in `panels.cljs`, and `shell.cljs` is NOT touched — three files
total.

## What changed

**The two `rf/reg-view`s become `rf.fresco/defview` boundaries behind migration
bridges.** `shell.cljs`'s `shell-view` is still an `rf/reg-view` tree, and its
`shell-view-tree` mounts `[spine-filters/Modal]` and `[spine-filters/RowContextMenu]` as
hiccup heads. So the public callables keep the names the shell already holds and become
`[:> <component> {}]`, while the boundaries take private `*View` names.

This is not a new shape. `panels/cancellation_cascade.cljs` already ships exactly it at
trunk — `(rf.fresco/as-component PopoverView)`, `(defn Popover [] [:> Popover-component
{}])`, mounted as `[cancellation-cascade/Popover]` ten lines from `[spine-filters/Modal]`
in the same shell mount block. A bridge is a legal Reagent head, which is why this
migration needs no `shell.cljs` edit and does not serialise against the other satellites.

**The one hiccup head site in the file becomes a call.** `[mute-row dispatch id]`, inside
the rf2-a38l keyed fragment, is now `(mute-row dispatch id)` — HD-016's standard repair.
The fragment is untouched: it still carries the key without adding a DOM node.

**The reads are HOISTED into the boundaries, and no reading arity stays in production.**
Both view bodies previously reached the substrate through helpers that are also called
from outside a boundary render. `rf.fresco/sub` refuses outside a render
(`:rf.error/fresco-sub-outside-render`) and an ambient `rf/subscribe` is refused inside
one (`:rf.error/ambient-frame-refused`), so one read cannot serve both lanes. The shipped
markup is now `row-context-menu-tree` and `dialog-tree`, both PURE OF THEIR ARGUMENTS;
`row-context-menu` and `dialog` are gone. All four executable reads are `rf.fresco/sub`
inside the two boundaries, and zero `rf/subscribe` remain in the file.

**The node lane's doors live in the test tree**, each reproducing its boundary's gate,
reads AND dispatch path — the same substitution `modals_aria_cljs_test` already makes for
`cancellation-cascade/popover-tree`. `modals_aria_cljs_test` needed no new require: it
already required this ns.

One subtlety worth recording, because it cost two assertions: the doors pass a wrapping
fn rather than the bare `rf/dispatch`. `rf/dispatch` is a MACRO, so it expands to the
`^:no-doc` `rf/dispatch-impl` seam AT ITS CALL SITE; the bare symbol never expands, so
`end-to-end-mute-from-context-menu`'s `with-redefs` capture stayed empty. Calling it
inside a fn puts the expansion where the boundary puts it.

One row got STRONGER rather than being ported: "menu closed after click" now asserts the
door answers nil, which grades the boundary's own gate. Looked for in the shell tree it
would have been absent whatever the slot held, and passed vacuously.

**No consumer changes.** `Modal`, `RowContextMenu`, `ribbon-mute-indicator`, `install!`,
`filter-event-bundles`, `hydrate!` and the localStorage data layer all keep their names,
arities and meanings.

## Census

Three-pass head census (line-oriented, whitespace-collapsed, comment-markers-stripped
then collapsed), all three agreeing, controls biting in both directions:

| | before | after |
|---|---|---|
| `rf/reg-view` declarations | 2 | 0 |
| plain-fn hiccup head sites | 1 (`[mute-row …]`) | 0 |
| `rf.fresco/defview` boundaries | 0 | 2 |
| executable reads in production | 4 (`rf/subscribe`) | 4 (`rf.fresco/sub`, both boundaries) |

Executable reads were counted with string literals and comments blanked, so a docstring
mention cannot inflate them: raw 4, executable 4 — no contamination on this surface.

Q1 answered by reading what the callees return, not by trusting call sites. `dialog-tree`
reaches `header`, `empty-state`, `list-section` → `mute-row`, `clear-all-button` and
`modal-chrome/modal-chrome` → `a11y`. `modal_chrome.cljs` censuses 3 symbol-head
occurrences and `a11y.cljs` 23 — every one a binding form, a `:require` or a CSS selector
string, zero hiccup heads, neither declaring a view. `modal-chrome` is called, never
headed.

Q2 verified here rather than assumed: zero `r/atom`, zero `with-let`, zero form-2/form-3,
zero `reagent` require, with the probes controlled against `views/resizable_table.cljs`
where they bite.

## What this evidence does NOT cover

Stated plainly rather than left implicit. **The node lane cannot grade head legality at
all** — `expand-tree` invokes a fn head, so `[helper …]` and `(helper …)` expand
identically, and a plain fn left in head position inside a boundary would grade
`:invalid` at runtime while every node row over it passed. The claim that this file is
head-free rests on the CENSUS above, not on the green below. Relatedly, the doors MIRROR
`ModalView` / `RowContextMenuView` rather than executing them, so that the boundaries
mount and paint through React under the bridge is the browser lane's to prove.

Both surfaces here render only under non-default state — a modal that is closed and a
context menu that is not open both render nothing — so the rows deliberately SEED that
state: `mute-manager-renders-muted-ids` mutes two ids and opens the manager, which is
what actually exercises the formerly-headed `mute-row`, and the menu rows seed the slot.

## Quality gates

Every number below is the runner's own captured exit code, taken on one command line in
one shell, never a harness-reported status. Gate artefacts were named per worktree and
per attempt.

| gate | captured exit | result |
|---|---|---|
| `compile-node-test.cjs node-test` | `COMPILE_EXIT=0` | 1951 files, 0 warnings |
| node-test, 4 xray namespaces + runner pin | `NODETEST_EXIT=0` | 179 tests, 768 assertions, 0 failures |
| same, SABOTAGED | `NODETEST_EXIT=1` | 4 failures, naming the plant |
| same, restored | `NODETEST_EXIT=0` | 179 tests, 768 assertions, 0 failures |
| `check_require_alias_dialect.py --verbose` | `0` | 2853 files, 11244 edges, 0 non-canonical |
| `check_retired_spellings.py` | `0` | self-test `0` |
| `check_ambient_durable_reads.py` | `0` | self-test `0` |
| `check_retired_composition_vocab.py` | `0` | self-test `0` |

Namespaces run: `spine-filters-cljs-test`, `modals-aria-cljs-test`, `shell-cljs-test`,
`control-axes-e2e.event-id-mute-e2e-cljs-test`, `re-frame.test-quiet-shadow-node-cljs-test`.
Selected at RUNTIME via `--test=`, which `shadow-cljs.edn` documents as the safe route
because it needs no recompile and cannot poison the shared build cache.

**The sabotage was recompiled, not just edited.** A plant the runtime never sees proves
nothing: the sabotage compile recompiled 254 files where a no-op recompiles 2, which is
the positive evidence that the bundle under test carried the fault. Restore was verified
against the committed blob hash and by `git diff --quiet HEAD` (exit 0) — both, because
the `--no-filters` form of the hash disagrees on this file's line endings and alone would
have read as a false "restore failed".

**Declared reliance on CI**, not run locally: the full `test:cljs` lane beyond the five
namespaces above, `test:xray-feature-gate` and its smoke tier, the adapter smokes,
`cljs-examples-compile`, `tools_jvm` and `mcp_conformance`. The changed-surface
classifier arms `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`,
`mcp_conformance` and `story_xray_browser` for this path; a README-only control armed
none, so that instrument was exercised in both directions. The browser tier is the one
that grades head legality and the bridges' real mount, and it is CI's.

One local full-suite run was killed by a runtime cap before writing its exit file. An
absent exit file is no verdict rather than a pass, so it is not counted above; a
background notification reported exit 0 for that same run while the captured value was
`NODETEST_EXIT=1` on 21 real failures.
