### PR TITLE
docs(prose): finish the deferred-handler sweep across the eight residual files (rf2-cti6)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -4,8 +4,11 @@
 
   Discovered during rf2-yf97 (websocket example): a handler scoped to
   frame :A doing `(js/setTimeout #(rf/dispatch [:foo]) 0)` produced a
-  dispatch that landed on :rf/default, not :A. The workaround the
-  example adopted was `:fx [[:dispatch ...]]` — the :dispatch fx in
+  dispatch that landed on :rf/default, not :A. That destination is
+  PRE-EP-0002 HISTORY — it is how the defect presented when it was
+  found, and there is no `:rf/default` floor any more; the same escape
+  now raises `:rf.error/no-frame-context` (see §2 below). The workaround
+  the example adopted was `:fx [[:dispatch ...]]` — the :dispatch fx in
   re-frame.fx explicitly threads `{:frame frame-id}` so it survives
   any async tier.
 
@@ -104,8 +107,11 @@
 ;; This is the rf2-yf97 scenario. A handler defers a dispatch via
 ;; setTimeout. The setTimeout callback runs on a fresh JS stack — the
 ;; dynamic binding established by `process-event!` has long since
-;; been popped. Without an explicit capture the dispatch falls
-;; through to `:rf/default`.
+;; been popped. Under EP-0002 there is no `:rf/default` floor beneath
+;; that dead binding, and this suite opts out of the fixture's ambient
+;; scope (`:ambient-frame nil`, above), so without an explicit capture
+;; the dispatch RAISES `:rf.error/no-frame-context` — which is exactly
+;; what the deftest immediately below is named for and asserts.
 ;;
 ;; This test documents the inherent dynamic-scope limit and points
 ;; users at the three explicit-capture affordances (`:fx [[:dispatch

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -79,7 +79,16 @@
       (with-new-frame [f :right]
         (is (= :right f))
         (is (= :right (rf/current-frame-id))))))
-  (testing "outside any binding the dynamic var falls back to :rf/default"
+  ;; NOT a resolver fallback. `current-frame-id` has no `:rf/default`
+  ;; floor — read with no scope in effect at all it RAISES
+  ;; `:rf.error/no-frame-context` (EP-0002). It reads `:rf/default` here
+  ;; because this ns's `make-reset-runtime-fixture` (above) installs an
+  ;; adapter and does NOT pass `:ambient-frame`, so the fixture binds its
+  ;; default ambient scope — `:rf/default` — around every test body. What
+  ;; this row pins is that the two `with-frame` scopes above UNWIND back
+  ;; to that ambient scope, not that absence resolves to anything.
+  (testing "after the with-frame scopes unwind, the dynamic var is back to
+            the fixture's ambient scope (:rf/default)"
     (is (= :rf/default (rf/current-frame-id)))))
 
 ;; ---- capture-frame — the ONE public HOLD primitive --------------------------
@@ -93,8 +102,10 @@
     (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
     (rf/dispatch-sync [:seed 99] {:frame :side})
     (let [handle (with-frame :side (rf/capture-frame))]
-      ;; Outside the with-frame, dynamic var has reverted; the captured
-      ;; handle still targets :side.
+      ;; Outside the with-frame, the dynamic var has reverted to the
+      ;; fixture's ambient scope (`:rf/default`) — not to a resolver
+      ;; fallback, of which there is none. The captured handle still
+      ;; targets :side.
       (is (= :rf/default (rf/current-frame-id)))
       (is (= :side (:frame handle)))
       (is (= 99 (:n (rf/app-db-value (:frame handle))))))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs
@@ -574,9 +574,12 @@
 ;; `dispatch` (rf2-1w07r) is a frame-bound dispatcher threaded down from
 ;; [[panel-tree]], so the deferred `:on-click` lands on the surrounding Xray
 ;; instance's frame. A bare global `rf/dispatch` would fire after render
-;; unwinds, when the ambient frame is gone, and leak to `:rf/default` — the
-;; click would silently switch some other shell's sub-view, or none. This is
-;; the tab's only dispatch: the six views read.
+;; unwinds, when the ambient frame is gone, and RAISE
+;; `:rf.error/no-frame-context` (EP-0002) — the click would do nothing at
+;; all rather than switch the wrong shell's sub-view. There is no
+;; `:rf/default` floor to leak to: the resolver bottoms out at nil, and
+;; React's no-provider context default is a SENTINEL, not `:rf/default`.
+;; This is the tab's only dispatch: the six views read.
 ;;
 ;; rf2-k97c.3 — it USED to be `reg-view`'s lexically injected `dispatch`.
 ;; `defview` binds no name inside a body, so [[Panel]] now builds the same

--- a/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj
@@ -21,10 +21,13 @@
        `{:frame :rf/xray}` map literal), so it never trips this guard.
 
     B. a global `rf/dispatch` / `rf/dispatch-sync` wired directly to an
-       `:on-*` handler — the bare global dispatch that leaks to
-       `:rf/default` after render unwinds. The fix is to dispatch
-       through a captured frame-aware dispatcher (the reg-view-injected
-       `dispatch`, a threaded `dispatch-fn`, or `(:dispatch (rf/capture-frame))`).
+       `:on-*` handler — the bare global dispatch that raises
+       `:rf.error/no-frame-context` after render unwinds (EP-0002:
+       there is no `:rf/default` floor, and React's no-provider context
+       default is a sentinel rather than a frame id). The fix is to
+       dispatch through a captured frame-aware dispatcher (the
+       reg-view-injected `dispatch`, a threaded `dispatch-fn`, or
+       `(:dispatch (rf/capture-frame))`).
 
   ## Migration state — COMPLETE (rf2-1w07r EPIC closed via rf2-nesy9)
 
@@ -83,8 +86,8 @@
 
   This is exactly the reactive-panel unchanged-subs toggle bug: after
   render scope unwinds the ambient frame is gone, so the bare dispatch
-  leaks to `:rf/default` / emits `:rf.error/no-frame-context`, leaving
-  the instance's state untouched. `\\s` spans newlines (Java regex), so
+  raises `:rf.error/no-frame-context`, leaving the instance's state
+  untouched. `\\s` spans newlines (Java regex), so
   the callback body need not be single-line. NARROW by design: it does
   NOT trip a dispatch carrying an explicit `{:frame frame}` opt (the
   `\\]\\s*\\)` tail requires the event vector to close the dispatch call)
@@ -244,7 +247,8 @@
         (str "rf2-1w07r — a global `rf/dispatch` / `rf/dispatch-sync` is "
              "wired directly to an `:on-*` handler in a de-singletoned "
              "(or new) file. After render unwinds the ambient frame is "
-             "gone, so a bare global dispatch leaks to `:rf/default`. "
+             "gone, so a bare global dispatch raises "
+             "`:rf.error/no-frame-context`. "
              "Dispatch through a captured frame-aware dispatcher (the "
              "reg-view-injected `dispatch`, a threaded `dispatch-fn`, or "
              "`(:dispatch (rf/capture-frame))`). Offenders:\n  "
@@ -253,8 +257,8 @@
 (deftest no-deferred-fn-bare-dispatch-in-migrated-files
   ;; rf2-16y3x — the reactive-panel unchanged-subs toggle installed a
   ;; DEFERRED `(fn [_e] (rf/dispatch [ev]))` on-click. The bare dispatch
-  ;; fired after render scope unwound (ambient frame gone) → leaked to
-  ;; `:rf/default` / `:rf.error/no-frame-context`, leaving Xray state
+  ;; fired after render scope unwound (ambient frame gone) → raises
+  ;; `:rf.error/no-frame-context`, leaving Xray state
   ;; untouched. The adjacency-only guard above missed the multiline
   ;; callback; this whole-file scan catches it so it cannot regress.
   (let [offs (multiline-offenders deferred-fn-bare-dispatch-pattern
@@ -264,8 +268,8 @@
              "[ev]))` (no `{:frame …}` opt, dispatch as the callback's first "
              "form) is wired to an `:on-*` handler in a de-singletoned (or "
              "new) file. After render unwinds the ambient frame is gone, so "
-             "the bare dispatch leaks to `:rf/default` and the instance's "
-             "state never changes. Call a captured frame-aware dispatcher "
+             "the bare dispatch raises `:rf.error/no-frame-context` and the "
+             "instance's state never changes. Call a captured frame-aware dispatcher "
              "(the reg-view-injected `dispatch` threaded down, a "
              "`dispatch-fn`, or `(:dispatch (rf/capture-frame))`). "
              "Offenders:\n  "

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -13,12 +13,15 @@
 
   Dispatches from `:on-click` / `:on-change` / `:on-key-down` /
   `:on-mouse-enter` fire LATER — after render commits and React has
-  POPPED `_currentValue` back to the context's default
-  (`:rf/default`). At click time the 3-tier frame resolution chain
-  (dynamic var → React-context tier → `:rf/default`) falls all the
-  way through, the dispatch lands on `:rf/default`'s router, and the
-  `:rf.xray/palette-*` handler reduces `:rf/default`'s db — leaving
-  Xray's palette slots untouched. Symptom: backdrop click does not
+  POPPED `_currentValue` back to the context's default, which is the
+  NO-PROVIDER SENTINEL, not `:rf/default`. At click time the frame
+  resolution chain has TWO tiers (dynamic var → React-context tier)
+  and nothing beneath them: the sentinel coerces to nil, so a bare
+  unscoped dispatch RAISES `:rf.error/no-frame-context` (EP-0002)
+  rather than routing anywhere. Either way the `:rf.xray/palette-*`
+  handler never reduces `:rf/xray`'s db — before EP-0002 it silently
+  reduced `:rf/default`'s db instead, which is how this defect
+  originally presented. Symptom: backdrop click does not
   close, arrow keys do not move the cursor, Esc does not close, input
   text does not update the query — the palette appears frozen.
 
@@ -40,6 +43,18 @@
   `rf/dispatch` (not `dispatch-sync`); the router drain is async via
   `goog.async.nextTick`. Tests use `rf.test-support/poll-until` to await
   the drain before asserting.
+
+  ONE WAY THE HARNESS DIFFERS FROM THE BROWSER, and the counterfactual
+  clauses below are worded for it. `make-xray-runtime-fixture` does not
+  opt out of `:ambient-frame`, so the fixture binds `:rf/default` as an
+  AMBIENT SCOPE around every body here. A handler invoked \"outside any
+  `with-frame`\" therefore still has that scope in effect: under this
+  harness an unscoped dispatch reduces `:rf/default`'s db — which is
+  precisely what the `:rf/default`-is-NOT-polluted rows pin — where the
+  browser, having no ambient scope at all, raises
+  `:rf.error/no-frame-context`. The property under test is the same
+  either way: the envelope's `:frame` is set at call time and never
+  depends on the click-time context read.
 
   ## Where the tree comes from (rf2-k97c.3)
 
@@ -140,8 +155,9 @@
   (testing "rf2-w8lxg — clicking the backdrop from OUTSIDE the
             :rf/xray frame-provider's render context still closes the
             palette. Without the explicit `{:frame :rf/xray}` opt the
-            click would land on :rf/default and the palette would stay
-            open."
+            click would reduce the fixture's ambient :rf/default db
+            instead (and raise in the browser, which has no ambient
+            scope), and the palette would stay open."
     (let [rendered (render-open-palette)
           backdrop (find-by-testid rendered "rf-xray-palette-backdrop")
           handler  (on-click backdrop)]
@@ -184,7 +200,8 @@
   (testing "rf2-w8lxg — ArrowDown keydown on the palette input from
             OUTSIDE the :rf/xray frame-provider's render context still
             updates :rf/xray's :palette-cursor. Without the explicit
-            frame opt the dispatch would land on :rf/default and the
+            frame opt the dispatch would reduce the fixture's ambient
+            :rf/default db instead (and raise in the browser), so the
             cursor would never move."
     (let [rendered (render-open-palette)
           input    (find-by-testid rendered "rf-xray-palette-input")
@@ -231,7 +248,8 @@
   (testing "rf2-w8lxg — typing into the palette input from OUTSIDE the
             :rf/xray frame-provider's render context still updates
             :rf/xray's :palette-query. Without the explicit frame opt
-            every keystroke would land on :rf/default and the
+            every keystroke would reduce the fixture's ambient
+            :rf/default db instead (and raise in the browser), so the
             displayed query would freeze."
     (let [rendered (render-open-palette)
           input    (find-by-testid rendered "rf-xray-palette-input")

--- a/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/fresco_live_panel_dom_cljs_test.cljs
@@ -501,9 +501,11 @@
             frame-bound `dispatch`; a `defview` binds no name inside a body,
             so the panel builds one from `rf/current-frame-id`. A bare global
             `rf/dispatch` in its place fires after render unwinds, when the
-            ambient frame is gone, and lands on `:rf/default` — where
-            `:rf.xray.fresco/set-view` writes a `:fresco-view` nobody reads,
-            and the DOM below never changes."
+            ambient frame is gone, and RAISES `:rf.error/no-frame-context` —
+            there is no `:rf/default` floor beneath the two resolution tiers
+            (EP-0002), and this ns's `:ambient-frame nil` leaves no ambient
+            scope to catch it either. `:rf.xray.fresco/set-view` never runs
+            at all, and the DOM below never changes."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done

--- a/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs
@@ -22,12 +22,16 @@
 
   ## The two bugs these mounted tests defend against
 
-  1. **Panel-local toggle leaked to `:rf/default`.** The unchanged-subs
+  1. **Panel-local toggle never reached `:rf/xray`.** The unchanged-subs
      footer button installed a deferred `(fn [_e] (rf/dispatch …))` —
-     a BARE global dispatch. After render scope unwinds the 3-tier frame
-     resolution falls through to `:rf/default` (or emits
-     `:rf.error/no-frame-context`), so the click never flipped Xray's
-     `:reactive/show-unchanged?` and the disclosure stayed collapsed.
+     a BARE global dispatch. After render scope unwinds the two-tier
+     frame resolution (dynamic var → React-context tier) has nothing
+     beneath it — React's no-provider default is a SENTINEL, not
+     `:rf/default` — so the dispatch raises `:rf.error/no-frame-context`
+     (EP-0002; before EP-0002 it silently reduced `:rf/default`'s db,
+     which is how the bug originally presented). Either way the click
+     never flipped Xray's `:reactive/show-unchanged?` and the
+     disclosure stayed collapsed.
      The fix threads a frame-aware `dispatch` down through
      `reactive-panel` → `unchanged-subs-section`, so the deferred click
      lands on the surrounding instance frame. Since rf2-k97c.3 that

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -17,12 +17,15 @@
 
   Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire
   LATER — after render commits and React has POPPED `_currentValue`
-  back to the context's default (`:rf/default`). At click time the
-  3-tier frame resolution chain (dynamic var → React-context tier →
-  `:rf/default`) falls all the way through, the dispatch lands on
-  `:rf/default`'s router, and the `:rf.xray/settings-*` handler
-  reduces `:rf/default`'s db — leaving Xray's `:settings-open?` flag
-  untouched. Symptom: X button does nothing, tabs do not switch, Esc
+  back to the context's default, which is the NO-PROVIDER SENTINEL,
+  not `:rf/default`. At click time the frame resolution chain has TWO
+  tiers (dynamic var → React-context tier) and nothing beneath them:
+  the sentinel coerces to nil, so a bare unscoped dispatch RAISES
+  `:rf.error/no-frame-context` (EP-0002) rather than routing anywhere.
+  Either way the `:rf.xray/settings-*` handler never reduces
+  `:rf/xray`'s db — before EP-0002 it silently reduced `:rf/default`'s
+  db instead, which is how this defect originally presented. Symptom:
+  X button does nothing, tabs do not switch, Esc
   does not close — the modal is stuck.
 
   The fix in `view.cljs` is mechanical: every `rf/dispatch` from a
@@ -37,7 +40,19 @@
   browser's click-fires-after-render reality. Click handlers use
   queued `rf/dispatch` (not `dispatch-sync`); the router drain is
   async via `goog.async.nextTick`. Tests use `rf.test-support/poll-until`
-  to await the drain before asserting."
+  to await the drain before asserting.
+
+  ONE WAY THE HARNESS DIFFERS FROM THE BROWSER, and the counterfactual
+  clauses below are worded for it. `make-xray-runtime-fixture` does not
+  opt out of `:ambient-frame`, so the fixture binds `:rf/default` as an
+  AMBIENT SCOPE around every body here. A handler invoked \"outside any
+  `with-frame`\" therefore still has that scope in effect: under this
+  harness an unscoped dispatch reduces `:rf/default`'s db — which is
+  precisely what the `:rf/default`-is-NOT-polluted rows pin — where the
+  browser, having no ambient scope at all, raises
+  `:rf.error/no-frame-context`. The property under test is the same
+  either way: the envelope's `:frame` is set at call time and never
+  depends on the click-time context read."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
@@ -104,7 +119,9 @@
             :rf/xray frame-provider's render context still flips
             :rf/xray's :settings-open? to false. Without the explicit
             `{:frame :rf/xray}` opt on the dispatch, the click would
-            land on :rf/default and the modal would stay open."
+            reduce the fixture's ambient :rf/default db instead (and
+            raise in the browser, which has no ambient scope), and the
+            modal would stay open."
     (let [rendered  (render-open-modal)
           close-btn (rf.test-helpers/find-by-testid rendered "rf-xray-settings-close")
           handler   (on-click close-btn)]
@@ -160,8 +177,9 @@
   (testing "rf2-smvvz — clicking a tab button from OUTSIDE the
             :rf/xray frame-provider's render context still updates
             :rf/xray's :settings-active-tab. Without the explicit
-            frame opt, every tab click would land on :rf/default and
-            the popup would stay frozen on the :general default.
+            frame opt, every tab click would reduce the fixture's
+            ambient :rf/default db instead (and raise in the browser),
+            so the popup would stay frozen on the :general default.
 
             Targets the Buffer tab (rf2-wknb3 retired the Filters
             tab that this test originally exercised; the routing


### PR DESCRIPTION
Finishes the deferred-handler prose sweep begun in `f0c2cde590` (PR #9659). That sweep
corrected thirteen files soundly and left eight describing the retired account. The residual
was recorded only as follow-up notes on the now-closed rf2-mhpo, which is why it needed its own
item. rf2-poxh is a different defect (the UIx gate roster) and is not touched here.

## The account these eight now carry

- Current no-scope operations **raise `:rf.error/no-frame-context`**. There is no `:rf/default`
  floor: `frame/current-frame` and `views/provider/current-frame` both bottom out at **nil**, and
  `require-current-frame!` throws on a nil read.
- React's no-provider context default is a **SENTINEL**, not `:rf/default`; it coerces to nil. So
  the resolution chain has **two** tiers (dynamic var, then React context), not three.
- **Explicit or fixture-provided scopes still route normally** — the half that makes four of these
  files subtler than they look. See the fixture table below.

Premises were verified at source rather than taken from the item:
`spec/006-ReactiveSubstrate.md`, `implementation/core/src/re_frame/views/provider.cljs`,
`implementation/core/src/re_frame/frame.cljc`, and
`implementation/core/src/re_frame/test_support.cljc` (`make-reset-runtime-fixture`).

## The fixture distinction, which changes what the correct wording is

`make-reset-runtime-fixture` binds `:ambient-frame` (**default `:rf/default`**) as
`*current-frame*` around each test body whenever an adapter is installed, and
`make-xray-runtime-fixture` deliberately does not thread that option. So "invoked outside any
`with-frame`" does **not** mean "no scope in effect" in every one of these namespaces:

| namespace | ambient scope | an unscoped dispatch there |
|---|---|---|
| `palette/dispatch_routing_cljs_test.cljs` | `:rf/default` (fixture default) | reduces `:rf/default`'s db |
| `settings/popup_dispatch_routing_cljs_test.cljs` | `:rf/default` (fixture default) | reduces `:rf/default`'s db |
| `panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs` | `:rf/default` (fixture default) | reduces `:rf/default`'s db |
| `runtime_cljs_test.cljs` | `:rf/default` (fixture default) | resolves `:rf/default` |
| `dispatch_frame_capture_cljs_test.cljs` | **`:ambient-frame nil`** | raises |
| `panels/fresco_live_panel_dom_cljs_test.cljs` | **`:ambient-frame nil`** | raises |

Had every site simply been rewritten to "raises", four of them would have become wrong in a new
way. The counterfactual clauses in the three `:rf/default`-ambient Xray namespaces are therefore
worded for the harness with the browser's behaviour named alongside, and each ns docstring now
says where that ambient scope comes from.

## Per-file: what it said, what it says now

**1. `tools/xray/src/day8/re_frame2_xray/panels/fresco.cljs`** (the one fenced source paragraph)
— said a bare post-render `rf/dispatch` would "leak to `:rf/default`" and "silently switch some
other shell's sub-view". Now: it raises `:rf.error/no-frame-context`, the click does nothing at
all, and there is no `:rf/default` floor to leak to.

**2. `implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs`** —
the banner comment said "Without an explicit capture the dispatch falls through to
`:rf/default`", sitting directly above `direct-dispatch-from-set-timeout-raises-no-frame-context`,
which asserts the opposite. Now it says the dispatch raises, naming both reasons (no floor, and
this suite's `:ambient-frame nil`). The ns docstring's rf2-yf97 discovery narrative said the
dispatch "landed on `:rf/default`"; that is accurate history and is **kept**, now explicitly
marked PRE-EP-0002 with a pointer to the current behaviour.

**3. `implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs`** — the label read
"outside any binding the dynamic var falls back to `:rf/default`". The **assertion is correct and
is unchanged**; only the label was wrong, because the fixture supplies that binding. The label now
says the `with-frame` scopes unwind back to the fixture's ambient scope, over a comment stating
that `current-frame-id` has no `:rf/default` floor. The second site in the same file ("dynamic var
has reverted") was accurate and is merely made explicit about reverting *to the ambient scope*.

**4. `tools/xray/test/day8/re_frame2_xray/frame_singleton_guard_test.clj`** — five sites, in the
ns docstring, a def docstring and three assertion message strings. Two said "leaks to
`:rf/default`"; two hedged "leaks to `:rf/default` / emits `:rf.error/no-frame-context`". All now
state the raise. **No pattern, no assertion and no offender logic changed** — the `\s`-bearing
regex prose is intact, and `check_escaped_continuations.py` passes.

**5. `tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs`** — the ns
docstring carried the full three-tier chain, "(dynamic var → React-context tier → `:rf/default`)
falls all the way through". Now two tiers, sentinel, raise, with the pre-EP destination kept as
marked history. Three `testing` counterfactuals reworded for the ambient fixture, and a new
paragraph documents the harness/browser difference. The `:rf/default`-is-NOT-polluted assertions
are correct negative controls and are **untouched** — they are precisely what the ambient scope
makes meaningful.

**6. `tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs`** —
same shape as 5: ns docstring three-tier chain corrected, two `testing` counterfactuals reworded,
same fixture paragraph added, negative controls untouched.

**7. `.../panels/reactive_panel_disclosure_dispatch_routing_cljs_test.cljs`** — ns docstring bug 1
said the 3-tier resolution "falls through to `:rf/default` (or emits
`:rf.error/no-frame-context`)". Now the two-tier account with the raise, pre-EP destination kept
as marked history. The in-test labels ("no leak to `:rf/default`, no no-frame-context") were
already correct and are untouched.

**8. `.../panels/fresco_live_panel_dom_cljs_test.cljs`** — "WHAT WOULD BREAK IT" said a bare
dispatch "lands on `:rf/default`" where the event "writes a `:fresco-view` nobody reads". Now it
raises and the event never runs, citing this ns's `:ambient-frame nil`. The separate ns-docstring
paragraph explaining why `:ambient-frame nil` is load-bearing was already correct and is
untouched, as is the `is` message contrasting `:rf/xray` with `:rf/default`.

## Preserved deliberately, not missed

Every surviving `:rf/default` mention in these eight files was read and kept on purpose:

- **Pre-EP history** — the rf2-yf97 discovery narrative (file 2), and the "before EP-0002 it
  silently reduced `:rf/default`'s db" clauses added as explicit history in files 5, 6 and 7.
- **Negative controls** — every `":rf/default's db is NOT polluted …"` / `":rf/default sees
  nothing"` assertion message across files 2, 5, 6, 7 and the `is` message in file 8. These assert
  a real, current property.
- **Correct mechanism prose** — file 5's `find-by-testid` comment already said ambient
  re-expansion "would raise `:rf.error/no-frame-context` rather than falling through to a
  synthesised `:rf/default`"; file 8's `:ambient-frame nil` rationale paragraph; file 2's
  already-corrected EP-0002 paragraph inside the deftest, and its synchronous-case "lands on
  :tenant-a … not :rf/default".
- **Real frame targets** — `seed-frames!`'s `{:frame :rf/default}` dispatches and the many
  `app-db-value :rf/default` reads are data, not claims.

## Scope

Comments, docstrings and assertion/testing label strings only. No runtime change, no
test-behaviour change, no assertion or pattern altered, no new gate, no repository-wide campaign.
All eight land together deliberately: the defect is one account contradicted in eight places, so
landing a subset would leave the tree carrying two contradictory accounts in the interval — the
defect being repaired, reintroduced by the repair.

## Verification is by hand, and that is stated rather than implied

**No gate validates this prose.** `check_doc_slugs.py` and `check_readme_links.py --ci` grade link
targets and heading anchors only, cover neither of these roots, and neither looks inside a fenced
code block. The lanes below prove the edits broke nothing; they say nothing about whether the
sentences are true. Each claim was checked against the source named above.

A three-pass census (line-oriented / whitespace-collapsed / comment-markers-stripped-then-
collapsed) was run over the eight files, because a claim broken across lines carries a `;;` at the
break that survives a plain flatten. Line-oriented read 83 token-bearing lines; collapsed read 85.
The post-edit re-run of the same instrument reads **4 wrong-destination matches against 22 before
the edits**, and all four survivors were inspected individually: two are explicit pre-EP history,
two are negations ("no longer falls through to", "no leak to"). The instrument has no polarity
awareness, so each was read rather than counted.

## Quality gates

| gate | captured exit | result |
|---|---|---|
| `npm run test:cljs` (compile + run, from `implementation/`) | `0` | 1962 files, **0 warnings**; 11723 tests, 58640 assertions, **0 failures, 0 errors** |
| `clojure -M:test` in `tools/xray` (JVM lane) | `0` | 1280 tests, 6145 assertions, **0 failures, 0 errors** |
| `clojure -M:test -n day8.re-frame2-xray.frame-singleton-guard-test` | `0` | 6 tests, 11 assertions — positive control that the edited guard ns actually runs |
| all 46 `scripts/check_*.py` ratchets | `0` each | **46 pass / 0 fail** |

Both lanes above were run on the final rebased base. Every exit code was captured from the runner
itself and read back from a file, never taken from a harness summary — the first `test:cljs`
attempt is exactly why: the harness reported exit 0 while the captured code was **1** (a missing
`node_modules` junction in the worktree, since created and verified by effect).

The ratchet set was run by discovering `scripts/check_*.py` rather than from a hand-written list,
so no gate can be missed through an enumeration error. Three reject `--verbose`
(`check_allocation_non_claim`, `check_architecture_census`, `check_escaped_continuations`); each
was re-run with its own accepted flags and exited `0`.

**The compile lane was proved RED for this class of edit.** A malformed docstring was planted in
`runtime_cljs_test.cljs` (a file this PR edits) with an editor write rather than a shell heredoc;
the plant was confirmed applied by hash before the run. `compile-node-test.cjs` then exited **1**,
naming `re_frame/runtime_cljs_test.cljs`. The restore was verified by hash — `git hash-object`
reproduced the committed blob `b46732611b9f6c85fc480358a563d00af52d9641` and
`git diff --quiet HEAD` exited 0 — so the green above is a live gate, not an inert one.

**Browser lanes not run.** The diff is comments, docstrings and assertion message strings — no
runtime behaviour, no markup, no assertion. A browser lane has nothing to say about it, and CI
covers the full matrix on this PR.
