### PR TITLE
xray: bridge exports for the L2 spine and the segment inspector (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -457,7 +457,10 @@
   contract is 'the host owns the container size' — spec/008 §Embed
   props inventory)."
   ([mount-point]      (mount-event-spine! mount-point nil))
-  ([mount-point opts] (render-panel! shell/event-list mount-point opts)))
+  ;; rf2-k97c.3 — `event-list-bridge`, not `event-list`. The bridge is the
+  ;; name this mount holds so the L2 spine's migration to a Fresco boundary
+  ;; happens entirely inside `shell.cljs`; see its comment there.
+  ([mount-point opts] (render-panel! shell/event-list-bridge mount-point opts)))
 
 ;; There is no dedicated Issues tab or aggregate panel. Issues surface
 ;; inline in the Epoch panel, via the L2 event-row pink-wash, and via
@@ -470,7 +473,10 @@
   `mount-point`. Self-gating — renders nil when no segment is open;
   short-circuits on `:rf.xray/segment-inspector-open?`."
   ([mount-point]      (mount-segment-inspector! mount-point nil))
-  ([mount-point opts] (render-panel! segment-inspector/Popup mount-point opts)))
+  ;; rf2-k97c.3 — `Popup-bridge`, not `Popup`, for the reason
+  ;; `mount-event-spine!` records above: the bridge is what frees this
+  ;; panel to migrate inside its own file.
+  ([mount-point opts] (render-panel! segment-inspector/Popup-bridge mount-point opts)))
 
 (defn mount-cancellation-cascade-side-panel!
   "Mount the cancellation-cascade side-panel in isolation at

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -285,9 +285,15 @@
     named an instance — mounts
     `[panel-view]`, the element this fn has always built. A map mounts
     `[panel-view props]`. The caller decides, because only the caller
-    knows whether its panel's view takes props at all: `[trace/Panel
-    {…}]` is an arity error, not an ignored map, so this must NOT be
-    filled in from `opts` here on every panel's behalf.
+    knows whether its panel's view takes props at all — and what a stray
+    map COSTS depends on the shape behind the name. A zero-arity
+    `rf/reg-view` head takes an ARITY ERROR rather than an ignored map
+    (`segment-inspector/Popup` today); a Fresco boundary takes the single
+    props map every `defview` takes and destructures away what it does
+    not read (`trace/Panel` since rf2-fcy5 — this sentence used to cite
+    it as the arity-error example, and that stopped being true when the
+    Trace panel migrated). Either way this must NOT be filled in from
+    `opts` here on every panel's behalf.
 
   rf2-2n8q — the 4-arity is an ADDITION and the couplings `mount-resources!`
   reserves this fn for are untouched: the frame-provider wrap and the

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
@@ -279,6 +279,36 @@
   (when @(rf/subscribe [:rf.xray/segment-inspector-open?])
     (popup-view dispatch)))
 
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `panels/mount-segment-inspector!` mounts this popup BY NAME through
+;; `render-panel!`. Naming the bridge here NOW, while it is still a plain
+;; alias, is what lets this panel's migration happen entirely INSIDE THIS
+;; FILE: [[Popup]] becomes the `rf.fresco/defview` boundary and this def
+;; becomes the real `rf.fresco/as-component` bridge, with `panels.cljs`
+;; never touched again. It is the shape `resources/Panel-bridge` already
+;; ships and the one RULING 1 selected — boundary on the natural name, a
+;; public bridge passed by the caller.
+;;
+;; `shell.cljs` ALSO mounts `[app-db-segment-inspector/Popup]` as a hiccup
+;; head, so that second caller has to move in the same step the boundary
+;; lands; the bridge here removes `panels.cljs` from that list, not
+;; `shell.cljs`.
+;;
+;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Popup
+;; (re-frame.core/view :id))`, so [[Popup]] is a VALUE and this def binds
+;; the SAME OBJECT — nothing downstream can tell the two names apart, and
+;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
+;; head position is the only position either name is used in.
+(def Popup-bridge
+  "The name `panels/mount-segment-inspector!` mounts this popup through —
+  a plain alias of [[Popup]] until this panel migrates to Fresco, when it
+  becomes the `as-component` bridge without the mount facade moving.
+  Scaffolding with a defined end: it is deleted with every other
+  `*-bridge` when the shell itself becomes a Fresco tree. See the comment
+  above."
+  Popup)
+
 (defn install!
   "Idempotent install for the segment-inspector's Xray-side
   registrations. Returns nil per the facade convention."

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2323,20 +2323,25 @@
   a one-line change at that call site, the shape PR #9581 recorded for
   `mount-resources!`.
 
-  `panels.cljs` and `panel_enum.cljc` (whose `:event-spine` row names
-  `shell/event-list` as a string) were both held by another worker when this
-  slice was written, so that one line could not be changed and the
-  migration would have shipped a BROKEN embed — silently, because
-  `panels_mount_cljs_test` drives `render-panel!` through a render STUB
-  that captures the tree and never renders it.
+  `panels.cljs` was held by another worker when that slice was written, so
+  that one line could not be changed and the migration would have shipped a
+  BROKEN embed — silently, because `panels_mount_cljs_test` drives
+  `render-panel!` through a render STUB that captures the tree and never
+  renders it.
 
-  EVERYTHING ELSE IS ALREADY IN PLACE. The body below is the thin
-  read-and-call shape every migrated view has, [[event-list-tree]] is
-  the pure fn, and the node lane's door already drives it. Making this a
-  boundary is: swap `rf/reg-view` for `rf.fresco/defview`, swap the six
-  `@(rf/subscribe …)` for `rf.fresco/sub`, add a public
-  `event-list-bridge`, and pass it at `panels.cljs`'s
-  `mount-event-spine!`.
+  THE CALLER-SIDE HALF HAS SINCE LANDED (rf2-k97c.3, the second alias
+  funnel). [[event-list-bridge]] below is the public bridge name and
+  `mount-event-spine!` already passes it, so the migration no longer waits
+  on `panels.cljs` and no longer touches it. `panel_enum.cljc`'s
+  `:event-spine` row still names `shell/event-list` as a string and stays
+  right: that column records the VIEW, exactly as the already-bridged rows
+  `trace/Panel` and `resources/Panel` do.
+
+  WHAT REMAINS IS ENTIRELY IN THIS FILE, and it is the whole of it: swap
+  `rf/reg-view` for `rf.fresco/defview` and swap the six
+  `@(rf/subscribe …)` for `rf.fresco/sub`. The body below is already the
+  thin read-and-call shape every migrated view has, [[event-list-tree]] is
+  the pure fn, and the node lane's door already drives it.
 
   [[dynamic-chrome]] therefore mounts it as a REAGENT ISLAND through
   `as-child`, exactly as it does the L2/L3 seam handle.
@@ -2402,6 +2407,33 @@
      ;; computation defined.
      :now-ms          (or @(rf/subscribe [:rf.xray/relative-time-now-ms])
                           (rf.interop/now-ms))}))
