### PR TITLE
feat(xray): migrate the App-DB segment inspector onto Fresco (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_segment_inspector.cljs
@@ -50,6 +50,7 @@
   the `{:frame :rf/xray}` opt at call time pins the envelope to
   Xray's frame regardless of click-time React context."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
@@ -210,17 +211,42 @@
       (f/format-edn (vec path))
       "(root)")]])
 
-(defn- popup-view
-  "Hiccup for the open popup. Caller (`Popup` reg-view) has gated on
-  `:rf.xray/segment-inspector-open?` already.
+(defn popup-tree
+  "The OPEN popup's markup, as a pure function of the values it is handed
+  — `:path`, `:value` and `:positioning`. The open/closed gate is the
+  CALLER's, so this never answers nil.
 
-  `dispatch` (rf2-nesy9) is the frame-aware dispatcher injected by the
-  `Popup` reg-view body so close lands on the surrounding instance
-  frame, not a `{:frame :rf/xray}` literal."
-  [dispatch]
-  (let [path        @(rf/subscribe [:rf.xray/segment-inspector-path])
-        value       @(rf/subscribe [:rf.xray/segment-inspector-value])
-        positioning @(rf/subscribe [:rf.xray/modal-positioning])
+  rf2-k97c.3 — split out of the view when the view became a Fresco
+  boundary, so the dialog stays drivable from the node lane without a
+  React commit. A boundary's body may only run inside a React render
+  window (`rf.fresco/sub` REFUSES outside one, naming the query), so
+  calling [[Popup]] is no longer a way to get hiccup; this is. It is PURE
+  of its arguments — no read, no `subscribe-once`, no fallback arity.
+
+  THE DISPATCHES ARE FRAME-CARRYING, captured here at render time
+  (rf2-nesy9). `rf/current-frame-id` answers the declared frame inside a
+  Fresco body — it neither reads nor dispatches, so the boundary's
+  refusal tier does not touch it — and an explicitly carried
+  `{:frame <id>}` still answers, because that tier deletes the ambient
+  FIND and not the carrying. This is what replaced `reg-view`'s lexically
+  injected bare `dispatch`, which a `defview` body does not bind.
+
+  `:inspector` is the 2-arg `(fn [value node-key] → hiccup)` emitting the
+  value-rendering head, and it DEFAULTS to the production-correct
+  `edn/inspect-view`, so the boundary passes nothing and a caller who
+  forgets gets the right head. It is a parameter rather than a branch for
+  the reason the tree's `as-child` islands are: the spelling is the
+  caller's, not a Fresco API. Its one other caller is the node lane, which
+  substitutes the Reagent twin `edn/inspect` — the two heads share ONE
+  private renderer and differ only in how each resolves the expansion
+  slots and its per-mount identity, none of which a node-lane row asserts
+  on. That substitution is what lets those rows walk the widget at all:
+  a boundary may not be invoked as a hiccup render fn, so a walker that
+  expands function components raises inside it."
+  [{:keys [path value positioning inspector]
+    :or   {inspector edn/inspect-view}}]
+  (let [frame       (rf/current-frame-id)
+        dispatch    (fn [ev] (rf/dispatch ev {:frame frame}))
         on-keydown  (handle-keydown dispatch)]
     ;; rf2-7oxvd — shared backdrop + dialog scaffold. This popover keeps
     ;; its own `backdrop-style` / `dialog-style` (the dim/blur/size
@@ -260,53 +286,129 @@
       ;; expand-state from colliding with the App-db Diff panel's
       ;; renders of the same value. The path's pr-str is stable across
       ;; renders so toggle state survives shadow-cljs reloads.
+      ;; rf2-k97c.3 — `inspect-view` by default, not `inspect`. Same
+      ;; value, same opts, same renderer; the ONLY difference is the head,
+      ;; and that is the whole point here — `inspect` emits
+      ;; `[ei/edn-inspector …]`, a Reagent head, which grades `:invalid`
+      ;; inside a Fresco body down the identical codec arm a plain `defn`
+      ;; does. `node-key` does double duty as the boundary's required
+      ;; `:mount-id`, and the path's `pr-str` is stable across renders, so
+      ;; expansion state still survives a reload exactly as it did.
       [:div {:data-testid "rf-xray-segment-inspector-body"
              :style       (body-style)}
-       (edn/inspect (f/display-value value)
-                          (str "segment-inspector/" (pr-str (vec path))))])))
+       (inspector (f/display-value value)
+                  (str "segment-inspector/" (pr-str (vec path))))])))
 
