### PR TITLE
feat(xray): migrate the resize-handle satellite onto Fresco (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
@@ -110,8 +110,50 @@
   highlight — the always-visible 1px accent stripe + cursor change
   on hover (via inline `:cursor`) carry the affordance. While
   dragging the body's cursor is overridden to `col-resize`
-  globally so the user reads the operation as continuous."
+  globally so the user reads the operation as continuous.
+
+  ## Substrate (rf2-k97c.3) — TWO FRESCO BOUNDARIES, ONE BRIDGE
+
+  Both views are `rf.fresco/defview`s: real React function components
+  whose reads are `rf.fresco/sub`, recorded by Fresco's own collector
+  rather than by the installed adapter's observer. Each is split into a
+  PURE `*-tree` fn of its already-read values plus a frame-bound
+  dispatcher, and a thin boundary that does the reading — the shipped
+  `shell.cljs` shape. The trees are what the node lane drives, so a row
+  walks the shipped markup without needing a render window.
+
+  The two boundaries are mounted DIFFERENTLY, because their parents
+  differ and the taxonomy keys on the parent:
+
+  - [[seam-handle-view]] is headed DIRECTLY by `shell.cljs`'s
+    `dynamic-chrome`, which is itself a Fresco boundary. Until this
+    migration it was a `reagent.core/as-element` island whose recorded
+    retiring condition was that migrating only the seam \"would split
+    one small file across two substrates for no gain\". This bead
+    migrates the whole file, so the condition is met and the island is
+    retired.
+  - [[Handle]] is a BRIDGE, because `shell.cljs`'s `shell-view-tree` is
+    still a Reagent tree and stays so until the epic's coupling (1) is
+    severed. `rf.fresco/as-component` is Fresco's own outward door; the
+    component is declared once at top level, as its contract requires.
+    SCAFFOLDING WITH A DEFINED END — when `mount.cljs` owns a Fresco
+    root and `shell-view` becomes a boundary, it heads
+    [[handle-view]] directly and both defs go.
+
+  THE MODE GATE STAYS ON THE REAGENT SIDE OF THE CROSSING, and that is
+  load-bearing rather than stylistic: `as-component`'s contract is that
+  prop NAMES round-trip and prop VALUES do not, so the keyword
+  `:inline` would not survive the props ABI — it would arrive as a
+  string and `(= mode :inline)` would be false for ever, silently
+  rendering no handle at all. [[Handle]] therefore decides in CLJS and
+  passes no props; [[handle-view]] takes none.
+
+  The reads are deliberately left INSIDE their conditionals. A Fresco
+  body is dynamically composed — its branches and early returns are
+  free to follow the data it reads (HD-002) — so gating a `sub` costs
+  nothing and no conditional had to be surrendered to hoist it."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.theme.tokens :refer [with-alpha]]))
 
@@ -402,59 +444,144 @@
    :touch-action     "none"
    :user-select      "none"})
 