+
+;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;;
+;; `panels/mount-event-spine!` mounts the L2 spine BY NAME through
+;; `render-panel!`, and that call site is the ONE line the docstring above
+;; records as blocking this view's migration. Naming the bridge here NOW,
+;; while it is still a plain alias, is what unblocks it: [[event-list]]
+;; becomes the `rf.fresco/defview` boundary and this def becomes the real
+;; `rf.fresco/as-component` bridge, with `panels.cljs` never touched again.
+;; It is the shape `resources/Panel-bridge` already ships and the one
+;; RULING 1 selected — boundary on the natural name, public bridge passed
+;; by the caller.
+;;
+;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def event-list
+;; (re-frame.core/view :id))`, so [[event-list]] is a VALUE and this def
+;; binds the SAME OBJECT — nothing downstream can tell the two names apart,
+;; and `dynamic-chrome`'s Reagent-island mount is unaffected. `render-panel!`
+;; always builds the component VECTOR `[panel-view]`, so head position is
+;; the only position either name is used in.
+(def event-list-bridge
+  "The name `panels/mount-event-spine!` mounts the L2 spine through — a
+  plain alias of [[event-list]] until this view migrates to Fresco, when
+  it becomes the `as-component` bridge without the mount facade moving.
+  Scaffolding with a defined end: it is deleted with every other
+  `*-bridge` when the shell itself becomes a Fresco tree. See the comment
+  above."
+  event-list)
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -166,10 +166,14 @@
 ;; ---- overlay / popup surfaces (3) --------------------------------------
 
 (deftest mount-segment-inspector-wraps-Popup-in-frame-provider
+  ;; rf2-k97c.3 — the expected head is `Popup-bridge`. It is still `=` to
+  ;; `Popup` (a `def` alias of the same value), so this row would pass
+  ;; either way; naming the bridge is what keeps the panel's migration from
+  ;; having to reopen this file.
   (let [[capture _ render-stub] (make-render-stub)]
     (with-redefs [rf.substrate.adapter/render render-stub]
       (panels/mount-segment-inspector! :mount-point)
-      (is (frame-provider-wrap? (captured-tree capture) segment-inspector/Popup)))))
+      (is (frame-provider-wrap? (captured-tree capture) segment-inspector/Popup-bridge)))))
 
 (deftest mount-cancellation-cascade-side-panel-wraps-SidePanel
   (let [[capture _ render-stub] (make-render-stub)]


### PR DESCRIPTION
The second alias-funnel round (rf2-k97c.3). `panels.cljs` is the serialising
surface for this epic, so the mounts that still passed a view var directly now
pass a bridge alias exported from the panel's own file — the shape #9654 landed
for epoch, trace and machine-inspector.

    mount-event-spine!        shell/event-list         ->  shell/event-list-bridge
    mount-segment-inspector!  segment-inspector/Popup  ->  segment-inspector/Popup-bridge

Both bridges are plain `def` aliases and bind the same value, so nothing
downstream can tell the two names apart. What they buy is that each panel's
migration to a Fresco boundary now happens entirely inside its own file without
reopening `panels.cljs`.

Folds in the dynshell worker's `event-list` follow-on: that view's docstring
loses the two recipe steps this change lands and records that the remaining two
(`reg-view` -> `defview`, six `@(rf/subscribe …)` -> `rf.fresco/sub`) are in-file.

## Two of the four sites were already bridges — verified, not repointed

The brief listed FOUR non-bridge names. Two of them already name bridges:

    :487  cancellation-cascade/SidePanel
    :494  cancellation-cascade/Popover

Both are `(defn X [] [:> X-component {}])` over `rf.fresco/as-component` of a
private `*View` boundary, under the header `;; ---- the migration bridges
(rf2-k97c.3) ----`, docstrings reading "Since rf2-k97c.3 it is the migration
bridge rather than the view". They landed that way in #9578 and the panel is
already migrated — there is nothing left to free.

They are byte-for-byte the same shape as `routing/Panel` at `:410`, which the
brief deliberately EXCLUDED. All three came from #9578, which RULING 1 records
as "the BRIDGE on the natural name; a PRIVATE `*View` behind it", forced by
`shell.cljs` mounting `[cancellation-cascade/Popover]` by name. RULING 1 puts
the convergence onto the `Panel-bridge` spelling at STEP 3, when `shell.cljs`
is rewritten, and says so as "a DECISION, NOT A PREFERENCE TO REVISIT".
Renaming them now would contradict that and buy nothing, so they are left alone.

## `panel_enum.cljc` is deliberately unchanged

Its `:view` column records the VIEW, not the mount name — the already-bridged
rows read `"trace/Panel"` and `"resources/Panel"` while `panels.cljs` mounts
their `Panel-bridge`. The single-source guard grades `:mount` names only.

## The docstring correction, and why it is a different fix than briefed

`render-panel!`'s `props` seam called `[trace/Panel {…}]` an arity error. At the
base this branch started from that was TRUE — `trace/Panel` was still an
`rf/reg-view` with a `[]` arg vector and #9661 was open. It merged as
`04350d02e5` during this work, so the claim became false under the rebase:
`Panel` is now a `defview` declaring `[_props]` and destructuring them away.

Rewritten around the SHAPE rather than a var whose shape migrates — a zero-arity
`rf/reg-view` head still takes a real arity error, a Fresco boundary ignores what
it does not read. The conclusion is unchanged.

## Quality gates

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:cljs` (attempt 1, pre-rebase tree) | **0** | 11686 tests, 58559 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (attempt 2) | **1** | DISCARDED — machine contention, not a real red (see below) |
| `npm run test:cljs` (attempt 3, SABOTAGE) | **1** | 1 failure, naming the plant |
| `npm run test:cljs` (attempt 4, shipping tree) | **0** | 11691 tests, 58586 assertions, 0 failures, 0 errors |
| `api-manifest gen --check` | **0** | in sync, 471 public vars — the two new publics add no rows |
| `api-manifest xray-spec-check` | **0** | in sync, 39 public-var references |
| Clojure reader parse of the edited `panels.cljs` | **0** | 20 top-level forms |

