### PR TITLE
feat(xray): migrate the edn-inspector popup stack onto Fresco (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_inspector_popup.cljs
@@ -83,6 +83,7 @@
   popups within this surface use sequential z-indexes derived from
   the stack position, so the topmost popup wins click + focus."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack type-scale]]
@@ -376,6 +377,52 @@
                   :font-family sans-stack}}
    title])
 
+;; =========================================================================
+;; the embedded widget's head — ONE PER LANE (rf2-k97c.3)
+;; =========================================================================
+;;
+;; `popup-chrome` is shared by two lanes and the only thing that differs
+;; between them is the head it embeds the value under. `views.edn-inspector`
+;; already ships BOTH (the T4 dual-head facade): `edn-inspector` is the
+;; Reagent `reg-view` head and `edn-inspector-view` is the Fresco boundary,
+;; over one renderer.
+;;
+;; The choice is therefore a PARAMETER here rather than a branch: the head
+;; is passed in, exactly as the tree's `as-child` islands pass `identity`
+;; or `reagent.core/as-element` rather than reaching for a Fresco API. The
+;; default is the Reagent one, so every existing direct caller of
+;; `popup-chrome` — the node-lane rows and [[edn-inspector-popup]] — keeps
+;; the hiccup it already had, and only the boundary opts in.
+;;
+;; SCAFFOLDING WITH A DEFINED END: when [[edn-inspector-popup]] is itself a
+;; Fresco body (or goes), [[fresco-inspector]] becomes the only lane and
+;; this parameter goes with the default.
+
+(defn reagent-inspector
+  "The embedded widget as a REAGENT head — `[ei/edn-inspector value opts]`,
+  the shape this file emitted before rf2-k97c.3 and still the right one
+  under a Reagent parent. `mount-id` is unused: the Reagent head is a
+  form-2 component and mints its own per-mount identity."
+  [_mount-id value opts]
+  [ei/edn-inspector value opts])
+
+(defn fresco-inspector
+  "The embedded widget as a FRESCO BOUNDARY head —
+  `[ei/edn-inspector-view {:mount-id … :value … :opts …}]`.
+
+  `edn-inspector-view` REFUSES a missing or non-string `:mount-id`, and
+  deliberately: a React function component has no form-2 outer body to
+  allocate one in, so an id minted in its body would be fresh on every
+  render and the widget would lose its expansion state each pass. The
+  popup's own `mount-id` is exactly the stable name it asks for — it is a
+  UUID minted once per popup and it already keys this popup's entry in
+  app-db — so it is qualified with the surface's name and handed down."
+  [mount-id value opts]
+  [ei/edn-inspector-view
+   {:mount-id (str "rf-xray-edn-inspector-popup-" mount-id)
+    :value    value
+    :opts     opts}])
+
 (defn popup-chrome
   "Render a single popup's chrome — header + body + close button.
   Public so tests can drive the chrome without mounting the
@@ -387,8 +434,13 @@
                  `:panel-id` derived from `mount-id`.
   `positioning`— `:fixed` / `:absolute` (modal-positioning sub).
   `stack-pos`  — integer position in the stack; used for z-index
-                 layering."
-  [{:keys [mount-id value opts positioning stack-pos]}]
+                 layering.
+  `inspector`  — 3-arg fn `(fn [mount-id value opts] → hiccup)` emitting
+                 the embedded widget's head. Defaults to
+                 [[reagent-inspector]]; the Fresco boundary passes
+                 [[fresco-inspector]]. See the section comment above."
+  [{:keys [mount-id value opts positioning stack-pos inspector]
+    :or   {inspector reagent-inspector}}]
   (let [{:keys [title panel-id default-expanded-depth
                 max-inline-width max-depth on-close]
          :or   {title "Inspect"
@@ -449,12 +501,17 @@
        ;; edn-inspector mount on the page (the panel underneath
        ;; almost certainly already mounts the same value at the
        ;; same path).
-       [ei/edn-inspector value
-        {:panel-id (keyword "rf.xray.edn-inspector-popup"
-                            (str (name panel-id) "-" mount-id))
-         :default-expanded-depth default-expanded-depth
-         :max-inline-width       max-inline-width
-         :max-depth              max-depth}]])))
+       ;;
+       ;; rf2-k97c.3 — CALLED rather than headed, so the lane's head
+       ;; (Reagent `reg-view` or Fresco boundary) is the caller's to
+       ;; choose. The opts map below is unchanged and is what both
+       ;; lanes carry.
+       (inspector mount-id value
+                  {:panel-id (keyword "rf.xray.edn-inspector-popup"
+                                      (str (name panel-id) "-" mount-id))
+                   :default-expanded-depth default-expanded-depth
+                   :max-inline-width       max-inline-width
+                   :max-depth              max-depth})])))
 
 ;; =========================================================================
 ;; public component — `edn-inspector-popup`