-(rf/reg-view Handle
-  "Render the resize handle when `mode` is `:inline` (the right-rail
-  default). Other modes render nil — `:popout` is a separate window
-  the user resizes via the OS, `:fullscreen` is full-viewport and
-  has no width to drag.
+(defn aria-max-panel-width-px
+  "The `aria-valuemax` the handle announces, in pixels.
+
+  rf2-vxpq1 — WAI-ARIA \"separator\" with `aria-valuenow` requires both
+  `aria-valuemin` AND `aria-valuemax`. The clamp ceiling is
+  viewport-fraction-based at write time (`config/max-panel-width-fraction`);
+  for the announced ARIA max we use a stable pixel approximation derived
+  from the window's inner width when available, falling back to a 2000px
+  assumed viewport (the same default the clamp uses when no viewport is
+  supplied). Computing once per render is fine — the value is read on
+  focus, not every paint.
+
+  Lives OUTSIDE [[handle-tree]] because it reads `js/window`, and the
+  tree is pure of its arguments so the node lane can drive it with a
+  literal."
+  []
+  (let [viewport-w (when (exists? js/window)
+                     (.-innerWidth js/window))]
+    (long (* (or viewport-w 2000)
+             config/max-panel-width-fraction))))
+
+(defn handle-tree
+  "The panel-width handle's node, as a PURE function of the live width,
+  the announced ARIA ceiling and a frame-bound dispatcher.
+
+  SPLIT OUT OF [[handle-view]] BY rf2-k97c.3, and pure of its arguments
+  by design: `test-helpers.dynamic-shell-tree` and the handle's own
+  suite drive THIS fn with values they take from the same subs, so a row
+  walks the shipped markup without a render window and without a
+  reading fallback arity — `rf.fresco/sub` is legal only inside a
+  boundary render, and a fallback arity that is dead in production
+  would be a reading path in a file this migration exists to empty.
+
+  `dispatch` is the frame-aware dispatcher [[handle-view]] takes from
+  `(:dispatch (rf/capture-frame))`. It is threaded rather than ambient
+  so the drag, the keyboard resize and the double-click reset all land
+  on the surrounding instance frame after render scope unwinds
+  (rf2-nesy9)."
+  [current-width aria-max dispatch]
+  [:div {:data-testid      "rf-xray-resize-handle"
+         :role             "separator"
+         :aria-orientation "vertical"
+         :aria-label       "Resize Xray panel"
+         :aria-valuemin    config/min-panel-width-px
+         :aria-valuemax    aria-max
+         :aria-valuenow    current-width
+         :title            (str "Drag to resize · double-click to reset · "
+                                "arrow keys for fine resize (Shift = coarse) · "
+                                "Home / End for ends · Enter to reset")
+         :tab-index        0
+         :on-pointer-down  (fn [^js e]
+                             (start-drag! e current-width dispatch))
+         :on-key-down      (fn [^js e]
+                             (when (handle-keydown! e current-width dispatch)
+                               (try (.preventDefault e)
+                                    (catch :default _ nil))))
+         :on-double-click  (fn [^js _e]
+                             (dispatch
+                               [:rf.xray/reset-panel-width]))
+         :style            (handle-style)}])
+
+(rf.fresco/defview handle-view
+  "The left-edge panel-width handle — a FRESCO BOUNDARY (rf2-k97c.3),
+  not an `rf/reg-view`. Reads the live panel width and hands its value,
+  the announced ARIA ceiling and a frame-bound dispatcher to
+  [[handle-tree]].
+
+  The READ is `rf.fresco/sub`, a plain call the shipped collector
+  records an edge for — no deref and no reaction owned by the installed
+  adapter. The FRAME it resolves against comes from React context,
+  which the enclosing `rf/frame-provider` in `shell.cljs` writes, so it
+  resolves the instance frame identically under today's
+  Reagent-rendered shell and under the Fresco root Xray will own.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which replaces the `dispatch` name `reg-view` used to inject
+  lexically (`defview` binds no name inside the body, so the injected
+  name is simply unresolved: a loud compile error rather than a silent
+  frame leak).
 
   Per rf2-70u8q yields silently to consumer-asserted browser-native
   resize: if the layout host's computed style declares
   `resize: horizontal` (or `:both`), the consumer has chosen to wire
-  their own handle — render nil so the page does not carry two.
+  their own handle — render nil so the page does not carry two. The
+  probe stays INSIDE the boundary so it is re-evaluated on every
+  boundary render exactly as it was under `reg-view`, and the read
+  stays inside the same conditional: a Fresco body's branches are free
+  to follow its data (HD-002), so gating a `sub` costs nothing.
 
-  `reg-view`-wrapped per rf2-in6l2 so the inner subscribe routes
-  through React-context to `:rf/xray` (the shell wraps the whole
-  chrome in `frame-provider {:frame :rf/xray}`)."
+  TAKES NO PROPS, and that is deliberate — see the ns docstring: the
+  `:inline` MODE GATE lives in [[Handle]] on the Reagent side of the
+  crossing, because `as-component` round-trips prop names but not prop
+  VALUES and the keyword would arrive as a string."
+  [_props]
+  (when-not (host-asserts-own-handle?)
+    (handle-tree (rf.fresco/sub [:rf.xray/panel-width-px])
+                 (aria-max-panel-width-px)
+                 (:dispatch (rf/capture-frame)))))
+
+;; ---- the migration bridge (rf2-k97c.3) ----------------------------------
+
+(def ^:private handle-component
+  "The React component [[handle-view]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the handle on
+  each parent render."
+  (rf.fresco/as-component handle-view))
+
+(defn Handle
+  "The callable `shell.cljs`'s `shell-view-tree` mounts, and the name
+  that file has always headed.
+
+  `shell-view-tree` is still a Reagent tree — it stays one until the
+  epic's coupling (1) is severed and `mount.cljs` owns a Fresco root —
+  so a React component is not a legal hiccup head there. This is the
+  T5 bridge: [[handle-component]] is mounted through `[:>]`, and the
+  shell's enclosing `rf/frame-provider` is what puts the instance frame
+  in React context for it. No second root, no adapter-kind branch, no
+  props ABI.
+
+  THE MODE GATE IS HERE rather than in the boundary, and it has to be:
+  `mode` is a KEYWORD, `as-component`'s contract round-trips prop names
+  but not prop values, and `:inline` crossing as `\"inline\"` would make
+  `(= mode :inline)` false for ever — a handle that silently never
+  renders. Deciding in CLJS and passing no props removes the hazard
+  rather than working around it.
+
+  `:popout` is a separate window the user resizes via the OS and
+  `:fullscreen` is full-viewport with no width to drag, so both render
+  nil exactly as before.
+
+  SCAFFOLDING WITH A DEFINED END: when `shell-view` becomes a boundary
+  it heads [[handle-view]] directly and both this and
+  [[handle-component]] are deleted."
   [mode]
-  (when (and (= mode :inline)
-             (not (host-asserts-own-handle?)))
-    (let [current-width @(rf/subscribe [:rf.xray/panel-width-px])
-          ;; rf2-vxpq1 — WAI-ARIA "separator" with `aria-valuenow`
-          ;; requires both `aria-valuemin` AND `aria-valuemax`. The
-          ;; clamp ceiling is viewport-fraction-based at write time
-          ;; (config/max-panel-width-fraction); for the announced
-          ;; ARIA max we use a stable pixel approximation derived
-          ;; from the window's inner width when available, falling
-          ;; back to a 2000px assumed viewport (the same default the
-          ;; clamp uses when no viewport is supplied). Computing once
-          ;; per render is fine — the value is read on focus, not
-          ;; every paint.
-          viewport-w     (when (exists? js/window)
-                           (.-innerWidth js/window))
-          aria-max       (long (* (or viewport-w 2000)
-                                  config/max-panel-width-fraction))]
-      [:div {:data-testid      "rf-xray-resize-handle"
-             :role             "separator"
-             :aria-orientation "vertical"
-             :aria-label       "Resize Xray panel"
-             :aria-valuemin    config/min-panel-width-px
-             :aria-valuemax    aria-max
-             :aria-valuenow    current-width
-             :title            (str "Drag to resize · double-click to reset · "
-                                    "arrow keys for fine resize (Shift = coarse) · "
-                                    "Home / End for ends · Enter to reset")
-             :tab-index        0
-             :on-pointer-down  (fn [^js e]
-                                 (start-drag! e current-width dispatch))
-             :on-key-down      (fn [^js e]
-                                 (when (handle-keydown! e current-width dispatch)
-                                   (try (.preventDefault e)
-                                        (catch :default _ nil))))
-             :on-double-click  (fn [^js _e]
-                                 (dispatch
-                                   [:rf.xray/reset-panel-width]))
-             :style            (handle-style)}])))
+  (when (= mode :inline)
+    [:> handle-component {}]))
 
 ;; ==========================================================================
 ;; L2/L3 seam handle (rf2-t2dsh)
@@ -677,11 +804,63 @@
    ;; was extracted; the seam IS the boundary).
    :position        "relative"})
 
