### PR TITLE
feat(xray): migrate the settings chrome to Fresco boundaries (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -134,10 +134,12 @@
 ;; ---- view ---------------------------------------------------------------
 
 (defn toast-view
-  "Hiccup for the open editor-hint toast. The caller (`Toast`) gates
-  the mount on `:rf.xray/editor-hint-open?`. `dispatch` is
-  the frame-aware dispatcher injected by the `reg-view` body so the
-  deferred `:on-click` handlers land on the surrounding instance frame."
+  "Hiccup for the open editor-hint toast. The caller that gates the
+  mount on `:rf.xray/editor-hint-open?` is [[Hint]] — since rf2-k97c.3
+  the gate lives in the boundary rather than in the [[Toast]] bridge.
+  `dispatch` is the frame-bound dispatcher [[Hint]] captured with
+  `(:dispatch (rf/capture-frame))`, so the deferred `:on-click`
+  handlers land on the surrounding instance frame."
   [dispatch]
   ;; The PRIMARY, reachable Esc-dismissal path is the
   ;; shell-level global keydown listener (`keybinding/handle-keydown`),

--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -44,8 +44,17 @@
       :rf.xray/editor-hint-open?         — sub: drives the toast mount
 
   Mounted at the shell-view root (sibling to the other modals) so its
-  subscribe resolves through the shell's `:rf/xray` frame-provider."
+  read resolves through the shell's `:rf/xray` frame-provider.
+
+  ## rf2-k97c.3 — the toast is a FRESCO BOUNDARY
+
+  [[Hint]] is an `rf.fresco/defview`, not an `rf/reg-view`. [[toast-view]]
+  needed no change at all: it already performed ZERO reads and was
+  already a pure fn of `dispatch`, so the migration is confined to the
+  boundary and the one-line bridge [[Toast]] the Dynamic shell still
+  mounts by name."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -178,15 +187,65 @@
              :style       (open-settings-button-style)}
     "Open Settings"]])
 
-(rf/reg-view Toast
-  "The open-in-editor editor-hint toast. Renders only when
-  `:rf.xray/editor-hint-open?` is true; closed-state is a single
-  subscribe + a `when` — cheap.
+(rf.fresco/defview Hint
+  "The open-in-editor editor-hint toast — a FRESCO BOUNDARY
+  (rf2-k97c.3), a real React function component rather than an
+  `rf/reg-view`.
 
-  `reg-view`-registered so the body's subscribes route through the
-  React-context tier to `:rf/xray`. The reg-view-injected `dispatch`
-  is threaded into `toast-view` so the deferred `:on-click` handlers
-  land on the surrounding instance frame."
+  Renders only when `:rf.xray/editor-hint-open?` is true, and the
+  closed-state cost is unchanged at ONE read and a `when`:
+  `rf.fresco/sub` is legal inside a `when` and records its edge where
+  the read happens (HD-002), so a branch not taken contributes no edge.
+
+  ONE READ, ONE BOUNDARY. The read is `rf.fresco/sub` — a plain call the
+  shipped collector records an edge for, rather than a deref of a
+  reaction the installed adapter owns. It is also a GOOD frame witness,
+  unlike most of the settings reads next door: `:rf.xray/editor-hint-open?`
+  is `(get db :editor-hint-open? false)` (registered in [[install!]]
+  above), a plain app-db read with a literal fallback, so it cannot be
+  satisfied by a process-global atom under a wrong frame.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body. It replaces
+  the name `reg-view` used to inject lexically: `defview` binds NO name
+  inside your body, so the bare `dispatch` the old body closed over
+  would be a LOUD compile error.
+
+  [[toast-view]] is unchanged — it reads nothing and always was a pure
+  fn of `dispatch`, so it needed no hoist and stays callable from the
+  node lane exactly as before.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[Toast]] mounts it with none, so it is destructured away."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/editor-hint-open?])
+    (toast-view (:dispatch (rf/capture-frame)))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Same shape, and the same defined end, as `settings/popup.cljs`'s bridge —
+;; its comment carries the full reasoning and is not repeated here.
+;; `shell.cljs`'s `shell-view` is still an `rf/reg-view` and mounts this
+;; toast as the Reagent hiccup head `[editor-hint/Toast]`, which a React
+;; component cannot be; `rf.fresco/as-component` is the outward door, and
+;; the frame comes from the enclosing `rf/frame-provider` through React
+;; context. When `shell-view` becomes a boundary it heads `Hint` directly
+;; and both defs below are deleted.
+
+(def ^:private Hint-component
+  "The React component [[Hint]] presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the toast on each parent render."
+  (rf.fresco/as-component Hint))
+
+(defn Toast
+  "The callable `shell.cljs` mounts, as `[editor-hint/Toast]`. Returns
+  Reagent-shaped hiccup interoping to the React component above.
+
+  It KEEPS THE NAME because the mount site is in a file this slice does
+  not own. The gate moved INTO [[Hint]], so this bridge is unconditional
+  and the `nil`-when-closed answer now comes from the boundary rather
+  than from here — the committed DOM is identical either way."
   []
-  (when @(rf/subscribe [:rf.xray/editor-hint-open?])
-    (toast-view dispatch)))
+  [:> Hint-component {}])

--- a/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
@@ -3,10 +3,11 @@
 
   Per `tools/xray/spec/018-Event-Spine.md` §9 Settings popup the
   modal is a transient overlay rather than a sidebar panel: open,
-  tweak, close. The same facade pattern as `palette.cljs` —
-  `reg-view`-wrapped `Modal` that short-circuits to nil when
-  `:rf.xray/settings-open?` is false; closed-state cost is one
-  subscribe + a `when`.
+  tweak, close. The same facade pattern as `palette.cljs` — a
+  short-circuit to nil when `:rf.xray/settings-open?` is false, with
+  a closed-state cost of one read + a `when`. Since rf2-k97c.3 that
+  gate lives in the [[Popup]] boundary rather than in the [[Modal]]
+  bridge, which is now unconditional; see the section below.
 
   ## Sections
 

--- a/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/popup.cljs
@@ -42,30 +42,138 @@
   ## Why the shell mounts the Modal
 
   Same rationale as the palette modal — mounting at the shell-root
-  means the subscribes resolve through the same `frame-provider` the
+  means the reads resolve through the same `frame-provider` the
   shell installed (`:rf/xray`), and the dispatches land on Xray's
   app-db rather than the host's. A `js/document.body` portal would
-  lose the frame context and silently read/write `:rf/default`."
+  lose the frame context and silently read/write `:rf/default`.
+
+  ## rf2-k97c.3 — the popup is a FRESCO BOUNDARY
+
+  [[Popup]] is an `rf.fresco/defview`, not an `rf/reg-view`. It owns
+  every read the popup performs — its own gate plus the thirteen this
+  namespace hoisted out of `settings/view.cljs` — and hands their values
+  to the pure `view/popup-tree`. [[Modal]] survives as the one-line
+  bridge the Dynamic shell still needs; its docstring carries the
+  condition that deletes it."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.settings.events :as events]
             [day8.re-frame2-xray.settings.subs :as subs]
             [day8.re-frame2-xray.settings.view :as view]))
 