Passing: 5 distinct gates, 6 green runs. Failing: none on the shipping tree —
the one standing red is the deliberate sabotage, and attempt 2 is the discarded
contention run declared below.

The final run's test count rose from 11686 to 11691 (58559 -> 58586 assertions)
against the control: that is #9661's five new Trace rows arriving with the rebase,
not drift in this change.

**Gate choice.** `npm run test:cljs` is the narrowest gate covering this diff:
shadow-cljs's `:node-test` build carries `../tools/xray/src` and
`../tools/xray/test`, so it compiles every edited file and runs
`panels_mount_cljs_test`, which asserts the exact head each mount fn delivers —
the one property these repoints change.

**It read this worktree.** The run prints its config root, and both runs printed
`…/re-frame2-worktrees/funnel-b/implementation/shadow-cljs.edn`.

**Sabotage.** Reverting a repoint to the literal direct name would NOT go red,
and that is a property of the change rather than a gap in the gate: the bridge
is a `def` alias binding the same object, so mount and assertion move together.
The discriminating plant is therefore a repoint to a genuinely different view —
`mount-segment-inspector!` pointed at `routing/Panel`:

    FAIL in (mount-segment-inspector-wraps-Popup-in-frame-provider)
    expected: (frame-provider-wrap? (captured-tree capture) segment-inspector/Popup-bridge)
      actual: (not (frame-provider-wrap? [... [#object[day8$re_frame2_xray$panels$routing$Panel]]] ...))

Exactly 1 failure against the same 11686 tests / 58559 assertions as the control,
so the plant did not crash a namespace and suppress others. Restored and verified
by blob hash against the committed object (`f4448ee86c…`, default form; `git diff
--quiet HEAD` exit 0 as a second instrument).

**Attempt 2 is declared, not hidden.** It exited 1 on a dependency-level
par-compile abort (`zprint.core`) with no per-file error and no mention of the
plant, while two peer JVM builds were running on the same machine. Re-run as
attempt 3 on the identical tree, it produced the precise assertion failure above.

**Not run locally, relying on CI:** `cljs_browser`, `examples_compile`,
`tools_jvm`, `mcp_conformance`, `story_xray_browser` — the other surfaces the
changed-surface classifier arms for these paths. No browser lane was run, so
`BROWSER_TEST_PORT` was not needed.