-(rf/reg-view Popup
-  "The App-DB segment inspector popup. Renders only when
-  `:rf.xray/segment-inspector-open?` is true; closed-state is a
-  single subscribe + a `when` — cheap.
+(rf.fresco/defview PopupView
+  "The App-DB segment inspector popup — a FRESCO BOUNDARY (rf2-k97c.3),
+  not an `rf/reg-view`. Renders only when
+  `:rf.xray/segment-inspector-open?` is true; closed-state is a single
+  subscription and a `when` — cheap.
 
-  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
-  through the React-context tier to `:rf/xray`.
+  ## WHY A BOUNDARY, AND WHAT ACTUALLY MOVED
 
-  rf2-nesy9 — threads the reg-view-injected frame-aware `dispatch` into
-  `popup-view` so close lands on the surrounding instance frame."
+  The frame reasoning of rf2-in6l2 is UNCHANGED and still the reason this
+  is a component rather than a fn: a boundary reads its frame from the
+  same `re-frame.adapter.context` React context `reg-view` consulted, so
+  the reads still resolve through the surrounding `:rf/xray`. What changed
+  is the OBSERVER — the reads are `rf.fresco/sub`, recorded by Fresco's
+  own collector rather than by whichever reaction machinery the installed
+  adapter supplies, which is this epic's coupling (3).
+
+  ## CLOSED-STATE COST IS PRESERVED EXACTLY
+
+  One subscription and a gate, as before. The other three reads sit inside
+  the `when`, and `rf.fresco/sub` records its edge WHERE THE READ HAPPENS
+  (HD-002), so a branch not taken contributes no edge.
+
+  Two consequences of `defview`'s contract, both load-bearing here:
+
+    * It binds NO name inside the body, so `reg-view`'s lexically injected
+      bare `dispatch` is gone. [[popup-tree]] builds one from the carried
+      frame instead — same target, same behaviour (rf2-nesy9).
+    * It takes ONE props map, so the old 0-arg call shape is gone. The
+      node lane drives [[popup-tree]] directly now.
+
+  PUBLIC so the shell's root swap can head it directly. [[Popup]] in front
+  of it is the name the Reagent shell still mounts — see that bridge's
+  docstring for why the two names sit this way round here."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/segment-inspector-open?])
+    (popup-tree
+      {:path        (rf.fresco/sub [:rf.xray/segment-inspector-path])
+       :value       (rf.fresco/sub [:rf.xray/segment-inspector-value])
+       :positioning (rf.fresco/sub [:rf.xray/modal-positioning])})))
+
+;; ---- the migration bridges (rf2-k97c.3) ----------------------------------
+;;
+;; TWO callers mount this popup by name, and funnel-b's `Popup-bridge`
+;; (below) took `panels/mount-segment-inspector!` off that list. The one
+;; that remains is `shell.cljs`, which mounts `[app-db-segment-inspector/
+;; Popup]` as a hiccup head — and it is FENCED to the shell root-swap
+;; slice, so it cannot move in this step.
+;;
+;; THAT INVERTS THE NAMING, and it is worth saying plainly because the
+;; comment this replaces predicted the other spelling. The mayor's
+;; 2026-09-10 ruling is that a boundary keeps the NATURAL name and the
+;; caller is handed a public bridge (#9581) — and it names the one
+;; constraint that forces #9578's opposite spelling: a fenced `shell.cljs`
+;; mounting the var BY NAME. That constraint is live here, so [[Popup]]
+;; stays the public callable and the boundary above takes the `*View`
+;; suffix. `machine_after_rings.cljs` records the same fork from the other
+;; side, where the constraint did NOT apply. Nothing about funnel-b's
+;; reasoning was wrong; only its assumption that `shell.cljs` would be
+;; free to move in the same step.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door: it answers a real
+;; React component for a boundary, which a React parent (Reagent here)
+;; mounts UNDER THE FRAME IT IS ALREADY IN, taking the frame from React
+;; context rather than from a second root. The crossing carries an EMPTY
+;; props map, the case `as-component`'s own note calls sound — the
+;; inspected value never crosses it; it is read inside the boundary.
+;;
+;; SCAFFOLDING WITH A DEFINED END. When the shell is itself a Fresco tree,
+;; [[PopupView]] takes the name directly, the `[:>]` goes, and the
+;; component plus both bridges below are deleted.
+
+(def ^:private Popup-component
+  "The React component [[PopupView]] presents as, for a non-Fresco parent.
+  Declared ONCE at top level, as `rf.fresco/as-component`'s contract
+  requires — deriving one per render mints a fresh element type and would
+  remount the dialog on every pass, taking its focus trap with it."
+  (rf.fresco/as-component PopupView))
+
+(defn Popup
+  "The segment-inspector popup's public callable — what `shell.cljs`
+  mounts as a hiccup head at the shell root, and what [[Popup-bridge]]
+  aliases for `panels.cljs`.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component [[PopupView]]
+  presents as. The enclosing `rf/frame-provider` is what puts `:rf/xray`
+  in React context for it.
+
+  The open/closed gate is inside [[PopupView]], so this is always mounted
+  and renders nothing while the inspector is closed — the same shape a
+  mounted `reg-view` returning nil had.
+
+  Callers wanting the MARKUP as data — the node-lane rows — build it from
+  [[popup-tree]] with the slots' values instead; this returns an interop
+  vector, not a tree to walk."
   []
-  (when @(rf/subscribe [:rf.xray/segment-inspector-open?])
-    (popup-view dispatch)))
+  [:> Popup-component {}])
 