-(rf/reg-view Modal
-  "The settings popup modal. Renders only when
-  `:rf.xray/settings-open?` is true; closed-state is a single
-  subscribe + a `when` — cheap.
+(rf.fresco/defview Popup
+  "The settings popup modal — a FRESCO BOUNDARY (rf2-k97c.3), a real
+  React function component rather than an `rf/reg-view`.
 
-  `reg-view`-registered so the body's subscribes route through the
-  React-context tier to `:rf/xray`.
+  Renders only when `:rf.xray/settings-open?` is true. CLOSED-STATE COST
+  IS STILL ONE READ AND A `when`: `rf.fresco/sub` is legal inside a
+  `when` and records its edge WHERE THE READ HAPPENS (HD-002), so a
+  branch not taken contributes no edge and a closed popup holds one
+  subscription, not fourteen.
 
-  The reg-view-injected `dispatch` (the frame-aware dispatcher
-  captured at render time) is threaded into `popup-view` so every
-  deferred `:on-*` handler in the popup tree lands on the surrounding
-  instance frame, not a `{:frame :rf/xray}` literal."
+  ## The reads
+
+  All fourteen are `rf.fresco/sub` — plain calls the shipped collector
+  records an edge for. No deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. That is the third of the epic's three
+  couplings, and the one a first-paint smoke test cannot see.
+
+  THIRTEEN OF THEM WERE HOISTED OUT OF `settings/view.cljs`, where they
+  sat inside [[view/popup-tree]] and its four section helpers.
+  `rf.fresco/sub` refuses outside a boundary render, so leaving them to
+  donate upward would have narrowed those helpers to being callable only
+  inside a React commit — and seven node-lane rows call
+  [[view/popup-tree]] directly. The cost of hoisting is one lost
+  conditional, recorded on [[view/popup-tree]]: all four tabs' slots are
+  read while the popup is open, where before only the active tab's were.
+
+  A NOTE FOR WHOEVER WRITES THE NEXT WITNESS FOR THIS SURFACE: eleven of
+  these queries are BAD witnesses for frame routing. `:rf.xray/setting`
+  is `(or (get-in db [:settings section key]) (config/get-setting …))`
+  (`settings/subs.cljs`), so every parameterised setting read falls
+  through to a PROCESS-GLOBAL atom when the app-db slot is unseeded — it
+  answers correctly under a deliberately wrong frame and witnesses
+  nothing. `:rf.xray/settings-open?`, `:rf.xray/settings-active-tab` and
+  `:rf.xray/settings-clear-confirm-open?` are the three whose reads
+  actually traverse the frame; their fallbacks are literals.
+
+  ## The dispatcher
+
+  `(:dispatch (rf/capture-frame))` — core's own door, which Fresco's
+  authoring surface deliberately does not duplicate, and which answers
+  the boundary's DECLARED frame inside a body. It replaces the name
+  `reg-view` used to inject lexically: `defview` binds NO name inside
+  your body, so the bare `dispatch` the old body closed over would be a
+  LOUD compile error, which is the good failure.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. [[Modal]] mounts it with none, so it is destructured away."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/settings-open?])
+    (view/popup-tree
+      (:dispatch (rf/capture-frame))
+      {:active-tab      (rf.fresco/sub [:rf.xray/settings-active-tab])
+       :positioning     (rf.fresco/sub [:rf.xray/modal-positioning])
+       :general         {:panel-position       (rf.fresco/sub [:rf.xray/setting :general :panel-position])
+                         :auto-open?           (rf.fresco/sub [:rf.xray/setting :general :auto-open-on-error?])
+                         :epoch-history        (rf.fresco/sub [:rf.xray/setting :general :epoch-history])
+                         :show-ungrouped?      (rf.fresco/sub [:rf.xray/show-ungrouped?])
+                         :show-unchanged-subs? (rf.fresco/sub [:rf.xray/setting :general :show-unchanged-subs?])
+                         :editor-override      (rf.fresco/sub [:rf.xray/setting :general :editor-override])
+                         :host-editor          (rf.fresco/sub [:rf.xray/editor-host-default])}
+       :highlight?      (rf.fresco/sub [:rf.xray/setting :diff :highlight-fn-ref-changes?])
+       :keys-on?        (rf.fresco/sub [:rf.xray/keybinding-enabled?])
+       :events-retained (rf.fresco/sub [:rf.xray/setting :buffer :events-retained])
+       :confirm-open?   (rf.fresco/sub [:rf.xray/settings-clear-confirm-open?])})))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `shell.cljs`'s `shell-view` is STILL an `rf/reg-view` — it is the Reagent
+;; root `mount.cljs` renders through the installed adapter's `:render`, and
+;; severing that is the parent epic's coupling (1), a later slice — and it
+;; mounts this modal as the Reagent hiccup head `[settings-popup/Modal]`.
+;; A React component is not a legal Reagent head, so the name that file
+;; reaches for has to stay a callable answering Reagent-shaped hiccup.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS ALREADY
+;; IN, taking the frame from React context rather than from a second root.
+;; So there is no second root here, no adapter-kind branch and no props ABI.
+;;
+;; THE PLAIN-FN FOOTGUN DOES NOT BITE THIS BRIDGE, and that is worth saying
+;; because the shell's own ns docstring warns about it: a plain Reagent fn
+;; skips the React-context tier, so an AMBIENT READ inside one would raise
+;; `:rf.error/no-frame-context`. [[Modal]] performs no read and no dispatch
+;; — it only mounts a React element. React context flows by the ELEMENT
+;; tree, not by Reagent's `:contextType`, so the enclosing
+;; `rf/frame-provider` reaches [[Popup]] regardless. `shell.cljs`'s own
+;; `surface-bridge` is this identical shape, shipped and green.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When `shell-view` is itself a
+;; Fresco boundary it heads `Popup` directly, `[:>]` goes, and both defs
+;; below are deleted.
+
+(def ^:private Popup-component
+  "The React component [[Popup]] presents as, for a non-Fresco parent.
+  Declared once at top level beside the view, as `rf.fresco/as-component`'s
+  contract requires — deriving it per render would mint a new component
+  type every time and remount the modal on each parent render."
+  (rf.fresco/as-component Popup))
+
+(defn Modal
+  "The callable `shell.cljs` mounts, as `[settings-popup/Modal]`. Returns
+  Reagent-shaped hiccup interoping to the React component above; the
+  shell's enclosing `rf/frame-provider` is what puts the instance frame in
+  React context for it.
+
+  It KEEPS THE NAME because the mount site is in a file this slice does not
+  own. The gate moved INTO [[Popup]], so this bridge is unconditional and
+  the `nil`-when-closed answer now comes from the boundary rather than from
+  here — the committed DOM is identical either way."
   []
-  (when @(rf/subscribe [:rf.xray/settings-open?])
-    (view/popup-view dispatch)))
+  [:> Popup-component {}])
 
 (defn install!
   "Idempotent install for the settings popup's Xray-side

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -1,43 +1,57 @@
 (ns day8.re-frame2-xray.settings.view
   "Pure-hiccup view for the Xray Settings popup modal (rf2-9poxq).
 
-  The view body is a plain Reagent fn; `settings/popup.cljs` wraps
-  it in `reg-view` so subscribes route to `:rf/xray`. Visual style
-  mirrors the palette modal (dim backdrop, centred dialog,
-  `tokens/bg-1` body) so the user gets a consistent affordance
-  class for transient overlays.
+  ## rf2-k97c.3 — THIS NAMESPACE READS NOTHING
+
+  Every fn here is now a PURE function of its arguments. The thirteen
+  ambient `@(rf/subscribe …)` reads this file used to perform are
+  hoisted into `settings/popup.cljs`'s Fresco boundary, which is why
+  `re-frame.core` is no longer required at all — the one measurement
+  that says the hoist is complete rather than mostly done.
+
+  The reason is mechanical, not stylistic. `rf.fresco/sub` refuses
+  outside a boundary render — `impl.collector/read-key!` raises
+  `:rf.error/fresco-sub-outside-render`, and its own message names the
+  remedy — so migrating a read INSIDE a helper narrows that helper to
+  being callable only within a React commit. [[popup-tree]] had seven
+  callers outside any render, all of them node-lane rows. Hoisting keeps
+  them working: a pure fn needs neither a render window nor
+  `subscribe-once`.
+
+  The node lane's door is in the TEST tree
+  (`test-helpers/settings-modal-tree`), mirroring
+  `test-helpers/dynamic_shell_tree` — deliberately NOT a reading arity
+  kept here, which would be a read path in the one file this migration
+  exists to empty.
+
+  Visual style mirrors the palette modal (dim backdrop, centred dialog,
+  `tokens/bg-1` body) so the user gets a consistent affordance class for
+  transient overlays.
 
   ## Why every deferred dispatch captures the surrounding frame (rf2-smvvz / rf2-r0o63 / rf2-nesy9)
 
-  Subscribes resolve through the React-context tier at RENDER time —
-  React's `_currentValue` for the `frame-context` is set to the
-  instance frame while the body of the `frame-provider`'s children is
-  rendering, so `(rf/subscribe …)` from inside the popup picks up the
-  right frame with no explicit opt.
-
-  Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire
-  LATER — after render commits and React has POPPED `_currentValue`
-  back to the context's no-provider sentinel. At click time the frame
-  resolution chain (dynamic var → React-context tier) bottoms out at
-  NIL: there is no `:rf/default` floor under EP-0002, so a bare
-  `rf/dispatch` RAISES `:rf.error/no-frame-context` and nothing lands
-  anywhere — Xray's `:settings-open?` flag is left untouched. Symptom:
-  X button does nothing, tabs do not switch, Esc does not close — the
-  modal is stuck.
+  Reads resolve at RENDER time, inside the boundary. Dispatches from
+  `:on-click` / `:on-change` / `:on-key-down` fire LATER — after render
+  commits and React has POPPED the frame context's `_currentValue` back
+  to its no-provider sentinel. At click time the frame resolution chain
+  (dynamic var → React-context tier) bottoms out at NIL: there is no
+  `:rf/default` floor under EP-0002, so a bare `rf/dispatch` RAISES
+  `:rf.error/no-frame-context` and nothing lands anywhere — Xray's
+  `:settings-open?` flag is left untouched. Symptom: X button does
+  nothing, tabs do not switch, Esc does not close — the modal is stuck.
 
   An EARLIER fix pinned every deferred handler to a `{:frame :rf/xray}`
   literal — correct for the singleton shell, but it entrenched the
   one-frame lock (rf2-1w07r): two shells on a page collided on the one
   global app-db. The current contract (rf2-r0o63 / rf2-nesy9) captures
-  the SURROUNDING instance frame instead: `settings/popup.cljs`'s
-  `Modal` `reg-view` body has a frame-aware `dispatch` injected by the
-  macro (closing over the render-time frame), and threads it into
-  `popup-view`, which fans it out to every section helper. Each
-  deferred handler calls that captured `dispatch` (never the global
-  `rf/dispatch`, never a literal), so N isolated instances each route
-  to their own frame."
-  (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
+  the SURROUNDING instance frame instead, and the migration preserves it
+  exactly: the boundary takes its dispatcher from
+  `(:dispatch (rf/capture-frame))` — core's own door, which answers the
+  boundary's DECLARED frame — and threads it into [[popup-tree]], which
+  fans it out to every section helper. Each deferred handler calls that
+  captured `dispatch` (never the global `rf/dispatch`, never a literal),
+  so N isolated instances each route to their own frame."
+  (:require [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -245,7 +259,23 @@
   [id]
   (str "rf-xray-settings-tabpanel-" (name id)))
 
-(defn- tab-button [dispatch {:keys [id label]} active?]
+(defn- tab-button
+  "One tab in the strip, as hiccup. CALLED rather than headed
+  (rf2-k97c.3) — the standard HD-016 repair, since every vector this
+  answers is keyword-headed all the way down.
+
+  It carries its OWN `:key`, which is the T2 cost of that inlining paid
+  in the cheapest available place. [[popup-tree]] builds the strip with
+  a `for`, so React needs a key per child; before the inlining the key
+  would have sat on the `[tab-button …]` vector, and a keyed fragment
+  around the call is the general remedy. Neither is needed here because
+  this helper already owns an attrs map and already knows `id` — so the
+  key goes in the attrs map, which is this file's standing convention
+  (`editor-override-section`, the panel-position radios and the
+  keybindings table all key that way, per rf2-a38l) and adds no DOM
+  node. A keyword `:key` is a plain key to Fresco's codec, the same as
+  to Reagent."
+  [dispatch {:keys [id label]} active?]
   ;; rf2-h4mnh — Settings popup inner tabs now carry the full WAI-
   ;; ARIA tab role: `role="tab"` + `aria-selected` per state +
   ;; stable `id` (so the body's `aria-labelledby` resolves) +
@@ -253,7 +283,8 @@
   ;; pattern Xray already ships on the L3 Dynamic + Static tab
   ;; strips (shell.cljs/tab-button). Keeps `:data-active` for
   ;; styling-key parity with existing CSS selectors / tests.
-  [:button {:data-testid    (str "rf-xray-settings-tab-" (name id))
+  [:button {:key            id
+            :data-testid    (str "rf-xray-settings-tab-" (name id))
             :id             (settings-tab-button-id id)
             :role           "tab"
             :aria-selected  (if active? "true" "false")
@@ -450,14 +481,19 @@
        ":rf.xray/editor"]
       " default doesn't match your installed editor."]]))
 
-(defn- general-section [dispatch]
-  (let [panel-position  @(rf/subscribe [:rf.xray/setting :general :panel-position])
-        auto-open?      @(rf/subscribe [:rf.xray/setting :general :auto-open-on-error?])
-        epoch-history   @(rf/subscribe [:rf.xray/setting :general :epoch-history])
-        show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
-        show-unchanged-subs? @(rf/subscribe [:rf.xray/setting :general :show-unchanged-subs?])
-        editor-override @(rf/subscribe [:rf.xray/setting :general :editor-override])
-        host-editor     @(rf/subscribe [:rf.xray/editor-host-default])]
+(defn- general-section
+  "The General tab's body, as a PURE function of `dispatch` and the seven
+  values it used to read for itself (rf2-k97c.3).
+
+  The seven names below are the seven the `let` bound before the
+  migration, in the same order, so the only thing that changed is WHERE
+  they come from: [[popup-tree]]'s caller reads them and hands them
+  down. They are destructured in a `let` rather than in the parameter
+  vector for the same reason — it keeps the body's shape identical and
+  the diff honest."
+  [dispatch general]
+  (let [{:keys [panel-position auto-open? epoch-history show-ungrouped?
+                show-unchanged-subs? editor-override host-editor]} general]
     [:div {:data-testid "rf-xray-settings-section-general"}
      [:h2 {:style (section-heading-style)} "General"]
 
@@ -726,39 +762,41 @@
 
 ;; ---- section: Diff (rf2-i39w2 Phase 3) ----------------------------------
 
-(defn- diff-section [dispatch]
-  (let [highlight? @(rf/subscribe [:rf.xray/setting :diff :highlight-fn-ref-changes?])]
-    [:div {:data-testid "rf-xray-settings-section-diff"}
-     [:h2 {:style (section-heading-style)} "Diff"]
-     [:p {:style {:color (:text-secondary tokens)
-                  :line-height 1.5
-                  :margin "0 0 16px 0"}}
-      "Controls for the structural-diff engine that powers App-DB Diff, "
-      "Sub-output diff, and the View-hiccup diff drilldown in the Views "
-      "panel."]
+(defn- diff-section
+  "The Diff tab's body, as a PURE function of `dispatch` and the one
+  value it used to read for itself (rf2-k97c.3)."
+  [dispatch highlight?]
+  [:div {:data-testid "rf-xray-settings-section-diff"}
+   [:h2 {:style (section-heading-style)} "Diff"]
+   [:p {:style {:color (:text-secondary tokens)
+                :line-height 1.5
+                :margin "0 0 16px 0"}}
+    "Controls for the structural-diff engine that powers App-DB Diff, "
+    "Sub-output diff, and the View-hiccup diff drilldown in the Views "
+    "panel."]
 
-     ;; ── Highlight fn-ref changes ────────────────────────────────
-     [:div {:style (field-style)}
-      [:label {:style {:display "flex" :align-items "center" :gap "8px"
-                       :cursor "pointer"
-                       :font-size (:body type-scale)
-                       :color (:text-primary tokens)}}
-       [:input {:data-testid "rf-xray-settings-diff-highlight-fn-ref"
-                :type        "checkbox"
-                :checked     (boolean highlight?)
-                :on-change   #(dispatch
-                                [:rf.xray/settings-update
-                                 :diff :highlight-fn-ref-changes?
-                                 (boolean (.. % -target -checked))])}]
-       "Highlight function-ref changes in view hiccup"]
-      [:p {:style (hint-style)}
-       "Off by default. The hiccup-diff engine treats function-valued "
-       "props (`:on-click`, `:on-change`, `:ref`, …) as opaque — "
-       "anonymous fns created fresh per render do NOT surface as a "
-       "diff. Flip this on when diagnosing memoization issues (a "
-       "child re-renders because the parent passes a new fn every "
-       "time); identity-different fns will surface as a distinct "
-       "accent-coloured `(fn ref changed)` chip."]]]))
+   ;; ── Highlight fn-ref changes ────────────────────────────────
+   [:div {:style (field-style)}
+    [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                     :cursor "pointer"
+                     :font-size (:body type-scale)
+                     :color (:text-primary tokens)}}
+     [:input {:data-testid "rf-xray-settings-diff-highlight-fn-ref"
+              :type        "checkbox"
+              :checked     (boolean highlight?)
+              :on-change   #(dispatch
+                              [:rf.xray/settings-update
+                               :diff :highlight-fn-ref-changes?
+                               (boolean (.. % -target -checked))])}]
+     "Highlight function-ref changes in view hiccup"]
+    [:p {:style (hint-style)}
+     "Off by default. The hiccup-diff engine treats function-valued "
+     "props (`:on-click`, `:on-change`, `:ref`, …) as opaque — "
+     "anonymous fns created fresh per render do NOT surface as a "
+     "diff. Flip this on when diagnosing memoization issues (a "
+     "child re-renders because the parent passes a new fn every "
+     "time); identity-different fns will surface as a distinct "
+     "accent-coloured `(fn ref changed)` chip."]]])
 
 ;; ---- section: Keybindings (rf2-ttnst) -----------------------------------
 ;;
@@ -818,7 +856,10 @@
    :font-size        (:body type-scale)
    :align-items      "center"})
 
-(defn- keybindings-section [dispatch]
+(defn- keybindings-section
+  "The Keybindings tab's body, as a PURE function of `dispatch` and the
+  one value it used to read for itself (rf2-k97c.3)."
+  [dispatch keys-on?]
   ;; The Handle-keys? master toggle is process global, not under
   ;; `:settings` — `config/keybinding-enabled?` is a bare `configure!`
   ;; slot, not a persisted settings key (see config.cljc §*keybinding-
@@ -830,67 +871,66 @@
   ;; setter only suppresses ATTACH; a host that pre-attached the
   ;; listener needs to also call `keybinding/detach!` for the change
   ;; to land immediately.
-  (let [keys-on? @(rf/subscribe [:rf.xray/keybinding-enabled?])]
-    [:div {:data-testid "rf-xray-settings-section-keybindings"}
-     [:h2 {:style (section-heading-style)} "Keybindings"]
+  [:div {:data-testid "rf-xray-settings-section-keybindings"}
+   [:h2 {:style (section-heading-style)} "Keybindings"]
 
-     ;; Master 'Handle keys?' toggle.
-     [:div {:style (field-style)}
-      [:label {:style {:display "flex" :align-items "center" :gap "8px"
-                       :cursor "pointer"
-                       :font-size (:body type-scale)
-                       :color (:text-primary tokens)}}
-       [:input {:data-testid "rf-xray-settings-keys-master-toggle"
-                :type        "checkbox"
-                :checked     (boolean keys-on?)
-                :on-change   (fn [^js e]
-                               (let [on? (boolean (.. e -target -checked))]
-                                 (dispatch [:rf.xray/keybinding-enabled-update on?])))}]
-       "Handle keys?"]
-      [:p {:style (hint-style)}
-       "Master switch for Xray's global keydown listener. Off → "
-       "Xray swallows no keystrokes; the host app's bindings fire "
-       "unimpeded. May require a page reload to fully detach. "
-       "(Setting: " [:code {:style {:font-family mono-stack
-                                    :color (:text-tertiary tokens)}}
-                     ":rf.xray/keybinding-enabled?"] ")"]]
+   ;; Master 'Handle keys?' toggle.
+   [:div {:style (field-style)}
+    [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                     :cursor "pointer"
+                     :font-size (:body type-scale)
+                     :color (:text-primary tokens)}}
+     [:input {:data-testid "rf-xray-settings-keys-master-toggle"
+              :type        "checkbox"
+              :checked     (boolean keys-on?)
+              :on-change   (fn [^js e]
+                             (let [on? (boolean (.. e -target -checked))]
+                               (dispatch [:rf.xray/keybinding-enabled-update on?])))}]
+     "Handle keys?"]
+    [:p {:style (hint-style)}
+     "Master switch for Xray's global keydown listener. Off → "
+     "Xray swallows no keystrokes; the host app's bindings fire "
+     "unimpeded. May require a page reload to fully detach. "
+     "(Setting: " [:code {:style {:font-family mono-stack
+                                  :color (:text-tertiary tokens)}}
+                   ":rf.xray/keybinding-enabled?"] ")"]]
 
-     ;; Read-only chord table. v1.1 will add rebind UI; for now
-     ;; the catalogue is enough to discover the bindings.
-     [:p {:style (hint-style)}
-      "Read-only in v1 — rebind UI lands in v1.1. The catalogue "
-      "mirrors spec/007-UX-IA.md §Keyboard."]
+   ;; Read-only chord table. v1.1 will add rebind UI; for now
+   ;; the catalogue is enough to discover the bindings.
+   [:p {:style (hint-style)}
+    "Read-only in v1 — rebind UI lands in v1.1. The catalogue "
+    "mirrors spec/007-UX-IA.md §Keyboard."]
 
-     (into [:div {:data-testid "rf-xray-settings-keybindings-table"
-                  :style {:border        (str "1px solid " (:border-subtle tokens))
-                          :border-radius "4px"
-                          :overflow      "hidden"
-                          :margin-top    "8px"}}]
-           (apply concat
-                  (for [{:keys [group rows]} keybinding-rows]
-                    (concat
-                      [[:div {:key   (str "g-" group)
-                              :style {:padding     "8px 10px"
-                                      :background  (:bg-1 tokens)
-                                      :color       (:text-tertiary tokens)
-                                      :font-size   (:caption type-scale)
-                                      :font-family sans-stack
-                                      :font-weight 600
-                                      :text-transform "uppercase"
-                                      :letter-spacing "0.05em"
-                                      :border-bottom (str "1px solid " (:border-subtle tokens))}}
-                        group]]
-                      (map-indexed
-                        (fn [idx [chord action]]
-                          [:div {:key   (str group "-" idx)
-                                 :style (keybinding-table-row-style (odd? idx))}
-                           [:span {:style {:font-family mono-stack
-                                           :color       (:text-primary tokens)
-                                           :font-size   (:body type-scale)}}
-                            chord]
-                           [:span {:style {:color (:text-secondary tokens)}}
-                            action]])
-                        rows)))))]))
+   (into [:div {:data-testid "rf-xray-settings-keybindings-table"
+                :style {:border        (str "1px solid " (:border-subtle tokens))
+                        :border-radius "4px"
+                        :overflow      "hidden"
+                        :margin-top    "8px"}}]
+         (apply concat
+                (for [{:keys [group rows]} keybinding-rows]
+                  (concat
+                    [[:div {:key   (str "g-" group)
+                            :style {:padding     "8px 10px"
+                                    :background  (:bg-1 tokens)
+                                    :color       (:text-tertiary tokens)
+                                    :font-size   (:caption type-scale)
+                                    :font-family sans-stack
+                                    :font-weight 600
+                                    :text-transform "uppercase"
+                                    :letter-spacing "0.05em"
+                                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+                      group]]
+                    (map-indexed
+                      (fn [idx [chord action]]
+                        [:div {:key   (str group "-" idx)
+                               :style (keybinding-table-row-style (odd? idx))}
+                         [:span {:style {:font-family mono-stack
+                                         :color       (:text-primary tokens)
+                                         :font-size   (:body type-scale)}}
+                          chord]
+                         [:span {:style {:color (:text-secondary tokens)}}
+                          action]])
+                      rows)))))])
 
 ;; ---- section: Buffer (rf2-ttnst; rf2-pu9sb epoch-history consolidation) -
 ;;
@@ -1029,49 +1069,50 @@
                :style       (danger-button-style)}
       "Clear"]]]])
 
