### PR TITLE
test(xray): acceptance harness for the epic's six behavioural criteria (rf2-k97c.3)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/acceptance/criteria.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/criteria.cljs
@@ -1,0 +1,1005 @@
+(ns day8.re-frame2-xray.acceptance.criteria
+  "THE ACCEPTANCE HARNESS for the rf2-k97c epic's SIX BEHAVIOURAL CRITERIA,
+  written against TODAY'S Xray so the root-swap PR inherits it rather than
+  writing one under its own time pressure (rf2-k97c.3, slice D).
+
+  This namespace holds the six criterion BODIES. It registers no `deftest`
+  of its own and its name carries no `-cljs-test` suffix, so neither lane
+  discovers it; the per-substrate test namespaces beside it each wrap these
+  six in `deftest` under their own adapter. One body, N substrates — which
+  is the whole point, because the claim the swap makes is a claim about
+  INDIFFERENCE to the installed adapter.
+
+  ## The six, and which fn answers each
+
+  | # | criterion                                                  | fn |
+  |---|------------------------------------------------------------|----|
+  | 1 | first display                                              | [[c1-first-display!]] |
+  | 2 | updates as the app changes                                 | [[c2-updates-as-the-app-changes!]] |
+  | 3 | Xray's own interactions                                    | [[c3-xrays-own-interactions!]] |
+  | 4 | tool-local state separate from the app, commands targeting the intended frame | [[c4-tool-local-state-and-frame-targeting!]] |
+  | 5 | Xray's activity never masquerading as application evidence | [[c5-no-masquerading-as-application-evidence!]] |
+  | 6 | clean teardown and reopen without disturbing the host      | [[c6-clean-teardown-and-reopen!]] |
+
+  ## THE SUBJECT: Xray's Static chrome, and why that one
+
+  [[mount-xray!]] mounts `static.shell/surface` — Xray's Static ribbon, tab
+  bar and detail panel, the largest piece of Xray's OWN CHROME that is
+  already re-authored as `rf.fresco/defview` boundaries. Three of the four
+  chrome layers, not one panel.
+
+  It is the right subject because it is the only piece of Xray whose mount
+  is adapter-INDEPENDENT today, and adapter-independence is the whole claim
+  the swap makes. The Dynamic shell is not yet migrated: `shell/shell-view`
+  is still an `rf/reg-view` painted through the installed adapter's
+  `:render`, which is the epic's coupling (1) and a later slice. When that
+  lands, this harness widens by one line — the vector [[mount-xray!]]
+  renders — and every row below is unchanged.
+
+  ## THE MOUNT VERB: Fresco's own root, which IS the post-swap mechanism
+
+  `rf.fresco.impl.mount/root!` creates and owns a React root and reads
+  through Fresco's collector. That is precisely what the epic's coupling
+  (1) asks `mount.cljs` to do, so a harness written against it is a harness
+  the swap PR satisfies by construction rather than by edit.
+
+  Measured at trunk 1bf7106126, this mechanism paints Xray's Static chrome
+  under BOTH a ratom-family adapter and an element-shaped one, with the
+  HOST'S adapter installed and untouched. That is the forward-looking
+  clause of the epic — *a future non-React browser adapter supplying only
+  the container quartet plus the listener API should get Xray with no
+  Xray-side work* — reduced to something a row can witness today.
+
+  ## THE FRAME: `:rf/xray`, deliberately, and it is load-bearing for two rows
+
+  [[xray-frame]] is `shell/default-frame-id`, which is where production
+  mounts the shell and where Xray's tool-local state lives. Mounting the
+  chrome into the APPLICATION's frame instead would put Xray's tab
+  selection into the app's `app-db` and its dispatches into the app's trace
+  ring — which is exactly what criteria 4 and 5 say must not happen, so a
+  harness that did it would be asserting against a world it had itself
+  arranged to be wrong.
+
+  ## WHAT EVERY ROW COMPARES AGAINST
+
+  LITERALS. Not a value read back out of the surface under test. A door
+  compared against the attrs it has just read agrees with itself under a
+  revert — both sides nil, the row green ON THE DEFECT — which is how a
+  hollow assertion survives its own sabotage run. Every expectation below
+  is spelled out: `\"rf-xray-static-detail-panel-flows\"`, `:machines`,
+  `0`, `empty-runtime`.
+
+  ## NODE LANE
+
+  Every fn short-circuits through [[browser?]] and reports the skip. The
+  `:node-test` build compiles these namespaces (`cljs-test$` matches
+  `-dom-cljs-test` too) but has no DOM to commit into."
+  (:require [cljs.test :refer-macros [is]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.mount :as rf.fresco.impl.mount]
+            [re-frame.fresco.test.runtime :as rf.fresco.test.runtime]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ===========================================================================
+;; Frames, queries and the literal expectations every row compares against
+;; ===========================================================================
+
+(def xray-frame
+  "Where the chrome mounts — `shell/default-frame-id`, i.e. `:rf/xray`.
+  Taken from the source rather than spelled `:rf/xray` here so a rename of
+  the singleton cannot leave this harness quietly pointing at a frame that
+  no longer exists."
+  shell/default-frame-id)
+
+(def app-frame
+  "THE INSPECTED APPLICATION's frame. Criterion 4 says Xray's state stays
+  out of it and criterion 5 says Xray's activity stays out of its
+  evidence, so this frame is an instrument in both rows rather than
+  scenery."
+  ::app)
+
+(def other-frame
+  "A SECOND live frame, the DEAF LEVER for criterion 4's routing half. A
+  command that had lost its frame capture and fallen through to an ambient
+  dispatcher would write here, or nowhere; a frame held at a distinct value
+  is the only thing that separates those two from a command that routed
+  where it was told."
+  ::other)
+
+(def selected-tab-q
+  "The read the Static tab bar and the Static detail panel BOTH make, and
+  the one a tab click invalidates. Named once because it is three things:
+  criterion 3's state assertion, criterion 4's frame probe, and — paired
+  with a frame — the collector's own cell address in criterion 6."
+  [:rf.xray.static/selected-tab])
+
+(def default-tab
+  "The tab the Static surface lands on with nothing selected. Read from
+  the source, because criterion 1 asserts the L4 panel's testid contains
+  it and criterion 3 asserts the click moved AWAY from it."
+  static-shell/default-tab)
+
+(def clicked-tab
+  "The tab criterion 3 presses. `:flows` is a registered Static tab that is
+  NOT [[default-tab]], so the L4 panel moving to it is the click's doing
+  and not the surface's resting state."
+  :flows)
+
+(def deaf-frame-tab
+  "The DISTINCT value [[other-frame]] is held at. Neither the default nor
+  [[clicked-tab]], so `unchanged` names a specific tab rather than the
+  value every frame answers with anyway."
+  :routes)
+
+(def probe-flow-id
+  "The flow criterion 2 registers INTO THE APPLICATION at run time — the
+  'app changes' half. Its row testid is derived below."
+  :rf2-acceptance/probe-flow)
+
+(def probe-flow-row-testid
+  "The literal testid the Static Flows panel gives [[probe-flow-id]]'s row.
+  `static/flows/panel.cljs` builds it as the prefix plus `(subs (pr-str
+  flow-id) 1)` — the printed keyword with its leading colon shaved — so
+  this is spelled out rather than recomputed, because a row that derives
+  its expectation the same way the subject does agrees with the subject
+  under any defect they share."
+  "rf-xray-static-flows-row-rf2-acceptance/probe-flow")
+
+(def empty-runtime
+  "What the collector census reads when it holds nothing. Spelled out
+  rather than captured, so criterion 6's baseline is a claim about ZERO
+  rather than about whatever happened to be standing — a baseline taken
+  from a dirty runtime lets a leak hide inside it."
+  {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0})
+
+;; ---- the application's own handlers ---------------------------------------
+;;
+;; Registered at ns LOAD, which is ahead of every test ns's `use-fixtures`
+;; form being evaluated — and that form is when the reset fixture captures
+;; its registrar baseline. A registration written after it is erased before
+;; the first row runs.
+
+(rf/reg-sub ::app-count (fn [db _] (:count db 0)))
+
+(rf/reg-event ::app-seed (fn [_ [_ v]] {:db {:count v}}))
+
+(rf/reg-event ::app-bump
+              (fn [{:keys [db]} _] {:db (update db :count (fnil inc 0))}))
+
+;; ===========================================================================
+;; Harness
+;; ===========================================================================
+
+(defn browser?
+  "True only under the real-DOM `:browser-test` build."
+  []
+  (rf.fresco.impl.mount/browser?))
+
+(defonce ^:private !last-uncaught (atom nil))
+
+(defonce ^:private error-capture-armed?
+  (when (exists? js/window)
+    (.addEventListener js/window "error"
+                       (fn [^js e] (reset! !last-uncaught (.-error e))))
+    true))
+
+(defn- uncaught-note
+  "A suffix naming the last uncaught error, for a row whose subject is
+  missing.
+
+  REACT SWALLOWS A RENDER-PHASE THROW. A re-frame refusal raised inside a
+  render does not reach a `try/catch` around the mount — React catches it,
+  reports 'an error occurred in <view>' to the console and re-raises it as
+  an UNCAUGHT window error — so `ex-message` and `ex-data`, the whole of
+  what re-frame refuses WITH, appear nowhere a row can read. Without this,
+  every assertion reddens on a nil node saying only that the chrome is
+  absent."
+  []
+  (if-some [e (when error-capture-armed? @!last-uncaught)]
+    (str " — an uncaught error was raised during render: "
+         (:rf.error/id (ex-data e) (ex-message e)))
+    ""))
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. It exists
+  for the CONTROLS: an absence asserted immediately after the world moves
+  is a race; an absence asserted after this is a decision."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+(defn- poll-until
+  "Resolve as soon as `pred` answers truthy, or after `budget-ms`. The
+  resolution value is `pred`'s last answer, so a caller asserts on the
+  VALUE rather than on the fact that polling ended.
+
+  A CENSUS READ IN THE SAME TURN AS A MOUNT IS NOT YET EVIDENCE: a
+  boundary reaches the collector's entry table asynchronously, so a
+  witness that ticks in the same turn as the mount comes back green having
+  observed nothing."
+  ([pred] (poll-until pred 4000))
+  ([pred budget-ms]
+   (js/Promise.
+     (fn [resolve]
+       (let [deadline (+ (js/Date.now) budget-ms)]
+         (letfn [(tick []
+                   (let [v (pred)]
+                     (cond
+                       v                          (resolve v)
+                       (> (js/Date.now) deadline) (resolve v)
+                       :else (js/requestAnimationFrame (fn [_] (tick))))))]
+           (tick)))))))
+
+(defn setup!
+  "Register Xray's handlers — which is what registers every Static L4 tab
+  entry, so the tab bar and the L4 mount both read the real registry — and
+  make the three frames, seeding the application with a known `:count`.
+
+  The application frame is made BEFORE anything mounts, so criterion 5's
+  ring assertions are about a frame that was recording all along."
+  []
+  (reset! !last-uncaught nil)
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id xray-frame})
+  (rf/make-frame {:id app-frame})
+  (rf/make-frame {:id other-frame})
+  (rf/dispatch-sync [::app-seed 0] {:frame app-frame})
+  nil)
+
+(defn mount-xray!
+  "Mount Xray's Static chrome through FRESCO'S OWN ROOT, at [[xray-frame]].
+
+  This is the post-swap mount: Xray creates and owns the React root, the
+  installed adapter's `:render` is never called, and the frame context is
+  established DELIBERATELY by naming the frame rather than inherited from
+  whatever the host's adapter happened to put in scope. `root!` commits
+  inside `flushSync`, so the first assertion does not read an empty
+  container."
+  []
+  (let [container (rf.fresco.impl.mount/fresh-container!)]
+    (rf.fresco.impl.mount/root! container xray-frame
+                                [static-shell/surface {}])))
+
+(defn unmount-xray!
+  "Take Xray down the way criterion 6 needs it taken down.
+
+  `rf.fresco.impl.mount/unmount!`, NOT `release!`. `release!` is the
+  FIXTURE door and its last act is `reset-runtime!`, which empties the
+  collector's tables — so a residue assertion after it reads zero whatever
+  the teardown did, and could never turn red. `unmount!` deliberately
+  empties nothing, which is what leaves a leak visible. The container is
+  removed here because `unmount!` deliberately does not touch the caller's
+  node."
+  [handle]
+  (rf.fresco.impl.mount/unmount! handle)
+  (when-some [c (:container handle)]
+    (when-some [p (.-parentNode c)] (.removeChild p c)))
+  nil)
+
+(defn- q [container sel] (.querySelector container sel))
+
+(defn- testid [container id]
+  (q container (str "[data-testid=\"" id "\"]")))
+
+(defn- detail-panel-testid
+  "The committed L4 panel's own testid, whatever tab it is showing — the
+  single string criteria 1 and 3 both read."
+  [container]
+  (some-> (q container
+             "[data-testid^=\"rf-xray-static-detail-panel-\"]")
+          (.getAttribute "data-testid")))
+
+(defn- panel-testid-for [tab-id]
+  (str "rf-xray-static-detail-panel-" (name tab-id)))
+
+(defn- tab-node [container tab-id]
+  (testid container (str "rf-xray-static-tab-" (name tab-id))))
+
+(defn- click!
+  "Click a committed node, or FAIL THIS ROW rather than aborting the lane.
+
+  A raw `.click` on nil throws out of the async block, and
+  `cljs.test/run-block` has no try/catch — under a plant that emptied the
+  chrome that takes the WHOLE browser lane down with no cljs.test summary,
+  and every namespace scheduled after it never runs. A row whose subject
+  has vanished should redden; it must not silence its neighbours."
+  [node label]
+  (if (some? node)
+    (do (.click node) true)
+    (do (is false (str "cannot click " label ": it is not in the committed "
+                       "DOM, so this row's subject is already gone"
+                       (uncaught-note)))
+        false)))
+
+(defn- selected-tab-in
+  "One frame's current Static tab, read WITHOUT taking a reference.
+  `subscribe-once` subscribes, derefs and unsubscribes, so a row may read
+  as many frames as it likes without moving the numbers criterion 6
+  measures."
+  [frame-id]
+  (rf/subscribe-once selected-tab-q {:frame frame-id}))
+
+(defn- app-db-of [frame-id]
+  @(:app-db (rf.frame/frame frame-id)))
+
+(defn- cache-of [frame-id]
+  @(:sub-cache (rf.frame/frame frame-id)))
+
+(defn- ref-count-of [frame-id query-v]
+  (or (:ref-count (get (cache-of frame-id) query-v)) 0))
+
+(defn- app-trace-event-ids
+  "Every event id the APPLICATION's trace ring recorded, as a vector of
+  whatever `:rf.event/v`'s head was. The instrument criterion 5 reads."
+  []
+  (->> (rf/trace-buffer app-frame {:flat true})
+       (keep #(first (get-in % [:tags :rf.event/v])))
+       (vec)))
+
+(defn- xray-namespaced?
+  "Is `k` a keyword in the `rf.xray` namespace or any `rf.xray.*`
+  sub-namespace? The same shape `self-noise/xray-internal-event-id?`
+  classifies by, written out here so criterion 5's instrument does not
+  route through the very production predicate whose job it is to keep
+  these events out of sight — a filter cannot be both the subject and the
+  instrument."
+  [k]
+  (and (keyword? k)
+       (when-some [ns* (namespace k)]
+         (or (= "rf.xray" ns*)
+             (str/starts-with? ns* "rf.xray.")))))
+
+(defn- fail-and-finish
+  "Report a rejection against `label`. Does not finish the row — the single
+  trailing step owns that, for the arm that never received a handle as much
+  as for the one that did."
+  [label]
+  (fn [e]
+    (is false (str label " never settled: " (.-message e) (uncaught-note)))
+    nil))
+
+(defn- skip! [n]
+  (is true (str "criterion " n " skipped: the :browser-test runner drives "
+                "the real React mount; this lane has no DOM")))
+
+;; ===========================================================================
+;; CRITERION 1 — first display
+;; ===========================================================================
+
+(defn c1-first-display!
+  "Xray's Static chrome COMMITS — all three layers plus the L4 panel on its
+  default tab — with the host's adapter installed and never called.
+
+  Four literal testids and one literal tab name. The L4 assertion compares
+  the panel's whole testid against `\"rf-xray-static-detail-panel-machines\"`
+  rather than against the surface's own idea of which tab is selected: a
+  panel that had lost its read and committed nothing would agree with a
+  derived expectation and disagree with this one."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 1) (done))
+    (do
+      (setup!)
+      (let [handle    (mount-xray!)
+            container (:container handle)]
+        (-> (poll-until #(testid container "rf-xray-static-surface"))
+            (.then
+              (fn [_]
+                (is (some? (testid container "rf-xray-static-surface"))
+                    (str "[" label "] criterion 1 — the Static surface envelope "
+                         "commits" (uncaught-note)))
+                (is (some? (testid container "rf-xray-static-ribbon"))
+                    (str "[" label "] criterion 1 — the L1 ribbon commits"
+                         (uncaught-note)))
+                (is (some? (testid container "rf-xray-static-tab-bar"))
+                    (str "[" label "] criterion 1 — the L3 tab bar commits"
+                         (uncaught-note)))
+                (is (= (panel-testid-for default-tab)
+                       (detail-panel-testid container))
+                    (str "[" label "] criterion 1 — the L4 detail panel commits "
+                         "on the default tab. Expected "
+                         (pr-str (panel-testid-for default-tab))
+                         ", got " (pr-str (detail-panel-testid container))
+                         (uncaught-note)))
+                (is (some? (tab-node container clicked-tab))
+                    (str "[" label "] criterion 1 — and every registered Static "
+                         "tab has a real control on screen, "
+                         (pr-str clicked-tab) " included, so criterion 3 has "
+                         "something to press" (uncaught-note)))))
+            (.catch (fail-and-finish (str "[" label "] criterion 1")))
+            (.then (fn [_] (unmount-xray! handle) (done))))))))
+
+;; ===========================================================================
+;; CRITERION 2 — updates as the app changes
+;; ===========================================================================
+
+(defn c2-updates-as-the-app-changes!
+  "A REAL change in the inspected application reaches Xray's committed DOM
+  through the production observation chain, and a settling window with the
+  chain NOT pumped does not.
+
+  The lever is the application registering a flow at run time — an ordinary
+  thing a live app does — and the witness is the Static Flows panel growing
+  that flow's row. The chain in between is the shipped one: the app's own
+  dispatch lands in its per-frame trace ring, `refresh-trace-rings!` mirrors
+  the rings into `:rf/xray`'s `:trace-buffer`, and the panel's read — which
+  is gated on that buffer — is invalidated and recommits.
+
+  `refresh-trace-rings!` is called explicitly because production reaches it
+  through `rf.interop/next-tick`, a task that never fires inside a
+  synchronous row.
+
+  THE CONTROL IS THE HALF THAT MAKES THE UPDATE MEAN LIVENESS. After the
+  flow exists but before the chain is pumped, a full settling window must
+  still show NO row: a panel that repainted there would make the positive
+  half pass for a reason that is not observation."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 2) (done))
+    (do
+      (setup!)
+      (let [handle    (mount-xray!)
+            container (:container handle)
+            row?      (fn [] (some? (testid container probe-flow-row-testid)))]
+        (-> ;; Land on the Flows tab, so the row this criterion watches for is
+            ;; on a surface that is actually committed.
+            (do (rf/dispatch-sync [:rf.xray.static/select-tab :flows]
+                                  {:frame xray-frame})
+                (poll-until #(testid container "rf-xray-static-flows")))
+            (.then
+              (fn [_]
+                (is (some? (testid container "rf-xray-static-flows"))
+                    (str "[" label "] PRECONDITION: the Static Flows panel is on "
+                         "screen, so a missing row below is the panel failing to "
+                         "follow the app rather than the panel being absent"
+                         (uncaught-note)))
+                (is (false? (row?))
+                    (str "[" label "] NON-VACUITY: the flow this row drives in is "
+                         "NOT on screen before the application registers it"))
+                ;; ---- the application changes ----------------------------
+                (rf/reg-flow probe-flow-id
+                             {:inputs      [[:probe :in]]
+                              :output-path [:probe :out]
+                              :doc         "criterion 2's run-time registration"
+                              :frame       app-frame}
+                             (fn [_] 0))
+                (is (some? (get-in (rf.flows/flows-snapshot)
+                                   [app-frame probe-flow-id]))
+                    (str "[" label "] PRECONDITION: the application's own registry "
+                         "really carries the new flow — so a missing row below is "
+                         "Xray failing to observe, not the flow failing to exist"))
+                (settle)))
+            (.then
+              (fn [_]
+                (is (false? (row?))
+                    (str "[" label "] CONTROL: given a full settling window with "
+                         "the observation chain NOT pumped, the committed DOM "
+                         "still does NOT carry the row. A panel that repainted "
+                         "here would make the assertion below pass for a reason "
+                         "that is not observation"))
+                ;; ---- the app does something, and Xray observes it -------
+                (rf/dispatch-sync [::app-bump] {:frame app-frame})
+                (trace-collector/refresh-trace-rings!)
+                (poll-until row?)))
+            (.then
+              (fn [_]
+                (is (true? (row?))
+                    (str "[" label "] criterion 2 — a real application change "
+                         "reached Xray's committed DOM through the production "
+                         "observation chain: the row "
+                         (pr-str probe-flow-row-testid) " is on screen"
+                         (uncaught-note)))
+                (is (= 1 (:count (app-db-of app-frame)))
+                    (str "[" label "] and the application really did move — its "
+                         "own `:count` is 1, so the pump above had a real event "
+                         "to carry. Got: "
+                         (pr-str (:count (app-db-of app-frame)))))))
+            (.catch (fail-and-finish (str "[" label "] criterion 2")))
+            (.then (fn [_] (unmount-xray! handle) (done))))))))
+
+;; ===========================================================================
+;; CRITERION 3 — Xray's own interactions
+;; ===========================================================================
+
+(defn c3-xrays-own-interactions!
+  "A REAL browser click on a REAL Static tab button moves the L4 panel, and
+  the pressed tab reports itself selected.
+
+  The whole round trip travels the shipped path: React's own click event,
+  the `:on-click` closure the tab button carries, the dispatcher the
+  `tab-bar` BOUNDARY captured with `(:dispatch (rf/capture-frame))`, the
+  handler, the invalidated read, the recommitted boundary. Nothing here
+  dispatches on the surface's behalf — that would exercise the reactivity
+  and skip the capture, which is the boundary's other half and the half
+  with somewhere to fail.
+
+  Both expectations are literals: `\"rf-xray-static-detail-panel-flows\"`
+  and `\"true\"`."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 3) (done))
+    (do
+      (setup!)
+      (let [handle    (mount-xray!)
+            container (:container handle)
+            aria-of   (fn [] (some-> (tab-node container clicked-tab)
+                                     (.getAttribute "aria-selected")))]
+        (-> (poll-until #(detail-panel-testid container))
+            (.then
+              (fn [_]
+                (let [btn (tab-node container clicked-tab)]
+                  (is (some? btn)
+                      (str "[" label "] PRECONDITION: the "
+                           (name clicked-tab) " tab button is committed, so "
+                           "there is a real control to press" (uncaught-note)))
+                  (is (= "false" (aria-of))
+                      (str "[" label "] PRECONDITION: and it is not already the "
+                           "selected tab, so the flip below is the click's "
+                           "doing. Got: " (pr-str (aria-of))))
+                  (is (= (panel-testid-for default-tab)
+                         (detail-panel-testid container))
+                      (str "[" label "] PRECONDITION: the L4 panel is showing "
+                           (pr-str (panel-testid-for default-tab))
+                           ". Got: " (pr-str (detail-panel-testid container))))
+                  (if (click! btn (str "the Static " (name clicked-tab) " tab"))
+                    (poll-until #(= (panel-testid-for clicked-tab)
+                                    (detail-panel-testid container)))
+                    (js/Promise.resolve nil)))))
+            (.then
+              (fn [_]
+                (is (= (panel-testid-for clicked-tab)
+                       (detail-panel-testid container))
+                    (str "[" label "] criterion 3 — the click reached the handler "
+                         "through the dispatcher the boundary captured, the read "
+                         "was invalidated and the L4 boundary recommitted on the "
+                         "new tab. Expected "
+                         (pr-str (panel-testid-for clicked-tab))
+                         ", got " (pr-str (detail-panel-testid container))
+                         (uncaught-note)))
+                (is (= "true" (aria-of))
+                    (str "[" label "] and the pressed button now reports itself "
+                         "selected, so the L3 boundary recommitted too rather "
+                         "than only the L4 one. Got: " (pr-str (aria-of))))))
+            (.catch (fail-and-finish (str "[" label "] criterion 3")))
+            (.then (fn [_] (unmount-xray! handle) (done))))))))
+
+;; ===========================================================================
+;; CRITERION 4 — tool-local state separate from the app, commands targeting
+;;               the intended frame
+;; ===========================================================================
+
+(defn c4-tool-local-state-and-frame-targeting!
+  "Xray's own state lands in Xray's frame and NOWHERE ELSE.
+
+  Three instruments, answering three different things:
+
+  - the TOOL's frame moved to [[clicked-tab]] — the command arrived;
+  - the APPLICATION's `app-db` is IDENTICAL to what it was — the tool
+    wrote nothing into the thing it is inspecting;
+  - a SECOND live frame, held at [[deaf-frame-tab]] before the mount, is
+    still there — the command routed where it was told rather than
+    everywhere, or somewhere else.
+
+  THE THIRD IS THE ONE THAT MAKES THIS A ROUTING CLAIM. A dispatcher that
+  lost its capture does not crash; it degrades to the ambient one, which
+  resolves a frame that is not the tool's. A positive-only row passes on a
+  dispatcher that routes everywhere and on one that routes elsewhere.
+
+  THE THEME TOGGLE CANNOT CARRY THIS ROW and is deliberately not used: its
+  read falls through `settings/subs.cljs` to `config/get-setting`, a
+  PROCESS-GLOBAL atom rather than any frame's `app-db`, so it passes under
+  a deliberately wrong frame and witnesses nothing about targeting. The
+  Static tab selection is an ordinary `app-db` read, which is why it is the
+  lever here."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 4) (done))
+    (do
+      (setup!)
+      ;; The deaf frame is loaded BEFORE the mount, so the control compares
+      ;; against a value a misrouted write would have to OVERWRITE. Held at
+      ;; the default instead, a dispatcher that had fallen through to an
+      ;; ambient frame and written the default there would be
+      ;; indistinguishable from one that never wrote at all.
+      (rf/dispatch-sync [:rf.xray.static/select-tab deaf-frame-tab]
+                        {:frame other-frame})
+      (let [handle    (mount-xray!)
+            container (:container handle)
+            !app-db   (atom nil)]
+        (-> (poll-until #(tab-node container clicked-tab))
+            (.then
+              (fn [_]
+                (reset! !app-db (app-db-of app-frame))
+                (is (= {:count 0} @!app-db)
+                    (str "[" label "] PRECONDITION: the application's db is the "
+                         "seeded {:count 0}, so the comparison after the click "
+                         "is against a known value. Got: " (pr-str @!app-db)))
+                (is (= default-tab (selected-tab-in xray-frame))
+                    (str "[" label "] PRECONDITION: the tool's frame holds the "
+                         "default tab. Got: "
+                         (pr-str (selected-tab-in xray-frame))))
+                (is (= deaf-frame-tab (selected-tab-in other-frame))
+                    (str "[" label "] PRECONDITION: while the second live frame "
+                         "holds " (pr-str deaf-frame-tab) ", so `unchanged` "
+                         "below is a claim about a real value. Got: "
+                         (pr-str (selected-tab-in other-frame))))
+                (if (click! (tab-node container clicked-tab)
+                            (str "the Static " (name clicked-tab) " tab"))
+                  (poll-until #(= clicked-tab (selected-tab-in xray-frame)))
+                  (js/Promise.resolve nil))))
+            (.then
+              (fn [_]
+                (is (= clicked-tab (selected-tab-in xray-frame))
+                    (str "[" label "] criterion 4 — the command landed in the "
+                         "frame the tree NAMED. Expected " (pr-str clicked-tab)
+                         ", got " (pr-str (selected-tab-in xray-frame))
+                         (uncaught-note)))
+                (is (= {:count 0} (app-db-of app-frame))
+                    (str "[" label "] criterion 4 — and the INSPECTED "
+                         "APPLICATION's db is untouched: Xray's tool-local state "
+                         "is not in the app it is inspecting. Expected "
+                         "{:count 0}, got " (pr-str (app-db-of app-frame))))
+                (is (= deaf-frame-tab (selected-tab-in other-frame))
+                    (str "[" label "] criterion 4 — CROSS-FRAME CONTROL: and the "
+                         "second live frame still holds "
+                         (pr-str deaf-frame-tab) ". A dispatcher that had lost "
+                         "its capture and fallen back to the ambient one would "
+                         "write here, or nowhere. Got: "
+                         (pr-str (selected-tab-in other-frame))))
+                (is (zero? (ref-count-of app-frame selected-tab-q))
+                    (str "[" label "] criterion 4 — and the tool took no "
+                         "subscription reference in the application's frame for "
+                         "its own read. Application cache keys: "
+                         (pr-str (keys (cache-of app-frame)))))))
+            (.catch (fail-and-finish (str "[" label "] criterion 4")))
+            (.then (fn [_] (unmount-xray! handle) (done))))))))
+
+;; ===========================================================================
+;; CRITERION 5 — Xray's activity never masquerading as application evidence
+;; ===========================================================================
+
+(defn c5-no-masquerading-as-application-evidence!
+  "Everything Xray does — mounting, rendering, and a real user interaction
+  with the tool — contributes NOTHING to the inspected application's
+  evidence.
+
+  The instrument is the APPLICATION's OWN per-frame trace ring, read
+  through `rf/trace-buffer`. That is the evidence a developer reads and the
+  evidence every downstream tool projects, so it is the right place to ask
+  the question — and it is upstream of `self-noise`'s display-time filter,
+  which means this row cannot be satisfied by Xray merely hiding its own
+  noise from its own list.
+
+  THE POSITIVE CONTROL IS LOAD-BEARING. An empty ring satisfies `no Xray
+  events` for free, and a ring that records nothing at all is exactly what
+  a broken instrument looks like. So the application dispatches its own
+  event first, and the row asserts that event IS in the ring before
+  asserting that Xray's is not.
+
+  `xray-namespaced?` is written out in this namespace rather than taken
+  from `self-noise`: a filter cannot be both the subject and the
+  instrument."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 5) (done))
+    (do
+      (setup!)
+      (let [handle    (mount-xray!)
+            container (:container handle)]
+        (-> (poll-until #(tab-node container clicked-tab))
+            (.then
+              (fn [_]
+                ;; The application does something of its own, so the ring is
+                ;; demonstrably recording.
+                (rf/dispatch-sync [::app-bump] {:frame app-frame})
+                (settle)))
+            (.then
+              (fn [_]
+                (is (true? (boolean (some #{::app-bump} (app-trace-event-ids))))
+                    (str "[" label "] POSITIVE CONTROL: the application's own "
+                         "event IS in its trace ring, so the absence asserted "
+                         "below is a property of Xray and not of a ring that "
+                         "records nothing. Ring: "
+                         (pr-str (app-trace-event-ids))))
+                ;; ---- Xray does something of its own ---------------------
+                (if (click! (tab-node container clicked-tab)
+                            (str "the Static " (name clicked-tab) " tab"))
+                  (poll-until #(= clicked-tab (selected-tab-in xray-frame)))
+                  (js/Promise.resolve nil))))
+            (.then
+              (fn [_]
+                (is (= clicked-tab (selected-tab-in xray-frame))
+                    (str "[" label "] NON-VACUITY: Xray's own interaction really "
+                         "happened — its tab moved to " (pr-str clicked-tab)
+                         " — so the absence below is about an event that was "
+                         "genuinely dispatched. Got: "
+                         (pr-str (selected-tab-in xray-frame))
+                         (uncaught-note)))
+                (settle)))
+            (.then
+              (fn [_]
+                (let [ids  (app-trace-event-ids)
+                      xray (filterv xray-namespaced? ids)]
+                  (is (= [] xray)
+                      (str "[" label "] criterion 5 — the application's trace "
+                           "ring carries NO `rf.xray`-namespaced event after a "
+                           "real Xray mount, render and interaction. Expected "
+                           "[], got " (pr-str xray)
+                           " — whole ring: " (pr-str ids)))
+                  ;; STRONGER THAN THE `rf.xray` FILTER ABOVE, and deliberately
+                  ;; so: the set of DISTINCT event ids in the application's ring
+                  ;; is exactly the two the application itself dispatched. That
+                  ;; catches a foreign event under ANY spelling, where the
+                  ;; assertion above catches only one the `rf.xray` namespace
+                  ;; happens to name. One dispatch emits several trace ops all
+                  ;; carrying the same `:rf.event/v`, so this is a set.
+                  (is (= #{::app-seed ::app-bump} (set ids))
+                      (str "[" label "] and the ONLY event ids in the "
+                           "application's ring are the two the application "
+                           "itself dispatched. Expected "
+                           (pr-str #{::app-seed ::app-bump}) ", got "
+                           (pr-str (set ids)))))))
+            (.catch (fail-and-finish (str "[" label "] criterion 5")))
+            (.then (fn [_] (unmount-xray! handle) (done))))))))
+
+;; ===========================================================================
+;; CRITERION 6 — clean teardown and reopen without disturbing the host
+;; ===========================================================================
+
+(defn- cell-key
+  "The collector's own address for the chrome's headline read —
+  `[frame-kw query-v]`, finer than the frame's sub-cache key and what
+  `!cells` is keyed by."
+  []
+  [xray-frame selected-tab-q])
+
+(defn- residue
+  "Everything that must return to baseline once Xray is gone, as one map,
+  so a failure names WHICH instrument still sees something. FIVE
+  instruments answering different questions — `unmount-xray!` being CALLED
+  is not one of them.
+
+  - `:ref-count`    the frame's own sub-cache reference for the headline read
+  - `:live-cell?`   the WATCH half: a live collector cell holds `add-watch`
+                    on its derived reaction for as long as it exists
+  - `:reader-edges` the LISTENER half: one reader slot per boundary
+                    registration reading that cell
+  - `:runtime`      the WHOLE collector census, which is what makes this a
+                    claim about the CHROME rather than about one query.
+                    Enumerating the chrome's boundaries here would go stale
+                    the first time a region gains a read; a census cannot.
+  - `:body-nodes`   the document's own child count, so a container or a
+                    portal left behind is visible
+
+  A release that dropped the reference and left the cell wired answers
+  clean to the first and dirty to the next three."
+  []
+  {:ref-count    (ref-count-of xray-frame selected-tab-q)
+   :live-cell?   (some? (rf.fresco.test.runtime/cell-reaction (cell-key)))
+   :reader-edges (count (rf.fresco.test.runtime/cell-readers (cell-key)))
+   :runtime      (rf.fresco.test.runtime/residue)
+   :body-nodes   (.-childElementCount (.-body js/document))})
+
+(defn c6-clean-teardown-and-reopen!
+  "Unmounting Xray returns everything it took, the HOST is undisturbed
+  across the whole cycle, and reopening takes the same numbers rather than
+  higher ones.
+
+  ## Teardown is MEASURED, not asserted
+
+  A row that only checks the chrome is gone passes over a leak. Five
+  instruments are read before the mount, while mounted, after the unmount,
+  after a reopen and after a second unmount.
+
+  ## THE REOPEN IS THE HALF THAT CATCHES A RELEASE THAT RELEASES NOTHING
+
+  A first mount's teardown can look clean for reasons that are not the
+  teardown's — a page that never had anything to lose reads zero whatever
+  the code does. Growth across open/close/open is the signature of a
+  release the substrate's own lifecycle cannot see, and it is only visible
+  on the second mount.
+
+  ## THE HOST HALF IS THE OTHER HALF OF THE CRITERION
+
+  `without disturbing the host` is not a restatement of `clean teardown`.
+  The application holds a LIVE SUBSCRIPTION across the entire cycle — a
+  real host reference, taken before Xray exists and still held after Xray
+  is gone twice — and the row asserts its ref-count, its value and the
+  application's `app-db` are exactly what they were. A tool that tore down
+  tidily but disposed a reference belonging to the app it was inspecting
+  passes every instrument above and fails here.
+
+  ## THE SETTLING POINT IS THE KIT'S OWN `quiesced!`
+
+  The collector gives a cell whose last reader unmounts one macrotask of
+  grace, deliberately, and the entry reaper's horizon sits outside a bare
+  `setTimeout 0`. A residue read before that point reports a LEAK against
+  a runtime behaving exactly as documented."
+  [{:keys [label]} done]
+  (if-not (browser?)
+    (do (skip! 6) (done))
+    (do
+      (setup!)
+      (let [;; The HOST's own live reference, taken before Xray exists.
+            host-ref   (rf/subscribe [::app-count] {:frame app-frame})
+            host-key   [::app-count]
+            !baseline  (atom nil)
+            !mounted   (atom nil)
+            !handle    (atom nil)
+            mount!     (fn []
+                         (reset! !handle (mount-xray!))
+                         (poll-until #(detail-panel-testid
+                                        (:container @!handle))))
+            unmount!   (fn []
+                         (when-some [h @!handle]
+                           (reset! !handle nil)
+                           (unmount-xray! h)))
+            host-refs  (fn [] (ref-count-of app-frame host-key))]
+        (-> (do
+              (is (= 0 @host-ref)
+                  (str "[" label "] PRECONDITION: the host's own subscription "
+                       "reads its seeded value. Got: " (pr-str @host-ref)))
+              (rf.fresco.test.runtime/quiesced!))
+            (.then
+              (fn [_]
+                (let [b (residue)]
+                  (reset! !baseline b)
+                  (is (= empty-runtime (:runtime b))
+                      (str "[" label "] BASELINE: the collector holds nothing "
+                           "before the first mount, so `returns to baseline` "
+                           "below is a return to ZERO rather than to a residue "
+                           "a leak could hide inside. Got: "
+                           (pr-str (:runtime b))))
+                  (is (= 0 (:ref-count b))
+                      (str "[" label "] BASELINE: and the tool's frame holds no "
+                           "sub-cache reference for the chrome's read. Keys: "
+                           (pr-str (keys (cache-of xray-frame)))))
+                  (is (= false (:live-cell? b))
+                      (str "[" label "] BASELINE: and no collector cell, so no "
+                           "watch"))
+                  (is (= 0 (:reader-edges b))
+                      (str "[" label "] BASELINE: and no reader edge, so no "
+                           "listener")))
+                (mount!)))
+            (.then
+              (fn [_]
+                (let [m (residue)]
+                  (reset! !mounted m)
+                  (is (pos? (:ref-count m))
+                      (str "[" label "] NON-VACUITY: the mount TOOK a sub-cache "
+                           "reference — otherwise the release below is a claim "
+                           "about nothing. Got: " (pr-str m) (uncaught-note)))
+                  (is (= true (:live-cell? m))
+                      (str "[" label "] NON-VACUITY: and a live collector cell, "
+                           "so there is a watch to lose"))
+                  (is (pos? (:reader-edges m))
+                      (str "[" label "] NON-VACUITY: and reader edges on it, so "
+                           "there are listeners to lose. Got: "
+                           (:reader-edges m)))
+                  (is (pos? (:cells (:runtime m)))
+                      (str "[" label "] NON-VACUITY: and the chrome's boundaries "
+                           "lit the collector up. Census: "
+                           (pr-str (:runtime m))))
+                  (is (pos? (:boundaries (:runtime m)))
+                      (str "[" label "] NON-VACUITY: with registrations holding "
+                           "reader slots"))
+                  (is (pos? (:edges (:runtime m)))
+                      (str "[" label "] NON-VACUITY: and dependency edges across "
+                           "the tree")))
+                (unmount!)
+                (rf.fresco.test.runtime/quiesced!)))
+            (.then
+              (fn [_]
+                (let [a (residue)
+                      b @!baseline]
+                  (is (= 0 (:ref-count a))
+                      (str "[" label "] criterion 6 — the unmount released the "
+                           "sub-cache reference COMPLETELY. Residue: "
+                           (pr-str a) " — frame cache keys: "
+                           (pr-str (keys (cache-of xray-frame)))))
+                  (is (= false (:live-cell? a))
+                      (str "[" label "] criterion 6 — NO RETAINED WATCHES: the "
+                           "collector cell for the chrome's read is gone, so no "
+                           "`add-watch` on a derived reaction survives. Residue: "
+                           (pr-str a)))
+                  (is (= 0 (:reader-edges a))
+                      (str "[" label "] criterion 6 — NO RETAINED LISTENERS: and "
+                           "no reader edge survives either. Residue: "
+                           (pr-str a)))
+                  (is (= empty-runtime (:runtime a))
+                      (str "[" label "] criterion 6 — and the WHOLE collector "
+                           "census is back at ZERO: every cell, edge, boundary "
+                           "registration and cached read-set entry the chrome "
+                           "took. Expected " (pr-str empty-runtime) ", got "
+                           (pr-str (:runtime a))))
+                  (is (= (:body-nodes b) (:body-nodes a))
+                      (str "[" label "] criterion 6 — and the document is back to "
+                           "the node count it had before Xray, so no container "
+                           "or portal is stranded. Before: " (:body-nodes b)
+                           ", after: " (:body-nodes a))))
+                ;; ---- the HOST, mid-cycle -------------------------------
+                (is (= 1 (host-refs))
+                    (str "[" label "] criterion 6 — HOST UNDISTURBED: the "
+                         "application's own live subscription still holds "
+                         "exactly the ONE reference it took before Xray "
+                         "existed. Got: " (host-refs)))
+                (is (= 0 @host-ref)
+                    (str "[" label "] criterion 6 — HOST UNDISTURBED: and it "
+                         "still derefs to its value rather than to a disposed "
+                         "reaction's. Got: " (pr-str @host-ref)))
+                ;; ---- reopen: the same numbers, not higher ones ----------
+                (mount!)))
+            (.then
+              (fn [_]
+                (let [r (residue)
+                      m @!mounted
+                      shape (fn [c] (select-keys c [:cells :cell-refs
+                                                    :boundaries :edges]))]
+                  (is (= (:ref-count m) (:ref-count r))
+                      (str "[" label "] criterion 6 — reopening takes the SAME "
+                           "sub-cache reference count (" (:ref-count m)
+                           ") rather than accumulating. Got: " (:ref-count r)))
+                  (is (= (:reader-edges m) (:reader-edges r))
+                      (str "[" label "] criterion 6 — and the same reader-edge "
+                           "count (" (:reader-edges m) ") — an edge left behind "
+                           "by the first teardown shows here as growth. Got: "
+                           (:reader-edges r)))
+                  (is (= (shape (:runtime m)) (shape (:runtime r)))
+                      (str "[" label "] criterion 6 — and the whole census is "
+                           "identical across the open/close/open cycle. First "
+                           "mount: " (pr-str (shape (:runtime m)))
+                           " — reopen: " (pr-str (shape (:runtime r)))))
+                  ;; Read-set entries are CACHED and reaped on their own
+                  ;; horizon, so a reopen inside the window may legitimately
+                  ;; reuse or rebuild them. What may never happen is growth.
+                  (is (<= (:entries (:runtime r)) (:entries (:runtime m)))
+                      (str "[" label "] criterion 6 — and the cached read-set "
+                           "entries did not grow. First mount: "
+                           (:entries (:runtime m)) " — reopen: "
+                           (:entries (:runtime r)))))
+                (unmount!)
+                (rf.fresco.test.runtime/quiesced!)))
+            (.then
+              (fn [_]
+                (let [a (residue)]
+                  (is (= empty-runtime (:runtime a))
+                      (str "[" label "] criterion 6 — the SECOND unmount returns "
+                           "to zero too, so the release is a property of "
+                           "teardown rather than of the first one happening to "
+                           "be clean. Expected " (pr-str empty-runtime)
+                           ", got " (pr-str (:runtime a))))
+                  (is (= 0 (:reader-edges a))
+                      (str "[" label "] criterion 6 — with no reader edge "
+                           "surviving it either. Residue: " (pr-str a))))
+                ;; ---- the HOST, after the whole cycle -------------------
+                (is (= 1 (host-refs))
+                    (str "[" label "] criterion 6 — HOST UNDISTURBED: after two "
+                         "full Xray lifecycles the application's subscription "
+                         "still holds exactly ONE reference. Got: " (host-refs)))
+                (is (= 0 @host-ref)
+                    (str "[" label "] criterion 6 — HOST UNDISTURBED: and still "
+                         "derefs to its seeded value. Got: " (pr-str @host-ref)))
+                (is (= {:count 0} (app-db-of app-frame))
+                    (str "[" label "] criterion 6 — HOST UNDISTURBED: and the "
+                         "application's db is exactly what it was seeded with. "
+                         "Expected {:count 0}, got "
+                         (pr-str (app-db-of app-frame))))))
+            (.catch (fail-and-finish (str "[" label "] criterion 6")))
+            (.then (fn [_]
+                     ;; Defensive: a row that reddened mid-flight may still hold
+                     ;; a mounted root, and a live root leaks into the next
+                     ;; namespace's baseline.
+                     (unmount!)
+                     (rf/unsubscribe [::app-count] {:frame app-frame})
+                     (done))))))))

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
@@ -33,7 +33,7 @@
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.test-support :as rf.test-support]
-            [day8.re-frame2-xray.acceptance.criteria :as criteria]
+            [day8.re-frame2-xray.acceptance.test-helpers.criteria :as criteria]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (def ^:private substrate

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
@@ -1,0 +1,74 @@
+(ns day8.re-frame2-xray.acceptance.reagent-dom-cljs-test
+  "THE RATOM-FAMILY ARM of the epic's acceptance harness (rf2-k97c.3,
+  slice D). Same six criterion bodies as the UIx arm beside it, same
+  subject, same mount verb; the ONLY variable is the installed adapter.
+
+  Two arms that differ in exactly one thing is what makes the pair
+  evidence. Either arm alone says 'Xray works here'; the pair says 'Xray
+  does not care which one is installed', which is the claim the root swap
+  makes and the thing the swap PR has to keep true.
+
+  ## WHY REAGENT RATHER THAN reagent-slim, AND IT IS A FINDING
+
+  Slice D's brief named reagent-slim for this arm. Measured at trunk
+  1bf7106126, Xray's chrome DOES NOT PAINT under the reagent-slim adapter
+  — on either mount path, the production one or this one — because
+  `frame-switcher/frame-switcher-view` raises `:rf.error/no-frame-context`
+  during render and React takes the whole subtree down with it. Reagent is
+  green on both paths in the same run, which is what makes that a
+  statement about reagent-slim rather than about this harness.
+
+  That defect is a PRODUCTION one and this slice is test-only, so it is
+  recorded rather than repaired: `substrate_gap_dom_cljs_test` pins it with
+  the Reagent control beside it, and this arm carries the criteria on the
+  ratom-family adapter that can hold them today. When the defect is fixed,
+  a reagent-slim arm is this file with one `:require` and one `:adapter`
+  changed.
+
+  ## NODE LANE
+
+  Every row short-circuits and reports the skip; see the UIx arm's
+  docstring."
+  (:require [cljs.test :refer-macros [async deftest testing use-fixtures]]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.acceptance.criteria :as criteria]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private substrate
+  {:id :reagent :label "Reagent — ratom-family"})
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(deftest c1-first-display
+  (testing "criterion 1 — first display, with a ratom-family adapter installed"
+    (async done (criteria/c1-first-display! substrate done))))
+
+(deftest c2-updates-as-the-app-changes
+  (testing "criterion 2 — Xray follows a real change in the inspected app"
+    (async done (criteria/c2-updates-as-the-app-changes! substrate done))))
+
+(deftest c3-xrays-own-interactions
+  (testing "criterion 3 — a real click on Xray's own control works end to end"
+    (async done (criteria/c3-xrays-own-interactions! substrate done))))
+
+(deftest c4-tool-local-state-and-frame-targeting
+  (testing "criterion 4 — tool state stays out of the app, commands route where told"
+    (async done (criteria/c4-tool-local-state-and-frame-targeting! substrate done))))
+
+(deftest c5-no-masquerading-as-application-evidence
+  (testing "criterion 5 — Xray's activity is absent from the app's own evidence"
+    (async done (criteria/c5-no-masquerading-as-application-evidence! substrate done))))
+
+(deftest c6-clean-teardown-and-reopen
+  (testing "criterion 6 — teardown returns everything, and the host is undisturbed"
+    (async done (criteria/c6-clean-teardown-and-reopen! substrate done))))

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
@@ -119,7 +119,25 @@
         (registry/register-xray-handlers!)
         (with-layout-host
           (fn [host]
-            (let [ret (xray-mount/open!)]
+            ;; `open!` is expected to REFUSE, which means RETURNING a
+            ;; diagnostic. When the denylist goes it will instead try to
+            ;; paint, and handing a hiccup shell to an element-shaped
+            ;; `:render` THROWS — measured, `:rf.error/hiccup-on-element-
+            ;; render-slot`. Caught here so that day's red is one named
+            ;; failure telling the reader what changed, rather than an
+            ;; uncaught error that also swallows every assertion below it.
+            (let [ret (try (xray-mount/open!)
+                           (catch :default e
+                             (is false
+                                 (str "`open!` THREW rather than refusing: "
+                                      (pr-str (:rf.error/id (ex-data e)
+                                                            (ex-message e)))
+                                      ". If the denylist has just been deleted "
+                                      "this row has done its job — delete it, "
+                                      "and the element-shaped arm's six "
+                                      "criteria now speak for the shipped "
+                                      "mount path."))
+                             ::threw))]
               (is (= false (:ok? ret))
                   (str "`open!` reports failure rather than a mount. Got: "
                        (pr-str ret)))

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
@@ -170,9 +170,16 @@
               (is (= true (xray-mount/mounted?))
                   (str "`open!` mounted on a ratom-family substrate. Returned: "
                        (pr-str (dissoc ret :node :unmount))))
-              (is (nil? (:diagnostic (xray-mount/status)))
-                  (str "with no diagnostic standing. Got: "
+              ;; `clear-diagnostic!` leaves an `{:ok? true}` marker rather
+              ;; than nil, so the literal to compare against is the FLAG,
+              ;; not the slot's emptiness.
+              (is (= true (:ok? (:diagnostic (xray-mount/status))))
+                  (str "with the diagnostic slot reporting health rather than a "
+                       "refusal. Got: "
                        (pr-str (:diagnostic (xray-mount/status)))))
+              (is (nil? (:reason (:diagnostic (xray-mount/status))))
+                  (str "and naming no refusal reason. Got: "
+                       (pr-str (:reason (:diagnostic (xray-mount/status))))))
               (is (some? (.getElementById js/document "rf-xray-root"))
                   "and a real mount root is in the document")
               (is (= 1 (.-childElementCount host))

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
@@ -1,0 +1,181 @@
+(ns day8.re-frame2-xray.acceptance.substrate-gap-dom-cljs-test
+  "THE GAP THE ROOT SWAP CLOSES, pinned at the exact seam it changes
+  (rf2-k97c.3, slice D).
+
+  The two arms beside this file — `acceptance.uix-dom-cljs-test` and
+  `acceptance.reagent-dom-cljs-test` — witness all six behavioural criteria
+  through Xray's own React root, and they are green on a ratom-family
+  adapter and on an element-shaped one alike. This file says what is still
+  NOT true, so the pair is not read as 'the epic is done'.
+
+  ## THE CLAIM
+
+  `mount.cljs`'s PUBLIC `open!` — the door a host app actually uses —
+  still paints through the INSTALLED adapter's `:render`, so it refuses an
+  element-shaped substrate outright rather than mounting. That is the
+  epic's coupling (1), still unsevered, and `react-element-render-kinds`
+  is the denylist child .4 deletes once the swap is proven.
+
+  [[the-public-mount-refuses-an-element-shaped-substrate]] asserts that
+  refusal against literals — `false`, `:unsupported-substrate`,
+  `:rf.adapter/uix` — and then measures that the HOST is undisturbed by it,
+  which is the half of criterion 6 a refusal still has to satisfy.
+  [[the-public-mount-succeeds-on-a-ratom-family-substrate]] is the control
+  that makes the first row a claim about the SUBSTRATE rather than about
+  this file's setup: same verb, same host element, same code path, and it
+  mounts.
+
+  ## THIS ROW IS MEANT TO GO RED
+
+  When the swap lands and the denylist goes, `open!` stops refusing and the
+  first row reddens. That red is the signal, not a regression: it means the
+  element-shaped arm's six criteria are now evidence about the SHIPPED
+  mount path rather than about Xray's root in isolation. Delete this row
+  then, and say in the PR that you did.
+
+  ## A SECOND GAP, MEASURED AND DELIBERATELY NOT PINNED HERE
+
+  Measured at trunk 1bf7106126 across three adapters in one browser run:
+  Xray's chrome DOES NOT PAINT under the reagent-slim adapter, on either
+  mount path — the public `open!` or Xray's own React root. In both cases
+  `frame-switcher/frame-switcher-view` raises `:rf.error/no-frame-context`
+  during render and React takes the whole subtree down. Full Reagent was
+  green on both paths in that same run, so it is a statement about
+  reagent-slim. `mount.cljs`'s own `unsupported-substrate-diagnostic` tells
+  the user Xray's shell 'is hiccup rendered through the ratom-family
+  adapters (Reagent / reagent-slim)', which that measurement contradicts.
+
+  There is NO ROW FOR IT HERE, on purpose. Reproducing it means provoking
+  an uncaught render-phase throw, and the browser runner fails a whole run
+  on an uncaught `pageerror` INDEPENDENTLY of the cljs.test summary — so a
+  row pinning it would red the lane for every unrelated suite in the build.
+  The finding is recorded in the bead and in
+  `acceptance.reagent-dom-cljs-test`'s docstring, which is why that arm
+  runs on Reagent rather than on the reagent-slim the brief named. Fixing
+  it is a production change and slice D is test-only.
+
+  ## FIXTURE
+
+  No `:adapter` in the fixture: each row installs its own with `rf/init!`,
+  so both arms sit in ONE namespace and the control is a control rather
+  than a second file that might differ in some other way."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.fresco.impl.mount :as rf.fresco.impl.mount]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as xray-mount]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      (xray-mount/reset-for-test!)
+                      (when (exists? js/globalThis)
+                        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false))
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser? [] (rf.fresco.impl.mount/browser?))
+
+(defn- with-layout-host
+  "Give `f` a real `[data-rf-xray-host]` element — the host app's own slot,
+  which is what `open!` looks for — and take it away afterwards however `f`
+  ends. The host is returned to `f` so a row can measure it."
+  [f]
+  (let [host (.createElement js/document "div")]
+    (.setAttribute host "data-rf-xray-host" "")
+    (.appendChild (.-body js/document) host)
+    (try
+      (f host)
+      (finally
+        (xray-mount/teardown!)
+        (.remove host)))))
+
+;; ===========================================================================
+;; The gap — the public mount still cannot paint on an element-shaped adapter
+;; ===========================================================================
+
+(deftest the-public-mount-refuses-an-element-shaped-substrate
+  (testing "rf2-k97c.3 — with an element-shaped adapter installed, Xray's
+            PUBLIC `open!` refuses rather than mounting, names the adapter
+            kind it refused, and leaves the host's own element exactly as it
+            found it.
+
+            This is the epic's coupling (1) still unsevered: `open!` paints
+            through the installed adapter's `:render`, and an element-shaped
+            `:render` takes substrate-native React elements rather than the
+            hiccup shell. The refusal is the DESIGNED behaviour — a clean
+            diagnostic instead of an uncaught React child error — so the row
+            asserts it is clean, not merely that it happened."
+    (if-not (browser?)
+      (is true "skipped: the :browser-test runner drives the real mount")
+      (do
+        (rf/init! rf.adapter.uix/adapter)
+        (registry/register-xray-handlers!)
+        (with-layout-host
+          (fn [host]
+            (let [ret (xray-mount/open!)]
+              (is (= false (:ok? ret))
+                  (str "`open!` reports failure rather than a mount. Got: "
+                       (pr-str ret)))
+              (is (= :unsupported-substrate (:reason ret))
+                  (str "and names the reason. Got: " (pr-str (:reason ret))))
+              (is (= :rf.adapter/uix (:adapter ret))
+                  (str "and names the adapter kind it refused, so the message "
+                       "tells the developer which install did it. Got: "
+                       (pr-str (:adapter ret))))
+              (is (= false (xray-mount/mounted?))
+                  "and nothing was mounted")
+              (is (= ret (:diagnostic (xray-mount/status)))
+                  (str "and the same diagnostic is readable through the public "
+                       "`status` surface, so a host can inspect it rather than "
+                       "having to catch a return value. Got: "
+                       (pr-str (:diagnostic (xray-mount/status)))))
+              ;; ---- the host is undisturbed by the refusal -----------------
+              (is (nil? (.getElementById js/document "rf-xray-root"))
+                  "no Xray mount root was created in the document")
+              (is (= 0 (.-childElementCount host))
+                  (str "the host's own slot is still empty — Xray put nothing "
+                       "in it. Got: " (.-childElementCount host)))
+              (is (= "" (.-display (.-style host)))
+                  (str "and its inline `display` is untouched, so a refused "
+                       "open leaves no layout residue behind. Got: "
+                       (pr-str (.-display (.-style host))))))))))))
+
+;; ===========================================================================
+;; The control — the same verb, on a substrate Xray can paint through
+;; ===========================================================================
+
+(deftest the-public-mount-succeeds-on-a-ratom-family-substrate
+  (testing "rf2-k97c.3 — CONTROL for the row above. Same `open!`, same host
+            element, same registrations: on a ratom-family adapter it
+            MOUNTS. Without this, the refusal above is satisfied by any
+            setup defect that stops Xray mounting for some other reason —
+            a missing host, an unregistered handler, a frame that was never
+            made — and the row would pass while measuring nothing about
+            substrates at all."
+    (if-not (browser?)
+      (is true "skipped: the :browser-test runner drives the real mount")
+      (do
+        (rf/init! rf.adapter.reagent/adapter)
+        (registry/register-xray-handlers!)
+        (with-layout-host
+          (fn [host]
+            (let [ret (xray-mount/open!)]
+              (is (= true (xray-mount/mounted?))
+                  (str "`open!` mounted on a ratom-family substrate. Returned: "
+                       (pr-str (dissoc ret :node :unmount))))
+              (is (nil? (:diagnostic (xray-mount/status)))
+                  (str "with no diagnostic standing. Got: "
+                       (pr-str (:diagnostic (xray-mount/status)))))
+              (is (some? (.getElementById js/document "rf-xray-root"))
+                  "and a real mount root is in the document")
+              (is (= 1 (.-childElementCount host))
+                  (str "inside the host's own slot, which now holds exactly the "
+                       "one node Xray put there. Got: "
+                       (.-childElementCount host))))))))))

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/test_helpers/criteria.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/test_helpers/criteria.cljs
@@ -1,14 +1,27 @@
-(ns day8.re-frame2-xray.acceptance.criteria
+(ns day8.re-frame2-xray.acceptance.test-helpers.criteria
   "THE ACCEPTANCE HARNESS for the rf2-k97c epic's SIX BEHAVIOURAL CRITERIA,
   written against TODAY'S Xray so the root-swap PR inherits it rather than
   writing one under its own time pressure (rf2-k97c.3, slice D).
 
   This namespace holds the six criterion BODIES. It registers no `deftest`
   of its own and its name carries no `-cljs-test` suffix, so neither lane
-  discovers it; the per-substrate test namespaces beside it each wrap these
-  six in `deftest` under their own adapter. One body, N substrates — which
-  is the whole point, because the claim the swap makes is a claim about
+  discovers it; the per-substrate test namespaces one directory up each wrap
+  these six in `deftest` under their own adapter. One body, N substrates —
+  which is the whole point, because the claim the swap makes is a claim about
   INDIFFERENCE to the installed adapter.
+
+  ## WHY IT SITS UNDER `test_helpers/` — DO NOT MOVE IT BACK
+
+  `test_helpers/` is the established home for support shared by DOM suites,
+  and the surface classifier arms the browser lane on that DIRECTORY:
+  `is_story_xray_dom_test_path` in `.github/scripts/report-changed-surfaces.sh`
+  matches `tools/{story,xray}/test/*/test_helpers/*.{cljs,cljc}`. A shared
+  body file outside it classifies `cljs_browser=false`, so a PR editing only
+  this file would run the Node lane — where the DOM suites requiring it find
+  no `document` and self-skip — and skip the one lane that mounts them. The
+  mirror suite `implementation/scripts/_changed-surfaces.test.cjs` walks the
+  require closure of every `*_dom_cljs_test` namespace and refuses exactly
+  that, so a move out of here reds `npm run test:scripts` on arrival.
 
   ## The six, and which fn answers each
 

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/uix_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/uix_dom_cljs_test.cljs
@@ -1,8 +1,8 @@
 (ns day8.re-frame2-xray.acceptance.uix-dom-cljs-test
   "THE ELEMENT-SHAPED ARM of the epic's acceptance harness (rf2-k97c.3,
   slice D). The six criterion bodies live in
-  `day8.re-frame2-xray.acceptance.criteria`; this namespace supplies ONE
-  thing — the installed adapter — and wraps them in `deftest`.
+  `day8.re-frame2-xray.acceptance.test-helpers.criteria`; this namespace
+  supplies ONE thing — the installed adapter — and wraps them in `deftest`.
 
   ## WHY UIx, AND NOT `test-react`
 
@@ -53,7 +53,7 @@
             [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.test-support :as rf.test-support]
-            [day8.re-frame2-xray.acceptance.criteria :as criteria]
+            [day8.re-frame2-xray.acceptance.test-helpers.criteria :as criteria]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (def ^:private substrate

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/uix_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/uix_dom_cljs_test.cljs
@@ -1,0 +1,105 @@
+(ns day8.re-frame2-xray.acceptance.uix-dom-cljs-test
+  "THE ELEMENT-SHAPED ARM of the epic's acceptance harness (rf2-k97c.3,
+  slice D). The six criterion bodies live in
+  `day8.re-frame2-xray.acceptance.criteria`; this namespace supplies ONE
+  thing — the installed adapter — and wraps them in `deftest`.
+
+  ## WHY UIx, AND NOT `test-react`
+
+  The brief asked for reagent-slim plus ONE element-shaped adapter, chosen
+  by reading what actually ships. `implementation/adapters/README.md`
+  §'Adapters that ship today' rosters three — Reagent, UIx, reagent-slim —
+  and of those UIx is the element-shaped one: its `:render` comes from
+  `re-frame.substrate.spine/make-react-adapter` and takes substrate-native
+  React ELEMENTS rather than hiccup, which is exactly the property
+  `mount.cljs`'s `react-element-render-kinds` names when it refuses to
+  paint on one.
+
+  `adapters/test-react/` was considered and REJECTED, on its own docstring
+  rather than on its shipping status. It 'simulates the React class-3
+  lifecycle in pure CLJC ... without React, a DOM, or jsdom', and states
+  it performs 'no automatic rerender on app-db change, React context
+  traversal, or DOM source annotation'. Every one of the six criteria
+  needs at least one of those: criterion 1 needs a DOM, 2 and 3 need
+  re-render on change, 4 needs React context traversal. A harness run on
+  it would report green having exercised none of them — the fail-open
+  shape this whole epic is trying not to ship.
+
+  ## WHAT THIS ARM IS EVIDENCE FOR
+
+  The epic's forward-looking clause: *a future non-React browser adapter
+  supplying only the container quartet plus the listener API should get
+  Xray with no Xray-side work*. The UIx adapter is INSTALLED here as the
+  inspected application's substrate and is never called to paint anything
+  — Xray owns its own root. Six green rows on a substrate whose `:render`
+  Xray cannot use is what 'indifferent to the installed adapter' means in
+  a form a row can witness.
+
+  ## WHAT IT IS NOT EVIDENCE FOR
+
+  Today's `mount.cljs` still REFUSES this adapter outright — `open!`
+  returns the `:unsupported-substrate` diagnostic and mounts nothing,
+  because the Dynamic shell is still an `rf/reg-view` painted through the
+  installed adapter's `:render`. That refusal is measured and pinned in
+  `substrate_gap_dom_cljs_test`, which is the companion to this file and
+  says plainly which part of the swap is still to come.
+
+  ## NODE LANE
+
+  `cljs-test$` matches `-dom-cljs-test` too, so the `:node-test` build
+  compiles this namespace. Every row short-circuits there and reports the
+  skip."
+  (:require [cljs.test :refer-macros [async deftest testing use-fixtures]]
+            [re-frame.adapter.uix :as rf.adapter.uix]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.acceptance.criteria :as criteria]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(def ^:private substrate
+  {:id :uix :label "UIx — element-shaped"})
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.uix/adapter
+     ;; `:ambient-frame nil` is load-bearing, not tidiness. There is NO
+     ;; `:rf/default` fallback — a nil frame context RAISES
+     ;; `:rf.error/no-frame-context` — so a dynamic-var frame left in
+     ;; ambient scope would let a read that failed to resolve its own
+     ;; context answer from somewhere else, which is a frame miss reading
+     ;; as a green row. Criterion 4 is the row that would go quietly wrong.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache makes
+                      ;; criterion 6's baseline read a residue that is not
+                      ;; this chrome's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(deftest c1-first-display
+  (testing "criterion 1 — first display, with an element-shaped adapter installed"
+    (async done (criteria/c1-first-display! substrate done))))
+
+(deftest c2-updates-as-the-app-changes
+  (testing "criterion 2 — Xray follows a real change in the inspected app"
+    (async done (criteria/c2-updates-as-the-app-changes! substrate done))))
+
+(deftest c3-xrays-own-interactions
+  (testing "criterion 3 — a real click on Xray's own control works end to end"
+    (async done (criteria/c3-xrays-own-interactions! substrate done))))
+
+(deftest c4-tool-local-state-and-frame-targeting
+  (testing "criterion 4 — tool state stays out of the app, commands route where told"
+    (async done (criteria/c4-tool-local-state-and-frame-targeting! substrate done))))
+
+(deftest c5-no-masquerading-as-application-evidence
+  (testing "criterion 5 — Xray's activity is absent from the app's own evidence"
+    (async done (criteria/c5-no-masquerading-as-application-evidence! substrate done))))
+
+(deftest c6-clean-teardown-and-reopen
+  (testing "criterion 6 — teardown returns everything, and the host is undisturbed"
+    (async done (criteria/c6-clean-teardown-and-reopen! substrate done))))


### PR DESCRIPTION
Slice D of rf2-k97c.3 â€” scaffold the epic's acceptance harness against TODAY'S Xray, so the root-swap PR inherits it rather than writing one under its own time pressure.

**Test-only. No production file is touched** â€” four new files, 1390 lines, all additions.

## What landed

| file | what it is |
|---|---|
| `acceptance/test_helpers/criteria.cljs` | the six behavioural criteria, ONCE, as bodies parameterised by a substrate descriptor |
| `acceptance/uix_dom_cljs_test.cljs` | the ELEMENT-SHAPED arm â€” UIx installed as the host's adapter |
| `acceptance/reagent_dom_cljs_test.cljs` | the RATOM-FAMILY arm â€” same six bodies, same subject, same mount verb |
| `acceptance/substrate_gap_dom_cljs_test.cljs` | what is still NOT true, pinned at the seam the swap changes, with a control |

The only variable between the two arms is the installed adapter. That is what makes the pair evidence for the claim the root swap makes â€” that Xray is indifferent to it â€” rather than two separate smoke tests.

**Subject**: Xray's Static chrome (`static.shell/surface`) â€” ribbon, tab bar and detail panel, the largest piece of Xray's own chrome already re-authored as `rf.fresco/defview` boundaries.

**Mount verb**: `rf.fresco.impl.mount/root!` â€” Xray creates and owns its React root, the installed adapter's `:render` is never called, and frame context is established deliberately by naming the frame. That IS the epic's coupling (1) as it will be severed, so the swap PR satisfies this harness by construction rather than by editing it. When the Dynamic shell is migrated, the harness widens by one line: the vector `mount-xray!` renders.

**Frame**: `:rf/xray`, deliberately. Mounting into the application's frame would put Xray's tab selection in the app's `app-db` and its dispatches in the app's trace ring â€” exactly what criteria 4 and 5 forbid â€” so a harness that did it would assert against a world it had arranged to be wrong. (Doing precisely that is sabotage 5 below, and three criteria catch it.)

## FINDING 1 â€” reagent-slim cannot host Xray today, which is why this arm runs on Reagent

The slice brief named reagent-slim for the ratom-family arm. Measured across three adapters in one browser run at trunk `1bf7106126`:

| adapter | public `open!` | Xray's own React root |
|---|---|---|
| Reagent | **paints** | **paints** |
| reagent-slim | mounts, then **raises**, nothing paints | **raises**, nothing paints |
| UIx | refuses (documented diagnostic) | **paints** |

Under reagent-slim, `frame-switcher/frame-switcher-view` raises `:rf.error/no-frame-context` during render and React takes the whole subtree down. Reagent was green on both paths in the same run, which is what makes this a statement about reagent-slim rather than about the harness. Five Xray source files require `reagent.core` directly (`shell.cljs`, `static/shell.cljs`, `panels/machine_after_rings.cljs`, `static/routes/panel.cljs`, `static/machines/definition_detail.cljs`) and cross into the surviving Reagent islands with full Reagent's `as-element`, which is not the installed adapter's door.

This **contradicts `mount.cljs`'s own `unsupported-substrate-diagnostic`**, which tells the developer Xray's shell "is hiccup rendered through the ratom-family adapters (Reagent / **reagent-slim**)."

Repairing it is a production change and this slice is test-only, so it is reported rather than fixed. There is also **no browser row pinning it**, on purpose: reproducing it means provoking an uncaught render-phase throw, and the browser runner fails a whole run on an uncaught `pageerror` independently of the cljs.test summary â€” a row for it would red the lane for every unrelated suite in the build. The measurement is recorded in `substrate_gap_dom_cljs_test`'s docstring, in `reagent_dom_cljs_test`'s docstring (which says why that arm is Reagent), and on the bead.

## FINDING 2 â€” `test-react` was considered for the element-shaped arm and rejected

Not on its shipping status but on its own docstring: it "simulates the React class-3 lifecycle in pure CLJC ... without React, a DOM, or jsdom", and performs "no automatic rerender on app-db change, React context traversal, or DOM source annotation". Criterion 1 needs a DOM, 2 and 3 need re-render on change, 4 needs React context traversal. A harness run on it reports green having exercised none of them. UIx is the element-shaped adapter that ships, and it is the one used.

## FINDING 3 â€” `release!` is the wrong teardown door for a residue assertion

`rf.fresco.impl.mount/release!` ends with `reset-runtime!`, which empties the collector's tables â€” so a criterion-6 row written through it reads zero whatever the teardown did and can never turn red. The harness uses `unmount!`, which deliberately empties nothing. The docstring records this; sabotage 6 shows the row biting because of it.

## The gap row is the acceptance gate, and it is meant to go red

`the-public-mount-refuses-an-element-shaped-substrate` asserts that today's public `open!` still refuses an element-shaped adapter â€” coupling (1), unsevered â€” and then measures that the host element is undisturbed by the refusal. When child .4 deletes `react-element-render-kinds`, that row reddens with a named failure telling the reader what changed. Delete it then; the element-shaped arm's six criteria become evidence about the shipped mount path.

## FIX — the shared criterion bodies now live under `test_helpers/`

The first CI run was red on one assertion in the surface-classifier's mirror suite:

```
tools/xray/test/day8/re_frame2_xray/acceptance/criteria.cljs
  is required by a Story/Xray DOM suite but does not schedule cljs-browser
```

Real, and on a surface this branch introduced. `implementation/scripts/_changed-surfaces.test.cjs`
walks the require closure of every `*_dom_cljs_test` namespace and demands each support file it
reaches arm the browser lane. `criteria.cljs` sat beside its suites, outside any `test_helpers/`
directory, and classified `cljs_browser=false` — so a PR editing only that file would have run the
Node lane, where the DOM suites requiring it find no `document` and self-skip, and skipped the one
lane that mounts them. That is the false-green shape the mirror suite exists to refuse.

**The classifier is right; the layout was wrong.** `is_story_xray_dom_test_path` in
`.github/scripts/report-changed-surfaces.sh` arms the browser lane on the DIRECTORY
`tools/{story,xray}/test/*/test_helpers/*.{cljs,cljc}`, and says why in terms: so that "a DOM suite
reaching for a fourth helper beside them is armed on arrival instead of on the next audit". Moving
the file into a `test_helpers/` directory takes that existing arm, so **neither half of the
classifier/mirror one-toucher pair is touched** — the repair is three lines of `:require` and a
rename.

Kept under `acceptance/` rather than folded into the tool-wide helpers directory, so the harness
stays one cohesive unit; multiple `test_helpers/` directories per tree are already established
practice (Story has two). The namespace becomes
`day8.re-frame2-xray.acceptance.test-helpers.criteria`, which is the same `test_helpers/` to
`test-helpers.` munging the three existing helpers already use. The ns docstring now records why the
file lives there, so it is not moved back.

## Quality gates

Every number below is the runner's own captured exit code, taken with the redirect and the echo on one command line, never one the harness reported about the same run. Browser lane served on port **8136** (the port the log recorded), from this worktree's own `out/browser-test`.

### This pass — the classifier repair, on the FINAL rebased base `a673775425`

| gate | captured exit | result |
|---|---|---|
| `npm run test:scripts` (the failing gate, from `implementation/`) | **0** | **123 tests, 123 pass, 0 fail** |
| `node --test scripts/_changed-surfaces.test.cjs` against a planted fault | **1** | see below |
| `scripts/check_require_alias_dialect.py` | **0** | the two `:require` rewrites are in scope |
| `scripts/check_test_lane_bijection.py` | **0** | the moved file keeps its lane |
| `scripts/check_retired_spellings.py` | **0** | |
| `scripts/check_thrown_error_messages.py` | **0** | |
| `scripts/check_view_lifetime_residue.py` | **0** | |
| `scripts/check-no-hardcoded-paths.sh` | **0** | |
| `scripts/check-commit-attribution.sh origin/main` | **0** | the 4 commits this branch introduces |

**The gate was shown to read this worktree, not a sibling.** With `criteria.cljs` moved back out of
`test_helpers/` — a layout that exists in no other tree — the mirror suite went red at captured exit
**1** with CI's exact message naming that path; restored, the file's `git hash-object` matches the
committed blob hash `841464b1287101b5a1a5bfbd4f7da8ee57fa1c53` and `git diff --quiet HEAD` exits 0.

**The green is not vacuous.** Replaying the mirror suite's own closure walk prints the support set it
reaches, and the moved file is in it — so the rename genuinely resolves from both suites' `:require`
forms rather than dropping out of the walk and passing by absence.

**Relied on CI, not re-run locally on this base**: the browser and node CLJS lanes. This worktree has
no `node_modules`, and installing one to re-compile would duplicate a gate CI runs automatically on
exactly the surfaces the classifier arms for these paths (`cljs_browser`, `cljs_node_test`,
`tools_jvm`, `mcp_conformance`). The change is a file move plus a namespace rename with no
production file touched, every reference rewritten (zero residual matches for the old namespace
tree-wide), and `shadow-cljs.edn` selects browser suites by the `-dom-cljs-test` ns suffix, which
this file has never carried.

### The original pass — on base `2e8ff1d510`, before the rebase



| gate | captured exit | result |
|---|---|---|
| `shadow-cljs compile browser-test` (focused to `acceptance.*-dom-cljs-test`) | **0** | 601 files, 0 warnings |
| `serve-and-run-browser-tests.cjs` | **0** | **14 tests, 121 assertions, 0 failures, 0 errors** |
| `compile-node-test.cjs node-test` (full) | **0** | 1955 files, 0 warnings |
| `node out/node-test.js --test=<the three namespaces>` | **0** | **14 tests, 14 assertions, 0 failures** â€” every row reports its skip rather than passing silently |
| `scripts/check_require_alias_dialect.py` | **0** | reads every git-tracked `.clj`/`.cljs`/`.cljc`, so these files are in scope |
| `scripts/check_test_lane_bijection.py` | **0** | PASS â€” 1629 test-defining files, 45 lanes, every file selected |
| `scripts/check_retired_spellings.py` | **0** | |

The node lane needed measuring rather than assuming: `fresco_live_panel_dom_cljs_test` is documented as absent from `out/node-test.js` despite its own docstring. These three namespaces ARE in the bundle (grepped), and they run and skip cleanly there.

**Relied on CI, not run locally**: `clj-kondo`, `splint`, `eslint`, `api-manifest`, the docs and portability workflows, the FULL browser-test lane, the full node-lane run, the adapter smokes and the Xray feature-matrix gate. The focused browser run above answers "did I break something obvious" once; re-running the full matrix locally buys wall-clock rather than information, and the merge criterion reads CI.

## Every assertion was shown to bite

Eight plants. Each anchored to a single line with the match count read BEFORE the run (zero is free; a hash convicts a no-op plant only after a run is spent), each restored with `git checkout HEAD --` and verified two ways â€” the committed blob id against `git hash-object` in both its filtered and `--no-filters` forms, and `git diff --quiet HEAD --`. All eight restores verified; the working tree is clean.

| # | plant | result |
|---|---|---|
| 1 | `static/shell.cljs` â€” rename the tab-bar testid | **C1 red**, both arms. 0 pageerrors |
| 2 | `trace_collector.cljs` â€” `refresh-trace-rings!` mirrors an empty snapshot | **C2 red**, both arms, on the positive half; the deaf control stayed green |
| 3 | `static/shell.cljs` â€” tab button's `:on-click` dispatches nothing | **C3 red** on both its assertions; C4 and C5's non-vacuity guards also fired, which is what they are for |
| 4 | `static/shell.cljs` â€” `tab-bar` passes ambient `rf/dispatch` instead of its captured frame dispatcher | **C4 red** on "the command landed in the frame the tree NAMED", with 6 uncaught `:rf.error/no-frame-context` â€” the documented degradation |
| 5 | `criteria.cljs` â€” mount Xray into the APPLICATION's frame | **C5 red on both its assertions**; C4's "app-db untouched" and cross-frame control and C6's three host-undisturbed rows all fired too. Mounting the tool in the app's frame IS a 4/5/6 violation and all three saw it |
| 6 | `criteria.cljs` â€” a teardown that tears nothing down | **C6 red on all eight residue assertions** across both arms â€” ref-count, live cell, reader edges, whole census, reopen accumulation, second unmount. Nothing else implicated |
| 7 | `mount.cljs` â€” delete `:rf.adapter/uix` from the denylist (exactly what child .4 will do) | **gap row red**, 7 named failures |
| 8 | `mount.cljs` â€” add `:rf.adapter/reagent` to the denylist | **gap control red** on all 5 of its assertions, while the refusal row stayed green â€” so the two rows discriminate |

Plant 7 initially came back as an uncaught ERROR that also swallowed seven assertions below it; the row now catches that throw and reports one named failure saying what changed, and was re-sabotaged to confirm the clean red.

**Every expectation compares against a LITERAL** â€” `"rf-xray-static-detail-panel-flows"`, `:machines`, `{:count 0}`, `0`, `#{::app-seed ::app-bump}`, `{:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}` â€” never against a value read back out of the subject. Criterion 5's `rf.xray` classifier is written out in the harness rather than taken from `self-noise`, because a filter cannot be both the subject and the instrument.

## Criterion 6 is measured, not asserted

Five instruments read at five points (before mount, mounted, after unmount, after reopen, after second unmount): the frame's sub-cache ref-count, the collector cell's existence (the watch), its reader-edge count (the listener), the whole collector census, and the document's node count. The host half is separate and real â€” the application holds a LIVE subscription across the entire cycle, taken before Xray exists, and the row asserts its ref-count, its value and the application's `app-db` are exactly what they were after two full Xray lifecycles.