@@ -506,14 +563,53 @@
 ;; stack view — renders every open popup over the active panel
 ;; =========================================================================
 
-(rf/reg-view edn-inspector-popup-stack
-  "Stack view that renders every open popup in z-index order. Mount
-  this once at the shell's overlay container (follow-on bead wires
-  it into `mount.cljs`); each entry's payload is the value + opts
-  the caller passed to `:open`.
+(defn popup-stack-tree
+  "The OPEN stack's markup, as a pure function of the values it is handed
+  — `:stack`, `:entries` and `:positioning`. The empty/non-empty gate is
+  the CALLER's, so this never answers nil.
 
-  Closed-state cost is one subscribe + a `when` — when the stack is
-  empty the body short-circuits to nil.
+  rf2-k97c.3 — split out of the view when the view became a Fresco
+  boundary, so the stack stays drivable from the node lane without a
+  React commit. A boundary's body may only run inside a React render
+  window (`rf.fresco/sub` REFUSES outside one, naming the query), so
+  calling the view var directly is no longer a way to get hiccup; this
+  is. It is PURE of its arguments — no read, no `subscribe-once`, no
+  fallback arity — which is precisely what the migration removes.
+
+  The embedded widget's head is [[fresco-inspector]] here rather than
+  `popup-chrome`'s Reagent default: this tree is what the boundary
+  renders, and a `reg-view` head grades `:invalid` down the same codec
+  arm a plain `defn` does."
+  [{:keys [stack entries positioning]}]
+  (into [:div {:data-testid "rf-xray-edn-inspector-popup-stack"
+               :data-rf-popup-count (count stack)}]
+        (map-indexed
+          (fn [idx mount-id]
+            (let [{:keys [value opts]} (get entries mount-id)]
+              ;; rf2-a38l — KEYED FRAGMENT rather than `with-meta` on
+              ;; the vector `popup-chrome` returns. Reagent reads that
+              ;; metadata; Fresco's codec takes a literal `:key` from
+              ;; an ATTRIBUTE MAP and reads Clojure metadata nowhere,
+              ;; so under a boundary every popup in the stack would
+              ;; lose its identity and React would reconcile them by
+              ;; position. The key does NOT go in the opts map — that
+              ;; is `popup-chrome`'s domain data, and `:key` is
+              ;; React's.
+              [:<> {:key mount-id}
+               (popup-chrome
+                 {:mount-id    mount-id
+                  :value       value
+                  :opts        opts
+                  :positioning positioning
+                  :stack-pos   idx
+                  :inspector   fresco-inspector})]))
+          stack)))
+
+(rf.fresco/defview edn-inspector-popup-stack-view
+  "Stack view that renders every open popup in z-index order — a FRESCO
+  BOUNDARY (rf2-k97c.3), not an `rf/reg-view`. Mounted once at the
+  shell's overlay container; each entry's payload is the value + opts
+  the caller passed to `:open`.
 
   This view is the entry point for **programmatic** opens — a
   context-menu handler dispatches
@@ -523,40 +619,90 @@
   **inline** opens (a panel that wants to control the popup
   imperatively from its own view tree).
 
-  `reg-view`-registered so its `subscribe` / `dispatch` calls resolve
-  against the frame it is mounted under. As a plain fn they would not
-  resolve at all: no `:contextType`, so the ambient read returns nil and
-  RAISES `:rf.error/no-frame-context` — there is no `:rf/default` floor
-  under EP-0002 (Spec 006 §Plain-fn footgun, which superseded the retired
-  `:rf.warning/plain-fn-under-non-default-frame-once`). The
-  view-id is auto-derived from the symbol per the canonical reg-view
-  convention; the surrounding shell mounts this stack under `:rf/xray`,
-  so all its `subscribe` calls resolve through the React-context tier
-  to the surrounding frame."
-  []
-  (let [stack   @(rf/subscribe [stack-slot])
-        entries @(rf/subscribe [entries-slot])
-        positioning @(rf/subscribe [:rf.xray/modal-positioning])]
+  ## WHY A BOUNDARY, AND WHAT ACTUALLY MOVED
+
+  The frame reasoning is UNCHANGED from the `reg-view` this replaced: a
+  boundary reads its frame from the same `re-frame.adapter.context` React
+  context that `rf/frame-provider` writes, so the reads still resolve
+  through the surrounding `:rf/xray` frame, and a plain `defn` here would
+  still raise `:rf.error/no-frame-context` (Spec 006 §Plain-fn footgun,
+  EP-0002 having removed the `:rf/default` floor). What changed is the
+  OBSERVER — the reads are `rf.fresco/sub`, recorded by Fresco's own
+  collector rather than by whichever reaction machinery the installed
+  adapter supplies, which is this epic's coupling (3).
+
+  ## CLOSED-STATE COST IS NOW WHAT IT ALWAYS CLAIMED TO BE
+
+  One subscription and a gate. The `reg-view` read all three slots
+  unconditionally and then gated, so its docstring's \"one subscribe + a
+  `when`\" was aspirational; `rf.fresco/sub` records its edge WHERE THE
+  READ HAPPENS, so moving the other two inside the `when` makes a closed
+  stack hold one edge instead of three. A branch not taken contributes
+  none — Fresco's documented behaviour (HD-002), not an accident.
+
+  PUBLIC, like `edn-inspector-view` and `resizable-table-view` beside it:
+  this is the head a Fresco parent writes, and the shell's root swap is
+  what will write it. [[edn-inspector-popup-stack]] in front of it is the
+  name the Reagent shell still mounts — see that bridge's docstring for
+  why the two names sit this way round here."
+  [_props]
+  (let [stack (rf.fresco/sub [stack-slot])]
     (when (seq stack)
-      (into [:div {:data-testid "rf-xray-edn-inspector-popup-stack"
-                   :data-rf-popup-count (count stack)}]
-            (map-indexed
-              (fn [idx mount-id]
-                (let [{:keys [value opts]} (get entries mount-id)]
-                  ;; rf2-a38l — KEYED FRAGMENT rather than `with-meta` on
-                  ;; the vector `popup-chrome` returns. Reagent reads that
-                  ;; metadata; Fresco's codec takes a literal `:key` from
-                  ;; an ATTRIBUTE MAP and reads Clojure metadata nowhere,
-                  ;; so under a boundary every popup in the stack would
-                  ;; lose its identity and React would reconcile them by
-                  ;; position. The key does NOT go in the opts map — that
-                  ;; is `popup-chrome`'s domain data, and `:key` is
-                  ;; React's.
-                  [:<> {:key mount-id}
-                   (popup-chrome
-                     {:mount-id    mount-id
-                      :value       value
-                      :opts        opts
-                      :positioning positioning
-                      :stack-pos   idx})]))
-              stack)))))
+      (popup-stack-tree
+        {:stack       stack
+         :entries     (rf.fresco/sub [entries-slot])
+         :positioning (rf.fresco/sub [:rf.xray/modal-positioning])}))))
+
+;; ---- the migration bridge (rf2-k97c.3) ----------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter, and `shell.cljs` mounts `[edn-inspector-popup/edn-inspector-
+;; popup-stack]` as a hiccup head — which a React component is not.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly this:
+;; it answers a real React component for a boundary, which a React parent
+;; (Reagent here) mounts UNDER THE FRAME IT IS ALREADY IN, taking the
+;; frame from React context rather than from a second root. No second
+;; root, no adapter-kind branch, no props ABI. The crossing carries an
+;; EMPTY props map, which is the case `as-component`'s own note calls
+;; sound — the inspected VALUES never cross it; they are read inside the
+;; boundary and reach the widget as ordinary CLJS.
+;;
+;; NAMING: the mayor's 2026-09-10 ruling is that a boundary keeps the
+;; NATURAL name and the caller is handed a PUBLIC bridge (#9581). The
+;; constraint that forced #9578's opposite spelling applies HERE and is
+;; why the names sit this way round: `shell.cljs` mounts this var BY NAME
+;; and is fenced to the root-swap slice, so the public name has to go on
+;; the thing that head site already writes. `machine_after_rings.cljs`
+;; records the same fork from the other side.
+;;
+;; SCAFFOLDING WITH A DEFINED END. When the shell is itself a Fresco
+;; tree, `edn-inspector-popup-stack-view` takes this name directly, the
+;; `[:>]` goes, and both defs below are deleted.
+
+(def ^:private edn-inspector-popup-stack-component
+  "The React component [[edn-inspector-popup-stack-view]] presents as, for
+  a non-Fresco parent. Declared ONCE at top level, as
+  `rf.fresco/as-component`'s contract requires — deriving one per render
+  mints a fresh element type and would remount every open popup, taking
+  its expansion state with it."
+  (rf.fresco/as-component edn-inspector-popup-stack-view))
+
+(defn edn-inspector-popup-stack
+  "The popup stack's public callable — what `shell.cljs` mounts as a
+  hiccup head at the shell root.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component
+  [[edn-inspector-popup-stack-view]] presents as. The enclosing
+  `rf/frame-provider` is what puts `:rf/xray` in React context for it.
+
+  The empty/non-empty gate is inside the boundary, so this is always
+  mounted and renders nothing while no popup is open — the same shape a
+  mounted `reg-view` returning nil had.
+
+  Callers wanting the MARKUP as data — the node-lane rows — build it from
+  [[popup-stack-tree]] with the slots' values instead; this returns an
+  interop vector, not a tree to walk."
+  []
+  [:> edn-inspector-popup-stack-component {}])

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_cljs_test.cljs
@@ -522,12 +522,39 @@
 ;; =========================================================================
 ;; stack view — renders every open entry; closed-state short-circuits
 ;; =========================================================================
+;;
+;; rf2-k97c.3 — `edn-inspector-popup-stack` is now an
+;; `rf.fresco/as-component` bridge and answers an interop vector, not a
+;; tree to walk. The markup is `popup-stack-tree`, a pure fn of the values
+;; the boundary reads.
+;;
+;; The helper below reproduces the boundary's gate and reads EXACTLY —
+;; same gate, same order, same query vectors — so every row here asserts
+;; on the same hiccup it did before, and a boundary that stopped reading
+;; one of these slots would diverge from its own test helper rather than
+;; silently agreeing with it.
+;;
+;; It is deliberately the AMBIENT `rf/subscribe`, because these rows run
+;; in the node lane with no React commit at all. What the boundary's own
+;; read resolves to — the frame React context names, not the ambient one
+;; — is the browser lane's subject.
+
+(defn- popup-stack-tree
+  "What calling the stack view directly returned before the migration:
+  nil while the stack is empty, the container otherwise."
+  []
+  (let [stack @(rf/subscribe [edn-inspector-popup/stack-slot])]
+    (when (seq stack)
+      (edn-inspector-popup/popup-stack-tree
+        {:stack       stack
+         :entries     @(rf/subscribe [edn-inspector-popup/entries-slot])
+         :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))))
 
 (deftest stack-view-renders-nothing-when-empty
   (edn-inspector-popup/install!)
   ;; Register the modal-positioning sub the stack view subscribes to.
   (rf/reg-sub :rf.xray/modal-positioning (fn [_ _] :fixed))
-  (is (nil? (edn-inspector-popup/edn-inspector-popup-stack))
+  (is (nil? (popup-stack-tree))
       "closed stack short-circuits to nil"))
 
 (deftest stack-view-renders-one-entry-per-open-popup
@@ -537,7 +564,7 @@
                      "m1" {:value 1 :opts {:title "A"}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m2" {:value 2 :opts {:title "B"}}])
-  (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+  (let [tree (popup-stack-tree)]
     (is (some? tree) "stack view renders when at least one popup is open")
     (is (some? (find-attr tree :data-testid
                           "rf-xray-edn-inspector-popup-stack"))
@@ -558,6 +585,6 @@
                      "m2" {:value 2 :opts {}}])
   (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                      "m3" {:value 3 :opts {}}])
-  (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+  (let [tree (popup-stack-tree)]
     (is (= 3 (-> tree second :data-rf-popup-count))
         "popup-count attribute reflects stack depth")))

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_inspector_popup_wireup_cljs_test.cljs
@@ -30,6 +30,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.views.edn-inspector :as ei]
@@ -225,10 +226,34 @@
   (registry/register-xray-handlers!)
   (rf/make-frame {:id :rf/xray}))
 
+;; rf2-k97c.3 — `edn-inspector-popup-stack` is now an
+;; `rf.fresco/as-component` bridge and answers an interop vector, not a
+;; tree to walk. `popup-stack-tree` below reproduces the boundary's gate
+;; and reads EXACTLY — same gate, same order, same query vectors — so the
+;; rows in this section assert on the hiccup they always did, and a
+;; boundary that stopped reading one of these slots would diverge from
+;; this helper rather than silently agreeing with it.
+;;
+;; Ambient `rf/subscribe` deliberately: these rows run under
+;; `rf/with-frame :rf/xray` in the node lane with no React commit. What
+;; the boundary's own read resolves to — the frame React context names —
+;; is the browser lane's subject.
+
+(defn- popup-stack-tree
+  "What calling the stack view directly returned before the migration:
+  nil while the stack is empty, the container otherwise."
+  []
+  (let [stack @(rf/subscribe [edn-inspector-popup/stack-slot])]
+    (when (seq stack)
+      (edn-inspector-popup/popup-stack-tree
+        {:stack       stack
+         :entries     @(rf/subscribe [edn-inspector-popup/entries-slot])
+         :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))))
+
 (deftest popup-stack-view-empty-when-stack-empty
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
-    (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+    (let [tree (popup-stack-tree)]
       (is (nil? tree)
           "stack view returns nil when no popups are open (closed-state
            cost is one subscribe + a when-gate)"))))
@@ -242,7 +267,7 @@
         [:rf.xray.edn-inspector-popup/open
          "m1" {:value {:foo :bar}
                :opts  {:title "Inspect cart"}}])
-      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+      (let [tree (popup-stack-tree)]
         (is (some? tree) "stack view returns hiccup when stack non-empty")
         (is (some? (find-by-testid tree "rf-xray-edn-inspector-popup-stack"))
             "outer stack container present")
@@ -258,7 +283,7 @@
                          "m1" {:value 1 :opts {}}])
       (rf/dispatch-sync [:rf.xray.edn-inspector-popup/open
                          "m2" {:value 2 :opts {}}])
-      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+      (let [tree (popup-stack-tree)]
         (is (some? (find-by-testid tree
                                    "rf-xray-edn-inspector-popup-backdrop-m1")))
         (is (some? (find-by-testid tree
@@ -296,26 +321,44 @@
 ;; floor and retired the warning, so the same plain `defn` today RAISES
 ;; `:rf.error/no-frame-context` instead (Spec 006 §Plain-fn footgun).
 ;;
-;; Post-fix the symbol is registered via `rf/reg-view`, so the auto-derived
-;; id `:day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-
-;; stack` is resolvable through `(rf/view id)`, and subscribes inside the
-;; render body resolve the surrounding `:rf/xray` frame from React context.
+;; rf2-1yif8's fix registered the symbol via `rf/reg-view`. rf2-k97c.3
+;; replaced that with an `rf.fresco/defview` BOUNDARY, and the frame
+;; reasoning is unchanged: a boundary reads its frame from the same
+;; `re-frame.adapter.context` React context `reg-view` consulted, so the
+;; reads still resolve through the surrounding `:rf/xray`. What moved is
+;; the observer — Fresco's collector rather than the installed adapter's.
+;;
+;; So the row below pins the same property one layer down, and pins it
+;; where it now bites: a `reg-view` head and a plain `defn` head grade
+;; `:invalid` down the IDENTICAL codec arm, so once the shell root is a
+;; boundary either one is a hard failure rather than a degradation. The
+;; assertion is that the stack view, and the head it embeds the value
+;; under, both grade `:boundary`.
 
-(def ^:private popup-stack-view-id
-  :day8.re-frame2-xray.views.edn-inspector-popup/edn-inspector-popup-stack)
-
-(deftest popup-stack-view-is-reg-view-registered
-  (testing "rf2-1yif8 — `edn-inspector-popup-stack` is `reg-view`-
-            registered under its auto-derived ns/sym id, so the body's
-            subscribes inherit the surrounding frame from React context
-            (the symptom under a plain `defn` was, on the runtime of the
-            day, the now-retired
-            `:rf.warning/plain-fn-under-non-default-frame-once` warning
-            firing on every panel-gallery `:rf/xray` render; under
-            EP-0002 the same shape raises `:rf.error/no-frame-context`)."
+(deftest popup-stack-view-is-a-fresco-boundary
+  (testing "rf2-k97c.3 — `edn-inspector-popup-stack-view` is an
+            `rf.fresco/defview` boundary, so the shell root becoming a
+            Fresco tree mounts it rather than refusing it. A revert to
+            `rf/reg-view` (or to a plain `defn`) grades `:invalid` down
+            the same codec arm and reds this row — which is the point,
+            since that revert is silent under Reagent."
     (setup-xray-frame!)
-    (is (some? (rf/view popup-stack-view-id))
-        "view is registered under the auto-derived ns/sym id")))
+    (is (= :boundary
+           (rf.fresco.impl.codec/head-kind
+             edn-inspector-popup/edn-inspector-popup-stack-view))
+        "the stack view is a Fresco boundary")
+    (is (= :boundary
+           (rf.fresco.impl.codec/head-kind
+             (first (edn-inspector-popup/fresco-inspector
+                      "m1" {:a 1} {}))))
+        "the head the boundary embeds the inspected value under is a
+         boundary too — a head-free subtree all the way down")
+    (is (= :invalid
+           (rf.fresco.impl.codec/head-kind
+             (first (edn-inspector-popup/reagent-inspector
+                      "m1" {:a 1} {}))))
+        "and the Reagent head it replaced grades :invalid, so the row
+         above is not vacuous")))
 
 (deftest popup-stack-view-subscribes-route-to-surrounding-frame
   (testing "rf2-1yif8 — when the stack view is rendered under `:rf/xray`,
@@ -341,15 +384,18 @@
       (rf/dispatch-sync
         [:rf.xray.edn-inspector-popup/open
          "xray-only" {:value :xray-payload :opts {}}]))
-    ;; Render the stack view under :rf/xray. After rf2-1yif8 this is a
-    ;; reg-view, so calling it under `with-frame :rf/xray` resolves
-    ;; subscribes through the dynamic-var tier (headless mode — no React
-    ;; context here, but the registered wrapper still routes through the
-    ;; surrounding frame). The pre-fix plain-fn would have ignored the
-    ;; `with-frame` binding entirely because the body's `rf/subscribe`
-    ;; calls would have fallen all the way through to `:rf/default`.
+    ;; Drive the stack under :rf/xray. Since rf2-k97c.3 the view is a
+    ;; Fresco boundary, whose body may only run inside a React render
+    ;; window, so the node lane reads the slots itself and hands them to
+    ;; the pure `popup-stack-tree` — the same slots in the same order the
+    ;; boundary reads. Under `with-frame :rf/xray` those ambient reads
+    ;; resolve through the dynamic-var tier; what the BOUNDARY's own read
+    ;; resolves to is the React-context tier and the browser lane's
+    ;; subject. Either way the property pinned here is the same one: the
+    ;; stack rendered under :rf/xray shows :rf/xray's entries and not
+    ;; :rf/default's.
     (rf/with-frame :rf/xray
-      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+      (let [tree (popup-stack-tree)]
         (is (some? tree)
             "stack view rendered some chrome under :rf/xray (proves :rf/xray's
              stack slot is non-empty from the view's perspective)")
@@ -365,7 +411,7 @@
              frames"))
       ;; And the stack's count attribute reflects :rf/xray's stack
       ;; depth exclusively (one entry), not the combined two.
-      (let [tree (edn-inspector-popup/edn-inspector-popup-stack)]
+      (let [tree (popup-stack-tree)]
         (is (= 1 (-> tree second :data-rf-popup-count))
             "popup-count reflects :rf/xray's stack only (one entry), not
              the two-entry total across frames")))))


### PR DESCRIPTION
Slice B6, phase 1 of rf2-k97c.3 — one of the two unscheduled `shell-view-tree` children.

## Why this is on the critical path

`views/edn_inspector_popup.cljs` is a child of `shell-view-tree` (headed at `shell.cljs:3166`)
and was still `rf/reg-view` at tip. A `reg-view` head grades `:invalid` down the **identical**
codec arm a plain `defn` does — `codec/boundary-head?` reads one own property, `frescoBoundary`,
set only by `rf.fresco/defview` — so the moment the shell root becomes a boundary this is a hard
failure, not a degradation. Verified at tip before building: `edn_inspector_popup.cljs:509` was
`(rf/reg-view edn-inspector-popup-stack`.

## The shape, and why the names sit this way round

This is the shape already landed for `panels/cancellation_cascade.cljs`, not a third one.

Under the mayor's 2026-09-10 naming ruling a boundary keeps the NATURAL name and the caller is
handed a public bridge (#9581). The constraint that forced #9578's opposite spelling applies
here and is why the names are inverted: `shell.cljs` mounts this var **by name** and is fenced to
the root-swap slice, so the public name has to stay on the thing that head site already writes.
`machine_after_rings.cljs:599-603` records the same fork from the other side.

| symbol | what it is now |
| --- | --- |
| `popup-stack-tree` | the markup as a **pure fn** of `:stack` / `:entries` / `:positioning`; the gate is the caller's, so it never answers nil |
| `edn-inspector-popup-stack-view` | the `rf.fresco/defview` **boundary**; public, like `edn-inspector-view` and `resizable-table-view` beside it, so the root swap can head it directly |
| `edn-inspector-popup-stack-component` | `rf.fresco/as-component`, declared once at top level |
| `edn-inspector-popup-stack` | now the **bridge** — keeps the name `shell.cljs:3166` heads, **unedited** |

`shell.cljs` is untouched. So are both `:3158` and `:3166`.

## Closed-state cost is now what the docstring always claimed

The old `reg-view` read all three slots unconditionally and *then* gated, so its
"one subscribe + a `when`" was aspirational — as was the same claim in
`tools/xray/spec/021-Dynamic-Panel-Designs.md` §10.0.7.1. `rf.fresco/sub` records its edge where
the read happens (HD-002), so the other two moved inside the `when`: a closed stack now holds
**one** edge instead of three. No spec edit needed — the prose was already describing this.

## The embedded widget's head is a parameter, not a branch

`views.edn-inspector` already ships both heads over one renderer (the T4 dual-head facade), so
`popup-chrome` takes an `:inspector` fn. The default is the Reagent head, so every existing
direct caller — the eleven node-lane `popup-chrome` rows and `edn-inspector-popup` — keeps the
hiccup it already had, and only the boundary opts in. `fresco-inspector` supplies the
`:mount-id` that `edn-inspector-view` refuses to go without.

Q1's second half was answered by reading what the callee returns rather than by the call site:
`theme/modal_chrome.cljs`'s `modal-chrome` returns `[:div backdrop [:div dialog children…]]` —
native tags only — and performs zero executable substrate reads. The subtree is head-free apart
from the one deliberate boundary head.

## The Q2 amendment bit, as predicted

Eight non-render call sites across two test files drove the view var directly
(`edn_inspector_popup_cljs_test.cljs` x3, `edn_inspector_popup_wireup_cljs_test.cljs` x5). A
boundary body may only run inside a React render window, so each file gains a private door
reproducing the boundary's gate and reads **exactly** — same gate, same order, same query
vectors — mirroring `cancellation_cascade_cljs_test.cljs:104` and
`test-helpers/dynamic_shell_tree.cljs`. No reading fallback arity was left in the production file.

Neither `modals_aria_cljs_test.cljs` nor `p3_polish_aria_cljs_test.cljs` references this popup
(measured: 0 hits in both), so this slice is not in that queue and touches no shared test file.

Executable-read census (comments and docstrings stripped, three passes — line-oriented,
whitespace-flattened, comment-markers-stripped-then-flattened, all three agreeing): 8 raw
`subscribe` mentions but **5 executable**; 2 raw `ei/edn-inspector` but **1 executable** head
site; 6 raw `current-frame-id` but **3 executable**. The prose contamination the amendment warns
about was real in this file.

## Head legality is asserted DIRECTLY, not inferred from a node-lane walk

Worth stating because the node lane structurally cannot prove it: `expand-tree` invokes a fn
head, so `[popup …]` and `(popup …)` expand identically and a green node row says nothing about
whether a head is legal inside a boundary.

This PR does not rely on that inference. The `reg-view`-registration row became a **direct
`head-kind` interrogation of the head values themselves**, controlled in both directions:

- `head-kind` of `edn-inspector-popup-stack-view` is `:boundary`;
- `head-kind` of the head `fresco-inspector` emits is `:boundary`;
- `head-kind` of the head `reagent-inspector` emits — the one this replaces — is `:invalid`,
  so the two positives are not vacuous.

That is the property the root swap actually needs, asserted without rendering anything.

## Quality gates

All exit codes below are the numbers **captured** by `echo $?` into a per-worktree, per-attempt
`.exit` file, not numbers reported about the run by anything else. On the sabotage run those two
disagreed: the captured code was **1** while the harness reported 0 for the same run.

| gate | attempt | captured exit | result |
| --- | --- | --- | --- |
| `node scripts/compile-node-test.cjs node-test` | 1 (baseline) | **0** | 1952 files, 1951 compiled, **0 warnings** |
| `node out/node-test.js` | 1 (baseline) | **0** | **11691 tests, 58588 assertions, 0 failures, 0 errors** |
| compile | 2 (sabotage) | **0** | 255 namespaces recompiled — the runtime observed the plant |
| `node out/node-test.js` | 2 (sabotage) | **1** | **11691 tests, 58588 assertions, 1 failure** |
| `check_require_alias_dialect.py` | 1 | **0** | pass |
| `check_ambient_durable_reads.py` | 1 | **0** | pass |
| `check_retired_spellings.py` | 1 | **0** | pass |
| `check_retired_composition_vocab.py` | 1 | **0** | pass |
| `check_view_lifetime_residue.py` | 1 | **0** | pass |
| `check_thrown_error_messages.py` | 1 | **0** | pass |

**Pass 8 / fail 0** on the restored tree (the sabotage red is the control, not a failure).

The compile phase was **split from** the run phase rather than chained, and the run phase was
gated on the compile's captured exit — so a failed compile could not leave the previously built
artefact to be served and pass on stale code.

**Which tree the gate read** — the compile prints its root, and both runs named
`…\popupmig-a\implementation\shadow-cljs.edn`, this worktree's own.

### Proof it can fail

Planted at a line already being edited: `fresco-inspector`'s head, `ei/edn-inspector-view` to
`ei/edn-inspector` (the Reagent head it replaces).

- **Not a no-op**: the executable match count moved 1 to 0 (and 0 to 1 for the Reagent
  spelling), and the blob hash moved `e017017e…` to `5e581f24…`. Match count read *before* the
  run, per the end-of-line-anchor hazard.
- **The runtime observed it**: 255 namespaces recompiled, so the red is about the planted source
  and not a stale artefact.
- **The red names what was planted**: `FAIL in (popup-stack-view-is-a-fresco-boundary)`,
  `actual: (not (= :boundary :invalid))`.
- **Nothing was truncated**: namespace and assertion totals are *identical* either side —
  11691 / 58588 both runs — so the plant added exactly one failure rather than silently
  stopping a lane.
- **Restore verified by hashing the bytes**, not by reading a diff: `git hash-object` returns
  `e017017e92697cea5e476e7d8e56d71454048b33`, equal to `git rev-parse HEAD:<path>`, with
  `git diff --quiet HEAD` exit 0 as a second independent instrument. (This file is `i/lf w/crlf`,
  so the default form is the one that reproduces the committed blob.)

### Not re-run after restore, deliberately

The restored tree is **byte-identical** to the tree that produced the baseline green — proven by
the blob hash above, not assumed — so a third 15-minute local cycle would re-derive a known
answer. CI's run on this push is the evidence about the pushed tree.

### What the local gate omits

The node lane only. It does not run the browser lane, the Xray feature-matrix gate, the adapter
smokes, or any JVM artefact. The required set is derived per-PR by the classifier at
`.github/scripts/report-changed-surfaces.sh`; read that rather than a list here, which would be
stale within a week.