-(defn- buffer-section [dispatch]
-  (let [events-retained @(rf/subscribe [:rf.xray/setting :buffer :events-retained])
-        confirm-open?   @(rf/subscribe [:rf.xray/settings-clear-confirm-open?])]
-    [:div {:data-testid "rf-xray-settings-section-buffer"
-           :style {:position "relative"}}
-     [:h2 {:style (section-heading-style)} "Buffer"]
-     [:p {:style {:color (:text-secondary tokens)
-                  :line-height 1.5
-                  :margin "0 0 16px 0"}}
-      "Tune how much history Xray retains for inspection. Lower "
-      "numbers keep memory smaller; higher numbers let you scroll "
-      "further back through past epochs."]
+(defn- buffer-section
+  "The Buffer tab's body, as a PURE function of `dispatch` and the two
+  values it used to read for itself (rf2-k97c.3)."
+  [dispatch events-retained confirm-open?]
+  [:div {:data-testid "rf-xray-settings-section-buffer"
+         :style {:position "relative"}}
+   [:h2 {:style (section-heading-style)} "Buffer"]
+   [:p {:style {:color (:text-secondary tokens)
+                :line-height 1.5
+                :margin "0 0 16px 0"}}
+    "Tune how much history Xray retains for inspection. Lower "
+    "numbers keep memory smaller; higher numbers let you scroll "
+    "further back through past epochs."]
 
-     ;; Epoch history slider was here; moved to General 2026-05-27
-     ;; per Mike. The slot stays `:general :epoch-history`; only
-     ;; the visual home changed.
+   ;; Epoch history slider was here; moved to General 2026-05-27
+   ;; per Mike. The slot stays `:general :epoch-history`; only
+   ;; the visual home changed.
 
-     (numeric-field
-       {:testid    "rf-xray-settings-buffer-events-retained"
-        :label     "Events retained (:buffer/events-retained)"
-        :value     events-retained
-        :default   50
-        :min       1
-        :on-commit #(dispatch
-                      [:rf.xray/settings-update
-                       :buffer :events-retained %])
-        :hint      "Number of events retained in each frame's trace ring."})
+   (numeric-field
+     {:testid    "rf-xray-settings-buffer-events-retained"
+      :label     "Events retained (:buffer/events-retained)"
+      :value     events-retained
+      :default   50
+      :min       1
+      :on-commit #(dispatch
+                    [:rf.xray/settings-update
+                     :buffer :events-retained %])
+      :hint      "Number of events retained in each frame's trace ring."})
 
-     ;; Destructive action — opens confirm modal.
-     [:div {:style {:margin-top "20px"}}
-      [:button {:data-testid "rf-xray-settings-clear-buffer-now"
-                :on-click    (fn [^js e]
-                               (.stopPropagation e)
-                               (dispatch
-                                 [:rf.xray/settings-confirm-clear-buffer]))
-                :style       (danger-button-style)}
-       "Clear buffer now"]
-      [:p {:style (hint-style)}
-       "Drops every retained epoch and the redaction counter. "
-       "This cannot be undone."]]
+   ;; Destructive action — opens confirm modal.
+   [:div {:style {:margin-top "20px"}}
+    [:button {:data-testid "rf-xray-settings-clear-buffer-now"
+              :on-click    (fn [^js e]
+                             (.stopPropagation e)
+                             (dispatch
+                               [:rf.xray/settings-confirm-clear-buffer]))
+              :style       (danger-button-style)}
+     "Clear buffer now"]
+    [:p {:style (hint-style)}
+     "Drops every retained epoch and the redaction counter. "
+     "This cannot be undone."]]
 
-     (when confirm-open?
-       [clear-buffer-confirm-modal dispatch])]))
+   (when confirm-open?
+     (clear-buffer-confirm-modal dispatch))])
 
 ;; ---- key handling -------------------------------------------------------
 
