### PR TITLE
fix(xray): give the Trace panel a per-mount inspector identity (rf2-pua3)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1797,10 +1797,10 @@ a master `mount-shell!` for the full 4-layer chrome. This per-panel
 surface is **internal-but-stable**, NOT a v1.0 host-facing embed
 contract: the 4-layer shell + the test suite depend on it and hosts
 MAY use it, but it carries no host-facing-contract guarantee (the
-opts vocabulary is two keys wide and one of them is only two
+opts vocabulary is two keys wide and one of them is only three
 panels': `:frame` on every mount fn, defaulting to `:rf/xray`, and
-`:instance-id` on `mount-app-db-diff!` (rf2-2n8q) and
-`mount-managed-fx!` (rf2-5ykm)) — the
+`:instance-id` on `mount-app-db-diff!` (rf2-2n8q),
+`mount-managed-fx!` (rf2-5ykm) and `mount-trace!` (rf2-pua3)) — the
 v1.0 host-facing embed contract is the **full-shell** embed per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
 §Full-shell embed contract. (rf2-jw2ny — one honest status across

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -547,8 +547,9 @@ that needs it, not in a central shim layer.
   [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract for
   internal use (shell composition, tests, future tools); it carries
   `:frame` universally and `:instance-id` on `mount-app-db-diff!`
-  (rf2-2n8q) and `mount-managed-fx!` (rf2-5ykm) — the two panels whose
-  view accepts it — and is not a host-facing embed contract.
+  (rf2-2n8q), `mount-managed-fx!` (rf2-5ykm) and `mount-trace!`
+  (rf2-pua3) — the three panels whose view accepts it — and is not a
+  host-facing embed contract.
 - **No two-way binding.** Beyond the `configure!` slots and the
   one-way **focus command** (§Host-facing focus API — the host pushes
   a focus *intent*, not arbitrary state, and Xray owns what it means),

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -407,9 +407,9 @@ embed contract. The `mount-<panel>!` aggregator surface enumerated in
 [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract is
 internal-but-stable (used by shell composition and tests); it accepts
 `:frame` — defaulting to `:rf/xray` — on every mount fn, plus
-`:instance-id` on `mount-app-db-diff!` (rf2-2n8q) and
-`mount-managed-fx!` (rf2-5ykm), which names one of two standalone
-mounts of that panel sharing a frame.
+`:instance-id` on `mount-app-db-diff!` (rf2-2n8q),
+`mount-managed-fx!` (rf2-5ykm) and `mount-trace!` (rf2-pua3), which
+names one of two standalone mounts of that panel sharing a frame.
 
 ### Static-mode Panel reg-views
 

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -169,14 +169,24 @@
   two-container commit in
   `panels/managed_fx_mount_instance_id_dom_cljs_test`.
 
+  rf2-pua3 — `mount-trace!` takes the SAME key, arrived at the same way:
+  rf2-fcy5 migrated that panel's mount to a boundary and gave each expanded
+  row's payload inspector a per-ROW `:mount-id`, which separates rows
+  within one panel and cannot separate two panels. It needs only ONE
+  qualifier, and for a different reason than managed-fx's one — that panel
+  passes a stable `:site-id`, so the logical expansion/zoom identity is
+  already keyed apart from the physical mount identity and only the latter
+  moves. Measured on a real two-container commit in
+  `panels/trace_mount_instance_id_dom_cljs_test`.
+
   It is SOME panels' opt rather than the surface's, and deliberately so:
   it is only meaningful where a panel's view accepts it, and handing a
   props map to a panel whose view takes none is an arity error rather
   than an ignored key. `render-panel!`'s `props` argument is the seam —
-  see its docstring. The two panels that take it each own their own
+  see its docstring. The three panels that take it each own their own
   normaliser (`app-db-diff-state/instance-token`,
-  `managed-fx-template/instance-token`) so a refusal names the caller's
-  own panel.
+  `managed-fx-template/instance-token`, `trace/instance-token`) so a
+  refusal names the caller's own panel.
 
   See `tools/xray/spec/007-UX-IA.md` §Mountable panel contract and
   `tools/xray/spec/008-Embedding-Contract.md` for the full
@@ -280,9 +290,9 @@
     provider at all — each one's docstring says its isolation comes
     from the ENCLOSING provider, which is this one.
   - `props` — OPTIONAL (rf2-2n8q), and it is the PANEL's props map, not
-    the mount opts. nil — every caller but `mount-app-db-diff!` and
-    `mount-managed-fx!` (rf2-5ykm), and those two only when the caller
-    named an instance — mounts
+    the mount opts. nil — every caller but `mount-app-db-diff!`,
+    `mount-managed-fx!` (rf2-5ykm) and `mount-trace!` (rf2-pua3), and
+    those three only when the caller named an instance — mounts
     `[panel-view]`, the element this fn has always built. A map mounts
     `[panel-view props]`. The caller decides, because only the caller
     knows whether its panel's view takes props at all — and what a stray
@@ -290,10 +300,11 @@
     `rf/reg-view` head takes an ARITY ERROR rather than an ignored map
     (`segment-inspector/Popup` today); a Fresco boundary takes the single
     props map every `defview` takes and destructures away what it does
-    not read (`trace/Panel` since rf2-fcy5 — this sentence used to cite
-    it as the arity-error example, and that stopped being true when the
-    Trace panel migrated). Either way this must NOT be filled in from
-    `opts` here on every panel's behalf.
+    not read (`epoch-panel/Panel` today — this sentence cited
+    `trace/Panel` as the arity-error example until rf2-fcy5 migrated it,
+    then as the ignored-map example until rf2-pua3 gave it a prop it
+    reads). Either way this must NOT be filled in from `opts` here on
+    every panel's behalf.
 
   rf2-2n8q — the 4-arity is an ADDITION and the couplings `mount-resources!`
   reserves this fn for are untouched: the frame-provider wrap and the
@@ -391,11 +402,38 @@
 
 (defn mount-trace!
   "Mount Xray's Trace tab in isolation at `mount-point`. Renders the
-  trace-buffer feed for the focused event-bundle."
+  trace-buffer feed for the focused event-bundle.
+
+  `opts :instance-id` — OPTIONAL (rf2-pua3). A non-blank string or a
+  keyword naming THIS mount, for the case where two standalone mounts
+  share one `:frame`. It qualifies the `:mount-id` of each EXPANDED ROW's
+  payload inspector — the widget's lifecycle key is `[frame-id mount-id]`
+  and its measured-width slot is keyed by the bare `mount-id`, so one
+  qualifier moves both. Left unnamed, two Trace panels showing one focused
+  epoch with matching rows expanded share one store entry, one
+  ResizeObserver and one width slot, and detaching either releases the
+  survivor's.
+
+  It qualifies NOTHING ELSE, and that is deliberate: this panel passes a
+  stable `:site-id`, so expansion and zoom are keyed by that rather than by
+  the mount-id and two panels of one epoch still open and close together.
+  ONE qualifier here where `mount-app-db-diff!` needs two — see
+  `trace/Panel`'s own `:instance-id` note for why the three panels differ.
+
+  OMIT IT when only one Trace panel is on screen in this frame, which is
+  every call site in this tree today: the ids are then byte-for-byte what
+  they were. `trace/instance-token` refuses, loudly, the shapes that could
+  not be stable across renders."
   ([mount-point]      (mount-trace! mount-point nil))
   ;; rf2-k97c.3 — `Panel-bridge`; see `mount-epoch-panel!` above for why
   ;; the mount moves to the bridge name BEFORE the panel migrates.
-  ([mount-point opts] (render-panel! trace/Panel-bridge mount-point opts)))
+  ;; rf2-pua3 — and the props map is what carries `:instance-id` across that
+  ;; bridge; `Panel-bridge`'s 1-arity is the door, its 0-arity is what an
+  ;; unnamed mount still takes.
+  ([mount-point opts]
+   (render-panel! trace/Panel-bridge mount-point opts
+                  (when-let [id (:instance-id opts)]
+                    {:instance-id id}))))
 
 (defn mount-machine-inspector!
   "Mount Xray's Machines tab in isolation at `mount-point`. Renders

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -394,18 +394,97 @@
 ;; measured-width slot. The row id is this panel's own per-record identity
 ;; (it is the trace event's `:id`, the same value `:panel-id` and `:site-id`
 ;; below already qualify with), so all three now derive from one source.
-;; The remaining case — TWO Trace panels in ONE frame — is rf2-5ykm's, and
-;; is not reachable from anything this file can name.
+;;
+;; rf2-pua3 — AND THE ROW ID IS NOT ENOUGH ONCE TWO TRACE PANELS SHARE ONE
+;; FRAME. The sentence that stood here assigned that case to rf2-5ykm; that
+;; bead is closed and covers Managed FX only, and the case is reachable from
+;; here the moment a caller mounts this panel twice. Two mounts of one
+;; focused epoch with matching rows expanded composed the SAME
+;; `rf-xray-trace-row-<id>`, so the second element installed no
+;; ResizeObserver at all and `release-mount!` tore the SHARED entry down —
+;; and cleared the SHARED width — when EITHER detached, leaving the survivor
+;; on screen unobserved and unmeasured. Measured on a real two-container
+;; commit before the repair, in
+;; `panels/trace_mount_instance_id_dom_cljs_test`.
+;;
+;; The caller names them, which is the ruling rf2-d2aj closed with and the
+;; shape `app-db-diff` and `managed-fx` already ship: an optional
+;; `:instance-id`, threaded from `mount-trace!` through the bridge and the
+;; boundary to [[payload-mount-id]] below.
+;;
+;; ONE QUALIFIER, AND IT MOVES THE `:mount-id` ALONE — which is a THIRD
+;; shape rather than a copy of either sibling. `managed-fx` needs one
+;; because `edn-widget/inspect-view` builds the `:mount-id` AND the
+;; `:panel-id` from one node-key and passes no `:site-id`; `app-db-diff`
+;; needs two because `value-body` composes its `:mount-id` and its
+;; `:site-id` separately. This panel passes a stable `:site-id` (rf2-pvsxs,
+;; just below), and the widget's `effective-id` is `(or site-id mount-id)` —
+;; so expansion and zoom are keyed `[panel-id site-id path]` and DO NOT READ
+;; THE MOUNT-ID AT ALL. The logical identity is therefore already separate
+;; from the physical one, and qualifying the mount-id moves exactly the two
+;; things that are per-live-mount — the store's lifecycle key `[frame-id
+;; mount-id]` and the measured-width slot, which is keyed by the bare
+;; `mount-id` — while leaving expansion, zoom, the row's own testids and the
+;; React keys byte-for-byte where they were. Two Trace panels of one epoch
+;; still open and close together ON PURPOSE; what they no longer share is a
+;; ResizeObserver and a width.
+
+(defn instance-token
+  "Normalise `trace/Panel`'s optional `:instance-id` prop to the string that
+  qualifies one mount's inspector `:mount-id`, or nil when the caller named
+  no instance — the single-mount default, which composes every id
+  byte-for-byte as it did before rf2-pua3.
+
+  A KEYWORD is accepted alongside a string, and its NAMESPACE is part of
+  the name: `:left/trace` tokenises to `left/trace`. `(subs (str id) 1)` is
+  what preserves it; `cljs.core/name` would drop it and restore the very
+  collision this removes, which is rf2-4bsq's landed repair one level up —
+  see [[Panel-bridge]], which tokenises BEFORE the Reagent crossing for
+  exactly that reason.
+
+  It is this panel's own normaliser rather than a call into a sibling's:
+  the panels are independent surfaces, they migrate on their own schedules,
+  and the refusal has to name the caller's OWN panel to be worth reading."
+  [instance-id]
+  (cond
+    (nil? instance-id)     nil
+    (keyword? instance-id) (subs (str instance-id) 1)
+    (string? instance-id)  (when (seq instance-id) instance-id)
+    :else
+    (throw (ex-info
+             (str "The Trace panel's :instance-id must be a non-blank string "
+                  "or a keyword naming ONE live mount of the panel; it was "
+                  (pr-str instance-id) ". It is composed into each expanded "
+                  "row's edn-inspector :mount-id, so it must be stable across "
+                  "that mount's renders — a value minted per render would lose "
+                  "the measured payload width on every pass. Omit it entirely "
+                  "when only one Trace panel is on screen in this frame.")
+             {:instance-id instance-id}))))
+
+(defn- payload-mount-id
+  "The expanded row payload inspector's `:mount-id` — the PHYSICAL identity,
+  one per live mount of one row.
+
+  `instance` is the already-tokenised per-mount name, or nil. nil composes
+  the string this panel has always composed; a name splices in after the
+  panel's own prefix and LEAVES THE ROW ID INTACT inside it, so the row
+  stays identifiable in a two-panel DOM."
+  [instance id]
+  (str "rf-xray-trace-row-" (when instance (str instance "/")) id))
 
 (defn- render-payload
   "Per-row payload renderer — the raw `:operation` · `:tags` · timing ·
   `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), rendered via