-;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
-;;
-;; `panels/mount-segment-inspector!` mounts this popup BY NAME through
-;; `render-panel!`. Naming the bridge here NOW, while it is still a plain
-;; alias, is what lets this panel's migration happen entirely INSIDE THIS
-;; FILE: [[Popup]] becomes the `rf.fresco/defview` boundary and this def
-;; becomes the real `rf.fresco/as-component` bridge, with `panels.cljs`
-;; never touched again. It is the shape `resources/Panel-bridge` already
-;; ships and the one RULING 1 selected — boundary on the natural name, a
-;; public bridge passed by the caller.
-;;
-;; `shell.cljs` ALSO mounts `[app-db-segment-inspector/Popup]` as a hiccup
-;; head, so that second caller has to move in the same step the boundary
-;; lands; the bridge here removes `panels.cljs` from that list, not
-;; `shell.cljs`.
-;;
-;; TODAY IT IS A NO-OP. `rf/reg-view` expands to `(def Popup
-;; (re-frame.core/view :id))`, so [[Popup]] is a VALUE and this def binds
-;; the SAME OBJECT — nothing downstream can tell the two names apart, and
-;; `render-panel!` always builds the component VECTOR `[panel-view]`, so
-;; head position is the only position either name is used in.
 (def Popup-bridge
-  "The name `panels/mount-segment-inspector!` mounts this popup through —
-  a plain alias of [[Popup]] until this panel migrates to Fresco, when it
-  becomes the `as-component` bridge without the mount facade moving.
-  Scaffolding with a defined end: it is deleted with every other
-  `*-bridge` when the shell itself becomes a Fresco tree. See the comment
-  above."
+  "The name `panels/mount-segment-inspector!` mounts this popup through.
+
+  Still a plain alias of [[Popup]], and deliberately unchanged by the
+  Fresco migration: [[Popup]] is itself the `as-component` bridge now, so
+  this name needed no second bridge of its own and adding one would have
+  duplicated it. `render-panel!` always builds the component VECTOR
+  `[panel-view]`, so head position is the only position either name is
+  used in, and the two remain indistinguishable downstream.
+
+  Scaffolding with a defined end: deleted with every other `*-bridge`
+  when the shell itself becomes a Fresco tree. See the comment above."
   Popup)
 
 (defn install!

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -21,8 +21,9 @@
     1. Settings popup  (`settings/view/popup-view`)
     2. Mute manager    (`spine-filters/dialog`)
     3. Filter edit-popup (`filters/edit-popup/popup-view`)
-    4. Cancellation-cascade popover — exercised via the Popover
-       reg-view's body (it renders a [:div {:role \"dialog\" ...}])
+    4. Cancellation-cascade popover — exercised via its `popover-tree`
+       (it renders a [:div {:role \"dialog\" ...}]); since rf2-k97c.3 the
+       view itself is a Fresco boundary, so the tree fn is the door
     5. App-DB segment-inspector popover — same shape as #4
 
   Tests render each view function directly (no shadow DOM, no Reagent
@@ -41,7 +42,8 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.view :as settings-view]
             [day8.re-frame2-xray.spine-filters :as spine-filters]
-            [day8.re-frame2-xray.test-support :as xray-test-support]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 (use-fixtures :each
   ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
@@ -158,16 +160,14 @@
 ;; (4) + (5) Popovers — cancellation-cascade + segment-inspector
 ;; -------------------------------------------------------------------------
 ;;
-;; These two use `reg-view` to gate on an `:open?` slot. The reg-view
-;; macro defs the symbol; invoking it directly under `with-frame`
-;; resolves subscribes against `:rf/xray` the same way the shell
-;; mount does.
-;;
-;; EXCEPT the cancellation-cascade popover, which since rf2-k97c.3 is a
-;; FRESCO BOUNDARY behind an `as-component` bridge: the var answers an
-;; interop vector, not a tree to walk. The helper below reproduces the
-;; boundary's own gate and reads exactly - same gate, same query vectors -
-;; so both rows below assert on the same hiccup they did before.
+;; BOTH of these gate on an `:open?` slot, and since rf2-k97c.3 BOTH are
+;; FRESCO BOUNDARIES behind an `as-component` bridge: the var answers an
+;; interop vector, not a tree to walk. (They used to be `reg-view`s, which
+;; could be invoked directly under `with-frame`; a boundary's body may
+;; only run inside a React render window.) The two helpers below reproduce
+;; each boundary's own gate and reads exactly - same gate, same order,
+;; same query vectors - so every row below asserts on the same hiccup it
+;; did before.
 
 (defn- cancellation-cascade-popover-tree
   "The cancellation-cascade popover's markup for the current state:
@@ -179,6 +179,28 @@
       {:cascade     @(rf/subscribe [:rf.xray/cancellation-cascade-for-focused-event])
        :positioning @(rf/subscribe [:rf.xray/modal-positioning])
        :expanded?   @(rf/subscribe [:rf.xray/cancellation-cascade-expanded?])})))
+
+(defn- segment-inspector-popup-tree
+  "The App-DB segment-inspector popup's markup for the current state:
+  nil while closed, the dialog otherwise. Mirrors
+  `app-db-segment-inspector/PopupView`'s gate and reads (rf2-k97c.3).
+
+  `:inspector` substitutes the REAGENT twin `edn/inspect` for the
+  boundary head production emits, because the shared assertion helpers
+  above find their nodes through `rf.test-helpers/find-by-testid`, which
+  EXPANDS function components — and a Fresco boundary raises when invoked
+  as a hiccup render fn. The substitution is sound for what the rows here
+  grade: both heads share one private renderer, and these rows assert on
+  the DIALOG's ARIA chrome, which sits above the widget and is untouched
+  by which head renders the value. Which head the panel emits is pinned
+  in `app-db-segment-inspector-cljs-test` off the unsubstituted tree."
+  []
+  (when @(rf/subscribe [:rf.xray/segment-inspector-open?])
+    (segment-inspector/popup-tree
+      {:path        @(rf/subscribe [:rf.xray/segment-inspector-path])
+       :value       @(rf/subscribe [:rf.xray/segment-inspector-value])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])
+       :inspector   edn/inspect})))
 
 (deftest cancellation-cascade-popover-carries-dialog-contract
   (testing "rf2-7389r — the cancellation-cascade popover (audit
@@ -202,7 +224,7 @@
     (xray-setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/open-segment-inspector []]))
-    (let [tree (rf/with-frame :rf/xray (segment-inspector/Popup))]
+    (let [tree (rf/with-frame :rf/xray (segment-inspector-popup-tree))]
       (is (some? tree) "Popup renders when open")
       (when tree
         (assert-dialog-contract!
@@ -263,7 +285,7 @@
   (xray-setup!)
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/open-segment-inspector []]))
-  (let [tree (rf/with-frame :rf/xray (segment-inspector/Popup))]
+  (let [tree (rf/with-frame :rf/xray (segment-inspector-popup-tree))]
     (is (some? tree) "Popup renders when open")
     (when tree
       (assert-dialog-focus-ref!

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_segment_inspector_cljs_test.cljs
@@ -23,11 +23,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.test-helpers :as rf.test-helpers]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.test-support :as xray-test-support]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.edn-widget :as edn]))
 
 (use-fixtures :each
   ;; `make-xray-runtime-fixture` (rf2-vj80u8) folds the bespoke `xray-init!`
@@ -118,6 +120,64 @@
             "reopened value sub did not slice to the new prefix")))))
 
 ;; ---- popup-view: header + body content ---------------------------------