@@ -1140,20 +1181,55 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(defn popup-view
-  "Hiccup for the open settings popup. Caller (`popup/Modal`) gates
-  the mount on `:rf.xray/settings-open?` — this fn assumes it's open
-  and always renders. ESC closes; click outside the dialog closes;
-  the ✕ button in the header closes.
+(defn popup-tree
+  "The open settings popup's WHOLE body, as a PURE function of
+  `dispatch` and the values [[day8.re-frame2-xray.settings.popup/Popup]]
+  reads. The caller gates the mount on `:rf.xray/settings-open?` — this
+  fn assumes it is open and always renders. ESC closes; click outside
+  the dialog closes; the ✕ button in the header closes.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher injected by the
-  `Modal` `reg-view` body — threaded down to every section helper so
-  deferred handlers land on the surrounding instance frame, not a
-  `{:frame :rf/xray}` literal."
-  [dispatch]
-  (let [active-tab  @(rf/subscribe [:rf.xray/settings-active-tab])
-        positioning @(rf/subscribe [:rf.xray/modal-positioning])
-        on-keydown  (handle-keydown dispatch)]
+  ## rf2-k97c.3 — WAS `popup-view`, AND IT READ FOR ITSELF
+
+  Before the migration this fn and its four section helpers performed
+  THIRTEEN ambient `@(rf/subscribe …)` reads between them. They are now
+  hoisted into the boundary, and the reason is not taste: `rf.fresco/sub`
+  refuses outside a boundary render (`:rf.error/fresco-sub-outside-render`,
+  `impl.collector/read-key!`), so a read-performing helper that anything
+  calls from OUTSIDE a React commit — a handler, a utility path, a
+  node-lane test — becomes uncallable the moment its read is migrated.
+  Seven such callers existed. A pure fn needs neither a render window nor
+  `subscribe-once`, so hoisting keeps every lane open.
+
+  `data` is that hoisted read-set, keyed by the tab that consumes it:
+
+      {:active-tab       — which inner tab is showing
+       :positioning      — `:rf.xray/modal-positioning` (fixed / absolute)
+       :general          — the seven General-tab values, as a map
+       :highlight?       — Diff tab
+       :keys-on?         — Keybindings tab
+       :events-retained  — Buffer tab
+       :confirm-open?}   — Buffer tab's nested confirm modal
+
+  WHAT THE HOIST COSTS, stated because it is a real behaviour change:
+  the four tabs' slots are now read whenever the popup is OPEN, where
+  before only the ACTIVE tab's were. That is the one lost conditional.
+  It is bounded — the gate is still conditional, so a CLOSED popup holds
+  ONE subscription, not fourteen, because `rf.fresco/sub` is legal inside
+  a `when` and records its edge where the read happens (HD-002). Four
+  extra `get-in`-shaped reads on an open modal is not a cost worth a
+  second boundary per tab, and a per-tab boundary would put a Fresco head
+  in this tree that the node lane could not walk.
+
+  `dispatch` (rf2-nesy9) is the frame-bound dispatcher — threaded down to
+  every section helper so deferred handlers land on the surrounding
+  instance frame, not a `{:frame :rf/xray}` literal. The boundary takes
+  it from `(:dispatch (rf/capture-frame))`; the node-lane door passes
+  `rf/dispatch` under `rf/with-frame`.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [dispatch {:keys [active-tab positioning general highlight? keys-on?
+                    events-retained confirm-open?]}]
+  (let [on-keydown (handle-keydown dispatch)]
     ;; rf2-7oxvd — shared backdrop + dialog scaffold. Keeps this modal's
     ;; own `backdrop-style` / `dialog-style`, its `tab-index "-1"` dialog
     ;; root, and its `handle-keydown` (Esc-closes + bare-letter tab
@@ -1200,8 +1276,13 @@
                    :role        "tablist"
                    :aria-label  "Settings sections"
                    :style       (tab-strip-style)}]
+            ;; rf2-k97c.3 — `tab-button` is CALLED, not headed. The
+            ;; standard HD-016 repair: a plain fn in head position is
+            ;; `:invalid` to Fresco's codec, and everything this one
+            ;; answers is keyword-headed, so the call terminates. Its
+            ;; `:key` moved into its own attrs map with it.
             (for [tab tabs]
-              [tab-button dispatch tab (= (:id tab) active-tab)]))
+              (tab-button dispatch tab (= (:id tab) active-tab))))
       ;; Body — rf2-h4mnh: closes the tabs/tabpanel loop. The body
       ;; carries `role="tabpanel"` + an `id` matching the active
       ;; tab button's `aria-controls`, and `aria-labelledby`