-(rf/reg-view SeamHandle
-  "Render the horizontal seam between the L2 event list and the L3 tab
-  bar as a draggable resize affordance (rf2-t2dsh). Always renders —
-  every mode that mounts the L2 list (Dynamic chrome only; Static mode
-  doesn't carry L2) renders the seam.
+(defn aria-max-events-list-height-px
+  "The `aria-valuemax` the seam announces, in pixels. Mirrors
+  [[aria-max-panel-width-px]] for the vertical axis — a stable pixel
+  approximation of the write-time clamp ceiling
+  (`config/max-events-list-height-fraction`), derived from the window's
+  inner height when available and falling back to a 1000px assumed
+  viewport.
+
+  Lives OUTSIDE [[seam-handle-tree]] because it reads `js/window`, and
+  the tree is pure of its arguments so the node lane can drive it with
+  a literal."
+  []
+  (let [viewport-h (when (exists? js/window)
+                     (.-innerHeight js/window))]
+    (long (* (or viewport-h 1000)
+             config/max-events-list-height-fraction))))
+
+(defn seam-handle-tree
+  "The L2/L3 seam node, as a PURE function of the live height, the
+  announced ARIA ceiling and a frame-bound dispatcher.
+
+  SPLIT OUT OF [[seam-handle-view]] BY rf2-k97c.3, and pure of its
+  arguments for the reason [[handle-tree]] is: it is what
+  `test-helpers.dynamic-shell-tree` composes into the node lane's
+  chrome, so a row walks the shipped seam markup rather than stopping
+  at a component head — and it needs neither a render window nor a
+  reading fallback arity to do it."
+  [current-height aria-max dispatch]
+  [:div {:data-testid      "rf-xray-event-list-seam"
+         :role             "separator"
+         :aria-orientation "horizontal"
+         :aria-label       "Resize events list"
+         :aria-valuemin    config/min-events-list-height-px
+         :aria-valuemax    aria-max
+         :aria-valuenow    current-height
+         :title            (str "Drag to resize events list · "
+                                "double-click to reset · "
+                                "arrow keys for fine resize (Shift = coarse) · "
+                                "Enter to reset")
+         :tab-index        0
+         :on-pointer-down  (fn [^js e]
+                             (start-seam-drag! e current-height dispatch))
+         :on-key-down      (fn [^js e]
+                             (when (handle-seam-keydown! e current-height dispatch)
+                               (try (.preventDefault e)
+                                    (catch :default _ nil))))
+         :on-double-click  (fn [^js _e]
+                             (dispatch
+                               [:rf.xray/reset-events-list-height]))
+         :style            (seam-handle-style)}])
+
+(rf.fresco/defview seam-handle-view
+  "The horizontal seam between the L2 event list and the L3 tab bar,
+  as a draggable resize affordance (rf2-t2dsh) — a FRESCO BOUNDARY
+  (rf2-k97c.3), not an `rf/reg-view`. Always renders: every mode that
+  mounts the L2 list (Dynamic chrome only; Static mode doesn't carry
+  L2) renders the seam.
 
   Per spec/007-UX-IA.md §Splitter affordance:
     - hover anywhere along the seam → `row-resize` cursor
@@ -691,33 +870,23 @@
       reset)
     - double-click resets to default
 
-  `reg-view`-wrapped per rf2-in6l2 so the inner subscribe routes
-  through React-context to `:rf/xray`."
-  []
-  (let [current-height @(rf/subscribe [:rf.xray/events-list-height-px])
-        viewport-h     (when (exists? js/window)
-                         (.-innerHeight js/window))
-        aria-max       (long (* (or viewport-h 1000)
-                                config/max-events-list-height-fraction))]
-    [:div {:data-testid      "rf-xray-event-list-seam"
-           :role             "separator"
-           :aria-orientation "horizontal"
-           :aria-label       "Resize events list"
-           :aria-valuemin    config/min-events-list-height-px
-           :aria-valuemax    aria-max
-           :aria-valuenow    current-height
-           :title            (str "Drag to resize events list · "
-                                  "double-click to reset · "
-                                  "arrow keys for fine resize (Shift = coarse) · "
-                                  "Enter to reset")
-           :tab-index        0
-           :on-pointer-down  (fn [^js e]
-                               (start-seam-drag! e current-height dispatch))
-           :on-key-down      (fn [^js e]
-                               (when (handle-seam-keydown! e current-height dispatch)
-                                 (try (.preventDefault e)
-                                      (catch :default _ nil))))
-           :on-double-click  (fn [^js _e]
-                               (dispatch
-                                 [:rf.xray/reset-events-list-height]))
-           :style            (seam-handle-style)}]))
+  HEADED DIRECTLY by `shell.cljs`'s `dynamic-chrome`, which is itself a
+  Fresco boundary. It was a `reagent.core/as-element` island until this
+  bead; the island's own recorded retiring condition was that migrating
+  only the seam \"would split one small file across two substrates for
+  no gain\", and this bead migrates the whole file — so the condition
+  is met, the crossing is gone and no bridge survives for it. Compare
+  [[Handle]], whose parent is still Reagent and which therefore keeps
+  one.
+
+  The read is `rf.fresco/sub` and the dispatcher is
+  `(:dispatch (rf/capture-frame))`, for the reasons [[handle-view]]'s
+  docstring gives.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. `dynamic-chrome` mounts it with none, so it is destructured
+  away."
+  [_props]
+  (seam-handle-tree (rf.fresco/sub [:rf.xray/events-list-height-px])
+                    (aria-max-events-list-height-px)
+                    (:dispatch (rf/capture-frame))))

--- a/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/resize_handle.cljs
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-xray.resize-handle
   "Resize affordances for the Xray shell: the LEFT-edge panel-width
   `Handle` (rf2-x8h9y + rf2-70u8q auto-inject contract) and the
-  L2/L3 seam `SeamHandle` (rf2-t2dsh) that drives the event-list
+  L2/L3 seam handle (rf2-t2dsh) that drives the event-list
   height.
 
   ## Two handles, one mental model
@@ -26,7 +26,7 @@
   `config/default-panel-width-px` (560px). Keyboard-navigable via
   arrow keys (8px step; 32px with Shift) and Home / End (clamp ends).
 
-  ## What `SeamHandle` is
+  ## What the seam handle is
 
   A full-width 8px-tall horizontal strip mounted between the L2 event
   list and the L3 tab bar in `dynamic-chrome`. Drag DOWN grows the
@@ -53,9 +53,11 @@
 
   If the layout host carries an explicit `resize: horizontal` (or
   `:both`) in its *computed* style, Xray interprets that as the
-  consumer asserting their own handle and renders nil from `Handle`
+  consumer asserting their own handle, and [[handle-view]] renders nil
   — no double-handle, the consumer wins. Detection happens at render
-  time via `getComputedStyle` on the host element.
+  time via `getComputedStyle` on the host element. The gate sits in the
+  BOUNDARY rather than in the [[Handle]] bridge on purpose: the bridge
+  is scaffolding that gets deleted, and this is shipped behaviour.
 
   ## Drag mechanics (global pointer capture)
 
@@ -148,10 +150,11 @@
   rendering no handle at all. [[Handle]] therefore decides in CLJS and
   passes no props; [[handle-view]] takes none.
 