+;;
+;; rf2-k97c.3 — `Popup` is now an `rf.fresco/as-component` bridge and
+;; answers an interop vector, not a tree to walk. The markup is
+;; `popup-tree`, a pure fn of the values the boundary reads.
+;;
+;; The helper below reproduces `PopupView`'s gate and reads EXACTLY —
+;; same gate, same order, same query vectors — so every row here asserts
+;; on the same hiccup it did before, and a boundary that stopped reading
+;; one of these slots would diverge from its own test helper rather than
+;; silently agreeing with it.
+;;
+;; Ambient `rf/subscribe` deliberately: these rows run under
+;; `rf/with-frame :rf/xray` in the node lane with no React commit at all.
+;; What the boundary's own read resolves to — the frame React context
+;; names, not the ambient one — is the browser lane's subject.
+
+(defn- popup-tree
+  "What calling `Popup` directly returned before the migration: nil while
+  closed, the dialog otherwise.
+
+  `:inspector` substitutes the REAGENT twin `edn/inspect` for the
+  boundary head production emits. That substitution is not cosmetic and
+  it is what lets the rows below read the rendered value at all:
+  `rf.test-helpers/find-by-testid` and `text-content` collect their nodes
+  off `expand-tree`, which INVOKES function components, and a Fresco
+  boundary may not be invoked as a hiccup render fn — it raises inside
+  the body. The two heads share ONE private renderer and differ only in
+  how each resolves the expansion slots and its per-mount identity,
+  neither of which any row here asserts on, so the markup these rows walk
+  is the markup production renders. WHICH HEAD THE PANEL ACTUALLY EMITS
+  is deliberately not graded here — it is erased by this substitution —
+  and `popup-body-embeds-a-legal-head-when-open` pins it directly off the
+  UNSUBSTITUTED tree instead."
+  []
+  (when @(rf/subscribe [:rf.xray/segment-inspector-open?])
+    (segment-inspector/popup-tree
+      {:path        @(rf/subscribe [:rf.xray/segment-inspector-path])
+       :value       @(rf/subscribe [:rf.xray/segment-inspector-value])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])
+       :inspector   edn/inspect})))
+
+(defn- popup-tree-as-emitted
+  "The popup's markup with the head production actually emits — no
+  substitution. Walk it RAW; expanding it raises inside the boundary,
+  which is the property `popup-body-embeds-a-legal-head-when-open`
+  exists to assert rather than to trip over."
+  []
+  (when @(rf/subscribe [:rf.xray/segment-inspector-open?])
+    (segment-inspector/popup-tree
+      {:path        @(rf/subscribe [:rf.xray/segment-inspector-path])
+       :value       @(rf/subscribe [:rf.xray/segment-inspector-value])
+       :positioning @(rf/subscribe [:rf.xray/modal-positioning])})))
+
+(defn- raw-nodes
+  "Every node in the tree AS THE PANEL EMITS IT — no expansion of any
+  kind, so a widget head is whatever the panel actually wrote there."
+  [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
 
 (deftest popup-renders-value-and-path-in-body-and-header
   (testing "rf2-e9tb0 — the open popup renders the inspected path in
@@ -127,7 +187,7 @@
     (setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/open-segment-inspector [:user]]))
-    (let [tree   (rf/with-frame :rf/xray (segment-inspector/Popup))
+    (let [tree   (rf/with-frame :rf/xray (popup-tree))
           title  (rf.test-helpers/find-by-testid tree "rf-xray-segment-inspector-title")
           body   (rf.test-helpers/find-by-testid tree "rf-xray-segment-inspector-body")]
       (is (some? tree) "Popup renders when open")
@@ -151,7 +211,7 @@
     (setup!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/open-segment-inspector []]))
-    (let [tree  (rf/with-frame :rf/xray (segment-inspector/Popup))
+    (let [tree  (rf/with-frame :rf/xray (popup-tree))
           title (rf.test-helpers/find-by-testid tree "rf-xray-segment-inspector-title")]
       (is (re-find #"root" (rf.test-helpers/text-content title))
           "root-path header title did not read '(root)'"))))
@@ -160,8 +220,66 @@
   (testing "rf2-e9tb0 — the closed-state body short-circuits to nil
             (the single-subscribe + `when` cheapness contract)"
     (setup!)
-    (is (nil? (rf/with-frame :rf/xray (segment-inspector/Popup)))
+    (is (nil? (rf/with-frame :rf/xray (popup-tree)))
         "closed segment inspector did not render nil")))
+
+;; ---- rf2-k97c.3: head legality, asserted DIRECTLY -----------------------
+;;
+;; The node lane structurally CANNOT prove this. `expand-tree` invokes a
+;; fn head, so `[popup …]` and `(popup …)` expand identically — a green
+;; row above says the markup is right, and says nothing whatever about
+;; whether a head inside it is legal under a Fresco boundary. And this is
+;; a MODAL: it renders nothing unless the open state is seeded, so its
+;; heads are invisible to any row that does not open it first.
+;;
+;; So the heads are interrogated directly rather than walked, and the
+;; interrogation is controlled in BOTH directions so a positive cannot be
+;; vacuous. `head-kind` is the codec's own dispatch — the same function
+;; `vec->element` uses to decide what to build — so this is the property
+;; the shell's root swap actually depends on.
+
+(deftest popup-view-is-a-fresco-boundary
+  (testing "rf2-k97c.3 — `PopupView` is an `rf.fresco/defview` boundary,
+            so the shell root becoming a Fresco tree mounts it rather
+            than refusing it. A revert to `rf/reg-view` (or to a plain
+            `defn`) grades `:invalid` down the same codec arm and reds
+            this row — which is the point, since that revert is silent
+            under Reagent."
+    (setup!)
+    (is (= :boundary (rf.fresco.impl.codec/head-kind
+                       segment-inspector/PopupView))
+        "PopupView is a Fresco boundary")))
+
+(deftest popup-body-embeds-a-legal-head-when-open
+  (testing "rf2-k97c.3 — the value-rendering head INSIDE the open dialog
+            is a boundary too, so the subtree is legal all the way down.
+            The dialog is opened first: a modal renders nothing while
+            closed, so a row that did not seed the open state would assert
+            on an empty tree and pass vacuously."
+    (setup!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/open-segment-inspector [:user]]))
+    (let [tree  (rf/with-frame :rf/xray (popup-tree-as-emitted))
+          heads (->> (raw-nodes tree)
+                     (filter vector?)
+                     (map first)
+                     (filter fn?))]
+      (is (some? tree) "the dialog is open, so there is a tree to grade")
+      (is (seq heads)
+          "there is a fn head in the emitted tree — otherwise the check
+           below is an absence reported by a dead instrument")
+      (is (every? #(= :boundary (rf.fresco.impl.codec/head-kind %)) heads)
+          "every fn head in the open dialog grades :boundary")
+      ;; Both directions: the Reagent head this replaced grades :invalid,
+      ;; so `:boundary` above is a real discrimination and not something
+      ;; `head-kind` says about everything.
+      (is (= :invalid (rf.fresco.impl.codec/head-kind
+                        (first (edn/inspect {:probe 1} "probe"))))
+          "`edn/inspect`, the Reagent head this file used to call, grades
+           :invalid")
+      (is (= :boundary (rf.fresco.impl.codec/head-kind
+                         (first (edn/inspect-view {:probe 1} "probe"))))
+          "`edn/inspect-view`, the head it calls now, grades :boundary"))))
 
 ;; ---- rf2-jmucu: off-head popup==panel-body consistency ------------------
 ;;


### PR DESCRIPTION
Slice B6, phase 2 of rf2-k97c.3 — the second unscheduled `shell-view-tree` child.
Phase 1 (`views/edn_inspector_popup.cljs`) is #9670.

## Why this is on the critical path

`panels/app_db_segment_inspector.cljs` is a child of `shell-view-tree` (headed at
`shell.cljs:3190`) and was still `rf/reg-view` at tip. A `reg-view` head grades `:invalid` down
the **identical** codec arm a plain `defn` does, so the moment the shell root becomes a boundary
this is a hard failure, not a degradation.

## The shape

| symbol | what it is now |
| --- | --- |
| `popup-tree` | the markup as a **pure fn** of `:path` / `:value` / `:positioning`; the gate is the caller's, so it never answers nil |
| `PopupView` | the `rf.fresco/defview` **boundary**; public, so the root swap can head it directly |
| `Popup-component` | `rf.fresco/as-component`, declared once at top level |
| `Popup` | now the **bridge** — keeps the name `shell.cljs:3190` heads, **unedited** |
| `Popup-bridge` | funnel-b's alias, **reused unchanged** |

`shell.cljs` is untouched, and so are `panels.cljs` and `panels_mount_cljs_test.cljs`.

## The naming is inverted from what the file predicted, and the comment now says so

funnel-b's bridge note assumed **ruling 1 (#9581)** — boundary on the natural name, public
bridge passed by the caller — and wrote that "`shell.cljs` ... has to move in the same step the
boundary lands". That ruling also names the one constraint that forces **#9578's opposite
spelling**: a fenced `shell.cljs` mounting the var BY NAME. That constraint is live here, so
`Popup` stays the public callable and the boundary takes the `*View` suffix.
`machine_after_rings.cljs:599-603` records the same fork from the other side, where the
constraint did not apply. Nothing in funnel-b's reasoning was wrong — only its assumption that
`shell.cljs` would be free to move in this step. The comment is corrected in place.

**`Popup-bridge` is reused, not duplicated.** `Popup` is itself the `as-component` bridge now,
so funnel-b's alias needed no second bridge of its own; adding one would have been strictly
worse. It is left as `(def Popup-bridge Popup)`, still `=` to `Popup`, so
`panels_mount_cljs_test.cljs:176`'s identity assertion keeps passing untouched.

I judged the existing exports by **what they are, not what they are called** — `Popup-bridge` is
a plain alias today, not an `as-component` bridge, which is why it needed no change while
`Popup` did.

## The subtree has to be legal all the way down, not just at the root

The body's value-rendering head moves from `edn/inspect` to `edn/inspect-view`: `inspect` emits
`[ei/edn-inspector …]`, itself an `:invalid` head inside a Fresco body. Same value, same opts,
same private renderer — only the head differs.

## Node-lane heads: the one real constraint, and how it is handled

`rf.test-helpers/find-by-testid` and `text-content` collect their nodes off `expand-tree`, which
**invokes** function components — and `defview`'s own docstring says a boundary must never be
mounted "as a hiccup render fn in a Reagent tree". So a node-lane row walking the open dialog
would raise *inside* the boundary.

The head is therefore a **parameter** of `popup-tree`, defaulting to the production-correct
`edn/inspect-view`, and the node-lane doors substitute the Reagent twin. That is the shape
`epoch/view_cljs_test.cljs`'s `expand-widgets` already lands, for the reason its own `text-content`
docstring gives; this is the cheaper spelling of it.

## Head legality is asserted DIRECTLY — the node lane cannot prove it

Stated plainly because it is a real limit: **the node lane structurally cannot prove head
legality.** `expand-tree` invokes a fn head, so `[popup …]` and `(popup …)` expand identically;
a green content row says the markup is right and says nothing about whether a head is legal
inside a boundary. And a substitution *erases* the very thing it makes walkable.

So the heads are interrogated directly off the **unsubstituted** tree, via the codec's own
dispatch, controlled in both directions:

- `head-kind` of `PopupView` is `:boundary`;
- every fn head in the **open** dialog grades `:boundary`, with a non-empty-heads control so the
  assertion is not an absence reported by a dead instrument;
- `head-kind` of `edn/inspect` — the head this file used to call — is `:invalid`, and of
  `edn/inspect-view` is `:boundary`, so the positives discriminate.

**The modal is opened first.** A modal renders nothing while closed, so a row that did not seed
the open state would assert over an empty tree and pass vacuously. `popup-body-embeds-a-legal-head-when-open`
dispatches `:rf.xray/open-segment-inspector` before grading.

**Nothing here is left unproven**, so there is no "unproven heads" list to state.

## Shared test file — strictly additive

Five non-render call sites moved: three in this panel's own test, **two in the shared
`modals_aria_cljs_test.cljs`** (so this phase, unlike phase 1, is in that queue).

- A new private door `segment-inspector-popup-tree` is **appended** beside the existing
  cancellation-cascade one. No other worker's door was edited.
- Only this surface's own two call sites changed. Verified: **0** changed lines in that file
  mention `settings-view`, `edit-popup` or `spine-filters` — B1's, B2's and B4's surfaces are
  untouched.
- Two stale comments describing *this* surface and the already-migrated cancellation-cascade one
  were corrected; neither belongs to B1/B2/B4.
- `p3_polish_aria_cljs_test.cljs` touches only `settings-view/popup-view`, so this slice is not
  in that file's queue at all.

## Quality gates

Exit codes are the numbers **captured** into a per-worktree, per-attempt `.exit` file, not
numbers reported about the run by anything else.

| gate | attempt | captured exit | result |
| --- | --- | --- | --- |
| `node scripts/compile-node-test.cjs node-test` | 1 (baseline) | **0** | 1954 files, **0 warnings** |
| `node out/node-test.js` | 1 (baseline) | **0** | **11700 tests, 58602 assertions, 0 failures, 0 errors** |
| compile | 2 (sabotage) | **0** | 256 namespaces recompiled — the runtime observed the plant |
| `node out/node-test.js` | 2 (sabotage) | **1** | **11700 tests, 58602 assertions, 1 failure** |
| `check_require_alias_dialect.py` | 1 | **0** | pass |
| `check_ambient_durable_reads.py` | 1 | **0** | pass |
| `check_retired_spellings.py` | 1 | **0** | pass |
| `check_retired_composition_vocab.py` | 1 | **0** | pass |
| `check_view_lifetime_residue.py` | 1 | **0** | pass |
| `check_thrown_error_messages.py` | 1 | **0** | pass |

**Pass 8 / fail 0** on the restored tree (the sabotage red is the control, not a failure).

The compile phase was **split from** the run phase and the run phase gated on the compile's
captured exit, so a failed compile could not leave a stale artefact to be served and pass.
On the sabotage run the captured code was **1** while the harness reported 0 for the same run.

**Which tree the gate read** — the compile prints its root; both runs named
`…\popupmig-a\implementation\shadow-cljs.edn`, this worktree's own.

### Proof it can fail

Planted at a line already being edited: `popup-tree`'s `:inspector` default,
`edn/inspect-view` to `edn/inspect` — i.e. the panel silently goes back to emitting the Reagent
head inside the boundary, which is exactly the regression this slice exists to prevent and one
that is **invisible under Reagent**.

- **Not a no-op**: the anchor's match count moved 1 to 0 (and 0 to 1 for the planted spelling),
  and the blob hash moved `cde2c905…` to `d20210d8…`. Match count read *before* the run.
- **The runtime observed it**: 256 namespaces recompiled.
- **The red names what was planted**: `FAIL in (popup-body-embeds-a-legal-head-when-open)` —
  the "every fn head grades `:boundary`" assertion.
- **Nothing was truncated**: totals *identical* either side — 11700 / 58602 both runs.
- **Restore verified by hashing the bytes**: `git hash-object` returns
  `cde2c90536f6b56ad0b0108bbe84f040e9d46c4e`, equal to `git rev-parse HEAD:<path>`, with
  `git diff --quiet HEAD` exit 0 as a second independent instrument. (`i/lf w/crlf`, so the
  default form is the one that reproduces the committed blob.)

Note what the plant demonstrates about the node lane's limits: it changed only the HEAD, so
every content and ARIA row stayed green — the node-lane doors substitute the Reagent twin and
could not see it. Only the direct `head-kind` row caught it. That is the coordinator's point,
reproduced as evidence rather than asserted.

### Not re-run after restore, deliberately

The restored tree is **byte-identical** to the tree that produced the baseline green — proven by
the blob hash, not assumed — so a third local cycle would re-derive a known answer. CI's run on
this push is the evidence about the pushed tree.

### What the local gate omits

The node lane only. Not the browser lane, the Xray feature-matrix gate, the adapter smokes, or
any JVM artefact. The required set is derived per-PR by the classifier at
`.github/scripts/report-changed-surfaces.sh`; read that rather than a list here.