@@ -1213,8 +1294,8 @@
              :aria-labelledby (settings-tab-button-id active-tab)
              :style           (body-style)}
        (case active-tab
-         :general     (general-section dispatch)
-         :diff        (diff-section dispatch)
-         :keybindings (keybindings-section dispatch)
-         :buffer      (buffer-section dispatch)
-         (general-section dispatch))])))
+         :general     (general-section dispatch general)
+         :diff        (diff-section dispatch highlight?)
+         :keybindings (keybindings-section dispatch keys-on?)
+         :buffer      (buffer-section dispatch events-retained confirm-open?)
+         (general-section dispatch general))])))

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -18,7 +18,9 @@
 
   ## Surfaces under test
 
-    1. Settings popup  (`settings/view/popup-view`)
+    1. Settings popup  (`settings/view/popup-tree`, driven through
+       `test-helpers.modal-trees/settings-popup-tree` since rf2-k97c.3 —
+       the popup's root is a Fresco boundary and no longer a callable)
     2. Mute manager    (`spine-filters/dialog-tree`)
     3. Filter edit-popup (`filters/edit-popup/popup-view`)
     4. Cancellation-cascade popover — exercised via its `popover-tree`
@@ -40,7 +42,7 @@
             [day8.re-frame2-xray.panels.cancellation-cascade
              :as cancellation-cascade]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.settings.view :as settings-view]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.edn-widget :as edn]))
@@ -119,7 +121,7 @@
   (xray-setup!)
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/settings-open]))
-  (let [tree (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))]
     (assert-dialog-contract! tree "rf-xray-settings-dialog"
                              "Settings popup")))
 
@@ -128,7 +130,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
-    (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
+    (let [tree  (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))
           close (rf.test-helpers/find-by-testid tree "rf-xray-settings-close")]
       (is (string? (:aria-label (rf.test-helpers/attrs close)))
           "Settings close ✕ carries an aria-label"))))
@@ -273,7 +275,7 @@
   (xray-setup!)
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/settings-open]))
-  (let [tree (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))]
     (assert-dialog-focus-ref! tree "rf-xray-settings-dialog"
                               "Settings popup")))
 

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -34,7 +34,7 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
-            [day8.re-frame2-xray.settings.view :as settings-view]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
              :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