-  The reads are deliberately left INSIDE their conditionals. A Fresco
-  body is dynamically composed — its branches and early returns are
-  free to follow the data it reads (HD-002) — so gating a `sub` costs
-  nothing and no conditional had to be surrendered to hoist it."
+  The panel handle's read is deliberately left INSIDE its yield
+  conditional. A Fresco body is dynamically composed — its branches and
+  early returns are free to follow the data it reads (HD-002) — so
+  gating a `sub` costs nothing, and no conditional had to be
+  surrendered in order to hoist a read out of one."
   (:require [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.config :as config]
@@ -244,7 +247,7 @@
   works without branching.
 
   `dispatch-fn` (rf2-nesy9) is the frame-aware dispatcher captured by
-  the `Handle` `reg-view` body; it is stashed in the drag-state so the
+  the [[handle-view]] boundary body; it is stashed in the drag-state so the
   document-level pointer-move listener (which fires after render
   unwinds) dispatches on the surrounding instance frame. Defaults to
   `rf/dispatch` for the test seam, which drives the lifecycle without a
@@ -345,7 +348,7 @@
   false and bubble normally.
 
   `dispatch-fn` (rf2-nesy9) is the frame-aware dispatcher captured by
-  the `Handle` `reg-view` body so the keyboard resize lands on the
+  the [[handle-view]] boundary body so the keyboard resize lands on the
   surrounding instance frame, not a `{:frame :rf/xray}` literal.
   Defaults to `rf/dispatch` for the test seam."
   ([^js e current-width] (handle-keydown! e current-width rf/dispatch))
@@ -659,7 +662,7 @@
   for the vertical axis.
 
   `dispatch-fn` (rf2-nesy9) is the frame-aware dispatcher captured by
-  the `SeamHandle` `reg-view` body; stashed in the seam-drag-state so
+  the [[seam-handle-view]] boundary body; stashed in the seam-drag-state so
   the document-level pointer-move listener dispatches on the
   surrounding instance frame. Defaults to `rf/dispatch` for the test
   seam.
@@ -742,7 +745,7 @@
   false and bubble normally.
 
   `dispatch-fn` (rf2-nesy9) is the frame-aware dispatcher captured by
-  the `SeamHandle` `reg-view` body. Defaults to `rf/dispatch` for the
+  the [[seam-handle-view]] boundary body. Defaults to `rf/dispatch` for the
   test seam."
   ([^js e current-height] (handle-seam-keydown! e current-height rf/dispatch))
   ([^js e current-height dispatch-fn]

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2885,17 +2885,23 @@
   hiccup head for the five region boundaries under it, so this is where
   the composition has to live.
 
-  TWO REAGENT ISLANDS, both still `rf/reg-view`s, both reached through
+  ONE REAGENT ISLAND, still an `rf/reg-view`, reached through
   `reagent.core/as-element` (the node lane's door passes `identity`, so
-  each stays the fn-headed vector a hiccup walker expands):
+  it stays the fn-headed vector a hiccup walker expands):
 
     * [[event-list]] — held back by a SHIPPED EMBED in a file another
       worker was holding, not by anything about the view. Its own
       docstring carries the measurement and the four-line recipe.
-    * `resize-handle/SeamHandle`. `resize_handle.cljs` also owns
-      `Handle`, which [[shell-view]] still mounts from a Reagent tree,
-      so migrating only the seam would split one small file across two
-      substrates for no gain.
+
+  THE SEAM'S ISLAND IS RETIRED (rf2-k97c.3), and it was retired by the
+  condition it was annotated with. It read: `resize_handle.cljs` also
+  owns `Handle`, which [[shell-view]] still mounts from a Reagent tree,
+  so migrating only the seam would split one small file across two
+  substrates for no gain. That bead migrated the WHOLE file, so the
+  condition is discharged — `resize-handle/seam-handle-view` is an
+  ordinary BOUNDARY HEAD here and the `as-element` crossing is gone.
+  `Handle` keeps a bridge in its own file because [[shell-view]] is
+  still Reagent; the seam needs none, because this view is not.
 
   The argument is the ordinary one-props-map vector every `defview`
   takes. [[surface-composer]] mounts it with none, so it is destructured
@@ -2918,7 +2924,7 @@
   (dynamic-chrome-tree [ribbon {}]
                        [events-ribbon {}]
                        (r/as-element [event-list])
-                       (r/as-element [resize-handle/SeamHandle])
+                       [resize-handle/seam-handle-view {}]
                        [tab-bar {}]
                        [detail-panel {}]))
 
@@ -3036,10 +3042,20 @@
   the landmark role and every modal mount.
 
   EVERYTHING HERE IS STILL REAGENT and stays so until the epic's coupling
-  (1) is severed: `resize-handle/Handle` and the seven modals are
-  `rf/reg-view`s mounted from a `reg-view` tree, which is exactly what
-  they have always been. They are NOT islands — nothing above them is a
-  boundary."
+  (1) is severed: the seven modals are `rf/reg-view`s mounted from a
+  `reg-view` tree, which is exactly what they have always been. They are
+  NOT islands — nothing above them is a boundary.
+
+  `resize-handle/Handle` is the one name here that is no longer a
+  `reg-view`, and it changes nothing at this mount site (rf2-k97c.3).
+  Its file migrated, so `Handle` is now a plain fn answering `[:> …]`
+  over Fresco's `as-component` bridge — which this Reagent tree heads
+  exactly as it always headed the `reg-view`, and which takes the
+  instance frame from the `rf/frame-provider` below through React
+  context. The mode gate stayed on this side of that crossing because
+  `as-component` round-trips prop names but not prop VALUES, and `mode`
+  is a keyword; `Handle` still takes it positionally, so the call below
+  is untouched."
   [{:keys [mode modal-positioning lens-mode frame-id]} surface*]
    ;; rf2-uu3lp — the outer `<div>` IS the shell-view's root so the
    ;; source-coord walk has a DOM node to annotate (Spec 006

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -2,7 +2,7 @@
   "CLJS tests for the L2/L3 events-list seam resize handle (rf2-t2dsh).
 
   Asserts:
-    1. `SeamHandle` mounts with the documented testid, role, and ARIA
+    1. The seam's markup carries the documented testid, role, and ARIA
        slots (`separator`, horizontal orientation, live `aria-valuenow`).
     2. The shell tree carries the seam BETWEEN the event-list and the
        tab-bar (DOM-order contract — the seam IS the boundary).
@@ -67,15 +67,39 @@
   [tree]
   (map (comp :data-testid rf.test-helpers/attrs) (rf.test-helpers/find-by-testid-prefix tree "")))
 
