### PR TITLE
feat(xray): the command palette becomes a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/palette.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette.cljs
@@ -1,46 +1,139 @@
 (ns day8.re-frame2-xray.palette
   "Facade for the Xray command palette (rf2-wm7z4).
 
-  Per the canonical Xray panel-facade pattern: the facade owns the
-  `reg-view` that wraps the plain-Reagent body in `palette/view`, and
-  an `install!` fn that wires the palette's subs / events / fxs
-  through the Xray-side registry.
+  Per the canonical Xray panel-facade pattern: the facade owns the view
+  that `shell.cljs` mounts, and an `install!` fn that wires the
+  palette's subs / events / fxs through the Xray-side registry. Since
+  rf2-k97c.3 that view is a FRESCO BOUNDARY reading through the shipped
+  collector, and the hiccup itself is a pure projection in
+  `palette/view` — the same read-and-call split every migrated Xray view
+  uses.
+
+  The three names, in the order a reader meets them:
+
+  - [[ModalView]] — the `rf.fresco/defview` BOUNDARY. Reads the four
+                    palette subs and calls `view/palette-view`.
+  - [[Modal]]     — the callable a still-`reg-view` shell mounts as a
+                    hiccup head. Scaffolding with a defined end (see its
+                    own docstring).
+  - [[install!]]  — idempotent install for the palette's subs + events.
 
   ## Modal vs Panel
 
   The palette is NOT a sidebar panel — it has no row in the sidebar
-  list and no canvas slot. The `Modal` reg-view is mounted at the
-  shell-view root (so it overlays the chrome and panels) and
-  short-circuits to `nil` when the palette is closed. The render
-  cost when closed is the subscribe call plus a `when` — cheap.
+  list and no canvas slot. [[Modal]] is mounted at the shell-view root
+  (so it overlays the chrome and panels) and short-circuits to `nil`
+  when the palette is closed. The render cost when closed is the
+  open-state read plus a `when` — cheap, and cheaper than it was: the
+  other three reads now sit INSIDE the `when`, and `rf.fresco/sub`
+  records an edge where the read happens, so a closed palette
+  subscribes to exactly one key rather than four (HD-002).
 
   ## Why the shell mounts the Modal
 
-  Mounting at the shell-root means the modal's subscribes resolve
-  through the same `frame-provider` the shell installed —
-  `:rf/xray` reads land on Xray's app-db, not the host's. A
-  top-level `js/document.body` portal would lose the frame context,
-  and under EP-0002 that is a LOUD failure rather than a quiet
-  misroute: there is no `:rf/default` floor, so the ambient read
-  raises `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun)."
+  Mounting at the shell-root means the modal resolves its frame through
+  the same `frame-provider` the shell installed — `:rf/xray` reads land
+  on Xray's app-db, not the host's. A top-level `js/document.body`
+  portal would lose the frame context, and under EP-0002 that is a LOUD
+  failure rather than a quiet misroute: there is no `:rf/default` floor,
+  so the read raises rather than silently answering the host's db."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.palette.events :as events]
             [day8.re-frame2-xray.palette.subs :as subs]
             [day8.re-frame2-xray.palette.view :as view]))
 
-(rf/reg-view Modal
-  "The palette modal. Renders only when `:rf.xray/palette-open?` is
-  true; closed-state is a single subscribe + a `when` — cheap.
+(rf.fresco/defview ^:private ModalView
+  "The palette modal's root — a FRESCO BOUNDARY (rf2-k97c.3), not an
+  `rf/reg-view`. Renders only when `:rf.xray/palette-open?` is true;
+  closed-state is one read plus a `when`.
 
-  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
-  through the React-context tier to `:rf/xray`.
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref and no reaction owned by the installed
+  adapter, which is the third of the epic's three couplings and the one
+  a first-paint smoke test cannot see. The FRAME they resolve against
+  comes from React context, which the enclosing frame boundary writes;
+  `rf/frame-provider` and `rf.fresco/frame-provider` write the SAME
+  context, so this resolves `:rf/xray` identically under today's
+  Reagent-rendered shell and under the Fresco root Xray will own.
 
-  rf2-nesy9 — threads the reg-view-injected frame-aware `dispatch`
-  into `palette-view` so deferred `:on-*` handlers land on the
-  surrounding instance frame, not a `{:frame :rf/xray}` literal."
+  THE THREE INNER READS SIT INSIDE THE `when` DELIBERATELY. `sub` is
+  legal anywhere in a body and records its edge where the read happens,
+  so a branch not taken contributes no edge (HD-002). A closed palette
+  therefore holds ONE subscription, not four — which is the same
+  short-circuit the `reg-view` era got by not calling `palette-view` at
+  all, expressed in the collector's own terms.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body and replaces
+  the `dispatch` the `reg-view` body used to inject lexically (rf2-nesy9;
+  `defview` binds no name). Every deferred `:on-*` handler in the tree
+  below closes over it, so a click landing after render scope has
+  unwound still reaches the surrounding instance frame rather than a
+  `{:frame :rf/xray}` literal — or, absent it, raising
+  `:rf.error/no-frame-context`, since EP-0002 left no `:rf/default`
+  floor to absorb an unframed dispatch.
+
+  The raw `:rf.xray/palette-query` value is passed through rather than
+  defaulted here: `view/palette-view` owns the `(or … \"\")` so the pure
+  fn defends itself for every caller, the node lane's door included.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. The shell mounts this with none, so it is destructured away."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/palette-open?])
+    (view/palette-view (:dispatch (rf/capture-frame))
+                       (rf.fresco/sub [:rf.xray/palette-query])
+                       (rf.fresco/sub [:rf.xray/palette-results])
+                       (rf.fresco/sub [:rf.xray/palette-cursor]))))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter, and `shell.cljs` mounts the palette as a hiccup head —
+;; `[palette/Modal]` at the shell-view root. `defview`'s contract is that
+;; a boundary is mounted as `[head props]` inside a Fresco body or
+;; through `as-component` from OUTSIDE, never as a hiccup render fn in a
+;; Reagent tree.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS
+;; ALREADY IN, taking the frame from React context rather than from a
+;; second root. So there is no second root here, no adapter-kind branch,
+;; and no props ABI.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When `mount.cljs` owns a
+;; Fresco root and `shell-view` is itself a boundary, it heads
+;; [[ModalView]] directly, `[:>]` goes, and both defs below are deleted.
+
+(def ^:private Modal-component
+  "The React component [[ModalView]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the palette on
+  each shell render, losing the input's focus and caret with it."
+  (rf.fresco/as-component ModalView))
+
+(defn Modal
+  "The palette's public callable — what `shell.cljs` mounts as a hiccup
+  head at the shell-view root.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component [[ModalView]]
+  presents as. The shell's enclosing `rf/frame-provider` is what puts
+  the instance frame in React context for it.
+
+  The open/closed gate is inside [[ModalView]], so this is always
+  mounted and renders nothing while the palette is closed — the same
+  shape a mounted `reg-view` returning nil had.
+
+  Callers wanting the MARKUP as data — the node-lane view rows — build
+  it from `view/palette-view` with the reads' values instead (the
+  `test-helpers.palette-tree` door does exactly that); this returns an
+  interop vector, not a tree to walk."
   []