-  the first-class edn-inspector widget's FRESCO boundary."
-  [{:keys [id raw] :as _row}]
+  the first-class edn-inspector widget's FRESCO boundary.
+
+  `instance` (rf2-pua3) is the tokenised per-mount name, or nil. It
+  qualifies the `:mount-id` and NOTHING else below — see the comment above
+  for why the `:panel-id` and `:site-id` deliberately stay shared."
+  [instance {:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-xray-trace-row-" id "-payload")
          :style       payload-container-style}
    [ei/edn-inspector-view
-    {:mount-id (str "rf-xray-trace-row-" id)
+    {:mount-id (payload-mount-id instance id)
      :value    raw
      :opts     {:panel-id (keyword "rf.xray.trace" (str "row-" id))
                 ;; rf2-pvsxs — trace rows survive tab leave-and-return
@@ -712,11 +791,16 @@
   `:row-extras` slot — see ns docstring of `views.resizable-table`).
   Returns the per-path db-diff sub-list (rf2-b3zw2) when the row is a
   `:rf.event/db-changed` op AND/OR the raw-EDN payload (spec/023 §3)
-  when the row is expanded."
-  [{:keys [id operation db-diff] :as row} expanded?]
+  when the row is expanded.
+
+  `instance` (rf2-pua3) is the tokenised per-mount name, or nil, and is
+  passed STRAIGHT THROUGH to the payload. The db-diff sub-list does not
+  take it: `db-diff-rows` renders through `edn/inspect-inline`, which
+  mounts no inspector and holds no per-mount lifecycle."
+  [instance {:keys [id operation db-diff] :as row} expanded?]
   (let [diff?    (= operation :rf.event/db-changed)
         diff-h   (when diff? (db-diff-rows id db-diff))
-        payload  (when expanded? (render-payload row))]
+        payload  (when expanded? (render-payload instance row))]
     (cond
       (and diff-h payload) [:<> diff-h payload]
       diff-h               diff-h
@@ -748,8 +832,14 @@
   Identical props and identical rendering — both heads hand the same map
   to the widget's own `render-table` and differ only in how they resolve
   the column-widths read and the drag dispatcher. It needs no instance
-  key: its state is keyed by the `:table-id` this panel supplies."
-  [rows expanded-row-ids]
+  key: its state is keyed by the `:table-id` this panel supplies.
+
+  rf2-pua3 — `instance` is the tokenised per-mount name, or nil, and this
+  fn only FORWARDS it to `op-row-extras`. It is deliberately NOT composed
+  into `:table-id`: the ops table's column widths are the operator's
+  chosen column layout for this arc, which two panels of one epoch share on
+  purpose, exactly as they share their expansion state."
+  [instance rows expanded-row-ids]
   [rt/resizable-table-view
    ;; rf2-hxfy — the React key lives in this props map rather than as
    ;; `^{:key "rows"}` reader meta on the `(flat-row-list …)` call in
@@ -776,7 +866,7 @@
                                                 (:id row))))
     :row-cells       (fn [row _i] (op-row-cells row))
     :row-extras      (fn [row _i]
-                       (op-row-extras row
+                       (op-row-extras instance row
                                       (contains? (or expanded-row-ids #{})
                                                  (:id row))))}])
 
@@ -842,8 +932,15 @@
 
   `feed` is the whole `:rf.xray/trace-feed` map — only `:rows` and
   `:empty-kind` are rendered (the `:envelope` / `:bands` / `:outcome`
-  slots are retained for cross-panel consumers, per `install!` below)."
-  [{:keys [feed focus focused-event-bundle expanded-ids]}]
+  slots are retained for cross-panel consumers, per `install!` below).
+
+  `instance` (rf2-pua3) is OPTIONAL and is the ALREADY-TOKENISED per-mount
+  name — `Panel` below runs [[instance-token]] once and hands the result
+  here, so the node-lane rows that drive this fn directly pass the token
+  itself rather than a raw `:instance-id`. Omitted (the shape every
+  existing caller in this tree passes) every id below is byte-for-byte what
+  it was."
+  [{:keys [feed focus focused-event-bundle expanded-ids instance]}]
   (let [{:keys [rows empty-kind]} feed]
     [:section {:data-testid "rf-xray-trace"
                :style       panel-root-style}
@@ -893,7 +990,7 @@
          ;; rf2-hxfy — its `:key` rides the props map `flat-row-list`
          ;; builds (see there); reader meta on this CALL form would
          ;; attach to the list and never reach React.
-         (flat-row-list rows expanded-ids)])]]))
+         (flat-row-list instance rows expanded-ids)])]]))
 
 (rf.fresco/defview Panel
   "The Trace panel's root view — the focused epoch's whole trace as a
@@ -937,11 +1034,52 @@
   Fresco's plain-fn-in-head-position rule never meets one.
 
   The argument is the ordinary one-props-map vector every `defview` takes.
-  This panel reads nothing from props — neither the L4 registry nor the
-  `mount-trace!` facade passes any — so it is destructured away."
-  [_props]
+
+  ## `:instance-id` — OPTIONAL, and it names ONE LIVE MOUNT (rf2-pua3)
+
+  This panel reads no DATA from props: everything it renders comes from the
+  four subs below and from nothing else, and the L4 registry and the
+  standalone embed both mount it with no props at all. The one prop it
+  takes is an IDENTITY.
+
+  Each expanded row's payload inspector needs a `:mount-id` that is unique
+  per LIVE MOUNT, because that string is the widget's lifecycle key (with
+  the frame) and its measured-width slot key. The row id alone is unique
+  within one panel; two panels of one focused epoch in one frame it cannot
+  separate, and nothing inside the widget can — a Fresco boundary is a
+  React function component with no per-instance storage its body may use,
+  so there is no id for it to mint. Left unnamed the two share one store
+  entry, one ResizeObserver and one width slot, and detaching either
+  releases the survivor's.
+
+  So the distinction is the caller's to make, and this prop is how:
+
+      [Panel {:instance-id \"left\"}]
+      [Panel {:instance-id \"right\"}]
+
+  A non-blank string or a keyword — and a keyword's NAMESPACE is part of
+  the name, so `:left/trace` and `:right/trace` are two instances and not
+  one (rf2-4bsq). It must be STABLE across that instance's renders — it is
+  an identity, not a per-render nonce — and [[instance-token]] refuses,
+  loudly, the shapes that could not be. OMIT IT when only one Trace panel
+  renders in this frame, which is every call site in this tree today: the
+  ids are then byte-for-byte what they were.
+
+  IT QUALIFIES THE PHYSICAL IDENTITY ONLY. Expansion, zoom and the row's
+  own testids are keyed by the `:site-id` and the row id and are left
+  exactly where they were, so two Trace panels of one epoch still open and
+  close together. The comment above `render-payload` carries the mechanism.
+
+  BOTH DOORS INTO THIS BOUNDARY ANSWER THE SAME. Mounted from a Fresco body
+  the prop arrives as written; mounted through [[Panel-bridge]] from a
+  Reagent parent it arrives already tokenised, because `[:>]` would
+  otherwise convert a keyword with `cljs.core/name` and drop its namespace.
+  The token is idempotent on its own output, so one value composes one set
+  of ids whichever head mounted it."
+  [{:keys [instance-id]}]
   (panel-tree
-    {:feed  (rf.fresco/sub [:rf.xray/trace-feed])
+    {:instance (instance-token instance-id)
+     :feed  (rf.fresco/sub [:rf.xray/trace-feed])
      :focus (rf.fresco/sub [:rf.xray/focus])
      ;; rf2-wcfsy — focused-event-bundle is a layer-3 composite over
      ;; `:rf.xray/event-bundles` + `:rf.xray/focus`, NOT an inline scan in
@@ -991,9 +1129,42 @@
 
   PUBLIC, because this panel is in `panel_enum` with a `mount-trace!`
   facade and `panels/render-panel!` takes the view to mount as an
-  ARGUMENT — so the embedding contract needs a name it can pass."
-  []
-  [:> Panel-component {}])
+  ARGUMENT — so the embedding contract needs a name it can pass.
+
+  rf2-pua3 — the 1-arity is how a REAGENT parent names an instance when it
+  renders two of these under one `frame-provider`:
+
+      [Panel-bridge {:instance-id \"left\"}]
+
+  The 0-arity stays because that is how the shell mounts an L4 tab
+  (`[(:panel tab)]`) and how `render-panel!` mounts the standalone embed
+  (`[panel-view]`) — one panel per frame, no instance to name.
+
+  ## The prop is TOKENISED HERE, before the crossing (rf2-4bsq)
+
+  `[:>]` converts each prop VALUE before React sees it, and Reagent's
+  `convert-prop-value` converts a named value with `cljs.core/name` — which
+  DROPS THE NAMESPACE. Passed through raw, `:left/trace` and `:right/trace`
+  would both arrive at the boundary as `\"trace\"`, so two panels the caller
+  had deliberately named apart would compose the same
+  `rf-xray-trace-row-trace/101` — one lifecycle entry, one ResizeObserver,
+  one width slot, and detaching either releasing the other's. That is
+  precisely the collision rf2-pua3 repairs, restored by the crossing.
+
+  So the bridge runs [[instance-token]] — the SAME normaliser the boundary
+  uses — and a STRING crosses, which Reagent preserves intact. The
+  boundary's own call on the far side is then a no-op (the fn is idempotent
+  on its own output), and a refused shape throws naming the CALLER's value
+  rather than whatever the crossing had turned it into.
+
+  A blank string tokenises to nil and so mounts with no props, exactly as
+  naming no instance does."
+  ([] (Panel-bridge nil))
+  ([props]
+   [:> Panel-component
+    (if-let [instance-id (instance-token (:instance-id props))]
+      {:instance-id instance-id}
+      {})]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
@@ -305,6 +305,13 @@
               "the two mounts composed two mount-ids")
 
           ;; ---- the observer half -------------------------------------
+          ;; These two are LIVENESS controls rather than the discriminating
+          ;; rows, and saying so matters: under the shared identity both
+          ;; lookups resolve to the SAME entry, so both pass while the defect
+          ;; is fully present (measured — they were the two rows in this
+          ;; deftest that stayed green on the unrepaired tree). What bites
+          ;; before the unmount is `not=` above; what bites after it is the
+          ;; survivor row below.
           (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
                          :observer)
               "the left mount installed its own ResizeObserver")
@@ -315,18 +322,28 @@
                observer already on the entry and installs none")
 
           ;; ---- the width half ----------------------------------------
-          ;; Measured for real: `container-ref-for`'s mount arm calls
-          ;; `measure-and-dispatch!` synchronously on ref attach, before it
-          ;; installs the observer, so a committed container with layout has
-          ;; already written its width by the time this line runs.
-          (is (some? (get (widths) id-l))
-              (str "control: the left mount MEASURED and wrote its width — "
-                   "without this the survivor's width below cannot be "
-                   "'kept' by anything. slot=" (pr-str (widths))))
-          (is (some? (get (widths) id-r))
-              (str "and so did the right, under its own key. Under the shared "
-                   "identity there is one key here, not two. slot="
-                   (pr-str (widths))))
+          ;; DRIVEN through the slot's own public event rather than read off
+          ;; a real measurement, and that is a finding rather than a
+          ;; shortcut: in the headless browser the committed payload
+          ;; container measures `clientWidth` 0, so `measure-and-dispatch!`'s
+          ;; `(pos? w)` guard never fires and the slot stays EMPTY on a
+          ;; perfectly healthy mount (measured on the pre-fix run: `slot={}`
+          ;; for both mounts). A row asserting a measured width would
+          ;; therefore be red for a reason that is not this defect. The slot
+          ;; is public for exactly this — its docstring says tests may drive
+          ;; measurements deterministically — and `:rf.xray.edn-inspector/
+          ;; set-width` is the very event the observer dispatches, under the
+          ;; very id the widget composes. So what these rows exercise is the
+          ;; half the defect actually breaks: WHICH KEY `release-mount!`
+          ;; clears when a sibling detaches.
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-l 640]
+                            {:frame :rf/xray})
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-r 480]
+                            {:frame :rf/xray})
+          (is (= 640 (get (widths) id-l))
+              (str "two live mounts hold TWO width slots — under the shared "
+                   "identity the right mount's write lands on the left's key "
+                   "and overwrites it. slot=" (pr-str (widths))))
 
           (unmount! right)
 
@@ -338,11 +355,11 @@
               "and the mount STILL ON SCREEN is still observed — releasing
                the survivor's entry is what the shared key did, and it left a
                live node with no observer and no width updates")
-          (is (some? (get (widths) id-l))
-              (str "and the survivor's measured width is STILL in the frame's "
-                   "slot — `release-mount!` clears the width under the "
-                   "detaching mount's id, which under the shared identity is "
-                   "the survivor's own. slot=" (pr-str (widths))))
+          (is (= 640 (get (widths) id-l))
+              (str "and the survivor's width is STILL in the frame's slot — "
+                   "`release-mount!` clears the width under the DETACHING "
+                   "mount's id, which under the shared identity is the "
+                   "survivor's own. slot=" (pr-str (widths))))
           (finally
             (unmount! left)))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
@@ -1,0 +1,433 @@
+(ns day8.re-frame2-xray.panels.trace-mount-instance-id-dom-cljs-test
+  "TWO STANDALONE `mount-trace!` MOUNTS IN ONE FRAME, WITH MATCHING ROWS
+  EXPANDED, read off a real React commit (rf2-pua3).
+
+  ## The claim, and why it needs a DOM
+
+  rf2-fcy5 migrated this panel's mount to a Fresco boundary and swapped its
+  inline payload head to `ei/edn-inspector-view` with a PER-ROW
+  `:mount-id`, which fixed the collisions WITHIN one panel — two rows
+  expanded at once each keep their own lifecycle. It left one ACROSS
+  panels: `mount-trace!` delegated with no props, `Panel-bridge` always
+  passed `{}`, the boundary ignored props, and `render-payload` derived the
+  `:mount-id` from the row id ALONE. So the same focused epoch mounted into
+  two containers under one frame emitted IDENTICAL mount-ids for matching
+  expanded rows.
+
+  A row asserting the opts key was THREADED would pass while both mounts
+  still collided, which is the failure one level up. So nothing here reads
+  the opts map, the captured tree, or the props. Two mounts are made
+  through the public facade into two real containers, and every assertion
+  reads `container.querySelector` — the DOM React committed on its own —
+  the widget's own per-mount store, or the frame's app-db width slot.
+
+  ## The two observables, and the SECOND is the one the defect breaks
+
+  `data-rf-mount-id` is stamped by the edn-inspector widget on every
+  committed container, carrying the BARE `:mount-id` this panel composed.
+  It is not decoration: `edn-inspector/container-ref-for` memoises the ref
+  callback on `[frame-id mount-id]`, `measure-and-dispatch!` writes the
+  measured width to `:rf.xray.edn-inspector/widths` under that same bare
+  string, and `release-mount!` clears BOTH when a mount detaches.
+
+  [[two-named-mounts-each-keep-their-own-observer-and-width]] is the half a
+  distinctness row would miss. Under the shared identity the SECOND mount
+  never installs a ResizeObserver at all (`container-ref-for` hands back
+  the memoised callback, whose mount arm is guarded on
+  `(nil? (:observer entry))`), and `release-mount!` then tears the SHARED
+  entry down — and clears the SHARED width slot — when EITHER mount
+  detaches, leaving the survivor on screen with no observer and no width.
+  So that row asserts both are held by each mount and STILL held by the
+  survivor afterwards.
+
+  ## WHAT THIS PANEL DELIBERATELY DOES NOT QUALIFY, and why it is ONE
+  ## qualifier here rather than the two `app-db-diff` needs
+
+  Trace passes a stable `:site-id` (`[:rf.xray.trace/row <id>]`, rf2-pvsxs)
+  alongside its `:mount-id`, and the widget's `effective-id` is
+  `(or site-id mount-id)` — so expansion and zoom are keyed
+  `[panel-id site-id path]` and DO NOT READ THE MOUNT-ID AT ALL. The
+  logical disclosure identity is therefore already separate from the
+  physical one, and qualifying the mount-id moves the lifecycle key and the
+  width slot while leaving expansion, zoom and the row's own testids
+  byte-for-byte where they were. That is the whole of the fix, and
+  [[two-named-mounts-share-their-disclosure-identity]] pins the half that
+  must NOT move: two lists of the same rows open and close together, and
+  what they no longer share is a ResizeObserver.
+
+  (`app-db-diff` needs two qualifiers because `value-body` composes its
+  `:mount-id` and its `:site-id` separately; `managed-fx` needs one because
+  `edn-widget/inspect-view` builds the `:mount-id` AND the `:panel-id` from
+  one node-key and passes no `:site-id`. This panel is a third shape.)
+
+  ## The negative control IS the defect, and it is a row rather than a note
+
+  [[two-unnamed-mounts-still-collide]] mounts the same two panels with NO
+  `:instance-id` and asserts the id sets are IDENTICAL. It carries two
+  claims at once: the instrument can see a collision (so the disjointness
+  above is separation and not silence), and omitting the opt leaves every
+  id byte-for-byte what it always was — which is every call site in this
+  tree today.
+
+  ## Substrate: the Reagent adapter, and the mount is the PUBLIC one
+
+  `mount-trace!` delegates to `rf.substrate.adapter/render`, so the
+  installed adapter is what renders. Nothing here reaches past the facade
+  to build a tree of its own — the thing under test is the mount fn.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`. The `:node-test` build's `cljs-test$`
+  regex also matches, so it LOADS under Node — where every row
+  short-circuits through [[browser?]] and reports the skip rather than
+  passing silently. A green node lane is therefore NOT evidence about this
+  file; `npm run test:browser` is. The node lane cannot see a
+  ResizeObserver at all."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.panels :as panels]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; READ-ONLY, and only for the per-mount store's public test
+            ;; surface (`lifecycle-key`, `mount-state-held`) and the public
+            ;; width-slot key. The widget's own lifecycle rows live in
+            ;; `views/edn_inspector_mount_state_cljs_test`; what W2 below
+            ;; asserts is that two STANDALONE MOUNTS hand that store two
+            ;; distinct keys, each with its own observer and its own width.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about, and
+                      ;; `trace/Panel` is a Fresco boundary — a neighbour's
+                      ;; entry left in the cache would make these rows read a
+                      ;; residue that is not this panel's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the seeded epoch ----------------------------------------------------
+
+(def ^:private dispatch-id 11)
+
+(def ^:private expanded-row-ids
+  "The two rows both mounts expand. TWO rather than one so the id SETS
+  below are sets rather than singletons — a splice that dropped the row id
+  would still pass with one."
+  [101 202])
+
+(defn- mk-trace [id operation time]
+  {:id        id
+   :time      time
+   :op-type   :rf.event
+   :operation operation
+   :tags      {:rf.trace/dispatch-id dispatch-id}})
+
+(def ^:private two-row-epoch
+  "A minimal `:rf/epoch-record` carrying two `trace-events`, shaped exactly
+  as `trace_fresco_boundary_dom_cljs_test` seeds one."
+  {:epoch-id      1
+   :dispatch-id   dispatch-id
+   :event-id      :test/event
+   :trigger-event [:test/event]
+   :db-before     {}
+   :db-after      {}
+   :renders       []
+   :sub-runs      []
+   :committed-at  1000
+   :trace-events  [(mk-trace 101 :rf.event/dispatched 100)
+                   (mk-trace 202 :rf.event/handler-ran 200)]})
+
+(defn- setup!
+  "Seed the epoch ring, pin focus at its cascade, and EXPAND both rows
+  BEFORE anything mounts, so the payload inspectors are in the very first
+  commit of each container.
+
+  The expansion slot lives in the frame's app-db and both mounts share it
+  DELIBERATELY: this bead qualifies the inspector's PHYSICAL identity and
+  leaves the logical disclosure identity exactly where it was. Two panels
+  showing the same epoch open and close together — which is also what makes
+  the rows MATCHING, and therefore what makes the collision reachable."
+  []
+  (registry/register-xray-handlers!)
+  (mount/ensure-xray-frame! :rf/xray)
+  (rf/dispatch-sync [:rf.xray/sync-epoch-history [two-row-epoch]]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/focus-event dispatch-id nil] {:frame :rf/xray})
+  (doseq [id expanded-row-ids]
+    (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand id] {:frame :rf/xray}))
+  nil)
+
+;; ---- mounting, and reading the DOM back ----------------------------------
+
+(defn- mount!
+  "Mount the Trace panel through the PUBLIC facade with `opts`, committed
+  synchronously.
+
+  `react-dom/flushSync` rather than a Reagent queue drain: the panel's view
+  is a Fresco boundary, which is not in Reagent's render queue at all, so
+  draining that queue commits nothing of this panel's and a row written
+  that way reads a container that never moved."
+  [opts]
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    (let [unmount (react-dom/flushSync
+                    (fn [] (panels/mount-trace! container opts)))]
+      {:container container :unmount unmount})))
+
+(defn- unmount!
+  "Tear one mount down inside `flushSync` so React's ref-detach has RUN by
+  the time the next line reads the per-mount store. A bare unmount
+  schedules it."
+  [{:keys [container unmount]}]
+  (react-dom/flushSync (fn [] (unmount)))
+  (.remove container))
+
+(defn- mount-ids
+  "Every `data-rf-mount-id` in `container`'s committed DOM, in document
+  order. Reads the DOM React wrote — nothing here reproduces the panel."
+  [container]
+  (->> (.querySelectorAll container "[data-rf-mount-id]")
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % "data-rf-mount-id"))))
+
+(defn- site-ids
+  "Every `data-rf-site-id` in `container`'s committed DOM. The LOGICAL
+  identity, which this bead must leave alone."
+  [container]
+  (->> (.querySelectorAll container "[data-rf-site-id]")
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % "data-rf-site-id"))))
+
+(defn- widths
+  "The frame's measured-width slot — a map of bare `mount-id` → px."
+  []
+  (or (rf/subscribe-once [ei/widths-slot] {:frame :rf/xray}) {}))
+
+(def ^:private id-prefix
+  "What `render-payload` puts in front of every payload mount-id. Named so
+  W3's splice assertion states the qualifier's POSITION rather than a
+  literal."
+  "rf-xray-trace-row-")
+
+;; ===========================================================================
+;; W1 — two NAMED standalone mounts compose two disjoint sets of mount-ids
+;; ===========================================================================
+
+(deftest two-named-mounts-compose-disjoint-inspector-mount-ids
+  (testing "rf2-pua3 — `mount-trace!` given two different `:instance-id`s
+            mounts two panels whose committed DOM carries two disjoint sets
+            of `data-rf-mount-id`, in the ONE `:rf/xray` frame they both
+            default to. Each id composes the widget's lifecycle key AND its
+            measured-width slot key, so disjointness here is disjointness of
+            both."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})]
+        (try
+          (let [ids-l (mount-ids (:container left))
+                ids-r (mount-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (some? (.querySelector (:container left)
+                                       "[data-testid=\"rf-xray-trace-row-101-payload\"]"))
+                "control: the left mount committed an EXPANDED row payload, so
+                 an empty intersection below means separation and not a panel
+                 that rendered its rows collapsed and mounted no inspector")
+            (is (= 2 (count ids-l))
+                (str "control: both expanded rows committed an inspector — "
+                     "so the sets below are sets. left=" (pr-str ids-l)))
+            (is (= (count ids-l) (count ids-r))
+                "naming an instance changes the ids, never the rows — two
+                 mounts of the same focused epoch over the same rows")
+
+            ;; ---- the claim ---------------------------------------------
+            (is (nil? (some (set ids-l) ids-r))
+                (str "no mount-id survives from one standalone mount to the "
+                     "other — the store's lifecycle key and the measured "
+                     "width slot are both derived from this string. left="
+                     (pr-str ids-l) " right=" (pr-str ids-r)))
+            (is (every? #(string/starts-with? % (str id-prefix "left/")) ids-l)
+                (str "each id carries the name THIS mount was given, rather "
+                     "than a per-render nonce or a shared string: "
+                     (pr-str ids-l))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W2 — the lifecycle half: each mount owns an observer AND a width, and keeps
+;;      both when its sibling goes
+;; ===========================================================================
+
+(deftest two-named-mounts-each-keep-their-own-observer-and-width
+  (testing "rf2-pua3 — two named standalone mounts hold two entries in the
+            widget's per-mount store, each with its OWN ResizeObserver and
+            its OWN entry in the frame's measured-width slot, and unmounting
+            one releases ONLY its own. Under the shared identity the second
+            mount never installs an observer at all, and `release-mount!`
+            tears the shared entry down AND clears the shared width when
+            either detaches — so the survivor is left on screen unobserved
+            and unmeasured, which a distinctness row alone cannot see."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})
+            id-l  (first (mount-ids (:container left)))
+            id-r  (first (mount-ids (:container right)))]
+        (try
+          (is (some? id-l)
+              "control: the left mount committed a widget, so the store keys
+               below name something that really mounted")
+          (is (not= id-l id-r)
+              "the two mounts composed two mount-ids")
+
+          ;; ---- the observer half -------------------------------------
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "the left mount installed its own ResizeObserver")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r))
+                         :observer)
+              "and so did the right — two live mounts, two observers. Under
+               the shared identity the second element's ref callback finds an
+               observer already on the entry and installs none")
+
+          ;; ---- the width half ----------------------------------------
+          ;; Measured for real: `container-ref-for`'s mount arm calls
+          ;; `measure-and-dispatch!` synchronously on ref attach, before it
+          ;; installs the observer, so a committed container with layout has
+          ;; already written its width by the time this line runs.
+          (is (some? (get (widths) id-l))
+              (str "control: the left mount MEASURED and wrote its width — "
+                   "without this the survivor's width below cannot be "
+                   "'kept' by anything. slot=" (pr-str (widths))))
+          (is (some? (get (widths) id-r))
+              (str "and so did the right, under its own key. Under the shared "
+                   "identity there is one key here, not two. slot="
+                   (pr-str (widths))))
+
+          (unmount! right)
+
+          ;; ---- the survivor keeps both -------------------------------
+          (is (nil? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r)))
+              "the detached mount is gone")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "and the mount STILL ON SCREEN is still observed — releasing
+               the survivor's entry is what the shared key did, and it left a
+               live node with no observer and no width updates")
+          (is (some? (get (widths) id-l))
+              (str "and the survivor's measured width is STILL in the frame's "
+                   "slot — `release-mount!` clears the width under the "
+                   "detaching mount's id, which under the shared identity is "
+                   "the survivor's own. slot=" (pr-str (widths))))
+          (finally
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W3 — the LOGICAL identity must NOT move
+;; ===========================================================================
+
+(deftest two-named-mounts-share-their-disclosure-identity
+  (testing "rf2-pua3 — the bound on this repair, as a row. Naming two mounts
+            qualifies the PHYSICAL identity only: the `:site-id` that keys
+            expansion and zoom (rf2-pvsxs) and the row's own testid are
+            IDENTICAL across the two panels, so two views of the same epoch
+            still open and close together and an operator's expansion choices
+            still survive a tab leave-and-return. A repair that qualified the
+            site-id too would pass W1 and W2 and silently change this."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount! {:instance-id "left"})
+            right (mount! {:instance-id "right"})]
+        (try
+          (let [sites-l (site-ids (:container left))
+                sites-r (site-ids (:container right))]
+            (is (seq sites-l)
+                (str "control: the left mount committed a site-id at all — "
+                     "this panel passes one, so an equality below is a "
+                     "measurement rather than two empty vectors agreeing. "
+                     "left=" (pr-str sites-l)))
+            (is (= sites-l sites-r)
+                (str "the LOGICAL identity is shared across the two mounts, "
+                     "deliberately. left=" (pr-str sites-l)
+                     " right=" (pr-str sites-r)))
+            (is (some? (.querySelector (:container right)
+                                       "[data-testid=\"rf-xray-trace-row-202-payload\"]"))
+                "and the row's own testid is untouched by the qualifier — it
+                 is the ROW's identity, not the inspector's"))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W4 — the negative control: unnamed mounts collide, and are unchanged
+;; ===========================================================================
+
+(deftest two-unnamed-mounts-still-collide
+  (testing "rf2-pua3 — the defect verbatim, kept as a row. Two standalone
+            mounts with NO `:instance-id` present the SAME mount-ids, which is
+            what makes W1's disjointness a measurement rather than a
+            coincidence; and the ids they present carry no instance segment at
+            all, so every existing single-mount call site composes exactly what
+            it always did."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            a     (mount! nil)
+            b     (mount! {})
+            named (mount! {:instance-id "left"})]
+        (try
+          (let [ids-a (mount-ids (:container a))
+                ids-b (mount-ids (:container b))
+                ids-n (mount-ids (:container named))]
+            (is (seq ids-a)
+                "control: both unnamed mounts committed widgets")
+            (is (= ids-a ids-b)
+                (str "two unnamed mounts present the SAME ids — so the "
+                     "instrument W1 uses CAN see a collision, and its "
+                     "disjointness is a measurement rather than silence. a="
+                     (pr-str ids-a)))
+            (is (= ids-a [(str id-prefix "101") (str id-prefix "202")])
+                (str "and they are byte-for-byte the ids this panel composed "
+                     "before rf2-pua3 — the row id and nothing else. a="
+                     (pr-str ids-a)))
+            (is (= ids-n
+                   (mapv #(str id-prefix "left/" (subs % (count id-prefix)))
+                         ids-a))
+                (str "a named mount's ids are the UNNAMED ids with the "
+                     "caller's name spliced in after the panel's own prefix "
+                     "— which says both halves at once: naming qualifies the "
+                     "id without disturbing the row id inside it, and an "
+                     "unnamed mount composes byte-for-byte what it always "
+                     "did. unnamed=" (pr-str ids-a) " named=" (pr-str ids-n)))
+            (is (= ids-a (mount-ids (:container a)))
+                "re-reading the same container is stable — these are
+                 identities, not per-render nonces"))
+          (finally
+            (unmount! named)
+            (unmount! b)
+            (unmount! a)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_mount_instance_id_dom_cljs_test.cljs
@@ -85,7 +85,7 @@
   passing silently. A green node lane is therefore NOT evidence about this
   file; `npm run test:browser` is. The node lane cannot see a
   ResizeObserver at all."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as string]
             ["react-dom" :as react-dom]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
@@ -108,6 +108,9 @@
   (rf.test-support/make-reset-runtime-fixture
     {:adapter       rf.adapter.reagent/adapter
      :ambient-frame nil
+     ;; `:async? true` because W2 is an `async` row, and `cljs.test` refuses
+     ;; a FUNCTION fixture in any namespace that carries one.
+     :async?        true
      :init-fn       (fn []
                       (xray-test-support/reset-all!)
                       ;; Fresco's collector tables are process-global
@@ -292,12 +295,12 @@
             and unmeasured, which a distinctness row alone cannot see."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
-      (let [_     (setup!)
-            left  (mount! {:instance-id "left"})
-            right (mount! {:instance-id "right"})
-            id-l  (first (mount-ids (:container left)))
-            id-r  (first (mount-ids (:container right)))]
-        (try
+      (async done
+        (setup!)
+        (let [left  (mount! {:instance-id "left"})
+              right (mount! {:instance-id "right"})
+              id-l  (first (mount-ids (:container left)))
+              id-r  (first (mount-ids (:container right)))]
           (is (some? id-l)
               "control: the left mount committed a widget, so the store keys
                below name something that really mounted")
@@ -324,26 +327,31 @@
           ;; ---- the width half ----------------------------------------
           ;; DRIVEN through the slot's own public event rather than read off
           ;; a real measurement, and that is a finding rather than a
-          ;; shortcut: in the headless browser the committed payload
-          ;; container measures `clientWidth` 0, so `measure-and-dispatch!`'s
-          ;; `(pos? w)` guard never fires and the slot stays EMPTY on a
-          ;; perfectly healthy mount (measured on the pre-fix run: `slot={}`
-          ;; for both mounts). A row asserting a measured width would
-          ;; therefore be red for a reason that is not this defect. The slot
-          ;; is public for exactly this — its docstring says tests may drive
-          ;; measurements deterministically — and `:rf.xray.edn-inspector/
-          ;; set-width` is the very event the observer dispatches, under the
-          ;; very id the widget composes. So what these rows exercise is the
-          ;; half the defect actually breaks: WHICH KEY `release-mount!`
-          ;; clears when a sibling detaches.
+          ;; shortcut. Two things were measured on the pre-fix runs. The
+          ;; synchronous measurement `container-ref-for` takes on ref-attach
+          ;; reads `clientWidth` 0 for the FIRST expanded row's payload
+          ;; container in this headless layout, so `measure-and-dispatch!`'s
+          ;; `(pos? w)` guard never fires for it and the slot can be EMPTY on
+          ;; a perfectly healthy mount (`slot={}`); and the ResizeObserver's
+          ;; own later callback DOES land a real width for other rows
+          ;; (`"rf-xray-trace-row-202" 1192`), asynchronously. So a row
+          ;; asserting a measured VALUE is red for a reason that is not this
+          ;; defect, and one asserting a specific value races a real
+          ;; measurement that may overwrite it. The slot is public for
+          ;; exactly this — its docstring says tests may drive measurements
+          ;; deterministically — and `:rf.xray.edn-inspector/set-width` is
+          ;; the very event the observer dispatches, under the very id the
+          ;; widget composes. These rows therefore assert on KEY PRESENCE,
+          ;; which is what the defect actually moves: WHICH KEY
+          ;; `release-mount!` clears when a sibling detaches.
           (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-l 640]
                             {:frame :rf/xray})
           (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-r 480]
                             {:frame :rf/xray})
-          (is (= 640 (get (widths) id-l))
+          (is (= 2 (count (select-keys (widths) [id-l id-r])))
               (str "two live mounts hold TWO width slots — under the shared "
-                   "identity the right mount's write lands on the left's key "
-                   "and overwrites it. slot=" (pr-str (widths))))
+                   "identity both writes land on ONE key. slot="
+                   (pr-str (widths))))
 
           (unmount! right)
 
@@ -355,13 +363,30 @@
               "and the mount STILL ON SCREEN is still observed — releasing
                the survivor's entry is what the shared key did, and it left a
                live node with no observer and no width updates")
-          (is (= 640 (get (widths) id-l))
-              (str "and the survivor's width is STILL in the frame's slot — "
-                   "`release-mount!` clears the width under the DETACHING "
-                   "mount's id, which under the shared identity is the "
-                   "survivor's own. slot=" (pr-str (widths))))
-          (finally
-            (unmount! left)))))))
+          ;; The store entry is dropped by a synchronous `swap!` but the width
+          ;; is cleared by a DISPATCH, which is queued — measured: the slot
+          ;; still read the pre-unmount value on the line straight after
+          ;; `flushSync(unmount)`. So poll for the clear to land, then read
+          ;; the survivor. Under the shared identity the two ids are one
+          ;; string, so the poll below succeeds on the SURVIVOR's own key
+          ;; being cleared, and the row after it is what reports that.
+          (-> (rf.test-support/poll-until
+                (fn [] (nil? (get (widths) id-r)))
+                {:label "release-mount! cleared the detaching mount's width"})
+              (.then
+                (fn [_]
+                  (is (some? (get (widths) id-l))
+                      (str "and the survivor's width is STILL in the frame's "
+                           "slot — `release-mount!` clears the width under the "
+                           "DETACHING mount's id, which under the shared "
+                           "identity is the survivor's own. slot="
+                           (pr-str (widths))))))
+              (.catch
+                (fn [e]
+                  (is false (str "the width clear never landed: "
+                                 (.-message e) " slot=" (pr-str (widths))))
+                  nil))
+              (.then (fn [_] (unmount! left) (done)))))))))
 
 ;; ===========================================================================
 ;; W3 — the LOGICAL identity must NOT move

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -493,19 +493,69 @@
     (is (= {} (crossed (delivered-by nil)))
         "and the bridge's 0-arity mounts the boundary with no props"))
 
-  (testing "rf2-2n8q — `:instance-id` is ONE PANEL's opt, not the surface's.
-            Only `app-db-diff/Panel` takes the prop; handing a props map to a
-            panel view that takes none is an arity error, not an ignored key,
-            so every other mount fn must keep delivering a bare element even
-            when its caller sets the opt."
+  (testing "rf2-2n8q — `:instance-id` is SOME PANELS' opt, not the surface's.
+            Only a panel whose view takes the prop may be handed a props map;
+            handing one to a view that takes none is an arity error, not an
+            ignored key, so every other mount fn must keep delivering a bare
+            element even when its caller sets the opt.
+
+            rf2-pua3 moved `mount-trace!` from the second group to the first —
+            `trace/Panel` now reads `:instance-id` — so the row that used to
+            name it here names `mount-epoch-panel!` instead, and the trace
+            half is asserted in [[mount-trace-instance-id-reaches-the-boundary]]
+            below. A panel is picked here for being a CURRENT member of the
+            no-prop group, not for being a permanent one."
     (let [[capture _ render-stub] (make-render-stub)]
       (with-redefs [rf.substrate.adapter/render render-stub]
-        (panels/mount-trace! :mount-point {:instance-id "left"})
         (panels/mount-epoch-panel! :mount-point {:instance-id "left"})
-        (is (= [trace/Panel-bridge] (delivered-element capture))
-            "the trace mount delivers its view with no props")
-        (is (= [epoch-panel/Panel-bridge] (nth (:tree (second @capture)) 2))
-            "and so does the epoch mount")))))
+        (is (= [epoch-panel/Panel-bridge] (delivered-element capture))
+            "the epoch mount delivers its view with no props")))))
+
+(defn- trace-delivered-by
+  "Mount the Trace panel through the public facade with `opts`; return the
+  element it delivered to the substrate."
+  [opts]
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [rf.substrate.adapter/render render-stub]
+      (panels/mount-trace! :mount-point opts))
+    (delivered-element capture)))
+
+(deftest mount-trace-instance-id-reaches-the-boundary
+  (testing "rf2-pua3 — `mount-trace!`'s `:instance-id` opt reaches the Fresco
+            boundary's props, across the real `Panel-bridge`. This is the
+            mount door onto the prop the panel now reads: a caller that MOUNTS
+            passes opts and never props, so before this the standalone embed
+            could not name an instance at all.
+
+            The DOM-level claim — that naming two mounts actually separates
+            their inspector lifecycle and width — is
+            `panels/trace_mount_instance_id_dom_cljs_test`'s. This row is only
+            that the opt survives the facade and the crossing, which is the
+            half a DOM row cannot localise when it fails."
+    (is (= {:instance-id "left"}
+           (crossed (trace-delivered-by {:instance-id "left"})))
+        "the opt crosses the bridge and arrives as a prop")
+    (is (= {:instance-id "left/trace"}
+           (crossed (trace-delivered-by {:instance-id :left/trace})))
+        "and a KEYWORD keeps its namespace — rf2-4bsq: `[:>]` would convert it
+         with `cljs.core/name` and drop the namespace, restoring the very
+         collision this removes, so the bridge tokenises BEFORE the crossing")
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-trace! :mount-point
+                             {:frame :my-app/cart :instance-id "right"})
+        (is (= {:frame :my-app/cart} (second (captured-tree capture)))
+            "and it composes with `:frame` rather than replacing it — the
+             frame-provider still wraps the frame the host named")))
+    (is (= [trace/Panel-bridge] (trace-delivered-by nil))
+        "an UNNAMED trace mount delivers the bare `[Panel-bridge]` element it
+         always delivered, not `[Panel-bridge {}]` — the shape the shell's
+         `[(:panel tab)]` and every standalone call site in this tree take
+         today, and what keeps their composed ids byte-for-byte unchanged")
+    (is (= [trace/Panel-bridge] (trace-delivered-by {:frame :my-app/cart}))
+        "opts carrying no instance name deliver it too")
+    (is (= {} (crossed (trace-delivered-by nil)))
+        "and the bridge's 0-arity mounts the boundary with no props")))
 
 ;; ---- contract — idempotency under repeat mount ------------------------
 


### PR DESCRIPTION
Closes rf2-pua3.

## The defect, reproduced before it was repaired

The bead was explicit that it was established from the landed data flow and the
unchanged inspector implementation, **not** from an executed two-container
browser reproduction. Discharging that was the first task, and it is discharged:
the witness was written and committed against the **unrepaired** tree and run
first, on `npm run test:browser`.

Pre-fix run, captured exit **1**, 8 failures and 0 errors on an otherwise-green
tree of 958 tests / 5321 assertions — all 8 in the new file:

* Two mounts given `{:instance-id "left"}` and `{:instance-id "right"}` both
  committed `["rf-xray-trace-row-101" "rf-xray-trace-row-202"]`. Identical.
* After unmounting the sibling, the **survivor's** store entry read `nil` —
  `(not (contains? nil :observer))`. That is the half a distinctness-only
  witness passes straight over, and it is the half that actually breaks.
* A second pre-fix run pinned the width half directly: both mounts' writes
  landed on **one** key (`(not (= 640 480))`).

## The repair

An optional `:instance-id` threaded through the facade, the bridge and the
boundary to the payload inspector — the pattern rf2-2n8q / rf2-5ykm shipped,
including tokenising **before** the Reagent crossing, since `cljs.core/name`
drops a keyword's namespace (rf2-4bsq).

**Trace needs ONE qualifier, on the `:mount-id` alone, and that is a third
shape rather than a copy of either sibling.** The brief said to check rather
than copy; this is what the check found. `managed-fx` needs one because
`edn-widget/inspect-view` builds the `:mount-id` *and* the `:panel-id` from one
node-key and passes no `:site-id`. `app-db-diff` needs two because `value-body`
composes its `:mount-id` and its `:site-id` separately. Trace passes a stable
`:site-id` (rf2-pvsxs) and the widget's `effective-id` is
`(or site-id mount-id)` — so expansion and zoom are keyed
`[panel-id site-id path]` and **never read the mount-id at all**.

The logical disclosure identity is therefore already separate from the physical
one. Qualifying the mount-id moves exactly the two things that are per-live-
mount — the store's lifecycle key `[frame-id mount-id]` and the measured-width
slot, keyed by the bare `mount-id` — and leaves expansion, zoom, row testids and
React keys byte-for-byte where they were. Two Trace panels of one epoch still
open and close together on purpose; what they no longer share is a
ResizeObserver and a width. A row pins that bound explicitly, so a future
repair that qualified the `:site-id` too would go red rather than pass.

Unnamed mounts — every call site in this tree today — compose every id
byte-for-byte as before, and a row asserts that against the literal
`["rf-xray-trace-row-101" "rf-xray-trace-row-202"]`.

## The witness

`panels/trace_mount_instance_id_dom_cljs_test` — two real containers through the
public facade, matching rows expanded, every assertion reading the DOM React
committed, the widget's own per-mount store, or the frame's width slot. Four
rows: disjoint mount-ids; **each mount keeps its own observer and width, and the
survivor keeps both after its sibling detaches**; the shared `:site-id` bound;
and the negative control that two *unnamed* mounts still collide, which is what
makes the disjointness a measurement rather than silence.

## Two measurement findings worth carrying

**The headless payload container measures `clientWidth` 0** for the first
expanded row, so `measure-and-dispatch!`'s `(pos? w)` guard never fires and the
width slot can be empty on a perfectly healthy mount (`slot={}`) — while the
ResizeObserver's own later callback *does* land a real width for other rows
(`"rf-xray-trace-row-202" 1192`), asynchronously. A row asserting a measured
value is red for a reason that is not this defect, and one asserting a specific
value races a real measurement. The rows therefore drive the slot through its
own public `:rf.xray.edn-inspector/set-width` event — which its docstring
sanctions, and which is the very event the observer dispatches under the very id
the widget composes — and assert on **key presence**, which is what the defect
moves.

**`release-mount!` drops the store entry with a synchronous `swap!` but clears
the width with a `dispatch`, which is queued.** The slot still read its
pre-unmount value on the line straight after `flushSync(unmount)`. The width row
polls for the clear to land rather than reading once; without that it would have
been a false green.

## Scope

Bounded as the bead asked. No identity framework, no widening of the migration.
`views/edn_inspector.cljs` and `views/edn_widget.cljs` needed **no change** —
the inspector has supported a caller-supplied per-mount identity since rf2-d2aj;
what was missing was a public way for a Trace caller to supply one.

The three spec lines each carried a two-panel enumeration of who takes
`:instance-id` that becomes false with this landing (rf2-jw2ny asks for one
honest status across `panels.cljs`, `008` and `API.md`), and one landed test
asserted in prose that `mount-trace!` delivers a bare element even when its
caller sets the opt. Both moved with the code.

## Quality gates

Every number below is the exit code **captured** from the runner into a
per-worktree, per-attempt `.exit` file, not one reported about the run. They
disagreed four times in this dispatch: the harness reported "exit code 0" for
all four runs whose captured exit was **1**, including both deliberate sabotage
runs, where believing the reported zero would have read as "the control does not
bite" and inverted the conclusion.

| Gate | Attempt | Captured exit | Result |
|---|---|---|---|
| `shadow-cljs compile browser-test` | 1 (pre-fix) | 0 | warnings only |
| `serve-and-run-browser-tests` | 1 (pre-fix) | **1** | 958 tests / 5321 assertions, 8 failures — all in the new witness |
| `shadow-cljs compile browser-test` | 2 (pre-fix) | 0 | |
| `serve-and-run-browser-tests` | 2 (pre-fix) | **1** | 9 failures — 7 in the witness, 2 pre-existing routing flakes (below) |
| `shadow-cljs compile browser-test` | 3 (post-fix) | 0 | |
| `serve-and-run-browser-tests` | 3 (post-fix) | **0** | 958 tests / 5320 assertions, **0 failures, 0 errors** |
| `shadow-cljs compile browser-test` | 4 (sabotage) | 0 | |
| `serve-and-run-browser-tests` | 4 (sabotage) | **1** | exactly 1 failure, naming the planted token |
| `compile-node-test node-test` | 1 | 0 | 1956 files, 0 warnings |
| `node out/node-test.js` | 1 | **0** | 11703 tests / 58607 assertions, **0 failures, 0 errors** |
| node compile + run | 2 (sabotage) | **1** | exactly 1 failure, naming the planted deftest |
| 45 repo `check_*` gates + `check-no-hardcoded-paths` + `check-ai-tracking-ratchet` | 1 | 0 | 45 pass, 0 fail |
| `check_allocation_non_claim` / `check_architecture_census` / `check_escaped_continuations` | 1 | 0 | (need args; run separately) |

The browser gate was run **split** — compile, then serve gated on the compile's
captured exit — rather than chained, so a failed compile cannot leave the
previous artefact in place for the serve step to test.

**Both lanes were proven to execute this diff by a planted fault, because
neither prints anything that identifies the tree it read.** A clean run's log
carries no per-namespace lines at all — measured: a grep for the new namespace
read 0, *and so did a grep for a known-present control namespace*, so that zero
was the instrument and not an absence. The plants settle it: the browser lane
went red naming `PLANTED-SABOTAGE-TOKEN` at the planted row, and the node lane —
the only lane that runs `panels_mount_cljs_test` — went red naming
`mount-trace-instance-id-reaches-the-boundary`. Each fault existed only in this
worktree, so a run that had wandered into a sibling's would have come back
green. Both restores were verified against the committed blob hash
(`git hash-object` default form, which is the correct form for these `i/lf
w/crlf` files) plus `git diff --quiet HEAD`, and both plant tokens read 0
residue.

**Flakes, not regressions.** Pre-fix run 2 carried two failures in
`rf2-async-nav` routing (`the-real-back-button-is-held-…`,
`the-browsers-own-back-and-forward-…`), both `poll-until` timeouts on real
Back-button popstate. They were absent from pre-fix run 1 and from the post-fix
run, and the only source change between runs 1 and 2 was inside the new test
file. Browser-history races, unrelated to this diff.

**One thing deliberately not repaired.** Scoping `check_escaped_continuations`
by hand to `tools/xray/spec/API.md` reports 5 escaped continuation lines at
`API.md:288-304`. Those are pre-existing and are not my lines (my edit is at
~410), and the gate's own corpus — the invocation CI runs — does not include
`tools/*/spec` at all: the whole-corpus run scans 291 files and exits 0, while
the explicit path exits 1. Repairing it would be sprawl into another item and
into a surface no gate grades.

**Not run locally, deliberately:** the rest of the required CI matrix. The two
test lanes above plus the ratchet sweep are the gates that cover this diff's
surfaces; the remainder is CI's job and re-running it locally buys wall-clock
rather than information. `scripts/check_fast_pr_gap.py` is the single path that
derives the required set.