-;; ---- SeamHandle component shape ----------------------------------------
+;; ---- the seam's markup (rf2-k97c.3) ------------------------------------
+;;
+;; The seam is `resize-handle/seam-handle-view`, a Fresco BOUNDARY, since
+;; rf2-k97c.3 — it stopped being a `reagent.core/as-element` island when
+;; the whole of `resize_handle.cljs` migrated. Its `rf.fresco/sub` is
+;; legal only inside a boundary render, so calling the boundary from the
+;; node lane would raise `:rf.error/fresco-sub-outside-render` rather
+;; than answer hiccup. These rows drive the boundary's PURE inner fn
+;; instead, reading the same sub the boundary reads so `aria-valuenow`
+;; is still the LIVE height rather than a fixture constant.
+
+(defn- seam-markup
+  "The seam's node as `seam-handle-view` composes it.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))`, the same door the
+  boundary uses — not `rf/dispatch`. That is what routes through
+  `rf/dispatch-impl`, so the `with-redefs` row below sees the event;
+  passing `rf/dispatch` instead makes it silently observe nothing."
+  []
+  (resize-handle/seam-handle-tree
+    @(rf/subscribe [:rf.xray/events-list-height-px])
+    (resize-handle/aria-max-events-list-height-px)
+    (:dispatch (rf/capture-frame))))
+
+;; ---- seam markup shape -------------------------------------------------
 
 (deftest seam-handle-renders-with-aria-shape
   (setup!)
   (rf/with-frame :rf/xray
-    (let [tree (resize-handle/SeamHandle)
+    (let [tree (seam-markup)
           props (second tree)]
       (is (some? tree)
-          "SeamHandle returns a hiccup tree")
+          "the seam composes a hiccup tree")
       (is (= "rf-xray-event-list-seam" (:data-testid props))
           "testid is the documented contract")
       (is (= "separator" (:role props))
@@ -94,7 +118,7 @@
 (deftest seam-handle-style-uses-row-resize-cursor
   (setup!)
   (rf/with-frame :rf/xray
-    (let [tree (resize-handle/SeamHandle)
+    (let [tree (seam-markup)
           style (:style (second tree))]
       (is (= "row-resize" (:cursor style))
           "seam hover cursor signals vertical-axis resize")
@@ -265,7 +289,7 @@
                                       ([ev]       (swap! dispatches conj ev) nil)
                                       ([ev _opts] (swap! dispatches conj ev) nil))]
       (rf/with-frame :rf/xray
-        (let [tree    (resize-handle/SeamHandle)
+        (let [tree    (seam-markup)
               handler (:on-double-click (second tree))]
           (is (fn? handler)
               "the seam node carries on-double-click")

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -287,7 +287,15 @@
             aria-valuemax alongside aria-valuemin and aria-valuenow."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (resize-handle/Handle :inline)
+      ;; rf2-k97c.3 — `handle-view` is a Fresco boundary now and its
+      ;; `rf.fresco/sub` is legal only inside a render, so the node lane
+      ;; drives the boundary's PURE inner fn. The announced ceiling comes
+      ;; from the shipped helper rather than a literal, because the
+      ;; ceiling's derivation is what rf2-vxpq1 is about.
+      (let [tree   (resize-handle/handle-tree
+                     480
+                     (resize-handle/aria-max-panel-width-px)
+                     rf/dispatch)
             attrs  (second tree)]
         (is (some? (:aria-valuemax attrs))
             "aria-valuemax is set")

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -2,10 +2,13 @@
   "CLJS tests for the Xray shell's horizontal resize handle (rf2-x8h9y).
 
   Asserts:
-    1. `Handle` mounts on `:inline` mode and short-circuits to nil on
-       `:popout` / `:fullscreen`.
-    2. The shell-view tree carries the handle when in default
-       `:inline` mode.
+    1. `Handle` — the `as-component` bridge since rf2-k97c.3 — mounts on
+       `:inline` mode and short-circuits to nil on `:popout` /
+       `:fullscreen`, and `handle-tree` carries the documented markup.
+    2. The shell-view tree MOUNTS the handle when in default `:inline`
+       mode. A hiccup walk stops at the bridge's `[:>]` interop head, so
+       this is a mount assertion rather than a markup one; the markup is
+       (1)'s subject and the mounted boundary is the browser lane's.
     3. Drag lifecycle — `start-drag!` flips `dragging?` to true,
        `simulate-up!` flips it back. `simulate-move!` dispatches the
        set-panel-width-px event with the start + delta.
@@ -53,40 +56,100 @@
 ;; semantically identical to `re-frame.test-helpers`; tests call
 ;; `rf.test-helpers/find-by-testid` directly (rf2-vj80u8 — no Xray walker facade).
 
-;; ---- mount on :inline / short-circuit on others ------------------------
+;; ---- the handle's own markup (rf2-k97c.3) -------------------------------
+;;
+;; `handle-tree` is the boundary's PURE inner fn — of the live width, the
+;; announced ARIA ceiling and a dispatcher. Driving it directly is what
+;; the node lane can assert without a React render window: `handle-view`
+;; is a Fresco boundary and its `rf.fresco/sub` is legal only inside one,
+;; so calling the BOUNDARY here would raise
+;; `:rf.error/fresco-sub-outside-render` rather than answer hiccup.
 
-(deftest handle-renders-on-inline-mode
+(defn- handle-markup
+  "The handle's node as `handle-view` composes it.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))`, the same door the
+  boundary uses — not `rf/dispatch`. That is what routes through
+  `rf/dispatch-impl`, so the `with-redefs` rows below see the events;
+  passing `rf/dispatch` instead makes them silently observe nothing."
+  []
+  (resize-handle/handle-tree
+    @(rf/subscribe [:rf.xray/panel-width-px])
+    (resize-handle/aria-max-panel-width-px)
+    (:dispatch (rf/capture-frame))))
+
+(deftest handle-tree-carries-the-documented-testid
   (setup!)
   (rf/with-frame :rf/xray
-    (let [tree (resize-handle/Handle :inline)]
+    (let [tree (handle-markup)]
       (is (some? tree)
-          "Handle returns a hiccup tree when mode is :inline")
+          "handle-tree returns a hiccup tree")
       (is (= "rf-xray-resize-handle" (:data-testid (second tree)))
           "the testid is the documented contract"))))
 
+;; ---- mount on :inline / short-circuit on others ------------------------
+;;
+;; The MODE GATE is [[resize-handle/Handle]]'s whole remaining job since
+;; rf2-k97c.3: it is the `as-component` bridge `shell-view-tree` heads,
+;; and it decides in CLJS — before the props crossing — because
+;; `as-component` round-trips prop names but not prop VALUES, so a
+;; keyword `mode` would not survive it. Non-`:inline` still answers nil;
+;; `:inline` answers the bridge's `[:>]` vector rather than markup.
+
+(deftest handle-mounts-the-bridge-on-inline-mode
+  (setup!)
+  (let [tree (resize-handle/Handle :inline)]
+    (is (some? tree)
+        "Handle mounts on :inline")
+    (is (= :> (first tree))
+        "it mounts through the as-component bridge's interop head")))
+
 (deftest handle-short-circuits-on-popout
   (setup!)
-  (rf/with-frame :rf/xray
-    (is (nil? (resize-handle/Handle :popout))
-        "popout mode has no handle — the OS-window's chrome handles resize")))
+  (is (nil? (resize-handle/Handle :popout))
+      "popout mode has no handle — the OS-window's chrome handles resize"))
 
 (deftest handle-short-circuits-on-fullscreen
   (setup!)
-  (rf/with-frame :rf/xray
-    (is (nil? (resize-handle/Handle :fullscreen))
-        "fullscreen mode has no resize — the panel fills the viewport")))
+  (is (nil? (resize-handle/Handle :fullscreen))
+      "fullscreen mode has no resize — the panel fills the viewport"))
 
 ;; ---- shell mounts the handle in :inline mode ---------------------------
+;;
+;; rf2-k97c.3 — a hiccup walk of the shell STOPS at the bridge's `[:>]`
+;; interop head, exactly as `shell.cljs` already records for its own
+;; `surface-bridge`. So what these two rows owe is that the shell MOUNTS
+;; the handle in `:inline` and does not in `:popout`; the markup behind
+;; the bridge is `handle-tree`'s subject above, and the mounted
+;; boundary's is the browser lane's.
+
+(defn- interop-heads
+  "Every `[:> component …]` node in the expanded tree, in pre-order.
+  The shell carries one for the Fresco surface and, in `:inline` only,
+  one for the resize handle."
+  [tree]
+  (->> (rf.test-helpers/expand-tree tree)
+       ;; `sequential?` as the branch test walks hiccup vectors and the
+       ;; lazy child seqs `for` produces, and deliberately does NOT
+       ;; descend attribute maps — nothing mounts from one.
+       (tree-seq sequential? seq)
+       (filter #(and (vector? %) (= :> (first %))))))
 
 (deftest shell-mounts-resize-handle
-  (testing "the resize handle is present in the shell tree when mode
+  (testing "the resize handle is mounted in the shell tree when mode
             is :inline (the default for the production right-rail
             mount)"
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree (dynamic-shell-tree/shell-view-tree {:mode :inline})]
-        (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-resize-handle"))
-            "resize handle present in :inline mode")))))
+      (let [inline (count (interop-heads
+                            (dynamic-shell-tree/shell-view-tree {:mode :inline})))
+            popout (count (interop-heads
+                            (dynamic-shell-tree/shell-view-tree {:mode :popout})))]
+        (is (pos? inline)
+            "the :inline shell carries interop heads")
+        (is (= (inc popout) inline)
+            "the :inline shell carries exactly ONE bridge more than
+             :popout — the resize handle's")))))
 
 (deftest shell-omits-resize-handle-in-popout
   (testing "popout mode hides the handle — separate OS window owns resize"
@@ -94,7 +157,11 @@
     (rf/with-frame :rf/xray
       (let [tree (dynamic-shell-tree/shell-view-tree {:mode :popout})]
         (is (nil? (rf.test-helpers/find-by-testid tree "rf-xray-resize-handle"))
-            "resize handle absent in :popout mode")))))
+            "no handle markup in :popout mode")
+        (is (nil? (resize-handle/Handle :popout))
+            "and the mount site itself answers nil, which is what puts
+             it there — the row above cannot distinguish an absent
+             handle from one hidden behind a bridge")))))
 
 ;; ---- drag lifecycle ----------------------------------------------------
 
@@ -195,7 +262,7 @@
                                       ([ev]       (swap! dispatches conj ev) nil)
                                       ([ev _opts] (swap! dispatches conj ev) nil))]
       (rf/with-frame :rf/xray
-        (let [tree    (resize-handle/Handle :inline)
+        (let [tree    (handle-markup)
               handler (:on-double-click (second tree))]
           (is (fn? handler)
               "the handle node carries on-double-click")
@@ -304,7 +371,7 @@
 (deftest handle-renders-tabindex-and-aria-valuenow
   (setup!)
   (rf/with-frame :rf/xray
-    (let [tree (resize-handle/Handle :inline)
+    (let [tree (handle-markup)
           props (second tree)]
       (is (= 0 (:tab-index props))
           "handle is keyboard-reachable via tab")
@@ -368,30 +435,43 @@
         (finally
           (remove-stub-host! host))))))
 
-(deftest handle-renders-nil-when-host-yields
-  ;; The end-to-end yield: Handle short-circuits to nil when the host
-  ;; carries `resize: horizontal` in its computed style.
+;; rf2-k97c.3 — THE YIELD GATE LIVES IN `handle-view`, THE BOUNDARY, and
+;; deliberately not in the `Handle` bridge beside the mode gate. The
+;; bridge is scaffolding with a defined end: when `shell-view` becomes a
+;; boundary, `Handle` is DELETED. A spec'd product behaviour (rf2-70u8q)
+;; parked there would be deleted with it, silently. The mode gate is in
+;; the bridge only because a keyword cannot cross the props ABI, and it
+;; moves INTO the boundary as a prop when the bridge goes.
+;;
+;; The node lane cannot call a boundary — `rf.fresco/sub` is legal only
+;; inside a render — so these two rows assert the PREDICATE the boundary
+;; gates on, plus the markup it gates. The composition of the two is the
+;; browser lane's subject.
+
+(deftest handle-yields-when-host-asserts-own-handle
   (when (exists? js/document)
     (let [host (ensure-stub-host! "horizontal")]
       (try
         (setup!)
-        (rf/with-frame :rf/xray
-          (is (nil? (resize-handle/Handle :inline))
-              "yield path: Handle returns nil when consumer asserts own resize"))
+        (is (true? (resize-handle/host-asserts-own-handle?))
+            "yield path: the gate `handle-view` short-circuits on is true,
+             so the boundary renders nil and the page carries one handle")
         (finally
           (remove-stub-host! host))))))
 
 (deftest handle-renders-when-host-does-not-yield
-  ;; The end-to-end no-yield: Handle renders when host has no
-  ;; explicit resize declaration (the zero-config consumer path).
+  ;; The no-yield path: the zero-config consumer, who declares no
+  ;; `resize` at all and gets Xray's handle.
   (when (exists? js/document)
     (let [host (ensure-stub-host! nil)]
       (try
         (setup!)
         (rf/with-frame :rf/xray
-          (let [tree (resize-handle/Handle :inline)]
+          (is (false? (resize-handle/host-asserts-own-handle?))
+              "no-yield path: the boundary's gate is false, so it renders")
+          (let [tree (handle-markup)]
             (is (some? tree)
-                "no-yield path: Handle renders when consumer has no own resize")
+                "and the markup it then composes is present")
             (is (= "rf-xray-resize-handle" (:data-testid (second tree)))
                 "the rendered tree is the documented handle node")))
         (finally

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
@@ -115,6 +115,31 @@
       :now-ms          (or @(rf/subscribe [:rf.xray/relative-time-now-ms])
                            (rf.interop/now-ms))})))
 
+(defn seam-handle-tree
+  "The L2/L3 seam's hiccup, read the way
+  `resize-handle/seam-handle-view` reads it.
+
+  Added by rf2-k97c.3, when the seam stopped being a
+  `reagent.core/as-element` island and became an ordinary Fresco
+  boundary headed by `shell/dynamic-chrome`. Before that this position
+  was the plain `[resize-handle/SeamHandle]` vector `expand-tree`
+  walked; now the seam is a boundary, so a vector headed by it would
+  stop the walk at a component head and a row would assert nothing
+  about the seam's markup. Driving the shipped `*-tree` fn is what
+  keeps that row evidence about the shipped seam.
+
+  `aria-max-events-list-height-px` is the boundary's own helper rather
+  than a literal, for the reason this ns reproduces reads rather than
+  fixing them: it reads `js/window`, which is absent under node, and
+  the helper's documented 1000px fallback is then exactly what the
+  boundary would announce."
+  ([] (seam-handle-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (resize-handle/seam-handle-tree
+     @(rf/subscribe [:rf.xray/events-list-height-px])
+     (resize-handle/aria-max-events-list-height-px)
+     dispatch)))
+
 (defn tab-bar-tree
   "The L3 tab bar's hiccup, read the way `shell/tab-bar` reads it — the
   raw `:rf.xray/selected-tab` value, with no `default-tab` fallback,
@@ -156,19 +181,22 @@
   its `data-rf-xray-dynamic-chrome` handle are the shipped definitions
   rather than a copy of them.
 
-  The chrome's TWO ISLANDS — `shell/event-list` (still an `rf/reg-view`;
-  its own docstring says why) and `resize-handle/SeamHandle` — are what
-  the boundary crosses with `reagent.core/as-element`. Here the seam
-  handle is the plain `[resize-handle/SeamHandle]` vector `expand-tree`
-  walks, and the L2 list is driven through `shell/event-list-tree` the
-  same way every other region is, so a row still walks the shipped L2
-  chrome rather than stopping at a component head."
+  The chrome's ONE REMAINING ISLAND is `shell/event-list` (still an
+  `rf/reg-view`; its own docstring says why), which the boundary crosses
+  with `reagent.core/as-element`. Here the L2 list is driven through
+  `shell/event-list-tree` the same way every other region is, so a row
+  still walks the shipped L2 chrome rather than stopping at a component
+  head.
+
+  THE SEAM WAS THE SECOND ISLAND AND IS NO LONGER ONE (rf2-k97c.3): it
+  is an ordinary Fresco boundary now, so it is driven through
+  [[seam-handle-tree]] exactly as every other region is."
   ([] (dynamic-chrome-tree (:dispatch (rf/capture-frame))))
   ([dispatch]
    (shell/dynamic-chrome-tree (ribbon-tree dispatch)
                               (events-ribbon-tree dispatch)
                               (event-list-tree dispatch)
-                              [resize-handle/SeamHandle]
+                              (seam-handle-tree dispatch)
                               (tab-bar-tree dispatch)
                               (detail-panel-tree))))
 


### PR DESCRIPTION
Slice B5 of the rf2-k97c.3 chrome-satellite split: `tools/xray/src/day8/re_frame2_xray/resize_handle.cljs` (723 lines, both views) onto the re-frame-native view layer.

## What changed

Both views become `rf.fresco/defview` boundaries, each split into a PURE `*-tree` fn of its already-read values plus a frame-bound dispatcher — the shipped `shell.cljs` shape. Reads move from ambient `@(rf/subscribe …)` to `rf.fresco/sub`; the dispatcher comes from `(:dispatch (rf/capture-frame))`, because `defview` binds no lexical `dispatch` the way `reg-view` did.

**The two boundaries mount differently, because the taxonomy keys on the PARENT:**

| view | parent | treatment |
|---|---|---|
| `seam-handle-view` | `shell.cljs`'s `dynamic-chrome` — already a Fresco boundary | headed DIRECTLY; the `as-element` island is RETIRED |
| `handle-view` | `shell.cljs`'s `shell-view-tree` — still Reagent | T5 bridge via `rf.fresco/as-component` |

## The three `shell.cljs` sites — deliberate, and conditioned

Called out explicitly so a reviewer sees the island retirement was not incidental. `shell.cljs` was authorised for exactly these three and nothing else.

1. **The seam head.** `(r/as-element [resize-handle/SeamHandle])` → `[resize-handle/seam-handle-view {}]`.
2. **`dynamic-chrome`'s docstring** — "TWO REAGENT ISLANDS" → "ONE".
3. **`shell-view-tree`'s docstring** — `resize-handle/Handle` is no longer an `rf/reg-view`.

**Why the island was retired rather than left alone.** Its own recorded retiring condition was that migrating only the seam *"would split one small file across two substrates for no gain"*. This bead migrates the WHOLE file, so the condition is discharged. Every island in this tree is annotated with the condition that retires it precisely so a later worker can retire it when the condition arrives.

Leaving sites 2 and 3 unedited was the alternative. It would have left two docstrings factually false, in a file nobody is scheduled to revisit — a stale doc claim that outlived the code it described.

`[resize-handle/Handle mode]` is UNCHANGED. The bridge keeps the name and the positional arity, so the mount site did not have to move.

## The mode gate stays on the Reagent side, and that is load-bearing

`as-component`'s contract is that prop NAMES round-trip and prop VALUES do not. The keyword `:inline` would arrive as the string `"inline"`, `(= mode :inline)` would be false for ever, and the handle would silently never render. `Handle` therefore decides in CLJS and passes no props.

The YIELD gate (rf2-70u8q) goes the other way — it stays in the BOUNDARY. The bridge is scaffolding that gets deleted when `shell-view` becomes a boundary; a spec'd product behaviour parked there would be deleted with it. Both are documented with the condition that retires them, so a later reader need not guess whether either was missed.

## Q1 / Q2, applied

**Q1 — is the hiccup head-free all the way down?** Yes, vacuously: a three-pass census (line-oriented, whitespace-collapsed, comment-stripped-and-collapsed, all three agreeing, controls biting) found **zero symbol-headed hiccup vectors** in the file. Every vector is `[:div …]`; `handle-style` and `seam-handle-style` were already CALLED. So T1 had nothing to inline and T2 never arose.

**Q2 — does it read the substrate or hold per-instance state?** Given an actual read, because a resize handle is the likeliest satellite to hold real DOM and pointer state.

- **The census is NOT contradicted.** Zero `r/atom`, zero `with-let`, zero Reagent form-2/form-3, zero `reagent` requires, zero `ResizeObserver`. The PR #9655 `container-ref-for` precedent does not apply — this file uses document-level pointer events, not observers.
- **It does hold real mutable drag state** — two `defonce` module-level atoms plus `js/document` listeners and a body-cursor override. That is NOT form-2 state, and the distinction is what makes the migration safe: the state is MODULE-level, so a `defview` re-render does not reallocate it. Contrast `edn_inspector`, whose form-2 outer body allocates per-mount and would rebuild its observer per render.
- **Reads were already in the right place.** Both reads sit in the view bodies, and every handler (`start-drag!`, `handle-keydown!`, and the seam pair) already takes width/height as an ARGUMENT rather than reading. Nothing donates a read into a non-render caller.
- **Reads stayed inside their conditionals.** A Fresco body's branches and early returns are free to follow the data it reads (HD-002), so no conditional was surrendered in order to hoist a read.

**The real bite was the TESTS**, which called both views directly, outside any render — exactly `:rf.error/fresco-sub-outside-render`. The `*-tree` split fixes it, and the trees carry NO reading fallback arity: an arity dead in production would be a reading path in a file this migration exists to empty.

## Quality gates

Every number below is the exit code captured on the runner's own command line and echoed, never one reported about the run. **In three separate runs the harness reported exit 0 for a run whose captured exit was 1** — the captured number is the verdict here.

| gate | phase | captured exit | result |
|---|---|---|---|
| `node-test` compile (final base) | compile | **0** | 1951 files, **0 warnings** |
| `node-test` suite (final base) | test | **0** | **11699 tests / 58602 assertions, 0 failures, 0 errors** |
| `browser-test` compile | compile | **0** | — |
| `browser-test` suite | test | **0** | **945 tests / 5241 assertions, 0 failures, 0 errors** |
| Xray feature gate (PR-smoke) | — | **0** | 5 scenarios, 0 failures, 10 matrix rows |
| `check_retired_spellings` | — | **0** | no retired product name introduced (0 in diff; control 36) |
| `check_require_alias_dialect` | — | **0** | the new `rf.fresco` alias conforms |
| `check_ambient_durable_reads` | — | **0** | — |
| `check_retired_composition_vocab` | — | **0** | — |
| `check_architecture_census` | — | **0** | 27 sources, 0 findings |

The test phase is gated on the compile phase's captured exit, not chained to it, so a failed compile cannot be masked by a stale artefact being served.

Gates were re-run on the FINAL BASE after rebasing onto funnel-b's `8ec185b880`; the test count rose 11687 → 11699, which is the evidence the new base was actually exercised.

### Proof it can fail — two sabotage cycles

**1. Node lane — does the gate see the seam through the newly-rewired composition?**
Planted a wrong testid in `seam-handle-tree`. Blob hash moved `aa70edc6…` → `606150b8…`, so the plant was not a silent no-op. Captured exit **1**, 3 failures, and the output named the planted token. Critically one of them was `shell-mounts-seam-between-list-and-tab-bar`, which walks `shell-view-tree` → `dynamic-chrome-tree` → the new `seam-handle-tree` door — so the migration's own wiring is demonstrably live. Restored; blob hash returned to `aa70edc6…` exactly and `git diff --quiet HEAD` exited 0. Re-run captured exit **0**.

**2. Browser lane — is the new head LEGAL?**
This one matters because **the node lane structurally cannot grade head legality**: `expand-tree` INVOKES a fn head, so `[f …]` and `(f …)` expand identically and a plain fn in head position inside a boundary passes every node row while grading `:invalid` at runtime. De-islanding the seam is precisely a head-legality change.

Planted the exact defect class — replaced the legal `defview` head with a PLAIN FN head (`[resize-handle/seam-handle-tree 200 700 nil]`) inside the `dynamic-chrome` boundary. Blob hash `05665bb4…` → `9cfa82d6…`. Captured exit **1**, **23 failures, every one in `shell_fresco_boundary_dom_cljs_test`** — W1 (chrome paints), W2 (reads are live), W3 (captured dispatcher), W4 (teardown). Restored; hash returned to `05665bb4…` exactly, `git diff --quiet HEAD` exit 0.

That is the positive evidence the browser lane both RUNS that witness and CATCHES an illegal head — the browser log carries only an aggregate summary, so a search of it would have proven nothing either way.

**The seam renders under DEFAULT state**, verified rather than assumed: `dynamic-chrome` renders it unconditionally (no gate), and `:rf.xray/mode` defaults to `:dynamic` via `(get db :mode :dynamic)`. So it has none of the render-only-under-non-default-state blind spot, and the witness above genuinely drove it.

## Scope

`panels.cljs`, `panels/**`, `shell_cljs_test.cljs`, `panel_gallery/panel_views.cljs`, `frame_switcher.cljs` and `static/mode_pill.cljs` are untouched. The seven shell-root modals are untouched — a `defview` is not a legal Reagent head, so migrating them needs a `shell.cljs` edit that belongs to the root swap, not here.