-  (when @(rf/subscribe [:rf.xray/palette-open?])
-    (view/palette-view dispatch)))
+  [:> Modal-component {}])
 
 (defn install!
   "Idempotent install for the palette's Xray-side registrations.

--- a/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/view.cljs
@@ -7,9 +7,24 @@
   - 16px type icon · label · right-aligned hint (epoch / coord / shortcut)
   - Arrows navigate · Enter invokes · Ctrl+Enter pops out
 
-  The component is a plain Reagent fn — the facade
-  `palette.cljs` wraps it in `reg-view` so its subscribes route to
-  the surrounding `:rf/xray` frame via React context.
+  ## rf2-k97c.3 — this namespace is PURE, and the reads live one level up
+
+  [[palette-view]] is a plain fn that takes its reads' VALUES and answers
+  hiccup. Nothing here subscribes. The facade `palette.cljs` owns the
+  `rf.fresco/defview` BOUNDARY — it reads the four palette keys through
+  `rf.fresco/sub` and calls [[palette-view]] with the values plus a
+  frame-bound dispatcher. That read-and-call split is `defview`'s own
+  documented extract-a-helper spelling and the shape every migrated Xray
+  view in this epic uses.
+
+  THE PURITY IS LOAD-BEARING, not incidental. `rf.fresco/sub` refuses
+  outside a boundary render, naming the query
+  (`:rf.error/fresco-sub-outside-render`), so a helper that read for
+  itself would be callable only inside a real React commit. Leaving this
+  fn pure keeps it callable from anywhere — which is what gives the node
+  lane a door onto the SHIPPED tree rather than a parallel fixture. That
+  door is `test-helpers.palette-tree`, which mirrors the boundary's reads
+  with `rf/subscribe` and drives this fn.
 
   ## Modal layer
 
@@ -49,15 +64,14 @@
 
   ## Why every deferred dispatch captures the surrounding frame
 
-  Subscribes resolve through the React-context tier at RENDER time —
-  React's `_currentValue` for the `frame-context` is set to the
-  instance frame while the body of the `frame-provider`'s children is
-  rendering, so `(rf/subscribe …)` from inside the palette picks up
-  the right frame with no explicit opt.
+  Reads resolve through the React-context tier at RENDER time — the
+  frame context's current value is the instance frame while the boundary
+  body runs, so the facade's `rf.fresco/sub` calls pick up the right
+  frame with no explicit opt.
 
   Dispatches from `:on-click` / `:on-change` / `:on-key-down` /
   `:on-mouse-enter` fire LATER — after render commits and React has
-  POPPED `_currentValue` back to the context's default, which is
+  POPPED that value back to the context's default, which is
   `re-frame.adapter.context/no-provider-sentinel` and NOT `:rf/default`.
   At click time BOTH tiers of the frame resolution chain come up empty —
   the dynamic var has unwound and the React-context tier reads the
@@ -68,14 +82,16 @@
   Enter, click on a row, ESC, backdrop click all refuse.
 
   So each deferred handler captures the SURROUNDING instance frame:
-  `palette.cljs`'s `Modal` `reg-view` body has a frame-aware `dispatch`
-  injected by the macro and threads it into `palette-view`, which fans
-  it out to every row + key handler. Each deferred handler calls that
+  `palette.cljs`'s `ModalView` boundary binds it through
+  `(:dispatch (rf/capture-frame))` — core's own door, which answers the
+  boundary's declared frame inside a body and replaces the `dispatch`
+  the `reg-view` era injected lexically (rf2-nesy9; `defview` binds no
+  name). It threads that dispatcher into [[palette-view]], which fans it
+  out to every row + key handler. Each deferred handler calls that
   captured `dispatch` (never the global `rf/dispatch`, never a
   `{:frame :rf/xray}` literal), so N isolated instances each route to
   their own frame."
-  (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.palette.sources :as sources]
+  (:require [day8.re-frame2-xray.palette.sources :as sources]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
@@ -223,10 +239,18 @@
   and this row both absent, with the refusal reaching a window `error`
   listener.
 
-  `palette-view` already binds `query` from the same subscription, so
-  passing it removes the duplicate read outright rather than donating it
-  upward into the enclosing boundary's window — strictly better than a
-  bare `(empty-row)` inline, which is the other spelling of the repair."
+  `palette-view` already binds `query`, so passing it removes the
+  duplicate read outright rather than donating it upward into the
+  enclosing boundary's window — strictly better than a bare
+  `(empty-row)` inline, which is the other spelling of the repair.
+
+  rf2-k97c.3 — THAT REPAIR IS WHY THIS HELPER NEEDED NOTHING FROM THE
+  FRESCO MIGRATION, and it is worth saying because a census taken before
+  #9657 still names this fn as the one ambient read among Xray's plain-
+  `defn` head targets. It reads nothing now. The migration's hoist landed
+  one level up instead, on `palette-view`'s three reads, which moved into
+  the `palette/ModalView` boundary; this fn was already in the shape that
+  hoist produces."
   [query]
   [:li {:data-testid "rf-xray-palette-empty"
         :style       (merge (row-style false)
@@ -285,13 +309,18 @@
 (defn- handle-input-keydown
   ;; EP-0002 — a deferred key handler fires at CLICK time,
   ;; after render has committed and the frame context has unwound, so it
-  ;; carries NO ambient frame stamp. It must therefore not `rf/subscribe`
-  ;; the cursor itself (that ambient read raises `:rf.error/no-frame-context`
-  ;; under no scope rather than falling through to a synthesised
-  ;; `:rf/default`). The `cursor` is read at RENDER time by `palette-view`
-  ;; (where the surrounding instance frame's React context is live) and
-  ;; threaded in alongside the frame-aware `dispatch`, mirroring how the
-  ;; dispatch itself is injected rather than resolved at click time.
+  ;; carries NO ambient frame stamp. It must therefore not read the
+  ;; cursor itself. Under rf2-k97c.3 that is doubly true and the refusal
+  ;; is a different one: `rf.fresco/sub` is legal ONLY inside a boundary
+  ;; render and raises `:rf.error/fresco-sub-outside-render` naming the
+  ;; query, where the `reg-view` era's ambient `rf/subscribe` raised
+  ;; `:rf.error/no-frame-context` instead. Both refuse; neither falls
+  ;; through to a synthesised `:rf/default`.
+  ;;
+  ;; The `cursor` is read at RENDER time by the `palette/ModalView`
+  ;; boundary (where the frame context is live), handed to `palette-view`
+  ;; and threaded in here alongside the frame-bound `dispatch` — the same
+  ;; treatment, for the same reason, as the dispatcher itself.
   [dispatch cursor ^js e results]
   (let [k         (.-key e)
         ctrl?     (or (.-ctrlKey e) (.-metaKey e))
@@ -319,18 +348,35 @@
 ;; ---- main view ---------------------------------------------------------
 
 (defn palette-view
-  "The hiccup for the open palette. Caller (`palette/Modal`) gates
-  the mount on `:rf.xray/palette-open?` — this fn assumes it's open
-  and always renders.
+  "The hiccup for the open palette, as a PURE function of its reads'
+  values. Caller (`palette/ModalView`) gates the mount on
+  `:rf.xray/palette-open?` — this fn assumes it's open and always
+  renders.
 
-  `dispatch` is the frame-aware dispatcher injected by the
-  `palette/Modal` `reg-view` body — threaded into every row + key
-  handler so deferred handlers land on the surrounding instance frame,
-  not a `{:frame :rf/xray}` literal."
-  [dispatch]
-  (let [query   (or @(rf/subscribe [:rf.xray/palette-query]) "")
-        results @(rf/subscribe [:rf.xray/palette-results])
-        cursor  @(rf/subscribe [:rf.xray/palette-cursor])]
+  ## The arguments are the boundary's reads (rf2-k97c.3)
+
+  `dispatch`   — the frame-bound dispatcher the boundary captured with
+                 `(:dispatch (rf/capture-frame))`, threaded into every
+                 row + key handler so deferred handlers land on the
+                 surrounding instance frame, not a `{:frame :rf/xray}`
+                 literal. See the ns docstring for why that matters.
+  `raw-query`  — `:rf.xray/palette-query`, passed through UNDEFAULTED.
+  `results`    — `:rf.xray/palette-results`.
+  `cursor`     — `:rf.xray/palette-cursor`.
+
+  THE `(or … \"\")` LIVES HERE RATHER THAN AT THE BOUNDARY, so the pure
+  fn defends itself for every caller — the boundary, the node lane's
+  `test-helpers.palette-tree` door, and any future one — instead of each
+  caller having to remember that an unset query reads nil and that a
+  `nil` `:value` turns the input into an uncontrolled component.
+
+  IT SUBSCRIBES TO NOTHING, AND THAT IS THE POINT. `rf.fresco/sub`
+  refuses outside a boundary render, so a reading helper would be
+  callable only inside a real React commit; taking values keeps this
+  callable from the node lane, which is what lets a node row walk the
+  SHIPPED tree."
+  [dispatch raw-query results cursor]
+  (let [query (or raw-query "")]
     ;; Shared backdrop + dialog scaffold. The palette keeps
     ;; its own `backdrop-style` / `dialog-style` and its `:auto-focus`
     ;; input owning Esc (handled in `handle-input-keydown`, exactly the

--- a/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs
@@ -19,13 +19,29 @@
 
   Hiccup traversal mirrors `spine-filters-cljs-test`'s pattern —
   expand-tree walks function-in-head-position nodes, then a depth-first
-  search by data-testid / role / attribute resolves each assertion."
+  search by data-testid / role / attribute resolves each assertion.
+
+  ## Where the tree comes from (rf2-k97c.3)
+
+  `palette/ModalView` is an `rf.fresco/defview` BOUNDARY now, so it is
+  not callable outside a React render window, and `view/palette-view` is
+  a PURE fn of its reads' values rather than a fn that reads for itself.
+  These rows therefore build the hiccup through
+  `test-helpers.palette-tree`, which mirrors the boundary's four reads in
+  the same order behind the same open-gate and drives the shipped
+  `palette-view` — so what is asserted below is still the SHIPPED tree
+  and not a parallel fixture.
+
+  `rf/dispatch` is passed explicitly, as it always was: these rows only
+  read attributes and never fire a handler, so the frame-bound door the
+  boundary captures is not what they are about. `palette.dispatch-
+  routing-cljs-test` owns that, and takes the helper's default instead."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
-            [day8.re-frame2-xray.palette.view :as view]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.palette-tree :as palette-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (use-fixtures :each
@@ -56,7 +72,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree   (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree   (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           dialog (rf.test-helpers/find-by-testid tree "rf-xray-palette-dialog")]
       (is (some? dialog) "the dialog wrapper renders")
       (is (= "dialog" (:role (props dialog))))
@@ -74,7 +90,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree  (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree  (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           input (rf.test-helpers/find-by-testid tree "rf-xray-palette-input")
           attrs (props input)]
       (is (some? input))
@@ -92,7 +108,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree    (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree    (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           input   (rf.test-helpers/find-by-testid tree "rf-xray-palette-input")
           listbox (rf.test-helpers/find-by-testid tree "rf-xray-palette-list")]
       (is (= (:aria-controls (props input))
@@ -108,7 +124,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           ul   (rf.test-helpers/find-by-testid tree "rf-xray-palette-list")]
       (is (some? ul) "the list wrapper renders")
       ;; Default palette open populates results (>0 commands registered)
@@ -124,7 +140,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-palette-row-")]
       (is (seq rows) "the palette renders at least one row")
       (doseq [row rows]
@@ -143,7 +159,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open]))
-    (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-palette-row-")
           ids  (mapv (comp :id props) rows)]
       (is (= (count ids) (count (set ids)))
@@ -156,7 +172,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open])
       (rf/dispatch-sync [:rf.xray/palette-cursor-set 0]))
-    (let [tree (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           rows (rf.test-helpers/find-by-testid-prefix tree "rf-xray-palette-row-")
           selected (filter #(= "true" (:aria-selected (props %))) rows)]
       (is (= 1 (count selected))
@@ -170,7 +186,7 @@
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/palette-open])
       (rf/dispatch-sync [:rf.xray/palette-cursor-set 0]))
-    (let [tree     (rf/with-frame :rf/xray (view/palette-view rf/dispatch))
+    (let [tree     (rf/with-frame :rf/xray (palette-tree/palette-tree rf/dispatch))
           input    (rf.test-helpers/find-by-testid tree "rf-xray-palette-input")
           rows     (rf.test-helpers/find-by-testid-prefix tree "rf-xray-palette-row-")
           active   (some (fn [row]

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -22,10 +22,15 @@
   close, arrow keys do not move the cursor, Esc does not close, input
   text does not update the query — the palette appears frozen.
 
-  The fix in `palette/view.cljs` is mechanical: every `rf/dispatch`
-  from a deferred handler carries `{:frame :rf/xray}` so the
-  envelope's `:frame` is set at call time and never depends on the
-  click-time React-context read.
+  The fix is mechanical and has had two spellings. Originally every
+  `rf/dispatch` from a deferred handler carried a `{:frame :rf/xray}`
+  literal. Since rf2-nesy9 the palette threads a FRAME-BOUND DISPATCHER
+  captured at render time instead, so N isolated Xray instances each
+  route to their own frame rather than all to the singleton; under
+  rf2-k97c.3 the `palette/ModalView` boundary captures it with
+  `(:dispatch (rf/capture-frame))`. Either way the envelope's `:frame`
+  is set at call time and never depends on the click-time context read,
+  which is the property these rows defend.
 
   ## How these tests reproduce the click-time path
 
@@ -34,14 +39,25 @@
   click-fires-after-render reality. Click handlers use queued
   `rf/dispatch` (not `dispatch-sync`); the router drain is async via
   `goog.async.nextTick`. Tests use `rf.test-support/poll-until` to await
-  the drain before asserting."
+  the drain before asserting.
+
+  ## Where the tree comes from (rf2-k97c.3)
+
+  `palette/Modal` is the `as-component` migration BRIDGE now — it
+  answers a `[:>]` interop vector, not a tree to walk — so these rows
+  build the hiccup through `test-helpers.palette-tree`, which mirrors
+  the `palette/ModalView` boundary's four reads in the same order behind
+  the same open-gate, and defaults `dispatch` to the boundary's own
+  `(:dispatch (rf/capture-frame))` door. That default is load-bearing
+  HERE specifically: it is the captured dispatcher whose click-time
+  routing is the whole subject of this ns."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
             [re-frame.test-support :as rf.test-support]
-            [day8.re-frame2-xray.palette :as palette]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.palette-tree :as palette-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; `make-xray-runtime-fixture` (rf2-vj80u8) composes core
@@ -73,6 +89,14 @@
   ;; rather than falling through to a synthesised `:rf/default`. (The
   ;; click-time HANDLER is still invoked OUTSIDE any scope — that is the
   ;; real click-fires-after-render path under test.)
+  ;;
+  ;; rf2-k97c.3 — the scope is BELT-AND-BRACES now rather than
+  ;; load-bearing, and is kept deliberately. `view/palette-view` is pure
+  ;; and every helper below it is CALLED rather than headed, so the tree
+  ;; `palette-tree` answers is keyword-headed all the way down and the
+  ;; walk has no fn head left to re-invoke. Keeping the scope costs
+  ;; nothing and means a future helper that is headed again cannot turn
+  ;; this walk red for the wrong reason.
   (rf/with-frame :rf/xray
     (rf.test-helpers/find-by-testid tree testid)))
 
@@ -108,7 +132,7 @@
 (defn- render-open-palette []
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/palette-open]))
-  (rf/with-frame :rf/xray (palette/Modal)))
+  (rf/with-frame :rf/xray (palette-tree/palette-tree)))
 
 ;; ---- tests --------------------------------------------------------------
 
@@ -187,7 +211,7 @@
     (let [_ (rf/with-frame :rf/xray
               (rf/dispatch-sync [:rf.xray/palette-open])
               (rf/dispatch-sync [:rf.xray/palette-cursor-set 2]))
-          rendered (rf/with-frame :rf/xray (palette/Modal))
+          rendered (rf/with-frame :rf/xray (palette-tree/palette-tree))
           input    (find-by-testid rendered "rf-xray-palette-input")
           handler  (on-key-down input)]
       (is (= 2 (:palette-cursor (rf/app-db-value :rf/xray))))

--- a/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs
@@ -141,12 +141,14 @@
   nil)
 
 (defn- mount!
-  "Mount `body` the way `shell.cljs:3100` mounts the palette — under the
-  outer `frame-provider` `mount.cljs` installs. That wrapper is the whole
-  point: a BARE mount raises `:rf.error/no-frame-context` for an entirely
-  different reason (`Modal` is itself a `reg-view`, and a `reg-view` at a
-  bare root has no context to read), which would be a false positive for
-  the fault under test.
+  "Mount `body` the way `shell.cljs` mounts the palette at the shell-view
+  root — under the outer `frame-provider` `mount.cljs` installs. That
+  wrapper is the whole point: a BARE mount fails for an entirely
+  different reason, which would be a false positive for the fault under
+  test. Under rf2-k97c.3 that different reason has simply changed hands
+  and stayed a refusal — `Modal` is the `as-component` bridge onto the
+  `ModalView` BOUNDARY now, and a boundary at a bare root resolves no
+  frame from React context either. The wrapper is what supplies one.
 
   Committed synchronously — React 19's `root.render` is otherwise async
   and the first assertion would read an empty container."

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/palette_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/palette_tree.cljs
@@ -1,0 +1,65 @@
+(ns day8.re-frame2-xray.test-helpers.palette-tree
+  "The node lane's door onto the Xray COMMAND PALETTE (rf2-k97c.3).
+
+  ## Why this exists
+
+  `palette/ModalView` is an `rf.fresco/defview` now — a real React
+  function component. A boundary's body may only run inside a React
+  render window (`rf.fresco/sub` REFUSES outside one, naming the query
+  and its own remedy), so `(palette/ModalView nil)` is not a callable
+  that answers hiccup, and `(palette/Modal)` answers the `[:>]` interop
+  vector of the migration bridge rather than a tree to walk.
+
+  The repair is `defview`'s own documented extract-a-helper spelling, the
+  one every migrated view in this epic uses: `palette/view.cljs` is PURE
+  and takes its reads' values, the boundary is the thin thing that reads
+  and calls it, and the node lane drives the pure fn. This ns is the
+  composer that does that driving — the palette's sibling of
+  `test-helpers.dynamic-shell-tree`.
+
+  ## It REPRODUCES THE BOUNDARY'S READS — same keys, same order, same gate
+
+  That is what makes a node-lane row evidence about the shipped palette
+  rather than about a parallel fixture. [[palette-tree]] mirrors
+  `palette/ModalView` line for line, with `rf.fresco/sub` swapped for
+  `rf/subscribe` (the node lane has no React render window and no
+  collector extent) and nothing else changed:
+
+    * the `:rf.xray/palette-open?` GATE is reproduced, so a closed
+      palette answers `nil` here exactly as it renders nothing there;
+    * the three inner reads sit INSIDE that gate, as they do in the
+      boundary (`sub` records its edge where the read happens, so a
+      closed palette holds one subscription rather than four — HD-002);
+    * `:rf.xray/palette-query` is passed through UNDEFAULTED, because the
+      `(or … \"\")` lives in `view/palette-view` and the lane must not
+      duplicate a derivation the shipped fn owns.
+
+  ## `dispatch` defaults to the SAME door the boundary uses
+
+  `(:dispatch (rf/capture-frame))` — so a handler this lane pulls off the
+  tree and fires LATER, outside any frame scope, carries the frame
+  exactly as the shipped one does. That is the whole subject of
+  `palette.dispatch-routing-cljs-test`, so the default has to be the real
+  door rather than a bare `rf/dispatch`. The 1-arity is for a row that
+  wants to supply its own (the ARIA rows do, since they only read
+  attributes and never fire anything).
+
+  ## Call these INSIDE a frame scope
+
+  Every fn here subscribes ambiently, so each call belongs inside
+  `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view` body
+  had, and the same one every existing caller already satisfies."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.palette.view :as view]))
+
+(defn palette-tree
+  "The open palette's hiccup, read the way `palette/ModalView` reads it —
+  the same four keys in the same order, behind the same open-gate.
+  Answers `nil` when the palette is closed, as the boundary does."
+  ([] (palette-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (when @(rf/subscribe [:rf.xray/palette-open?])
+     (view/palette-view dispatch
+                        @(rf/subscribe [:rf.xray/palette-query])
+                        @(rf/subscribe [:rf.xray/palette-results])
+                        @(rf/subscribe [:rf.xray/palette-cursor])))))


### PR DESCRIPTION
Slice B3 of the Xray chrome-satellite split (rf2-k97c.3): the command palette moves onto the re-frame-native view layer.

## What changed

`palette/Modal` stops being an `rf/reg-view`. `palette.cljs` now carries `rf.fresco/defview ^:private ModalView`, which reads the four palette keys through `rf.fresco/sub` and hands the values — plus a dispatcher captured with `(:dispatch (rf/capture-frame))` — to `view/palette-view`, which becomes a PURE function of them. That is the read-and-call split every migrated view in this epic already uses.

**`shell.cljs` needed no edit, and that is the point of the shape chosen.** It mounts `[palette/Modal]` as a hiccup head at the shell-view root. `Modal` stays a callable: the `rf.fresco/as-component` bridge answering `[:> Modal-component {}]` — the shape `cancellation-cascade/Popover` already ships, which `shell.cljs:3135` heads the same way four lines from the palette's own mount. Scaffolding with a defined end, stated in its docstring: when `mount.cljs` owns a Fresco root, `shell-view` heads `ModalView` directly and both defs go.

`view.cljs` no longer requires `re-frame.core` at all — the namespace subscribes to nothing.

## Three things a reviewer would otherwise flag

**The three inner reads sit INSIDE the open-gate `when`, and that is not a regression to four eager reads.** `rf.fresco/sub` is legal anywhere in a body and records its edge where the read happens (HD-002, and the collector's own `sub` docstring says so), so a branch not taken contributes no edge. A CLOSED palette therefore holds one subscription rather than four — the `reg-view` era's short-circuit preserved rather than paid for.

**`palette-view`'s purity is load-bearing, not cosmetic.** `sub` refuses outside a boundary render (`:rf.error/fresco-sub-outside-render`, naming the query), so letting its three reads donate upward would have narrowed it to being callable only inside a real React commit — and it has **ten non-render call sites across two node-lane suites**. Taking values keeps it callable from anywhere, which is what gives the node lane a door onto the SHIPPED tree. That door is `test-helpers/palette_tree.cljs`, the palette's sibling of `test-helpers/dynamic_shell_tree.cljs`: same four keys, same order, same gate, `rf/subscribe` in place of `rf.fresco/sub`, and `dispatch` defaulting to the boundary's own `capture-frame` door so a handler fired later routes identically.

**`empty-row` needed no change, and a live census claim about it is stale.** A tree-wide census named `palette.view/empty-row` as the one ambient read among Xray's 46 plain-`defn` head targets. Measured at this tip: it performs **no read at all** — PR #9657 repaired it to `(empty-row query)`, a pure fn of its argument — and its caller set is **exactly one** private in-namespace call at `view.cljs:405`. The census predates #9657. The migration's hoist landed one level up, on `palette-view`'s three reads.

## Head-site census: zero, measured both ways

Three-pass census (line-oriented; whitespace-collapsed; comment-stripped-then-collapsed) over both source files finds **zero** plain-`defn` or `reg-view` hiccup head sites. Every helper — `modal-chrome`, `empty-row`, `result-row`, `empty-message`, the style fns — was already CALLED. Remaining candidates are `ns` require vectors, `defn` arg vectors and `[[wikilinks]]` in docstrings.

Control, same instrument, on an unmigrated sibling read-only: `filters/pills.cljs` reports `pill` as a real head candidate. The instrument bites, so the zero is absence and not a broken probe.

Transitive check (Q1's second half — "a call site is not evidence of a head-free subtree"): `modal-chrome`, `theme/a11y`, `theme/tokens` and `palette/sources` were read, not assumed. All return keyword-headed hiccup, and a read/dispatch census over the four returns zero against a live control of 11 in `shell.cljs`.

## Which branches are proven where — the non-default-state question

A node-lane green says nothing about head legality, because `expand-tree` invokes a fn head and so expands `[f …]` and `(f …)` identically. That blind spot is **vacuous here**: there are no heads in these files in either direction, so there is nothing for head legality to grade. Stated explicitly rather than left implied.

Branch coverage, since two of the three render only under non-default state:

| branch | renders when | proven where |
|---|---|---|
| `ModalView` returns nil | palette closed (default) | feature gate stages a closed palette |
| `empty-row` | open + query matches nothing | **browser**, `empty_row_frame_context_dom_cljs_test` W1 — sabotage-proven below |
| `result-row` | open + results non-empty | **browser**, feature-gate smoke scenario `command palette chord, fuzzy filter, execute verb, and recents round-trip`; plus the node aria rows |

Both pins were confirmed to walk real subjects rather than trusted by description — each was made to go red by a plant (below), which is what proves it grades anything.

## Quality gates

Run from this worktree. Every number below is the runner's own captured exit code, taken in the same shell as the redirect.

| gate | phase | captured exit | result |
|---|---|---|---|
| `node-test` compile | control | **0** | 1952 files, 0 warnings |
| `node-test` run | control | **0** | 11686 tests / 58559 assertions, 0 failures, 0 errors |
| `node-test` run | **sabotage** | **1** | 1 failure, naming the plant |
| `browser-test` compile | control | **0** | 1053 files, 5 warnings (all pre-existing, see below) |
| `browser-test` run | control | **0** | 945 tests / 5241 assertions, 0 failures, 0 errors |
| `browser-test` run | **sabotage** | **1** | 2 failures, both in the palette DOM witness |
| `test:xray-feature-gate --smoke` | control | **0** | 5 scenarios, 0 failures, 10 matrix rows |
| `check_require_alias_dialect.py` | ratchet | **0** | |
| `check_retired_spellings.py` | ratchet | **0** | |
| `check_ambient_durable_reads.py` | ratchet | **0** | |

Pass 7 / fail 0 on the control runs; the two sabotage runs failed by construction, which was their purpose.

**The 5 browser-compile warnings are not mine.** All five are `:infer-warning`s in `implementation/fresco/test/re_frame/fresco/login_server_crossing_ssr_dom_cljs_test.cljs`; no warning names any file in this change.

### Proving the gates can fail

**Node lane.** Planted `:role "listbox"` → `:role "SABOTAGE-not-a-listbox"` in `palette-view` (match count read as 1 before the run, so the plant was not a silent no-op; blob hash moved `f7cd4877…` → `1aaf8452…`). Result: captured exit **1**, exactly **1 failure**, reading `(not (= "listbox" "SABOTAGE-not-a-listbox"))` in `non-empty results carry the listbox role`. Test and assertion counts identical to the control (11686 / 58559), so the plant was scoped and stopped no namespace.

**Browser lane, and this one is the load-bearing sabotage.** The plant went in the BOUNDARY BODY — `(when …)` → `(when-not …)` on the open-gate in `palette.cljs`, a code path the node lane cannot reach at all. Result: captured exit **1**, **2 failures**, both in `w1-empty-row-commits-under-a-provider`, naming `rf-xray-palette-dialog` and `rf-xray-palette-empty`. The log carries `Testing day8.re-frame2-xray.palette.empty-row-frame-context-dom-cljs-test`, which is the positive evidence that the witness runs — the control run's summary names no individual suite, so its green alone would not have shown that. Counts again identical to the control (945 / 5241).

That red is what demonstrates the browser lane genuinely grades the new Fresco boundary through the `as-component` bridge under a real `frame-provider`. `0 errors` and no `pageerror` on it is itself informative: the boundary did not RAISE, it correctly rendered nothing — so this migration's failure mode here is a blank palette, not a refusal.

Both restores verified by blob hash against the committed object (`view.cljs` `f7cd4877da0f392ea4d33023552018177f0b5eb6`, `palette.cljs` `65ddcb5f62f034da8632366b2607e1634a95c42a`), each confirmed a second way with `git diff --quiet HEAD` exiting 0. Both files are `i/lf w/crlf`, so the default `git hash-object` form is the one that reproduces the committed blob; `--no-filters` does not, and was not used to judge either restore.

### Declared, not waited out

`test:xray-feature-gate --smoke` was run GREEN but was **not** sabotage-proven — that would have cost a third full browser compile. It is nominated here only as the witness for the non-empty-results branch, and its palette scenario was verified present at source (`scenarios.cjs:3878`, `smoke: true` at `:3884`; 5 smoke flags in the file, 5 scenarios reported run). The same boundary plant that reddened the DOM lane asserts the identical `rf-xray-palette-dialog` testid this gate polls, so the code path under it is proven-red by the browser sabotage above.

This branch is based on `1bf7106126`; `origin/main` has since moved to `18db9e29ab`. A three-dot diff against the merge base is exactly the six files below, and no commit upstream touches any of them, so there is nothing here that reverts a sibling's landing. Gates were not re-run against the newer base — CI's run is the evidence about that tree.

## Scope

Six files, all inside slice B3:

- `tools/xray/src/day8/re_frame2_xray/palette.cljs`
- `tools/xray/src/day8/re_frame2_xray/palette/view.cljs`
- `tools/xray/test/day8/re_frame2_xray/palette/aria_cljs_test.cljs`
- `tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs`
- `tools/xray/test/day8/re_frame2_xray/palette/empty_row_frame_context_dom_cljs_test.cljs`
- `tools/xray/test/day8/re_frame2_xray/test_helpers/palette_tree.cljs` (new)

No fenced file touched: `panels.cljs`, `panels/**`, `shell_cljs_test.cljs`, `panel_gallery/panel_views.cljs`, `frame_switcher.cljs` and `static/mode_pill.cljs` are all untouched, as are the other four satellites' files. `palette/sources` was left structurally alone — other code cites its set-as-data shape.

Stale prose was corrected only where this change makes it wrong: the `reg-view` docstrings in both source files, `handle-input-keydown`'s note on which refusal a click-time read now raises, the DOM suite's `mount!` note on why a bare mount is a false positive, and the two node suites' accounts of where their tree comes from.

## Left alone, recorded rather than fixed

- `dispatch_routing_cljs_test`'s ns docstring still describes the pre-EP-0002 three-tier fall-through to `:rf/default`. Pre-existing, not made wrong by this change, and the same class `rf2-78wg` already owns.
- Both palette node suites carry a `[re-frame.frame :as rf.frame]` require that neither uses. Pre-existing.