@@ -155,7 +155,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
-    (let [tree   (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
+    (let [tree   (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))
           strip  (rf.test-helpers/find-by-testid tree "rf-xray-settings-tab-strip")
           attrs  (props strip)]
       (is (= "tablist" (:role attrs))
@@ -170,7 +170,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
-    (let [tree     (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
+    (let [tree     (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))
           ;; Theme tab removed rf2-ou3pn; Filters tab removed
           ;; rf2-wknb3. The four remaining tabs each carry the full
           ;; WAI-ARIA tab contract.
@@ -205,7 +205,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
-    (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
+    (let [tree  (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))
           body  (rf.test-helpers/find-by-testid tree "rf-xray-settings-body")
           attrs (props body)]
       (is (= "tabpanel" (:role attrs))
@@ -227,7 +227,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
-    (let [tree  (rf/with-frame :rf/xray (settings-view/popup-view rf/dispatch))
+    (let [tree  (rf/with-frame :rf/xray (modal-trees/settings-popup-tree rf/dispatch))
           input (rf.test-helpers/find-by-testid tree "rf-xray-settings-epoch-history-input")
           ;; The label sits in the same <div> field; find by html-for.
           label (some (fn [node]

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -20,7 +20,7 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
@@ -60,14 +60,14 @@
 
 (deftest toast-renders-nil-when-closed
   (rf/with-frame :rf/xray
-    (is (nil? (editor-hint/Toast))
+    (is (nil? (modal-trees/editor-hint-toast-tree))
         "Toast renders nil when editor-hint-open? is false")))
 
 (deftest toast-renders-when-open
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/editor-hint-show]))
   (rf/with-frame :rf/xray
-    (let [rendered (editor-hint/Toast)]
+    (let [rendered (modal-trees/editor-hint-toast-tree)]
       (is (some? rendered)
           "Toast renders hiccup when editor-hint-open? is true")
       (is (rf.test-helpers/find-by-testid rendered "rf-xray-editor-hint-toast")

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -22,7 +22,7 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.settings.popup :as popup]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.settings.view :as view]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
@@ -49,7 +49,7 @@
 (deftest modal-renders-nil-when-closed
   (setup!)
   (rf/with-frame :rf/xray
-    (let [rendered (popup/Modal)]
+    (let [rendered (modal-trees/settings-popup-tree)]
       (is (nil? rendered)
           "Modal renders nil when settings-open? is false"))))
 
@@ -58,7 +58,7 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/settings-open]))
   (rf/with-frame :rf/xray
-    (let [rendered (popup/Modal)]
+    (let [rendered (modal-trees/settings-popup-tree)]
       (is (some? rendered)
           "Modal renders hiccup when settings-open? is true")
       (is (find-by-testid rendered "rf-xray-settings-backdrop")
@@ -95,7 +95,7 @@
     (rf/dispatch-sync [:rf.xray/settings-open])
     (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
   (rf/with-frame :rf/xray
-    (let [rendered (popup/Modal)]
+    (let [rendered (modal-trees/settings-popup-tree)]
       (is (find-by-testid rendered "rf-xray-settings-section-general"))
       (is (find-by-testid rendered "rf-xray-settings-panel-position-right-rail"))
       (is (find-by-testid rendered "rf-xray-settings-auto-open-on-error"))
@@ -127,7 +127,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             box      (find-by-testid rendered "rf-xray-settings-show-unchanged-subs")]
         (is (some? box) "the restored show-unchanged-subs checkbox renders")
         (is (= false (:checked (second box)))
@@ -138,7 +138,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-update :general :show-unchanged-subs? true]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             box      (find-by-testid rendered "rf-xray-settings-show-unchanged-subs")]
         (is (= true (:checked (second box)))
             "the checkbox reflects the flipped-on pin")))))
@@ -157,7 +157,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :buffer]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         (is (find-by-testid rendered "rf-xray-settings-section-buffer"))
         (is (nil? (find-by-testid rendered "rf-xray-settings-epoch-history-input"))
             "Epoch history slider is no longer in Buffer (relocated back to General)")
@@ -192,7 +192,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :filters]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         (is (nil? (find-by-testid rendered "rf-xray-settings-section-filters"))
             "Filters section is gone")
         (is (nil? (find-by-testid rendered "rf-xray-settings-tab-filters"))
@@ -218,7 +218,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         ;; Picker container.
         (is (find-by-testid rendered "rf-xray-settings-editor-override")
             "editor-override field group renders")
@@ -249,7 +249,7 @@
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :editor-override {:custom ""}]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         (is (find-by-testid rendered "rf-xray-settings-editor-override-custom-input")
             "custom template input renders once the override is the
              :custom shape")))))
@@ -282,7 +282,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             default-radio (find-by-testid rendered "rf-xray-settings-editor-override-default")
             vscode-radio  (find-by-testid rendered "rf-xray-settings-editor-override-vscode")]
         (is (true? (:checked (second default-radio)))
@@ -300,7 +300,7 @@
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :editor-override :idea]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             default-radio (find-by-testid rendered "rf-xray-settings-editor-override-default")
             idea-radio    (find-by-testid rendered "rf-xray-settings-editor-override-idea")]
         (is (false? (:checked (second default-radio))))
@@ -327,7 +327,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/settings-select-tab :general]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         (is (nil? (find-by-testid rendered "rf-xray-settings-use-system-colors"))
             "Use system colors toggle no longer renders")
         (is (nil? (find-by-testid rendered "rf-xray-settings-section-theme"))
@@ -346,7 +346,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-select-tab tab-id]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)]
+      (let [rendered (modal-trees/settings-popup-tree)]
         (is (find-by-testid rendered section-testid)
             (str "tab " tab-id " renders its section"))))))
 
@@ -381,7 +381,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-open]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             backdrop (find-by-testid rendered "rf-xray-settings-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
@@ -402,7 +402,7 @@
       (rf/dispatch-sync [:rf.xray/settings-open])
       (rf/dispatch-sync [:rf.xray/set-modal-positioning :absolute]))
     (rf/with-frame :rf/xray
-      (let [rendered (popup/Modal)
+      (let [rendered (modal-trees/settings-popup-tree)
             backdrop (find-by-testid rendered "rf-xray-settings-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -44,7 +44,7 @@
             [re-frame.test-helpers :as rf.test-helpers]
             [re-frame.test-support :as rf.test-support]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.settings.popup :as popup]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
@@ -95,7 +95,7 @@
 (defn- render-open-modal []
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/settings-open]))
-  (rf/with-frame :rf/xray (popup/Modal)))
+  (rf/with-frame :rf/xray (modal-trees/settings-popup-tree)))
 
 ;; ---- tests --------------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/settings/settings_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/settings_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,434 @@
+(ns day8.re-frame2-xray.settings.settings-fresco-boundary-dom-cljs-test
+  "Real-DOM witnesses for the Xray SETTINGS chrome as Fresco boundaries
+  (rf2-k97c.3).
+
+  ## Why a browser row at all — the node lane cannot see this
+
+  The node lane drives `settings.view/popup-tree` through
+  `test-helpers.modal-trees`, which reproduces the boundary's reads with
+  `rf/subscribe`. That is evidence about COMPOSITION — what hiccup the
+  values produce — and it is evidence about nothing else, BY
+  CONSTRUCTION: it never mounts a boundary, never crosses the
+  `as-component` bridge, and never asks the collector for anything. A
+  green node lane is therefore compatible with a settings popup that
+  paints nothing, or that paints once and never updates again. Only a
+  committed DOM can answer those, and this file is the settings sibling
+  of `shell_fresco_boundary_dom_cljs_test`.
+
+  ## The mount is the PRODUCTION crossing
+
+  `shell.cljs`'s `shell-view` is still an `rf/reg-view` — severing that
+  is the parent epic's coupling (1) and a later slice — and it mounts
+  these two modals as the Reagent hiccup heads `[settings-popup/Modal]`
+  and `[editor-hint/Toast]`, inside its own `[rf/frame-provider …]`.
+  [[mount-modal!]] reproduces exactly that two-level form and nothing
+  else. The shell's surrounding chrome is
+  `shell_fresco_boundary_dom_cljs_test`'s subject, not this file's; what
+  is under test here is the crossing — Reagent parent → plain-fn bridge →
+  `[:>]` → Fresco boundary → React context frame → `rf.fresco/sub`.
+
+  Nothing below ever calls a view a second time. Every assertion after
+  the mount reads `container.querySelector…` — the DOM React committed on
+  its own.
+
+  ## The three rows
+
+  W1 asks whether the popup PAINTS through the bridge. W2 asks whether
+  its reads are LIVE AND FRAME-ROUTED, by pressing a real tab button and
+  holding a second live frame as the deaf lever. W3 asks the same paint
+  question of the second boundary, the editor-hint toast, whose gate is
+  the one read that did NOT move out of a helper.
+
+  ## THE WITNESS IS CHOSEN, NOT CONVENIENT — most of this surface cannot witness routing
+
+  W2 watches `:rf.xray/settings-active-tab`. That is deliberate and the
+  alternatives are traps. `:rf.xray/setting` — the query behind ELEVEN of
+  the boundary's fourteen reads, the theme toggle and every General-tab
+  value among them — is
+
+      (or (get-in db [:settings section key]) (config/get-setting section key))
+
+  in `settings/subs.cljs`, so an unseeded app-db slot falls through to a
+  PROCESS-GLOBAL atom. A control backed by process-global state answers
+  correctly under a deliberately WRONG frame, so it witnesses the read
+  path and says nothing whatever about frame routing. Only three queries
+  on this surface have LITERAL fallbacks and therefore traverse the
+  frame: `:rf.xray/settings-open?`, `:rf.xray/settings-active-tab` and
+  `:rf.xray/settings-clear-confirm-open?`. W2 uses the second because it
+  is also DRIVEN FROM INSIDE the boundary — a real click on a real
+  button, through the dispatcher the body captured — so one row exercises
+  the read path and the captured-dispatcher write path in a single round
+  trip through the frame.
+
+  ## Node-lane behaviour
+
+  This ns matches the `:browser-test` build's regex and also loads under
+  `:node-test`, where every row short-circuits through [[browser?]] and
+  reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
+            [day8.re-frame2-xray.settings.popup :as settings-popup]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private modal-frame
+  "The frame this suite's modal instance owns. NOT `:rf/xray`: the
+  production singleton is shared with every other suite on the page, and
+  naming a private frame is what makes W2's negative half mean
+  something."
+  ::modal)
+
+(def ^:private other-frame
+  "A second live frame W2 dispatches into as its DEAF LEVER — the
+  negative control. A write here must move nothing in the popup above."
+  ::other)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about;
+                      ;; a neighbour's boundary left in the entry cache
+                      ;; would make these rows read a residue that is not
+                      ;; this popup's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; NO `flush-render!` HELPER HERE, and its absence is a finding rather than
+;; an omission. A Fresco boundary is NOT in Reagent's render queue — its
+;; update is scheduled by the collector through React — so draining
+;; Reagent's queue commits nothing of these boundaries', and a row written
+;; that way reads a DOM that has not moved and reports a live popup as
+;; dead. Mount is committed with `flushSync` (React's own door) and
+;; everything after it is polled.
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROL in W2: an absence asserted immediately after the world
+  moves is a race, and an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- poll-until
+  "Resolve as soon as `pred` answers truthy, or after `budget-ms`. The
+  resolution value is `pred`'s last answer, so a caller asserts on the
+  value rather than on the fact that polling ended."
+  ([pred] (poll-until pred 2000))
+  ([pred budget-ms]
+   (js/Promise.
+     (fn [resolve]
+       (let [deadline (+ (js/Date.now) budget-ms)]
+         (letfn [(tick []
+                   (let [v (pred)]
+                     (cond
+                       v                          (resolve v)
+                       (> (js/Date.now) deadline) (resolve v)
+                       :else (js/requestAnimationFrame (fn [_] (tick))))))]
+           (tick)))))))
+
+(defn- setup!
+  "Register Xray's handlers — which is what installs the settings subs
+  and events these rows drive — and make the frames.
+
+  `:rf/xray` is made as well as the two this suite names. It is
+  `shell/default-frame-id`, the production singleton, and several Xray
+  registrations reach it by that name regardless of which frame an
+  instance is mounted at; a missing frame is a loud re-frame refusal, and
+  one raised inside a React render surfaces only as 'an error occurred
+  in <…>' with the message nowhere on screen."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id shell/default-frame-id})
+  (rf/make-frame {:id modal-frame})
+  (rf/make-frame {:id other-frame})
+  nil)
+
+(defn- mount-modal!
+  "Mount one shell-root modal the way `shell.cljs` mounts it — the
+  enclosing `frame-provider` included:
+
+      [rf/frame-provider {:frame …} [settings-popup/Modal]]
+
+  THAT WRAPPER IS LOAD-BEARING. The bridge itself performs no read, so it
+  would not refuse without one; the BOUNDARY behind it takes its frame
+  from React context, and at a bare root there is no context to take. The
+  provider is what puts the instance frame there, exactly as
+  `shell-view`'s does in production (rf2-uu3lp).
+
+  Committed synchronously — React 19's `root.render` is otherwise async
+  and the first assertion would read an empty container."
+  [frame view]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame frame} [view]])))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line reads anything. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+;; ---- the diagnostic ------------------------------------------------------
+;;
+;; A re-frame refusal raised inside a React render does NOT reach a
+;; `try/catch` around `flushSync`: React 19 catches it, reports "an error
+;; occurred in <…>" to the console, and re-raises it as an UNCAUGHT window
+;; error. Its `ex-message` and `ex-data` — the whole of what re-frame
+;; refuses WITH — then appear nowhere a row can read, and every assertion
+;; below reddens on a nil testid saying only that the popup is absent.
+;; Capturing the error object is what turns several uninformative failures
+;; into one that names the refusal.
+
+(defonce ^:private !last-uncaught (atom nil))
+
+(defonce ^:private error-capture-armed?
+  (when (exists? js/window)
+    (.addEventListener js/window "error"
+                       (fn [^js e] (reset! !last-uncaught (.-error e))))
+    true))
+
+(defn- uncaught-note
+  "A suffix naming the last uncaught error, for a row whose subject is
+  missing. Empty when nothing was thrown — in which case the absence is
+  the finding rather than a hidden exception."
+  []
+  (if-some [e (when error-capture-armed? @!last-uncaught)]
+    (str " — an uncaught error was raised during render: "
+         (:rf.error/id (ex-data e) (ex-message e))
+         " · at: "
+         (let [s (str (.-stack ^js e))]
+           (->> (str/split-lines s)
+                (remove #(str/blank? %))
+                (filter #(str/includes? % "at "))
+                (take 14)
+                (str/join " | "))))
+    ""))
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid [container id]
+  (q container (str "[data-testid=\"" id "\"]")))
+
+(defn- active-tabpanel-id
+  "The committed settings body's `id`, which encodes the ACTIVE TAB. This
+  is W2's needle: it moves only if the boundary re-ran on a real
+  `:rf.xray/settings-active-tab` change."
+  [container]
+  (some-> (testid container "rf-xray-settings-body") (.getAttribute "id")))
+
+;; ===========================================================================
+;; W1 — the settings popup PAINTS through the bridge
+;; ===========================================================================
+
+(deftest w1-settings-popup-paints-through-the-bridge
+  (testing "rf2-k97c.3 — `settings.popup/Popup` is a Fresco boundary and
+            commits its dialog through the private `as-component` bridge
+            `shell.cljs` still mounts by the name `Modal`. Epic
+            criterion 1.
+
+            THIS ROW CARRIES WHAT THE NODE LANE GAVE UP. Every settings
+            row in `popup_cljs_test` now drives `view/popup-tree` through
+            `test-helpers.modal-trees`, because a boundary's body only
+            runs inside a React render window. Those rows are evidence
+            about COMPOSITION; this one is the only evidence that the
+            composition reaches a screen."
+    (if-not (browser?)
+      (is true "skipped: no DOM under the :node-test build")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-modal! modal-frame settings-popup/Modal)]
+          (-> (settle)
+              (.then
+                (fn [_]
+                  ;; CLOSED FIRST, and this half is not decoration: the
+                  ;; gate now lives INSIDE the boundary rather than in
+                  ;; the Reagent bridge, so `nil`-when-closed is a claim
+                  ;; about the boundary that only a DOM can check.
+                  (is (nil? (testid container "rf-xray-settings-dialog"))
+                      "closed: the boundary commits no dialog")
+                  (rf/dispatch-sync [:rf.xray/settings-open] {:frame modal-frame})
+                  (poll-until #(testid container "rf-xray-settings-dialog"))))
+              (.then
+                (fn [dialog]
+                  (is (some? dialog)
+                      (str "open: the dialog is committed to the DOM"
+                           (uncaught-note)))
+                  (is (some? (testid container "rf-xray-settings-backdrop"))
+                      "the backdrop is committed")
+                  (is (some? (testid container "rf-xray-settings-tab-strip"))
+                      "the tab strip is committed")
+                  ;; The default tab's SECTION, which is the half that
+                  ;; proves the hoisted reads reached `popup-tree` — an
+                  ;; envelope with no body would satisfy every assertion
+                  ;; above it.
+                  (is (some? (testid container "rf-xray-settings-section-general"))
+                      "the General section is committed, so the hoisted
+                       values reached the section helpers")
+                  (teardown! root container)
+                  (done)))))))))
+
+;; ===========================================================================
+;; W2 — the reads are LIVE and FRAME-ROUTED, driven by a real click
+;; ===========================================================================
+
+(deftest w2-tab-click-rerenders-the-boundary-on-its-own-frame
+  (testing "rf2-k97c.3 — pressing a real tab button dispatches through
+            the dispatcher the BOUNDARY captured
+            (`(:dispatch (rf/capture-frame))`), the boundary re-runs on
+            the resulting `:rf.xray/settings-active-tab` change, and the
+            committed DOM moves. Epic criterion 3 (observation) and the
+            frame half of criterion 2.
+
+            THE CLICK IS THE POINT. A `dispatch-sync` from the test would
+            exercise the read path while BYPASSING the captured
+            dispatcher, which is the half a wrong frame would break.
+
+            THE DEAF LEVER IS THE CONTROL. The same event is then
+            dispatched into a second live frame; if the popup moved on
+            that, its reads would not be frame-routed at all and the
+            positive half above would be worth nothing."
+    (if-not (browser?)
+      (is true "skipped: no DOM under the :node-test build")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-modal! modal-frame settings-popup/Modal)]
+          (rf/dispatch-sync [:rf.xray/settings-open] {:frame modal-frame})
+          (-> (poll-until #(testid container "rf-xray-settings-body"))
+              (.then
+                (fn [_]
+                  (is (= "rf-xray-settings-tabpanel-general"
+                         (active-tabpanel-id container))
+                      (str "baseline: the popup opens on the General tab"
+                           (uncaught-note)))
+                  ;; A REAL CLICK, on the real committed button. React's
+                  ;; delegated listener turns it into the boundary's own
+                  ;; `:on-click`, which calls the captured dispatcher.
+                  (.click (testid container "rf-xray-settings-tab-buffer"))
+                  (poll-until
+                    #(= "rf-xray-settings-tabpanel-buffer"
+                        (active-tabpanel-id container)))))
+              (.then
+                (fn [switched?]
+                  (is switched?
+                      (str "the click re-rendered the boundary and the "
+                           "committed tabpanel became Buffer"
+                           (uncaught-note)))
+                  (is (some? (testid container "rf-xray-settings-section-buffer"))
+                      "the Buffer section is the committed body")
+                  (is (nil? (testid container "rf-xray-settings-section-general"))
+                      "the General section is gone — a real swap, not an
+                       accumulation")
+                  ;; ---- the deaf lever -------------------------------
+                  (rf/dispatch-sync [:rf.xray/settings-select-tab :diff]
+                                    {:frame other-frame})
+                  (settle)))
+              (.then
+                (fn [_]
+                  (is (= "rf-xray-settings-tabpanel-buffer"
+                         (active-tabpanel-id container))
+                      "CONTROL: the same event on a SECOND live frame moved
+                       nothing here, so the boundary's reads resolve
+                       through its own frame rather than ambiently")
+                  (is (nil? (testid container "rf-xray-settings-section-diff"))
+                      "CONTROL: the Diff section did not appear")
+                  ;; And the lever is not simply broken: the SAME event on
+                  ;; THIS frame does move the popup. Without this, a deaf
+                  ;; lever and a dead event are the same observation.
+                  (rf/dispatch-sync [:rf.xray/settings-select-tab :diff]
+                                    {:frame modal-frame})
+                  (poll-until
+                    #(= "rf-xray-settings-tabpanel-diff"
+                        (active-tabpanel-id container)))))
+              (.then
+                (fn [moved?]
+                  (is moved?
+                      (str "COUNTER-CONTROL: the identical event on the "
+                           "popup's OWN frame does move it, so the deaf "
+                           "lever above measured routing rather than a "
+                           "dead event" (uncaught-note)))
+                  (teardown! root container)
+                  (done)))))))))
+
+;; ===========================================================================
+;; W3 — the editor-hint toast paints through its own bridge
+;; ===========================================================================
+
+(deftest w3-editor-hint-toast-paints-through-the-bridge
+  (testing "rf2-k97c.3 — `settings.editor-hint/Hint` is the slice's second
+            boundary. Its gate is the ONE read on this surface that did
+            not move out of a helper, because `toast-view` was already
+            pure, so this row is the whole of that boundary's evidence.
+
+            `:rf.xray/editor-hint-open?` is `(get db :editor-hint-open?
+            false)` — a plain app-db read with a literal fallback — so
+            unlike most of the settings queries it genuinely traverses
+            the frame, and the closed/open transition below is a frame
+            claim as well as a paint claim."
+    (if-not (browser?)
+      (is true "skipped: no DOM under the :node-test build")
+      (async done
+        (setup!)
+        (let [{:keys [container root]} (mount-modal! modal-frame editor-hint/Toast)]
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (nil? (testid container "rf-xray-editor-hint-toast"))
+                      "closed: the boundary commits no toast")
+                  (rf/dispatch-sync [:rf.xray/editor-hint-show] {:frame modal-frame})
+                  (poll-until #(testid container "rf-xray-editor-hint-toast"))))
+              (.then
+                (fn [toast]
+                  (is (some? toast)
+                      (str "open: the toast is committed to the DOM"
+                           (uncaught-note)))
+                  (is (some? (testid container "rf-xray-editor-hint-open-settings"))
+                      "the 'Open Settings' button is committed")
+                  ;; The deaf lever again, cheaply: dismissing on ANOTHER
+                  ;; frame must leave this toast standing.
+                  (rf/dispatch-sync [:rf.xray/editor-hint-dismiss] {:frame other-frame})
+                  (settle)))
+              (.then
+                (fn [_]
+                  (is (some? (testid container "rf-xray-editor-hint-toast"))
+                      "CONTROL: a dismiss on a SECOND live frame did not
+                       close this toast")
+                  (rf/dispatch-sync [:rf.xray/editor-hint-dismiss] {:frame modal-frame})
+                  (poll-until #(nil? (testid container "rf-xray-editor-hint-toast")))))
+              (.then
+                (fn [_]
+                  (is (nil? (testid container "rf-xray-editor-hint-toast"))
+                      (str "COUNTER-CONTROL: the identical dismiss on the "
+                           "toast's OWN frame does close it"
+                           (uncaught-note)))
+                  (teardown! root container)
+                  (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/modal_trees.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/modal_trees.cljs
@@ -1,0 +1,112 @@
+(ns day8.re-frame2-xray.test-helpers.modal-trees
+  "The node lane's door onto Xray's shell-root MODALS (rf2-k97c.3).
+
+  ## Why this exists
+
+  Xray's shell-root overlays — the Settings popup, the editor-hint toast,
+  the filter edit-popup, the palette, the mute manager, the cancellation
+  cascade — are migrating from `rf/reg-view` to `rf.fresco/defview`
+  BOUNDARIES, i.e. real React function components. A boundary's body may
+  only run inside a React render window: `rf.fresco/sub` REFUSES outside
+  one, raising `:rf.error/fresco-sub-outside-render` and naming the query
+  (`fresco.impl.collector/read-key!`). So `(popup/Modal)` no longer
+  answers the modal's hiccup — it answers the `[:>]` interop head of the
+  bridge the Reagent shell still mounts it through.
+
+  The repair is `defview`'s own documented extract-a-helper spelling, the
+  one every migrated view in this epic already uses: the view file
+  exports a PURE `*-tree` fn of its reads' VALUES, the boundary is the
+  thin thing that reads and calls it, and the node lane drives the tree
+  fn. This ns is the composer that does that driving — the modal sibling
+  of `test-helpers.dynamic-shell-tree` and `test-helpers.static-shell-tree`.
+
+  ## Why the door is HERE and not a reading arity on the view
+
+  Keeping a `([dispatch])` arity on the view that subscribed for itself
+  would have kept every existing caller working with no edit at all. It
+  was rejected deliberately: a reading fallback that is DEAD IN
+  PRODUCTION is still a read path in the very file the migration exists
+  to empty, and `settings/view.cljs` no longer requires `re-frame.core`
+  at all — which is the measurement that says the hoist is complete
+  rather than mostly done. The lane difference belongs in the lane that
+  differs.
+
+  ## Each door REPRODUCES ITS BOUNDARY'S READS — same subs, same order
+
+  That is what makes a node-lane row evidence about the shipped modal
+  rather than about a parallel fixture. Each fn below mirrors the
+  boundary beside it, with `rf.fresco/sub` swapped for `rf/subscribe`
+  (the node lane has no React render window and no collector extent) and
+  nothing else changed — including the boundary's own OPEN GATE, so a
+  door called against a closed modal answers `nil` exactly as the
+  boundary does.
+
+  ## APPEND-ONLY
+
+  Several satellite slices migrate their modals in parallel and each adds
+  its OWN door here. Append yours; do not edit or `harmonise` anybody
+  else's. Append-only is what keeps concurrent workers in one namespace
+  from conflicting on shared lines.
+
+  ## Call these INSIDE a frame scope
+
+  Every fn here subscribes ambiently, so each call belongs inside
+  `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
+  bodies had, and the same one every existing caller already satisfies."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
+            [day8.re-frame2-xray.settings.view :as settings-view]))
+
+;; ---- Settings popup (slice B1) -------------------------------------------
+
+(defn settings-popup-tree
+  "The Settings popup's hiccup, read the way `settings.popup/Popup` reads
+  it — the same fourteen subs in the same order, gate first.
+
+  Answers `nil` when `:rf.xray/settings-open?` is false, which is the
+  boundary's own short-circuit reproduced rather than approximated: a row
+  that asserts the closed modal renders nothing keeps asserting it here.
+
+  `dispatch` defaults to `(:dispatch (rf/capture-frame))`, the SAME door
+  the boundary uses, so a handler a row pulls off the tree and fires later
+  carries the frame the shipped one does. The explicit arity is for rows
+  that want to pass a recording double.
+
+  THE THIRTEEN NON-GATE READS ARE HOISTED, and that is the whole reason
+  this door exists — `settings/view.cljs` performed them itself until
+  rf2-k97c.3. `settings.view/popup-tree` records what the hoist cost."
+  ([] (settings-popup-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (when @(rf/subscribe [:rf.xray/settings-open?])
+     (settings-view/popup-tree
+       dispatch
+       {:active-tab      @(rf/subscribe [:rf.xray/settings-active-tab])
+        :positioning     @(rf/subscribe [:rf.xray/modal-positioning])
+        :general         {:panel-position       @(rf/subscribe [:rf.xray/setting :general :panel-position])
+                          :auto-open?           @(rf/subscribe [:rf.xray/setting :general :auto-open-on-error?])
+                          :epoch-history        @(rf/subscribe [:rf.xray/setting :general :epoch-history])
+                          :show-ungrouped?      @(rf/subscribe [:rf.xray/show-ungrouped?])
+                          :show-unchanged-subs? @(rf/subscribe [:rf.xray/setting :general :show-unchanged-subs?])
+                          :editor-override      @(rf/subscribe [:rf.xray/setting :general :editor-override])
+                          :host-editor          @(rf/subscribe [:rf.xray/editor-host-default])}
+        :highlight?      @(rf/subscribe [:rf.xray/setting :diff :highlight-fn-ref-changes?])
+        :keys-on?        @(rf/subscribe [:rf.xray/keybinding-enabled?])
+        :events-retained @(rf/subscribe [:rf.xray/setting :buffer :events-retained])
+        :confirm-open?   @(rf/subscribe [:rf.xray/settings-clear-confirm-open?])}))))
+
+;; ---- Open-in-editor hint toast (slice B1) --------------------------------
+
+(defn editor-hint-toast-tree
+  "The editor-hint toast's hiccup, read the way
+  `settings.editor-hint/Hint` reads it — one sub, then the gate.
+
+  Answers `nil` when `:rf.xray/editor-hint-open?` is false, reproducing
+  the boundary's short-circuit.
+
+  `settings.editor-hint/toast-view` needed NO hoist — it reads nothing
+  and always was a pure fn of `dispatch` — so this door exists only
+  because the GATE moved into the boundary."
+  ([] (editor-hint-toast-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (when @(rf/subscribe [:rf.xray/editor-hint-open?])
+     (editor-hint/toast-view dispatch))))


### PR DESCRIPTION
Slice B1 of the chrome-satellite split (rf2-k97c.3): the Xray **settings chrome** moves onto Fresco boundaries.

## What changed

Three source files, two of them now real `rf.fresco/defview` boundaries:

* `settings/popup.cljs` — `Popup` is the boundary. It owns all **fourteen** reads (its own gate plus the thirteen hoisted out of `settings/view.cljs`) as `rf.fresco/sub`, and takes its dispatcher from `(:dispatch (rf/capture-frame))`. `Modal` survives as a one-line `as-component` bridge, because `shell.cljs`'s `shell-view` is still an `rf/reg-view` and mounts it as a Reagent hiccup head.
* `settings/editor_hint.cljs` — `Hint` is the boundary; `toast-view` needed no hoist because it already read nothing. `Toast` is the matching bridge.
* `settings/view.cljs` — now **reads nothing at all**. Every fn is pure of its arguments, `popup-view` becomes `popup-tree` taking a hoisted read-set, and `re-frame.core` is no longer required by the namespace — which is the measurement that says the hoist is complete rather than mostly done.

A reading fallback arity on the view was considered and deliberately rejected: a fallback that is dead in production is still a read path in the one file this migration exists to empty. The lane difference lives in the lane that differs.

## The node-lane door

`test_helpers/modal_trees.cljs` is new, mirroring `test-helpers/dynamic_shell_tree.cljs`. Each door reproduces its boundary's reads — same queries, same order, gate included — with `rf.fresco/sub` swapped for `rf/subscribe`, so a node-lane row stays evidence about the shipped modal rather than about a parallel fixture.

**The doors in that file are APPEND-ONLY.** Slices B2 (filters) and B4 (spine_filters) are queued behind this one and will add their own; the settings call sites in `modals_aria_cljs_test.cljs` and `p3_polish_aria_cljs_test.cljs` are the only lines this PR changes in those two shared files.

## The DOM witness

`settings/settings_fresco_boundary_dom_cljs_test.cljs` is the browser-lane witness — the node lane never mounts a boundary, never crosses the bridge and never asks the collector for anything, so a green node lane is compatible with a popup that paints nothing.

W2 watches `:rf.xray/settings-active-tab` deliberately. `:rf.xray/setting` — the query behind eleven of the fourteen reads — is `(or (get-in db [:settings section key]) (config/get-setting section key))`, so an unseeded app-db slot falls through to a **process-global atom** and answers correctly under a deliberately wrong frame. Only three queries on this surface have literal fallbacks and therefore traverse the frame; W2 uses the one that is also driven from inside the boundary, so a single round trip exercises the read path and the captured-dispatcher write path together.

## Rebase onto current trunk

This branch was green at its original base and then stopped merging because trunk moved. It has been rebased onto `a673775425`; the three commits are unchanged in content and message.

**One file conflicted: `modals_aria_cljs_test.cljs`, and exactly one hunk in it** — the `## Surfaces under test` list in the namespace docstring. `p3_polish_aria_cljs_test.cljs` auto-merged, and so did the require block of the conflicted file.

The two sides were independent and additive, as the shared-test-file protocol for this satellite set anticipated:

* **trunk** rewrote row 2 to `spine-filters/dialog-tree`
* **this branch** rewrites row 1 to `settings/view/popup-tree` plus its `modal-trees` door note

Adjacent lines, so git could not interleave them. **Both assertions were kept**; neither side was taken wholesale.

Three trunk commits touched files this branch carries since the old merge base — `a673775425` (App-DB segment inspector), `bf7dd1b614` (boundary-read hoist) and `e0fe148e80` (resize-handle pure trees) — and all three land only in the two shared aria test files. Every line those commits added to those files was checked to survive the rebase: 35 of 35, 24 of 24 and 9 of 9 respectively, with a negative control confirming the instrument reports a missing line as missing. In particular `segment-inspector-popup-tree`, `mute-manager-dialog-tree`, `cancellation-cascade-popover-tree`, the `edn-widget` require and the `resize-handle/handle-tree` block are all intact, and `origin/main...HEAD` removes nothing but the settings call sites this branch owns.

The require block needs no `settings.view` alias any more — the merged file references it zero times, because the three settings call sites now go through the door.

## Quality gates

**Re-run on the rebased tree.** Every captured exit code below is the runner's own, redirect and echo on one command line; none is a harness-reported figure.

**55 distinct gates run, 55 passed, 0 failed** — 5 lane phases, 46 python check gates, 4 shell check gates. Two further rows below are instruments rather than gates: one deliberate sabotage run (expected red, and red) and one negative control (expected red, and red).

| Gate | Captured exit | Result |
|---|---|---|
| `compile-node-test.cjs node-test` (full) | 0 | 1957 files, 1956 compiled, 0 warnings |
| Node lane — `node out/node-test.js` (full) | 0 | Ran 11704 tests, 58611 assertions. 0 failures, 0 errors |
| Node lane — focused on the two shared aria namespaces | 0 | Ran 22 tests, 89 assertions. 0 failures, 0 errors |
| Focused-selector negative control (nonexistent ns) | 1 | `no tests matched --test= selector(s)` — the selector discriminates, so the 22 above is a real selection |
| `shadow-cljs compile browser-test` (narrowed to the settings witness ns) | 0 | 582 files, 0 warnings |
| Browser DOM witness — `serve-and-run-browser-tests.cjs`, port 8141 | 0 | Ran 3 tests, 17 assertions. 0 failures, 0 errors |
| 46 × `scripts/check_*.py` (every python gate in `scripts/`) | 0 each | all pass, including the require-alias dialect ratchet, the test-lane bijection, the retired-spelling and retired-composition-vocab ratchets, the ambient-durable-reads and view-lifetime-residue scans |
| `scripts/check_require_alias_dialect.py` — **sabotaged** | **1** | names the planted line at `modals_aria_cljs_test.cljs:36` |
| `scripts/check_require_alias_dialect.py` — restored | 0 | clean |
| `scripts/check-commit-attribution.sh origin/main` | 0 | no AI attribution in the 3 commits this branch introduces |
| `scripts/check-beads-pr-boundary.sh origin/main` | 0 | no beads-database paths in the diff |
| `scripts/check-ai-tracking-ratchet.sh` | 0 | clean |
| `scripts/check-no-hardcoded-paths.sh` | 0 | clean |

Both compile logs name this worktree's own `shadow-cljs.edn`, so each lane is known to have read the rebased tree rather than a sibling checkout.

The browser runner logged `Serving ... on http://127.0.0.1:8141` — the requested port, not an OS-chosen fallback.

### The sabotage proof

The ratchet row above is a live discrimination on the rebased tree: `[re-frame.core :as rf]` was replaced with `:as rfcore` at a single anchored line whose match count was read as 1 before the run. The gate went red, exit 1, naming that file and that line number — a fault that exists only in this checkout. The restore was verified by content hash against the committed object (`git hash-object` reproducing `eeb9f7eb3c...`) and by `git diff --quiet HEAD` at exit 0, and the ratchet returned to 0.

The original DOM-witness sabotage — reverting the boundary's dispatcher to the historical `{:frame :rf/xray}` literal pin, which turned W2 red on all four of its claims while W1 and W3 stayed green, with identical 3-test/17-assertion totals across all three runs — was proved at the pre-rebase tree and is not re-proved here. The witness itself was re-run on the rebased tree and is the green row above. Re-running a heavyweight browser sabotage after a rebase that changed four docstring lines would buy wall-clock rather than information.

### What CI covers that this does not

The local browser gate is narrowed to the settings witness namespace so the sabotage signal stays unambiguous. The changed-surface classifier arms six surfaces for this diff — `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and `story_xray_browser`. The first two are covered above; the full 177-namespace browser lane, the examples compile sweep, the JVM lanes, the MCP conformance run, the Xray story browser gate and the lint/docs/portability workflows are **relied on from CI** rather than duplicated locally.

## Also in this PR

One follow-up commit corrects two docstring paragraphs the migration left stale — `popup.cljs`'s ns docstring still described `Modal` as a `reg-view`-wrapped gate, and `toast-view`'s still attributed its `dispatch` to a `reg-view`-injected name. Both were contradicted by text the migration commits added further down the same files. Prose only; no code or behaviour change.
