### PR TITLE
fix(xray): give Epoch and Machine Inspector per-mount inspector identities (rf2-3ymg)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -344,7 +344,33 @@
   Renders the numbered event-bundle — the focused epoch's complete
   computational timeline (DISPATCH → COEFFECTS → HANDLER → FLOW →
   FX → SUBSCRIPTIONS → VIEWS) with conditional rendering per the
-  trace stream."
+  trace stream.
+
+  `opts :instance-id` — OPTIONAL (rf2-3ymg). A non-blank string or a
+  keyword naming THIS mount, for the case where two standalone mounts
+  share one `:frame`. It qualifies the `:mount-id` of all THIRTEEN of this
+  panel's `edn-inspector` heads — the widget's lifecycle key is
+  `[frame-id mount-id]` and its measured-width slot is keyed by the bare
+  `mount-id`, so one qualifier moves both. Left unnamed, two Epoch panels
+  showing one focused epoch compose identical ids site for site
+  (the DISPATCH step's is a CONSTANT), share one store entry, one
+  ResizeObserver and one width slot per site, and detaching either
+  releases the survivor's.
+
+  It qualifies NOTHING ELSE, and that is deliberate: every one of the
+  thirteen sites passes a stable `:site-id`, so expansion and zoom are
+  keyed by that rather than by the mount-id and two panels of one epoch
+  still open and close together.
+
+  IT IS NOT WHAT SEPARATES THIS PANEL FROM A MACHINE INSPECTOR. The two
+  share one cascade renderer, and that collision is repaired statically
+  inside `machine-inspector/instance-token` rather than by asking a
+  caller to name mounts of two DIFFERENT panels apart — see there.
+
+  OMIT IT when only one Epoch panel is on screen in this frame, which is
+  every call site in this tree today: the ids are then byte-for-byte what
+  they were. `epoch-view/instance-token` refuses, loudly, the shapes that
+  could not be stable across renders."
   ([mount-point]      (mount-epoch-panel! mount-point nil))
   ;; rf2-k97c.3 — `Panel-bridge`, the name RULING 1's spelling has the
   ;; CALLER pass. Today it is a plain alias of the `reg-view` (the same
@@ -353,7 +379,13 @@
   ;; `panels/epoch/view.cljs` and THIS FILE IS NOT TOUCHED AGAIN. Moving
   ;; every remaining mount to its bridge name in one pass is what lets the
   ;; panel migrations run in parallel instead of queueing on this file.
-  ([mount-point opts] (render-panel! epoch-panel/Panel-bridge mount-point opts)))
+  ;; rf2-3ymg — and the props map is what carries `:instance-id` across that
+  ;; bridge; `Panel-bridge`'s 1-arity is the door, its 0-arity is what an
+  ;; unnamed mount still takes.
+  ([mount-point opts]
+   (render-panel! epoch-panel/Panel-bridge mount-point opts
+                  (when-let [id (:instance-id opts)]
+                    {:instance-id id}))))
 
 (defn mount-app-db-diff!
   "Mount Xray's App-DB tab in isolation at `mount-point`. Renders the
@@ -441,11 +473,35 @@
   The auxiliary inspectors (AfterRingsOverlay, ArcOverlay,
   ClusterView, ScrubberStrip, SimSideRail) render under this Panel
   — they are not independently mountable (see ns docstring §Internal
-  sub-components)."
+  sub-components).
+
+  `opts :instance-id` — OPTIONAL (rf2-3ymg), and this panel is the one
+  whose UNNAMED behaviour also changed. Element 2 renders through
+  `epoch-view/machine-cascade-mini-pipeline`, the SHARED renderer the
+  Epoch panel's HANDLER step uses (rf2-g2axio), so this panel composes
+  inspector `:mount-id`s in the EPOCH panel's id namespace. Mounted beside
+  an Epoch panel over one cascade, both emitted
+  `epoch/machine-cascade-transition-delta/<step>` for the same transition
+  and shared one lifecycle entry, one ResizeObserver and one width slot
+  across two DIFFERENT panels. `machine-inspector/instance-token` now
+  answers this panel's own name for an unnamed mount rather than nil, so
+  that pair is separate with NO caller action — which is right, because
+  which panel is rendering is statically known and an embedder mounting
+  one of each cannot see the collision to work around it.
+
+  Pass `:instance-id` for the case a caller CAN see: two standalone
+  MACHINE INSPECTORS sharing one `:frame`. The caller's token rides below
+  this panel's own (`machine-inspector/left`)."
   ([mount-point]      (mount-machine-inspector! mount-point nil))
   ;; rf2-k97c.3 — `Panel-bridge`; see `mount-epoch-panel!` above for why
   ;; the mount moves to the bridge name BEFORE the panel migrates.
-  ([mount-point opts] (render-panel! machine-inspector/Panel-bridge mount-point opts)))
+  ;; rf2-3ymg — the props map carries `:instance-id` across the bridge. The
+  ;; 0-arity door stays the unnamed one; `instance-token` is what makes
+  ;; that case non-nil here, NOT this line.
+  ([mount-point opts]
+   (render-panel! machine-inspector/Panel-bridge mount-point opts
+                  (when-let [id (:instance-id opts)]
+                    {:instance-id id}))))
 
 (defn mount-routing!
   "Mount Xray's Routing tab in isolation at `mount-point`. Renders

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2003,6 +2003,115 @@
       [:span {:style sub-header-trailing-style}
        trailing])]))
 
+;; ---- per-mount inspector identity (rf2-3ymg) -----------------------------
+;;
+;; THE THIRTEEN `ei/edn-inspector-view` HEADS BELOW EACH COMPOSE A
+;; `:mount-id` FROM A LOGICAL SITE, AND A LOGICAL SITE CANNOT NAME A LIVE
+;; MOUNT. `"epoch/dispatch-event"` is a CONSTANT; the machine cascade's
+;; three are a role plus a step ordinal. Those separate the roles WITHIN one
+;; panel, which is the question rf2-k97c.3 was answering, and they are
+;; silent on a different one: which of two panels on screen is this?
+;;
+;; It matters because that string is physical. The widget keys its per-mount
+;; store by `[frame-id mount-id]` (`ei/lifecycle-key`), `container-ref-for`
+;; MEMOISES the ref callback on that key and installs a ResizeObserver only
+;; when the entry has none, and `release-mount!` disconnects the entry and
+;; clears the measured-width slot — keyed by the BARE mount-id — when EITHER
+;; holder detaches. So two mounts sharing one id do not merely look alike:
+;; the second installs no observer at all, and the first one to go takes the
+;; survivor's observer and width with it, leaving a live panel on screen
+;; unobserved and unmeasured. Measured on real two-container commits before
+;; the repair, in `panels/epoch_machine_mount_instance_id_dom_cljs_test`.
+;;
+;; TWO COLLISIONS, AND THEY ARE FIXED BY DIFFERENT MEANS — which is the
+;; shape finding here rather than a copy of the Trace landing's.
+;;
+;;   * TWO EPOCH PANELS in one frame. Nothing inside the panel can tell two
+;;     mounts of ITSELF apart — a Fresco boundary is a React function
+;;     component with no per-instance storage its body may use, so there is
+;;     no id for it to mint. The CALLER names them, through the optional
+;;     `:instance-id` that `app-db-diff`, `managed-fx` and `trace` already
+;;     take. Unnamed — every call site in this tree today — every id is
+;;     byte-for-byte what it was.
+;;
+;;   * AN EPOCH PANEL AND A MACHINE INSPECTOR. This one is sharper and it is
+;;     NOT the caller's to fix. The two panels render one cascade through
+;;     ONE [[machine-cascade-mini-pipeline]], off one
+;;     `projection/machine-cascade-rows` — which is rf2-g2axio's whole point,
+;;     and is why both emitted `epoch/machine-cascade-transition-delta/1` for
+;;     the same transition. WHICH PANEL IS RENDERING IS STATICALLY KNOWN, so
+;;     requiring a caller to work around it would be asking them to repair a
+;;     shared helper's id namespace by hand — and a caller embedding one of
+;;     each cannot see the collision to work around it. The Machine
+;;     Inspector is the GUEST in this file's id namespace, so ITS normaliser
+;;     (`machine-inspector/instance-token`) never answers nil: it names
+;;     itself, and a caller's `:instance-id` qualifies further on top.
+;;
+;; ONE QUALIFIER EITHER WAY, AND IT MOVES THE `:mount-id` ALONE. All
+;; thirteen sites pass a stable `:site-id` beside it, and the widget's
+;; `effective-id` is `(or site-id mount-id)` — so expansion and zoom are
+;; keyed `[panel-id site-id path]` and DO NOT READ THE MOUNT-ID AT ALL. The
+;; logical disclosure identity is therefore already separate from the
+;; physical one: qualifying the mount-id moves exactly the lifecycle key and
+;; the width slot, and leaves expansion, zoom, every step's own testids and
+;; the React keys byte-for-byte. Two Epoch panels of one epoch still open
+;; and close together ON PURPOSE, and so do an Epoch panel and a Machine
+;; Inspector over the cascade they share; what they no longer share is a
+;; ResizeObserver and a width. A row pins that bound, so a repair that
+;; qualified the `:site-id` too goes red rather than passing.
+;;
+;; The value is threaded as an ordinary argument — through `ctx` where the
+;; panel already has one, and as a trailing parameter on the helpers below
+;; it. NOT a dynamic var: `machine-cascade-view` and the violation / error
+;; blocks build their children inside `for` and `map-indexed`, whose lazy
+;; seqs are realised by the renderer AFTER the boundary body has returned
+;; and any `binding` has popped, so an ambient value would read nil for
+;; exactly the rows that carry the most inspectors.
+
+(defn instance-token
+  "Normalise [[Panel]]'s optional `:instance-id` prop to the string that
+  qualifies one mount's inspector `:mount-id`s, or nil when the caller named
+  no instance — the single-mount default, which composes every id
+  byte-for-byte as it did before rf2-3ymg.
+
+  A KEYWORD is accepted alongside a string, and its NAMESPACE is part of the
+  name: `:left/epoch` tokenises to `left/epoch`. `(subs (str id) 1)` is what
+  preserves it; `cljs.core/name` would drop it and restore the very
+  collision this removes, which is rf2-4bsq's landed repair one level up —
+  see [[Panel-bridge]], which tokenises BEFORE the Reagent crossing for
+  exactly that reason.
+
+  It is this panel's own normaliser rather than a call into a sibling's: the
+  panels are independent surfaces, they migrate on their own schedules, and
+  the refusal has to name the caller's OWN panel to be worth reading."
+  [instance-id]
+  (cond
+    (nil? instance-id)     nil
+    (keyword? instance-id) (subs (str instance-id) 1)
+    (string? instance-id)  (when (seq instance-id) instance-id)
+    :else
+    (throw (ex-info
+             (str "The Epoch panel's :instance-id must be a non-blank string "
+                  "or a keyword naming this mount, or omitted. Got: "
+                  (pr-str instance-id))
+             {:rf.xray/instance-id instance-id}))))
+
+(defn- inspector-mount-id
+  "Compose one `ei/edn-inspector-view` `:mount-id` — the panel's own logical
+  `site` id, qualified by `instance` when this mount was named.
+
+  The instance is the OUTERMOST segment (`left/epoch/dispatch-event`) rather
+  than a suffix, because it answers a different question from everything to
+  its right: the tail says WHICH SITE, the head says WHICH MOUNT OF THE
+  PANEL. `machine-inspector/epoch/machine-cascade-transition-delta/1` then
+  reads as exactly what it is — the Machine Inspector's copy of a row the
+  Epoch panel's cascade renderer composed.
+
+  Unnamed, this is `identity` on the site id, which is what keeps every
+  existing single-mount call site byte-for-byte."
+  [instance site]
+  (if instance (str instance "/" site) site))
+
 ;; ---- DISPATCH step -------------------------------------------------------
 
 ;; rf2-akvfe — `machine-dispatch?` + `machine-event-gloss-line` RETIRED with
@@ -2028,12 +2137,12 @@
   fix the body was plain text — the operator saw the dispatch event
   styled DIFFERENTLY in the Event panel (inspector-styled) vs the
   Epoch panel (plain) for the same value."
-  [{:keys [event]}]
+  [{:keys [event]} instance]
   (when (vector? event)
     [:div {:data-testid "rf-xray-epoch-dispatch-event"}
      [:div {:style dispatch-body-style}
       [ei/edn-inspector-view
-       {:mount-id "epoch/dispatch-event"
+       {:mount-id (inspector-mount-id instance "epoch/dispatch-event")
         :value    event
         :opts     {:site-id "epoch-dispatch-event"
                    :card?   false
@@ -2329,10 +2438,18 @@
   click-to-navigate `:rf.xray/focus-epoch` button). When omitted
   (direct test calls of the renderer) the parent-epoch chip falls
   back to the unresolved variant. The index is built once per panel
-  render in `Panel` and threaded down via `ctx`."
-  ([step] (render-dispatch-step step nil))
+  render in `Panel` and threaded down via `ctx`.
+
+  `instance` (rf2-3ymg) is the mount qualifier [[Panel]] tokenised out of
+  its `:instance-id` prop, or nil for the single-mount default. It reaches
+  the DISPATCH step's own inspector, whose `:mount-id` is otherwise the
+  CONSTANT `\"epoch/dispatch-event\"` — the sharpest of the thirteen, since
+  two mounts of this panel collide on it even with no data in common. See
+  the §per-mount inspector identity commentary above [[dispatch-body]]."
+  ([step] (render-dispatch-step step nil nil))
+  ([step dispatch-id->epoch-id] (render-dispatch-step step dispatch-id->epoch-id nil))
   ([{:keys [source coord duration-ms step-number violations] :as step}
-    dispatch-id->epoch-id]
+    dispatch-id->epoch-id instance]
    [:div {:data-testid "rf-xray-epoch-step-dispatch"
           :data-step-kw "dispatch"
           :data-source (when source (name source))}
@@ -2356,9 +2473,9 @@
        :testid "rf-xray-epoch-dispatch"
        :duration-ms duration-ms}
       nil)
-    (dispatch-body step)
+    (dispatch-body step instance)
     ;; rf2-xgeag — `:event` boundary violations attach to DISPATCH.
-    (violation-blocks :dispatch violations)]))
+    (violation-blocks :dispatch violations instance)]))
 
 ;; ---- COEFFECT step -------------------------------------------------------
 
@@ -2373,7 +2490,8 @@
   injecting N user-defined cofx; system-injected cofx (e.g.
   framework-auto `:db`, `:event`) are filtered at projection time
   (rf2-cq0ch + the `system-cofx-ids` set)."
-  [{:keys [id value input no-value? step-number violations errors]}]
+  ([step] (render-coeffect-step step nil))
+  ([{:keys [id value input no-value? step-number violations errors]} instance]
   (let [cofx-meta  (when (keyword? id)
                      (try (rf/handler-meta {:source :store :kind :cofx :id id})
                           (catch :default _ nil)))
@@ -2436,10 +2554,10 @@
      ;; rf2-yz57h — a coeffect-injection EXCEPTION attaches here as the
      ;; shared inline 'Exception Thrown' card (button-19), under the
      ;; COEFFECT step where it occurred (no longer collapsed onto HANDLER).
-     (error-blocks :coeffect errors)
+     (error-blocks :coeffect errors instance)
      ;; rf2-xgeag — `:cofx` boundary violations attach to the matching
      ;; COEFFECT step by cofx-id.
-     (violation-blocks :coeffect violations)]))
+     (violation-blocks :coeffect violations instance)])))
 
 ;; ---- RECORDABLE COEFFECTS step (rf2-9fyn40 · EP-0010 · EP-0017 §9) -------
 
@@ -3208,7 +3326,7 @@
   `:state` nor `:tags` changed (`machine-logical-state-changed?`) — the
   box would otherwise show a no-op diff. Returns nil in that case so the
   caller renders no source slot at all for the row."
-  [{:keys [step before after] :as _row}]
+  [{:keys [step before after] :as _row} instance]
   (when (proj/machine-logical-state-changed? before after)
     (let [before-ls (proj/machine-logical-state before)
           after-ls  (proj/machine-logical-state after)]
@@ -3216,7 +3334,9 @@
              :style cascade-row-source-style}
        [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-delta-" step)}
         [ei/edn-inspector-view
-         {:mount-id (str "epoch/machine-cascade-transition-delta/" step)
+         {:mount-id (inspector-mount-id
+                      instance
+                      (str "epoch/machine-cascade-transition-delta/" step))
           :value    after-ls
           :opts     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-transition-delta step]
                              :card?                  false
@@ -3290,13 +3410,15 @@
   Returns nil when the machine carries no `:data` (a data-less machine) so
   the caller renders no body slot — the `[START]` pill + `started in {state}`
   verb already tell the birth story."
-  [{:keys [step data]}]
+  [{:keys [step data]} instance]
   (when (some? data)
     [:div {:data-testid (str "rf-xray-epoch-machine-cascade-source-" step)
            :style cascade-row-source-style}
      [:div {:data-testid (str "rf-xray-epoch-machine-cascade-start-data-" step)}
       [ei/edn-inspector-view
-       {:mount-id (str "epoch/machine-cascade-start-data/" step)
+       {:mount-id (inspector-mount-id
+                    instance
+                    (str "epoch/machine-cascade-start-data/" step))
         :value    data
         :opts     {:site-id                [:rf.xray.epoch/machine-cascade-start-data step]
                    :card?                  false
@@ -3330,12 +3452,12 @@
   tokens with the same per-token palette as the Figma authority's
   `.syntax-*` classes, so the cascade code body matches the HANDLER
   step's source body."
-  [machine-meta row source-form]
+  [machine-meta row source-form instance]
   (cond
     ;; rf2-it4vt — the `[START]` row's body is the machine's INITIAL :data
     ;; (the initial logical :state rides the header verb).
     (= :start (:kind row))
-    (cascade-row-start-body row)
+    (cascade-row-start-body row instance)
 
     ;; rf2-iwy0c part A — transition rows show the logical-state delta,
     ;; NOT the transition map literal. Self/internal transitions (no
@@ -3356,7 +3478,7 @@
     ;; banner stay — neither was part of the removed block (the banner is the
     ;; restore/record headline; the delta box is the {:state :tags} summary).
     (= :transition (:kind row))
-    (let [delta   (cascade-row-transition-delta row)
+    (let [delta   (cascade-row-transition-delta row instance)
           history (structured-cascade-history-banner row)]
       (when (or delta history)
         [:div {:data-testid (str "rf-xray-epoch-machine-cascade-transition-body-"
@@ -3395,7 +3517,7 @@
   captured (`:data-before` absent — e.g. a fixture trace) the inspector
   mounts in browse mode (no `:before`), still surfacing the written
   value."
-  [{:keys [data-write data-before step] :as _row}]
+  [{:keys [data-write data-before step] :as _row} instance]
   ;; rf2-32kyr — the redundant "data Δ" CAPTION text is dropped; the row reads
   ;; `<arrow> <edn-inspector value>` (just the light-grey arrow into the delta
   ;; value, no label). The arrow + the inspector value are otherwise unchanged.
@@ -3404,7 +3526,9 @@
    [:span {:style cascade-detail-data-arrow-style} "↳"]
    [:span {:style cascade-detail-value-style}
     [ei/edn-inspector-view
-     {:mount-id (str "epoch/machine-cascade-data/" step)
+     {:mount-id (inspector-mount-id
+                   instance
+                   (str "epoch/machine-cascade-data/" step))
       :value    data-write
       :opts     (cond-> {:site-id                [:rf.xray.epoch/machine-cascade-data step]
                          :card?                  false
@@ -3432,7 +3556,7 @@
 
   Each slot elides cleanly when the underlying data is absent so the
   row stays minimal for actions that ran without side-effects."
-  [row]
+  [row instance]
   (let [{:keys [data-write fx]} row]
     (when (or (some? data-write) (seq fx))
       [:div {:data-testid (str "rf-xray-epoch-machine-cascade-outcome-"
@@ -3443,7 +3567,7 @@
        ;; the cascade row tells the operator 'this action changed X
        ;; from A to B' inline (rf2-5hjb5).
        (when (some? data-write)
-         (cascade-row-action-data-diff row))
+         (cascade-row-action-data-diff row instance))
        ;; Per-action FX attribution — each fx-id the action emitted
        ;; in its outcome's `:fx` slot. The view layer already
        ;; surfaces these via the FX step's `:attributed-to` chip;
@@ -3504,7 +3628,7 @@
   guard/action's `file:line`), so the box itself does not re-render a coord
   line — matching the outer card, which dropped its redundant jump-to-source
   link in rf2-wnvid for the same reason."
-  [{:keys [kind threw? outcome exception step] :as row}]
+  [{:keys [kind threw? outcome exception step] :as row} instance]
   (let [threw? (or (true? threw?)
                    (= :threw outcome)
                    (= :rf.error/action-threw outcome))]
@@ -3527,7 +3651,7 @@
          ;; Collapsible stack + ex-data — the SAME disclosure the outer card
          ;; uses (`error-block-details`), so the `ex-data` / source depth
          ;; reads one click away exactly as on a handler throw.
-         (error-block-details testid-base {:exception exception})]))))
+         (error-block-details testid-base {:exception exception} instance)]))))
 
 ;; rf2-ge6uj ISSUE 3 — the transition zone is collapsed to ONE prominent
 ;; row. The TRANSITION row's header carries `[#step] [TRANSITION badge]
@@ -3566,7 +3690,7 @@
   `[START]` pill + `started in {state}` verb + a CAUSE tag chip
   (`explicit` / `lazy` / `spawned`) + the initial-`:data` body box, with
   NO source-link (a birth has no spec call-site) and NO outcome chip."
-  [machine-meta row]
+  [machine-meta row instance]
   (let [{:keys [kind step phase duration-ms outcome threw? cause]} row
         coord       (cascade-row-coord machine-meta row)
         source-form (cascade-row-source-form machine-meta row)
@@ -3675,20 +3799,20 @@
      ;; render their source (or the rf2-iwy0c machine-def link when none
      ;; was captured); the `:transition` row renders the rf2-iwy0c
      ;; logical-state DELTA box (`{:state :tags}` before → after).
-     (cascade-row-source-body machine-meta row source-form)
+     (cascade-row-source-body machine-meta row source-form instance)
      ;; rf2-2hj0h item 8 — when a GUARD or ACTION THREW, render the EXCEPTION
      ;; BOX directly below the step's code, modeled on the OUTER pipeline's
      ;; inline exception card (`error-block`): ✗ 'Exception Thrown' title +
      ;; verbatim message + collapsible stack / ex-data. This is the row's
      ;; failure outcome display (paired with item 7: success = clean, no
      ;; tick; failure = exception box). A clean row renders nothing here.
-     (cascade-row-exception-box row)
+     (cascade-row-exception-box row instance)
      ;; Per-row outcome details — kind-specific. rf2-ge6uj ISSUE 3 — the
      ;; `:transition` row carries NO extra detail body: the prominent
      ;; header verb (`<before> → <after>`) is the focal point and the
      ;; prior repetitive `state … / event …` lines are gone.
      (case kind
-       :action     (cascade-row-action-outcome-details row)
+       :action     (cascade-row-action-outcome-details row instance)
        nil)]))
 
 (defn- machine-cascade-view
@@ -3715,7 +3839,7 @@
   numbered ordinal chips alone carry the pipeline reading. The per-row
   `position: relative` rail-anchor wrapper is gone with the rail, so each
   row renders directly (no wrapper div)."
-  [machine-meta cascade-rows]
+  [machine-meta cascade-rows instance]
   (let [n (count cascade-rows)]
     [:div {:data-testid "rf-xray-epoch-handler-machine-cascade"
            :data-cascade-row-count (str n)
@@ -3740,7 +3864,7 @@
              ;; Clojure metadata nowhere). `machine-cascade-rows-reach-react-
              ;; with-distinct-keys` in the view test grades it at the renderer.
              (for [row cascade-rows]
-               (cascade-row-view machine-meta row))))]))
+               (cascade-row-view machine-meta row instance))))]))
 
 (defn- event-handler-orientation-line
   "Render the EVENT HANDLER orientation line (rf2-akvfe) — ONE structured
@@ -3811,8 +3935,38 @@
   `rf-xray-epoch-handler-machine` host the Epoch panel always rendered,
   so every cascade-row testid (`rf-xray-epoch-machine-cascade-row-N`,
   `-ordinal-N`, `-kind-*`, `-phase-*`, `-verb-link-N`, `-source-body-N`,
-  `-outcome-N`, `-data-write-N`, …) is identical on both surfaces."
-  [cascade event-id]
+  `-outcome-N`, `-data-write-N`, …) is identical on both surfaces.
+
+  ## `instance` — WHO IS RENDERING THIS CASCADE (rf2-3ymg)
+
+  Being consumed by two panels is what made this fn's inspector mount-ids
+  collide ACROSS them: both surfaces composed
+  `epoch/machine-cascade-transition-delta/<step>` for the same transition,
+  so they shared one lifecycle entry, one ResizeObserver and one
+  measured-width slot, and detaching either released the other's. Measured
+  on a real Epoch-plus-Machine-Inspector commit, with NEITHER caller
+  naming anything, in
+  `panels/epoch_machine_mount_instance_id_dom_cljs_test`.
+
+  The shared testids above are NOT affected and must not be: they are the
+  cascade ROW's identity, the thing the extraction promised would stay
+  identical on both surfaces. What `instance` qualifies is the inspector's
+  PHYSICAL identity — the `:mount-id` alone, which the widget keys its
+  per-mount store and its width slot by, and which its `effective-id`
+  ignores in favour of the `:site-id` each site also passes. So expansion
+  and zoom still track together across the two panels, deliberately.
+
+  Each CALLER supplies its own, and they answer differently because the
+  question differs. The Epoch panel passes [[instance-token]]'s value —
+  nil unless the embedder named that mount, which keeps every id
+  byte-for-byte. The Machine Inspector passes
+  `machine-inspector/instance-token`'s, which NEVER answers nil: it is a
+  guest in this file's id namespace, which panel is rendering is
+  statically known, and a caller embedding one of each cannot see the
+  collision to work around it. See §per-mount inspector identity above
+  [[dispatch-body]]."
+  ([cascade event-id] (machine-cascade-mini-pipeline cascade event-id nil))
+  ([cascade event-id instance]
   ;; rf2-ge6uj ISSUE 2 — read the registration meta under the `:event`
   ;; kind, NOT a (non-existent) `:machine` kind. A machine is registered
   ;; as an `:event` handler carrying `:rf/machine? true` + the stamped spec
@@ -3830,7 +3984,7 @@
      ;; section (what trigger, which machine, what starting state), then the
      ;; numbered cascade pipeline below.
      (event-handler-orientation-line cascade event-id)
-     (machine-cascade-view machine-meta cascade)]))
+     (machine-cascade-view machine-meta cascade instance)])))
 
 (defn- machine-block
   "Render the machine-handler section as a SINGLE TIME-ORDERED CASCADE
@@ -3845,8 +3999,8 @@
   category-grouped sub-sections (TRANSITION / GUARDS / LIFECYCLE /
   AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF / FX) are REPLACED, not
   augmented (per Mike: 'pre-alpha; no back-compat shim')."
-  [{:keys [cascade] :as _machine-row} event-id]
-  (machine-cascade-mini-pipeline (or cascade []) event-id))
+  [{:keys [cascade] :as _machine-row} event-id instance]
+  (machine-cascade-mini-pipeline (or cascade []) event-id instance))
 
 ;; ---- handler source --------------------------------------------------
 ;;
@@ -4036,7 +4190,7 @@
   lane is the right place to test. Every migrated panel in this tree made
   the same call. `nil` renders as `db-before` absent, which is what a
   direct caller passing no `ctx` means."
-  [db-post-handler db-write? record]
+  [db-post-handler db-write? record instance]
   (let [db-before (:db-before record)
         ;; rf2-4wywy — t1 (post-handler, pre-flow) is the authoritative
         ;; HANDLER `:db`; fall back to the record's post-flow `:db-after`
@@ -4067,7 +4221,9 @@
        [:div {:data-testid "rf-xray-epoch-handler-db-full-with-diff"
               :style handler-db-all-style}
         [ei/edn-inspector-view
-         {:mount-id (str "epoch/handler-db-full-with-diff/" (:epoch-id record))
+         {:mount-id (inspector-mount-id
+                      instance
+                      (str "epoch/handler-db-full-with-diff/" (:epoch-id record)))
           :value    db-after
           :opts     {:site-id [:rf.xray.epoch/handler-db-full-with-diff (:epoch-id record)]
                      :before db-before
@@ -4130,7 +4286,7 @@
      ;; Machine cascade BEFORE db diff (the cascade IS the story for
      ;; machines — rf2-u69j7 redesign).
      (when machine
-       (machine-block machine event-id))
+       (machine-block machine event-id (:instance ctx)))
      ;; :db diff — always present for non-machine handlers (rf2-93436);
      ;; folded into SNAPSHOT DIFF for machines. rf2-4wywy — the
      ;; post-handler (t1) db is threaded so the diff shows ONLY the
@@ -4141,7 +4297,8 @@
      ;; stays present for a clean handler that simply returned no `:db`.
      (when (and (not machine?) (not threw?))
        (handler-db-diff-block db-post-handler db-write?
-                              (:selected-epoch-record ctx)))
+                              (:selected-epoch-record ctx)
+                              (:instance ctx)))
      ;; :fx — the canonical vector-of-vectors, FULL via edn-inspector.
      ;; rf2-5t8y8 — sub-header carries a trailing entry-count chip ("N
      ;; entr{y,ies}") that the edn-inspector vector-header chrome alone
@@ -4151,7 +4308,9 @@
          [:div {:data-testid "rf-xray-epoch-handler-fx"}
           (sub-header ":fx" (str n " entr" (if (= 1 n) "y" "ies")))
           [ei/edn-inspector-view
-           {:mount-id (str "epoch/handler-fx/" event-id)
+           {:mount-id (inspector-mount-id
+                        (:instance ctx)
+                        (str "epoch/handler-fx/" event-id))
             :value    fx-vec
             :opts     {:site-id                [:rf.xray.epoch/handler-fx event-id]
                        :card?                  false
@@ -4164,7 +4323,9 @@
          [:div {:data-testid "rf-xray-epoch-handler-other"}
           (sub-header "other" (str n " entr" (if (= 1 n) "y" "ies")))
           [ei/edn-inspector-view
-           {:mount-id (str "epoch/handler-other/" event-id)
+           {:mount-id (inspector-mount-id
+                        (:instance ctx)
+                        (str "epoch/handler-other/" event-id))
             :value    other-effects
             :opts     {:site-id                [:rf.xray.epoch/handler-other event-id]
                        :card?                  false
@@ -4223,8 +4384,8 @@
      ;; it. (Coeffect / interceptor exceptions now land under their OWN
      ;; steps per rf2-yz57h, so this slot carries only genuine handler
      ;; throws.)
-     (error-blocks :handler errors)
-     (violation-blocks :handler violations)])))
+     (error-blocks :handler errors (:instance ctx))
+     (violation-blocks :handler violations (:instance ctx))])))
 
 ;; ---- FLOW step -----------------------------------------------------------
 
@@ -4262,8 +4423,9 @@
   Graceful fallback: when the projection carried no pre/post snapshots
   (a pre-rf2-ta0y7 runtime, or neither t1 nor t2 on the stream) the
   body falls back to the per-path `[path] before → after` scalar line."
-  [{:keys [flow-id frame path before after duration-ms step-number
-           db-pre-flow db-post-flow errors]}]
+  ([step] (render-flow-step step nil))
+  ([{:keys [flow-id frame path before after duration-ms step-number
+            db-pre-flow db-post-flow errors]} instance]
   (let [;; rf2-20359j — flows are FRAME-DIVERGENT-per-id (Spec 013), so the
         ;; source-coord lookup reads the per-frame `rf.flows/flow-meta`
         ;; (the `(handler-meta :flow id)` replacement after rf2-en00bk
@@ -4318,7 +4480,9 @@
               :style handler-db-all-style}
         (sub-header ":db" (fmt/path-display path))
         [ei/edn-inspector-view
-         {:mount-id (str "epoch/flow-db-diff/" flow-id)
+         {:mount-id (inspector-mount-id
+                      instance
+                      (str "epoch/flow-db-diff/" flow-id))
           :value    diff-after
           :opts     {:site-id [:rf.xray.epoch/flow-db-diff flow-id]
                      :before  diff-before
@@ -4341,7 +4505,7 @@
             [:span {:style coeffect-body-value-style} (ei/mini after 30)])]))
      ;; rf2-ahhgn — a flow-eval exception (the flow's compute fn threw,
      ;; aborting the cascade pre-commit) attaches here as an inline card.
-     (error-blocks :flow errors)]))
+     (error-blocks :flow errors instance)])))
 
 ;; ---- SIDE EFFECTS step (rf2-kt6js — the pre-rf2-kt6js FX step) ----------
 
@@ -4415,7 +4579,7 @@
   cleanly when no coord was captured (framework-shipped fx with no
   user source, production builds without coords; the synthesised `:db`
   row has no reg-site)."
-  [idx {:keys [fx-id status args value duration-ms attributed-to]}]
+  [idx {:keys [fx-id status args value duration-ms attributed-to]} instance]
   (let [db-row?  (= :db fx-id)
         skipped? (= :skipped status)
         noop?    (= :noop status)
@@ -4455,7 +4619,9 @@
        db-row?         (db-destination-marker idx)
        (some? payload) [:span {:style fx-row-args-style}
                         [ei/edn-inspector-view
-                         {:mount-id (str "epoch/fx-row-args/" fx-id "/" idx)
+                         {:mount-id (inspector-mount-id
+                                        instance
+                                        (str "epoch/fx-row-args/" fx-id "/" idx))
                           :value    payload
                           :opts     {:site-id [:rf.xray.epoch/fx-row-args fx-id idx]
                                      :card? false
@@ -4483,12 +4649,12 @@
   (exception) resolved the `:failing-id` against an `fx-id` in the FX
   step's `:rows`. A throwing fx (button-18) surfaces its message + coord
   inline on its own row."
-  [idx row]
+  [idx row instance]
   [:div {:key (str "fx-row-" idx)
          :data-testid (str "rf-xray-epoch-fx-row-wrapper-" idx)}
-   (fx-row-view idx row)
-   (error-blocks (keyword (str "fx-row-" idx)) (:errors row))
-   (violation-blocks (keyword (str "fx-row-" idx)) (:violations row))])
+   (fx-row-view idx row instance)
+   (error-blocks (keyword (str "fx-row-" idx)) (:errors row) instance)
+   (violation-blocks (keyword (str "fx-row-" idx)) (:violations row) instance)])
 
 ;; ---- SIDE EFFECTS flat ledger (rf2-j630b — supersedes kt6js 3-tier) -----
 
@@ -4526,7 +4692,8 @@
   that didn't match a row attach to the step level (rf2-xgeag /
   rf2-ahhgn) and render at the foot. `:db` schema-fail (pre-commit) →
   just the `:db` CROSS row, no fx rows (atomicity)."
-  [{:keys [rows step-number threw violations errors] :as step}]
+  ([step] (render-side-effects-step step nil))
+  ([{:keys [rows step-number threw violations errors] :as step} instance]
   (let [skipped? (= :skipped (proj/step-status step))]
     [:div {:data-testid "rf-xray-epoch-step-side-effects"
            :data-step-kw "side-effects"
@@ -4542,11 +4709,11 @@
        ;; rf2-yz57h — side effects never ran (upstream `:before`-chain throw).
        (skipped-body "rf-xray-epoch-side-effects" "Side effects")
        [:div {:style margin-top-5-style}
-        (map-indexed (fn [i row] (fx-row-with-violations i row)) rows)])
+        (map-indexed (fn [i row] (fx-row-with-violations i row instance)) rows)])
      ;; rf2-ahhgn — fx exceptions that didn't match a row (no-such-fx,
      ;; or an fx-id absent from `:rows`) attach to the step level.
-     (error-blocks :side-effects errors)
-     (violation-blocks :side-effects violations)]))
+     (error-blocks :side-effects errors instance)
+     (violation-blocks :side-effects violations instance)])))
 
 ;; ---- SUBSCRIPTIONS step --------------------------------------------------
 
@@ -4651,7 +4818,7 @@
   the value on unchanged rows is fine. Leaf-scalar → `ei/mini`;
   container → a plain `ei/edn-inspector` mount (no `:before`, no
   `:added?` — no diff signal)."
-  [{:keys [sub-id changed? first-run? before after]} idx]
+  [{:keys [sub-id changed? first-run? before after]} idx instance]
   ;; rf2-fyd8u — leaf-scalar branch: paint the change signal at this
   ;; row level (the inspector has no leaf-scalar annotation surface).
   ;; Containers fall through to the inspector mount. Testid naming
@@ -4703,7 +4870,9 @@
     ;; diff opts (rf2-o77z4).
     [:div {:style subs-value-cell-fill-style}
      [ei/edn-inspector-view
-      {:mount-id (str "epoch/subs-value/" sub-id "/" idx)
+      {:mount-id (inspector-mount-id
+                                      instance
+                                      (str "epoch/subs-value/" sub-id "/" idx))
        :value    after
        :opts     (cond-> {:panel-id :rf.xray.epoch/subs-value
                           :site-id  [:rf.xray.epoch/subs-value sub-id idx :full+diff]
@@ -4789,7 +4958,7 @@
   per-row violation sub-block renders INLINE via the resizable-table's
   `:row-extras` slot — directly below the row, before the next row
   begins. Parity with the sibling FX step's `fx-row-with-violations`."
-  [rows]
+  [rows instance]
   (let [columns [{:id :sub    :label "sub"    :default-flex "1fr"}
                  {:id :inputs :label "inputs" :default-flex "1fr"}
                  {:id :value  :label "value"  :default-flex "1fr"}]]
@@ -4885,7 +5054,7 @@
          ;; value cell
          [:div {:data-rf-xray-resizable-col "value"
                 :style subs-cell-changed-style}
-          (subs-value-cell row i)]])
+          (subs-value-cell row i instance)]])
       ;; rf2-zuh3p — per-row violations attach inline as `:row-extras`
       ;; so the schema-violation sub-block renders directly below its
       ;; owning row (mirrors the FX step's `fx-row-with-violations`
@@ -5041,7 +5210,7 @@
         :testid "rf-xray-epoch-subscriptions"}
        nil)
      (when (pos? n)
-       (subscriptions-table visible-rows))
+       (subscriptions-table visible-rows (:instance ctx)))
      (when (pos? l)
        (disposed-subs-table disposed-rows))
      ;; rf2-xgeag · rf2-zuh3p — `:sub-return` boundary violations.
@@ -5135,7 +5304,7 @@
   A no-arg render (`render-args` absent) reads `(no args)` — italic
   muted, parity with the col-3 `(none)` subs placeholder. Unmounted
   rows carry no `:render-args` so they read `(no args)` too."
-  [{:keys [view-id render-args prev-render-args]} idx]
+  [{:keys [view-id render-args prev-render-args]} idx instance]
   ;; rf2-yi0nr — size-guard the args (and the prev-args the diff annotates
   ;; against) so a fat prop collapses to the shared `:rf.size/large-elided`
   ;; chip rather than dumping the whole value inline.
@@ -5147,7 +5316,9 @@
       [:div {:style                  views-render-args-fill-style
              :data-rf-render-args-diff (if (some? prev-render-args) "diff" "plain")}
        [ei/edn-inspector-view
-        {:mount-id (str "epoch/view-render-args/" view-id "/" idx)
+        {:mount-id (inspector-mount-id
+                                        instance
+                                        (str "epoch/view-render-args/" view-id "/" idx))
          :value    render-args
          :opts     (cond-> {:panel-id :rf.xray.epoch/view-render-args
                             :site-id  [:rf.xray.epoch/view-render-args view-id idx]
@@ -5223,7 +5394,7 @@
   rf2-jnxfj — mounts through the shared `rt/resizable-table` so
   column widths are user-draggable + persist across reloads via
   the `:rf.xray.epoch/views` table-id slot."
-  [rows]
+  [rows instance]
   (let [columns [{:id :view :label "view" :default-flex "1fr"}
                  ;; rf2-u3lii — col-2 render-args DIFF, between view + subs.
                  {:id :render-args :label "render-args" :default-flex "1fr"}
@@ -5274,7 +5445,7 @@
                                   (str "rf-xray-epoch-view-row-coord-" i))]]
          ;; col-2 render-args DIFF (rf2-u3lii) — this render's args vs
          ;; the SAME instance's previous render (edn-inspector :before).
-         (views-render-args-cell row i)
+         (views-render-args-cell row i instance)
          ;; subs cell — colour-coded per-sub (green/orange/grey).
          (views-subs-cell subs-read sub-status i)])}]))
 
@@ -5289,7 +5460,8 @@
   when both halves are non-empty; collapses to one half when the other
   is absent. `:unmounted-count` (projection) carries M; N is the
   rendered remainder."
-  [{:keys [rows unmounted-count step-number]}]
+  ([step] (render-views-step step nil))
+  ([{:keys [rows unmounted-count step-number]} instance]
   (let [total (count rows)
         m     (or unmounted-count 0)
         n     (- total m)
@@ -5311,7 +5483,7 @@
         :testid "rf-xray-epoch-views"}
        nil)
      (when (pos? total)
-       (views-table rows))]))
+       (views-table rows instance))])))
 
 ;; ---- SCHEMA VIOLATION sub-block (rf2-xgeag) -----------------------------
 ;;
@@ -5442,9 +5614,11 @@
   Previously-discrete fields (headline `where · failing-id`, path,
   value, separate handler + schema 'open' buttons) all retired —
   subsumed by the prose + humanized explain."
-  [step-key idx {:keys [where failing-id path rollback? recovery frame
-                        explain explain-humanized kind sensitive? decoded]
-                 :as   _row}]
+  ([step-key idx row] (violation-block step-key idx row nil))
+  ([step-key idx {:keys [where failing-id path rollback? recovery frame
+                         explain explain-humanized kind sensitive? decoded]
+                  :as   _row}
+    instance]
   (let [recovery-label  (violation-recovery-label where rollback? recovery)
         ;; The schema source-coord resolution varies by :where. For
         ;; `:app-db`, the schema is registered at a PATH (not
@@ -5536,7 +5710,9 @@
        [:div {:data-testid (str testid-base "-explain")
               :style schema-violation-explain-body-style}
         [ei/edn-inspector-view
-         {:mount-id (str "epoch/violation-explain/" step-key "/" idx)
+         {:mount-id (inspector-mount-id
+                      instance
+                      (str "epoch/violation-explain/" step-key "/" idx))
           :value    humanized-shown
           :opts     {:site-id [:rf.xray.epoch/violation-explain step-key idx]
                      :default-expanded-depth 16}}]])
@@ -5545,17 +5721,18 @@
      ;; redacted at the substrate emit site (not a humanizer artifact).
      (when sensitive?
        [:div {:style schema-violation-sensitive-style}
-        "(value redacted — slot declared :sensitive?)"])]))
+        "(value redacted — slot declared :sensitive?)"])])))
 
 (defn violation-blocks
   "Render every violation in `violations` as a sub-block inside the
   current step's body. `step-key` is the owning step keyword (used
   for stable test ids). nil-safe."
-  [step-key violations]
-  (when (seq violations)
-    [:div {:data-testid (str "rf-xray-epoch-violations-" (name step-key))}
-     (map-indexed (fn [i v] (violation-block step-key i v))
-                  violations)]))
+  ([step-key violations] (violation-blocks step-key violations nil))
+  ([step-key violations instance]
+   (when (seq violations)
+     [:div {:data-testid (str "rf-xray-epoch-violations-" (name step-key))}
+      (map-indexed (fn [i v] (violation-block step-key i v instance))
+                   violations)])))
 
 ;; ---- inline EXCEPTION card (rf2-ahhgn) ----------------------------------
 
@@ -5617,7 +5794,7 @@
   link). The depth lives behind one click; the common read is the
   headline + message above. Returns nil when neither a stack nor
   ex-data is available (nothing to disclose)."
-  [testid-base {:keys [exception]}]
+  [testid-base {:keys [exception]} instance]
   (let [stack   (exception-stack exception)
         ex-data* (exception-ex-data exception)]
     (when (or stack (seq ex-data*))
@@ -5630,7 +5807,9 @@
          [:div {:data-testid (str testid-base "-ex-data")}
           [:div {:style error-block-data-label-style} "ex-data"]
           [ei/edn-inspector-view
-           {:mount-id (str "epoch/error-ex-data/" testid-base)
+           {:mount-id (inspector-mount-id
+                        instance
+                        (str "epoch/error-ex-data/" testid-base))
             :value    ex-data*
             :opts     {:site-id [:rf.xray.epoch/error-ex-data testid-base]
                        :card?   false
@@ -5664,8 +5843,10 @@
   `step-key` + `idx` give stable test ids. The card paints the failing
   step's blast radius right where the work happened — the inline half of
   rf2-ahhgn, polished by rf2-wnvid for ALL exception kinds."
-  [step-key idx {:keys [message recovery db-rolled-back? operation
-                        action-id via-wildcard?] :as row}]
+  ([step-key idx row] (error-block step-key idx row nil))
+  ([step-key idx {:keys [message recovery db-rolled-back? operation
+                         action-id via-wildcard?] :as row}
+    instance]
   (let [recovery-label (error-recovery-label recovery db-rolled-back?)
         testid-base    (str "rf-xray-epoch-error-"
                             (name (or step-key :unknown)) "-" idx)
@@ -5724,18 +5905,19 @@
               :style error-block-message-style}
         machine-attr])
      ;; 3. Collapsible details — stack + ex-data behind a disclosure
-     (error-block-details testid-base row)]))
+     (error-block-details testid-base row instance)])))
 
 (defn error-blocks
   "Render every exception in `errors` as an inline card inside the
   current step's body (rf2-ahhgn). `step-key` is the owning step keyword
   (stable test ids). nil-safe — a clean step passes nil/empty and renders
   nothing."
-  [step-key errors]
-  (when (seq errors)
-    [:div {:data-testid (str "rf-xray-epoch-errors-" (name step-key))}
-     (map-indexed (fn [i e] (error-block step-key i e))
-                  errors)]))
+  ([step-key errors] (error-blocks step-key errors nil))
+  ([step-key errors instance]
+   (when (seq errors)
+     [:div {:data-testid (str "rf-xray-epoch-errors-" (name step-key))}
+      (map-indexed (fn [i e] (error-block step-key i e instance))
+                   errors)])))
 
 ;; `rolled-back-banner` retired per rf2-w8evg — the rf2-8resu
 ;; redesign moved the `:where :app-db` violation from HANDLER to the
@@ -5772,18 +5954,24 @@
   `:subs-filter-mode`, both now read once in [[Panel]]'s boundary body).
   Most steps ignore it."
   [step ctx]
-  (case (:step step)
-    :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
-    :recordable-cofx   (render-recordable-cofx-step step)
-    :coeffect          (render-coeffect-step step)
-    :interceptors      (render-interceptors-step step)
-    :interceptor       (render-interceptor-step step)
-    :handler           (render-handler-step step ctx)
-    :flow              (render-flow-step step)
-    :side-effects      (render-side-effects-step step)
-    :subscriptions     (render-subscriptions-step step ctx)
-    :views             (render-views-step step)
-    nil))
+  ;; rf2-3ymg — `:instance` rides `ctx` like every other cascade-level
+  ;; value, and reaches the steps that mount an `ei/edn-inspector-view`.
+  ;; The three that mount none (`:recordable-cofx`, `:interceptors`,
+  ;; `:interceptor`) are not passed it, which is the honest signal that
+  ;; they have no per-mount identity to qualify.
+  (let [instance (:instance ctx)]
+    (case (:step step)
+      :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx) instance)
+      :recordable-cofx   (render-recordable-cofx-step step)
+      :coeffect          (render-coeffect-step step instance)
+      :interceptors      (render-interceptors-step step)
+      :interceptor       (render-interceptor-step step)
+      :handler           (render-handler-step step ctx)
+      :flow              (render-flow-step step instance)
+      :side-effects      (render-side-effects-step step instance)
+      :subscriptions     (render-subscriptions-step step ctx)
+      :views             (render-views-step step instance)
+      nil)))
 
 ;; ---- pipeline view -------------------------------------------------------
 
@@ -5951,10 +6139,53 @@
   boundary in its own right. So nothing in the interior wants a
   component of its own.
 
-  The argument is the ordinary one-props-map vector every `defview`
-  takes. This panel reads nothing from props — neither the L4 registry
-  nor the standalone embed passes any — so it is destructured away."
-  [_props]
+  The argument is the ordinary one-props-map vector every `defview` takes.
+
+  ## `:instance-id` — OPTIONAL, and it names ONE LIVE MOUNT (rf2-3ymg)
+
+  This panel reads no DATA from props: everything it renders comes from the
+  three subs below and from nothing else, and the L4 registry and the
+  standalone embed both mount it with no props at all. The one prop it takes
+  is an IDENTITY.
+
+  Each of the thirteen `ei/edn-inspector-view` heads below needs a
+  `:mount-id` that is unique per LIVE MOUNT, because that string is the
+  widget's lifecycle key (with the frame) and its measured-width slot key.
+  The logical site is unique within one panel; two mounts of THIS panel in
+  one frame it cannot separate, and nothing inside can — a Fresco boundary
+  is a React function component with no per-instance storage its body may
+  use, so there is no id for it to mint. Left unnamed the two share one
+  store entry, one ResizeObserver and one width slot per site, and
+  detaching either releases the survivor's.
+
+  So the distinction is the caller's to make, and this prop is how:
+
+      [Panel {:instance-id \"left\"}]
+      [Panel {:instance-id \"right\"}]
+
+  A non-blank string or a keyword — and a keyword's NAMESPACE is part of
+  the name, so `:left/epoch` and `:right/epoch` are two instances and not
+  one (rf2-4bsq). It must be STABLE across that instance's renders — it is
+  an identity, not a per-render nonce — and [[instance-token]] refuses,
+  loudly, the shapes that could not be. OMIT IT when only one Epoch panel
+  renders in this frame, which is every call site in this tree today: the
+  ids are then byte-for-byte what they were.
+
+  IT QUALIFIES THE PHYSICAL IDENTITY ONLY. Expansion, zoom and every step's
+  own testids are keyed by the `:site-id` and the step's own ids, and are
+  left exactly where they were, so two Epoch panels of one epoch still open
+  and close together. The §per-mount inspector identity commentary above
+  [[dispatch-body]] carries the mechanism — and the SECOND collision it
+  names, the one with the Machine Inspector over the cascade they share,
+  which this prop is deliberately NOT the fix for.
+
+  BOTH DOORS INTO THIS BOUNDARY ANSWER THE SAME. Mounted from a Fresco body
+  the prop arrives as written; mounted through [[Panel-bridge]] from a
+  Reagent parent it arrives already tokenised, because `[:>]` would
+  otherwise convert a keyword with `cljs.core/name` and drop its namespace.
+  The token is idempotent on its own output, so one value composes one set
+  of ids whichever head mounted it."
+  [{:keys [instance-id]}]
   (let [{:keys [status steps epoch-history outcome]}
         (rf.fresco/sub [:rf.xray/epoch-pipeline])]
     [:section {:data-testid "rf-xray-epoch-panel"
@@ -5973,6 +6204,10 @@
            (pipeline-view steps
                           {:dispatch-id->epoch-id (proj/dispatch-id->epoch-id-index
                                                     epoch-history)
+                           ;; rf2-3ymg — this mount's qualifier, tokenised
+                           ;; ONCE here and threaded down `ctx` with the
+                           ;; rest. Nil unless the caller named the mount.
+                           :instance (instance-token instance-id)
                            ;; rf2-k97c.3 — the two reads the HANDLER and
                            ;; SUBSCRIPTIONS rows used to perform
                            ;; THEMSELVES, hoisted here and threaded down
@@ -6032,6 +6267,39 @@
   PUBLIC, because this panel carries a `mount-epoch-panel!` facade and
   `panels/render-panel!` takes the view to mount as an ARGUMENT — so the
   embedding contract needs a name it can pass. Deleted with the component
-  above when the shell itself becomes a Fresco tree."
-  []
-  [:> Panel-component {}])
+  above when the shell itself becomes a Fresco tree.
+
+  rf2-3ymg — the 1-arity is how a REAGENT parent names an instance when it
+  renders two of these under one `frame-provider`:
+
+      [Panel-bridge {:instance-id \"left\"}]
+
+  The 0-arity stays because that is how the shell mounts an L4 tab
+  (`[(:panel tab)]`) and how `render-panel!` mounts the standalone embed
+  (`[panel-view]`) — one panel per frame, no instance to name.
+
+  ## The prop is TOKENISED HERE, before the crossing (rf2-4bsq)
+
+  `[:>]` converts each prop VALUE before React sees it, and Reagent's
+  `convert-prop-value` converts a named value with `cljs.core/name` — which
+  DROPS THE NAMESPACE. Passed through raw, `:left/epoch` and `:right/epoch`
+  would both arrive at the boundary as `\"epoch\"`, so two panels the caller
+  had deliberately named apart would compose the same
+  `epoch/epoch/dispatch-event` — one lifecycle entry, one ResizeObserver,
+  one width slot, and detaching either releasing the other's. That is
+  precisely the collision rf2-3ymg repairs, restored by the crossing.
+
+  So the bridge runs [[instance-token]] — the SAME normaliser the boundary
+  uses — and a STRING crosses, which Reagent preserves intact. The
+  boundary's own call on the far side is then a no-op (the fn is idempotent
+  on its own output), and a refused shape throws naming the CALLER's value
+  rather than whatever the crossing had turned it into.
+
+  A blank string tokenises to nil and so mounts with no props, exactly as
+  naming no instance does."
+  ([] (Panel-bridge nil))
+  ([props]
+   [:> Panel-component
+    (if-let [instance-id (instance-token (:instance-id props))]
+      {:instance-id instance-id}
+      {})]))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -274,6 +274,65 @@
 
 ;; ---- per-machine focused-event section ---------------------------------
 
+;; ---- per-mount inspector identity (rf2-3ymg) -----------------------------
+
+(def ^:private owner-token
+  "What this panel calls itself inside the SHARED cascade renderer's id
+  namespace. See [[instance-token]] for why it is unconditional."
+  "machine-inspector")
+
+(defn instance-token
+  "Normalise [[Panel]]'s optional `:instance-id` prop to the string that
+  qualifies this mount's inspector `:mount-id`s inside the shared
+  `epoch-view/machine-cascade-mini-pipeline`.
+
+  ## IT NEVER ANSWERS NIL, AND THAT IS THE DIFFERENCE FROM EVERY SIBLING
+
+  `app-db-diff`, `managed-fx`, `trace` and the Epoch panel all answer nil
+  for an unnamed mount, so their ids stay byte-for-byte what they were.
+  Those panels each own the id namespace they compose into. THIS ONE DOES
+  NOT: element 2 renders through the Epoch panel's cascade renderer
+  (rf2-g2axio, deliberately — so the two surfaces cannot diverge), and that
+  renderer composes `epoch/machine-cascade-*` ids. An Epoch panel and a
+  Machine Inspector over one cascade therefore collided on the widget's
+  lifecycle key and its width slot with NEITHER caller having done anything
+  unusual, and neither could see it to work around it.
+
+  Which panel is rendering is STATICALLY KNOWN, so it is answered
+  statically: unnamed, this is [[owner-token]]; named, the caller's token
+  rides BELOW it (`machine-inspector/left`) so two Machine Inspectors are
+  also distinct, and so a Machine Inspector named `left` cannot collide
+  with an Epoch panel named `left` either.
+
+  A KEYWORD is accepted alongside a string, and its NAMESPACE is part of
+  the name: `:left/machines` tokenises to `left/machines`. `(subs (str id)
+  1)` is what preserves it; `cljs.core/name` would drop it and restore the
+  very collision this removes (rf2-4bsq) — see [[Panel-bridge]], which
+  tokenises BEFORE the Reagent crossing for exactly that reason. The fn is
+  IDEMPOTENT on its own output, so the boundary's second call after the
+  crossing is a no-op.
+
+  It is this panel's own normaliser rather than a call into a sibling's:
+  the panels are independent surfaces, they migrate on their own
+  schedules, and the refusal has to name the caller's OWN panel to be
+  worth reading."
+  [instance-id]
+  (let [named (cond
+                (nil? instance-id)     nil
+                (keyword? instance-id) (subs (str instance-id) 1)
+                (string? instance-id)  (when (seq instance-id) instance-id)
+                :else
+                (throw (ex-info
+                         (str "The Machine Inspector's :instance-id must be a "
+                              "non-blank string or a keyword naming this "
+                              "mount, or omitted. Got: " (pr-str instance-id))
+                         {:rf.xray/instance-id instance-id})))]
+    (cond
+      (nil? named)                     owner-token
+      (= named owner-token)            owner-token
+      (str/starts-with? named (str owner-token "/")) named
+      :else                            (str owner-token "/" named))))
+
 (defn- focused-event-section
   "Render the focused machine's section (rf2-g2axio redesign). The
   Machine tab now shows EXACTLY THREE elements: the Prev/Next nav (in
@@ -327,7 +386,8 @@
            guard-blocked-edge-ids start? no-op?]
     :as _record}
    as-child
-   fit-signal]
+   fit-signal
+   instance]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance is GONE; xyflow + elkjs own positioning end-to-end
   ;; inside `MachineChart`. The panel only computes the from/to node-ids
@@ -384,7 +444,7 @@
       ;; (a machine is registered as an `:event` handler carrying its spec
       ;; under `:rf/machine`), so the cascade rows' guard / action
       ;; source-coords resolve identically to the Epoch panel.
-      (epoch-view/machine-cascade-mini-pipeline cascade machine-id)]
+      (epoch-view/machine-cascade-mini-pipeline cascade machine-id instance)]
      ;; ── ELEMENT 3 — the topology chart ─────────────────────────────
      ;; The chart carries its OWN toolbar (zoom / pan / fit controls —
      ;; `machine-canvas/Chart`), so the bespoke list/canvas wrapper +
@@ -559,7 +619,7 @@
   argument now. `target-frame` likewise ARRIVES AS AN ARGUMENT rather
   than being read here, for the same reason: a `rf.fresco/sub` raises
   outside a collector window, and this fn is node-lane-driven."
-  [records cascade as-child fit-signal target-frame]
+  [records cascade as-child fit-signal target-frame instance]
   (let [;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
@@ -600,7 +660,7 @@
        ;; `focused-event-section` answers hiccup whose own attribute map
        ;; is not ours to write into, so the key rides the fragment.
        [:<> {:key (h/focused-event-section-key target-frame record)}
-        (focused-event-section cascade record as-child fit-signal)]])))
+        (focused-event-section cascade record as-child fit-signal instance)]])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
@@ -692,7 +752,15 @@
   were hoisted because a `rf.fresco/sub` raises outside a collector
   window, which would have made this whole tree callable only inside a
   real React commit."
-  [{:keys [empty-kind]} records cascade as-child fit-signal target-frame]
+  ;; rf2-3ymg — the 6-arity keeps every direct caller that has no instance
+  ;; to name working, and answers this panel's OWN token for them rather
+  ;; than nil: the cascade ids below are composed in the Epoch panel's id
+  ;; namespace, so `no instance` still has to say which panel is rendering.
+  ([data records cascade as-child fit-signal target-frame]
+   (panel-tree data records cascade as-child fit-signal target-frame
+               (instance-token nil)))
+  ([{:keys [empty-kind]} records cascade as-child fit-signal target-frame
+    instance]
   (let [;; The first record's machine-id drives the prev/next nav (a
         ;; cascade may touch multiple machines; the nav's "this machine"
         ;; is the head section's machine).
@@ -725,10 +793,11 @@
        ;; does not duplicate-subscribe the same composite handle.
        [:div {:data-testid "rf-xray-machine-inspector-focused-event-host"
               :style focused-event-host-style}
-        (focused-event-view records cascade as-child fit-signal target-frame)]
+        (focused-event-view records cascade as-child fit-signal target-frame
+                            instance)]
 
        :else
-       (blank-state))]))
+       (blank-state))])))
 
 (rf.fresco/defview Panel
   "The Machine Inspector (Machine tab) root — a FRESCO BOUNDARY
@@ -765,10 +834,38 @@
   consumer on the Static surface. [[focused-event-section]] records the
   condition that retires it.
 
-  The argument is the ordinary one-props-map vector every `defview`
-  takes. This panel reads nothing from props — neither the L4 registry
-  nor the standalone embed passes any — so it is destructured away."
-  [_props]
+  The argument is the ordinary one-props-map vector every `defview` takes.
+
+  ## `:instance-id` — OPTIONAL, and this panel's default is NOT nil
+  ## (rf2-3ymg)
+
+  This panel reads no DATA from props: everything it renders comes from the
+  five subs below. The one prop it takes is an IDENTITY, and it is passed
+  to [[instance-token]] — whose contract differs from every sibling's in
+  one deliberate way, for a reason that is about this panel's position
+  rather than about taste.
+
+  Element 2 is the SHARED mini-pipeline, `epoch-view/machine-cascade-mini-
+  pipeline`, the very renderer the Epoch panel's EVENT HANDLER step uses
+  (rf2-g2axio). Its inspector `:mount-id`s are composed in that file's id
+  namespace — `epoch/machine-cascade-transition-delta/<step>` and its
+  siblings — so an Epoch panel and a Machine Inspector displaying one
+  cascade composed IDENTICAL ids, shared one lifecycle entry, one
+  ResizeObserver and one measured-width slot ACROSS TWO DIFFERENT PANELS,
+  and detaching either released the other's.
+
+  That is not a collision a caller should have to name its way out of:
+  which panel is rendering is statically known, and an embedder mounting
+  one of each cannot see the collision to work around it. So this panel's
+  token never answers nil — it names ITSELF, and a caller's `:instance-id`
+  qualifies further on top, for the separate case of two MACHINE
+  INSPECTORS in one frame.
+
+  Accepted shapes and the Reagent-crossing rule are the siblings' — a
+  non-blank string or a keyword whose NAMESPACE is part of the name
+  (rf2-4bsq), stable across that instance's renders, tokenised by
+  [[Panel-bridge]] BEFORE the crossing."
+  [{:keys [instance-id]}]
   (panel-tree (rf.fresco/sub [:rf.xray/machine-inspector-data])
               (rf.fresco/sub [:rf.xray/machine-transitions-for-focused-event])
               ;; rf2-g2axio — the focused epoch's projected machine-cascade
@@ -778,7 +875,11 @@
               (:cascade (rf.fresco/sub [:rf.xray/machine-focused-epoch-cascade]))
               r/as-element
               (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])
-              (rf.fresco/sub [:rf.xray/target-frame])))
+              (rf.fresco/sub [:rf.xray/target-frame])
+              ;; rf2-3ymg — this mount's qualifier for the SHARED
+              ;; mini-pipeline's inspector ids. Never nil; see the
+              ;; docstring above and [[instance-token]].
+              (instance-token instance-id)))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;
@@ -831,9 +932,34 @@
 
   PUBLIC, because this panel carries a `mount-machine-inspector!` facade
   and `panels/render-panel!` takes the view to mount as an ARGUMENT, so
-  the embedding contract needs a name it can pass."
-  []
-  [:> Panel-component {}])
+  the embedding contract needs a name it can pass.
+
+  rf2-3ymg — the 1-arity is how a REAGENT parent names an instance when it
+  renders two of these under one `frame-provider`:
+
+      [Panel-bridge {:instance-id \"left\"}]
+
+  The 0-arity stays because that is how the shell mounts an L4 tab
+  (`[(:panel tab)]`) and how `render-panel!` mounts the standalone embed
+  (`[panel-view]`) — one panel per frame, no instance to name. Note that
+  the 0-arity is NOT the same as `no qualifier` here: [[instance-token]]
+  answers this panel's own name for it, because the cascade ids it
+  composes into belong to the Epoch panel.
+
+  ## The prop is TOKENISED HERE, before the crossing (rf2-4bsq)
+
+  `[:>]` converts each prop VALUE before React sees it, and Reagent's
+  `convert-prop-value` converts a named value with `cljs.core/name` —
+  which DROPS THE NAMESPACE. Passed through raw, `:left/machines` and
+  `:right/machines` would both arrive as `\"machines\"`, so two panels the
+  caller had deliberately named apart would compose the same ids again.
+  So the bridge runs [[instance-token]] — the SAME normaliser the boundary
+  uses, idempotent on its own output — and a STRING crosses, which Reagent
+  preserves intact; a refused shape throws naming the CALLER's value
+  rather than whatever the crossing had turned it into."
+  ([] (Panel-bridge nil))
+  ([props]
+   [:> Panel-component {:instance-id (instance-token (:instance-id props))}]))
 
 ;; ---- production value sources --------------------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
@@ -1,0 +1,546 @@
+(ns day8.re-frame2-xray.panels.epoch-machine-mount-instance-id-dom-cljs-test
+  "TWO STANDALONE `mount-epoch-panel!` MOUNTS IN ONE FRAME, AND AN EPOCH
+  PANEL BESIDE A MACHINE INSPECTOR SHARING ONE CASCADE, read off real React
+  commits (rf2-3ymg).
+
+  ## The claim, and why it needs a DOM
+
+  rf2-k97c.3 replaced thirteen inline EDN heads in `panels/epoch/view` with
+  `ei/edn-inspector-view`, each carrying a `:mount-id` composed from a
+  LOGICAL site — `\"epoch/dispatch-event\"` is a CONSTANT, and the machine
+  cascade's three are a role plus a step ordinal. Those separate the roles
+  within ONE panel and cannot separate two live mounts, which is a different
+  question.
+
+  TWO collisions follow, and the second is the sharper one:
+
+    * two standalone Epoch panels over one focused epoch in one frame
+      compose IDENTICAL mount-ids, role for role; and
+    * an Epoch panel and a MACHINE INSPECTOR displaying the same machine
+      cascade compose identical mount-ids too — because they render it
+      through the SAME `machine-cascade-mini-pipeline`, off the SAME
+      `projection/machine-cascade-rows`, which is the whole point of
+      rf2-g2axio's extraction. The Machine Inspector is a GUEST in the
+      Epoch panel's id namespace and had no way to say so.
+
+  A row asserting an opts key was THREADED would pass while both mounts
+  still collided, which is the failure one level up. So nothing here reads
+  the opts map, the captured tree or the props. The mounts are made through
+  the PUBLIC facades into real containers, and every assertion reads
+  `container.querySelector` — the DOM React committed on its own — the
+  widget's own per-mount store, or the frame's app-db width slot.
+
+  ## The two observables, and the SECOND is the one the defect breaks
+
+  `data-rf-mount-id` is stamped by the edn-inspector widget on every
+  committed container, carrying the BARE `:mount-id` the panel composed. It
+  is not decoration: `edn-inspector/container-ref-for` memoises the ref
+  callback on `[frame-id mount-id]`, `measure-and-dispatch!` writes the
+  measured width to `:rf.xray.edn-inspector/widths` under that same bare
+  string, and `release-mount!` clears BOTH when a mount detaches.
+
+  [[two-named-epoch-mounts-each-keep-their-own-observer-and-width]] is the
+  half a distinctness row would miss. Under the shared identity the SECOND
+  mount never installs a ResizeObserver at all (`container-ref-for` hands
+  back the memoised callback, whose mount arm is guarded on
+  `(nil? (:observer entry))`), and `release-mount!` then tears the SHARED
+  entry down — and clears the SHARED width — when EITHER mount detaches,
+  leaving the survivor on screen with no observer and no width.
+
+  ## WHY THE TWO PANELS ARE FIXED BY DIFFERENT MEANS, and that is the shape
+  ## finding rather than a copy of the Trace landing's
+
+  ONE qualifier, on the `:mount-id` ALONE — every one of the thirteen sites
+  passes a stable `:site-id` alongside it, and the widget's `effective-id`
+  is `(or site-id mount-id)`, so expansion and zoom are keyed by the
+  site-id and DO NOT READ THE MOUNT-ID AT ALL. That much this surface
+  shares with Trace, and [[two-named-epoch-mounts-share-their-disclosure-identity]]
+  pins the half that must NOT move.
+
+  What it does NOT share is where the qualifier comes from. The two-Epoch
+  collision is between two mounts of ONE panel, which nothing inside the
+  panel can tell apart, so the CALLER names them — the optional
+  `:instance-id` the three shipped panels already take. The
+  Epoch-vs-Machine-Inspector collision is between two DIFFERENT panels, and
+  which panel is rendering is STATICALLY KNOWN: no caller should have to
+  work around a shared helper's id namespace, and a caller embedding one of
+  each cannot see the collision to work around it. So the Machine
+  Inspector's own normaliser never answers nil — it names ITSELF, and the
+  caller's `:instance-id` qualifies further on top.
+  [[epoch-and-machine-inspector-do-not-share-cascade-mount-ids]] mounts one
+  of each with NO opts at all and is the row that states it.
+
+  ## The negative control IS the defect, and it is a row rather than a note
+
+  [[two-unnamed-epoch-mounts-still-collide]] mounts two Epoch panels with no
+  `:instance-id` and asserts the id sets are IDENTICAL. It carries two
+  claims at once: the instrument can see a collision (so the disjointness
+  above is separation and not silence), and omitting the opt leaves every
+  Epoch id byte-for-byte what it always was — which is every call site in
+  this tree today.
+
+  ## Substrate: the Reagent adapter, and the mounts are the PUBLIC ones
+
+  `mount-epoch-panel!` and `mount-machine-inspector!` delegate to
+  `rf.substrate.adapter/render`, so the installed adapter is what renders.
+  Nothing here reaches past the facades to build a tree of its own — the
+  things under test are the mount fns.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium) per
+  `implementation/shadow-cljs.edn`. The `:node-test` build's `cljs-test$`
+  regex also matches, so it LOADS under Node — where every row
+  short-circuits through [[browser?]] and reports the skip rather than
+  passing silently. A green node lane is therefore NOT evidence about this
+  file; `npm run test:browser` is. The node lane cannot see a
+  ResizeObserver at all, and `expand-tree` INVOKES a fn head, so it cannot
+  grade head legality here either."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panels :as panels]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; READ-ONLY, and only for the per-mount store's public test
+            ;; surface (`lifecycle-key`, `mount-state-held`) and the public
+            ;; width-slot key. The widget's own lifecycle rows live in
+            ;; `views/edn_inspector_mount_state_cljs_test`; what W2 below
+            ;; asserts is that two STANDALONE MOUNTS hand that store two
+            ;; distinct keys, each with its own observer and its own width.
+            [day8.re-frame2-xray.views.edn-inspector :as ei]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     ;; `:async? true` because W2 is an `async` row, and `cljs.test` refuses
+     ;; a FUNCTION fixture in any namespace that carries one.
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about, and
+                      ;; both panels' roots are Fresco boundaries — a
+                      ;; neighbour's entry left in the cache would make these
+                      ;; rows read a residue that is not theirs.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the seeded epoch ----------------------------------------------------
+
+(def ^:private machine-id :auth/login)
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(def ^:private fixture-history
+  "ONE epoch carrying BOTH a dispatch and a machine macrostep, so the one
+  seeding drives both panels: the Epoch panel projects a DISPATCH step (the
+  constant `epoch/dispatch-event` mount-id) and — because a
+  `:rf.machine/transition` classifies the handler `:reg-machine` — a HANDLER
+  step whose `:machine {:cascade …}` renders through the shared
+  mini-pipeline, while the Machine Inspector renders that SAME cascade off
+  `:rf.xray/machine-focused-epoch-cascade`, which calls the SAME
+  `projection/machine-cascade-rows` over the SAME `:trace-events`."
+  [{:epoch-id      1
+    :dispatch-id   "d-1"
+    :event         [:auth/submit]
+    :trigger-event [:auth/submit]
+    :trace-events
+    [{:id 1 :time 10 :operation :rf.event/dispatch
+      :tags {:event [:auth/submit] :rf.trace/dispatch-id "d-1"}}
+     {:id 2 :time 20 :operation :rf.machine/transition
+      :tags {:machine-id machine-id
+             :before     {:state :idle :data {}}
+             :after      {:state :authing :data {}}
+             :event      [:auth/submit]
+             :rf.trace/dispatch-id "d-1"}}]}])
+
+(defn- setup!
+  "Register Xray's handlers plus the test-override seam the fixtures write
+  through, then seed the machine registry, the epoch ring and the focus.
+
+  The Machine Inspector needs the registered-machines / definitions
+  overrides to paint its focused-event section at all; the Epoch panel needs
+  neither and reads the same history and focus. Both panels default to the
+  `:rf/xray` frame, which is what makes the collision reachable."
+  []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
+                     [machine-id]]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test
+                     {machine-id fixture-definition}]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-epoch-history-for-test fixture-history]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-focus-epoch-id-for-test 1]
+                    {:frame :rf/xray})
+  nil)
+
+;; ---- mounting, and reading the DOM back ----------------------------------
+
+(defn- mount-with!
+  "Mount `panel-mount-fn` through the PUBLIC facade with `opts`, committed
+  synchronously.
+
+  `react-dom/flushSync` rather than a Reagent queue drain: both panels' root
+  views are Fresco boundaries, which are not in Reagent's render queue at
+  all, so draining that queue commits nothing of theirs and a row written
+  that way reads a container that never moved."
+  [panel-mount-fn opts]
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    (let [unmount (react-dom/flushSync
+                    (fn [] (panel-mount-fn container opts)))]
+      {:container container :unmount unmount})))
+
+(defn- mount-epoch! [opts] (mount-with! panels/mount-epoch-panel! opts))
+(defn- mount-machines! [opts] (mount-with! panels/mount-machine-inspector! opts))
+
+(defn- unmount!
+  "Tear one mount down inside `flushSync` so React's ref-detach has RUN by
+  the time the next line reads the per-mount store. A bare unmount schedules
+  it."
+  [{:keys [container unmount]}]
+  (react-dom/flushSync (fn [] (unmount)))
+  (.remove container))
+
+(defn- mount-ids
+  "Every `data-rf-mount-id` in `container`'s committed DOM, in document
+  order. Reads the DOM React wrote — nothing here reproduces a panel."
+  [container]
+  (->> (.querySelectorAll container "[data-rf-mount-id]")
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % "data-rf-mount-id"))))
+
+(defn- site-ids
+  "Every `data-rf-site-id` in `container`'s committed DOM. The LOGICAL
+  identity, which this bead must leave alone."
+  [container]
+  (->> (.querySelectorAll container "[data-rf-site-id]")
+       (js/Array.from)
+       (array-seq)
+       (mapv #(.getAttribute % "data-rf-site-id"))))
+
+(defn- cascade-mount-ids
+  "The subset of `container`'s mount-ids the SHARED mini-pipeline composed.
+  Named by the role segment rather than by a whole literal, because the step
+  ordinal rides the tail and the qualifier rides elsewhere — what this
+  selects is `which renderer emitted it`, which is the axis the cross-panel
+  row is about."
+  [container]
+  (filterv #(string/includes? % "machine-cascade") (mount-ids container)))
+
+(defn- widths
+  "The frame's measured-width slot — a map of bare `mount-id` → px."
+  []
+  (or (rf/subscribe-once [ei/widths-slot] {:frame :rf/xray}) {}))
+
+;; ===========================================================================
+;; W1 — two NAMED standalone Epoch mounts compose two disjoint sets of ids
+;; ===========================================================================
+
+(deftest two-named-epoch-mounts-compose-disjoint-inspector-mount-ids
+  (testing "rf2-3ymg — `mount-epoch-panel!` given two different
+            `:instance-id`s mounts two panels whose committed DOM carries two
+            disjoint sets of `data-rf-mount-id`, in the ONE `:rf/xray` frame
+            they both default to. Each id composes the widget's lifecycle key
+            AND its measured-width slot key, so disjointness here is
+            disjointness of both."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount-epoch! {:instance-id "left"})
+            right (mount-epoch! {:instance-id "right"})]
+        (try
+          (let [ids-l (mount-ids (:container left))
+                ids-r (mount-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (some? (.querySelector (:container left)
+                                       "[data-testid=\"rf-xray-epoch-panel\"]"))
+                "control: the left mount committed the Epoch panel at all, so
+                 an empty intersection below means separation and not a panel
+                 that rendered an empty state and mounted no inspector")
+            (is (seq ids-l)
+                (str "control: the panel committed at least one inspector — "
+                     "so the sets below are sets. left=" (pr-str ids-l)))
+            (is (= (count ids-l) (count ids-r))
+                "naming an instance changes the ids, never the rows — two
+                 mounts of the same focused epoch over the same steps")
+
+            ;; ---- the claim ---------------------------------------------
+            (is (nil? (some (set ids-l) ids-r))
+                (str "no mount-id survives from one standalone mount to the "
+                     "other — the store's lifecycle key and the measured "
+                     "width slot are both derived from this string. left="
+                     (pr-str ids-l) " right=" (pr-str ids-r)))
+            (is (every? #(string/includes? % "left") ids-l)
+                (str "each id carries the name THIS mount was given, rather "
+                     "than a per-render nonce or a shared string: "
+                     (pr-str ids-l))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W2 — the lifecycle half: each mount owns an observer AND a width, and keeps
+;;      both when its sibling goes
+;; ===========================================================================
+
+(deftest two-named-epoch-mounts-each-keep-their-own-observer-and-width
+  (testing "rf2-3ymg — two named standalone Epoch mounts hold two entries in
+            the widget's per-mount store, each with its OWN ResizeObserver and
+            its OWN entry in the frame's measured-width slot, and unmounting
+            one releases ONLY its own. Under the shared identity the second
+            mount never installs an observer at all, and `release-mount!`
+            tears the shared entry down AND clears the shared width when
+            either detaches — so the survivor is left on screen unobserved and
+            unmeasured, which a distinctness row alone cannot see."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (let [left  (mount-epoch! {:instance-id "left"})
+              right (mount-epoch! {:instance-id "right"})
+              id-l  (first (mount-ids (:container left)))
+              id-r  (first (mount-ids (:container right)))]
+          (is (some? id-l)
+              "control: the left mount committed a widget, so the store keys
+               below name something that really mounted")
+          (is (not= id-l id-r)
+              "the two mounts composed two mount-ids")
+
+          ;; ---- the observer half -------------------------------------
+          ;; These two are LIVENESS controls rather than the discriminating
+          ;; rows, and saying so matters: under the shared identity both
+          ;; lookups resolve to the SAME entry, so both pass while the defect
+          ;; is fully present. What bites before the unmount is `not=` above;
+          ;; what bites after it is the survivor row below.
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "the left mount installed its own ResizeObserver")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r))
+                         :observer)
+              "and so did the right — two live mounts, two observers. Under
+               the shared identity the second element's ref callback finds an
+               observer already on the entry and installs none")
+
+          ;; ---- the width half ----------------------------------------
+          ;; DRIVEN through the slot's own public event rather than read off a
+          ;; real measurement, and that is a finding rather than a shortcut.
+          ;; The headless payload container measures `clientWidth` 0, so
+          ;; `measure-and-dispatch!`'s `(pos? w)` guard need never fire and
+          ;; the slot can be EMPTY on a perfectly healthy mount; meanwhile the
+          ;; ResizeObserver's own later callback DOES land real widths,
+          ;; asynchronously. So a row asserting a measured VALUE is red for a
+          ;; reason that is not this defect, and one asserting a specific
+          ;; value races a real measurement that may overwrite it. The slot is
+          ;; public for exactly this, and `:rf.xray.edn-inspector/set-width`
+          ;; is the very event the observer dispatches, under the very id the
+          ;; widget composes. These rows therefore assert on KEY PRESENCE,
+          ;; which is what the defect actually moves: WHICH KEY
+          ;; `release-mount!` clears when a sibling detaches.
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-l 640]
+                            {:frame :rf/xray})
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-r 480]
+                            {:frame :rf/xray})
+          (is (= 2 (count (select-keys (widths) [id-l id-r])))
+              (str "two live mounts hold TWO width slots — under the shared "
+                   "identity both writes land on ONE key. slot="
+                   (pr-str (widths))))
+
+          (unmount! right)
+
+          ;; ---- the survivor keeps both -------------------------------
+          (is (nil? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r)))
+              "the detached mount is gone")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "and the mount STILL ON SCREEN is still observed — releasing the
+               survivor's entry is what the shared key did, and it left a live
+               node with no observer and no width updates")
+          ;; The store entry is dropped by a synchronous `swap!` but the width
+          ;; is cleared by a DISPATCH, which is queued — the slot still reads
+          ;; its pre-unmount value on the line straight after
+          ;; `flushSync(unmount)`. So poll for the clear to land, then read the
+          ;; survivor. Under the shared identity the two ids are one string, so
+          ;; the poll below succeeds on the SURVIVOR's own key being cleared,
+          ;; and the row after it is what reports that.
+          (-> (rf.test-support/poll-until
+                (fn [] (nil? (get (widths) id-r)))
+                {:label "release-mount! cleared the detaching mount's width"})
+              (.then
+                (fn [_]
+                  (is (some? (get (widths) id-l))
+                      (str "and the survivor's width is STILL in the frame's "
+                           "slot — `release-mount!` clears the width under the "
+                           "DETACHING mount's id, which under the shared "
+                           "identity is the survivor's own. slot="
+                           (pr-str (widths))))))
+              (.catch
+                (fn [e]
+                  (is false (str "the width clear never landed: "
+                                 (.-message e) " slot=" (pr-str (widths))))
+                  nil))
+              (.then (fn [_] (unmount! left) (done)))))))))
+
+;; ===========================================================================
+;; W3 — the CROSS-PANEL half, and it takes NO opts at all
+;; ===========================================================================
+
+(deftest epoch-and-machine-inspector-do-not-share-cascade-mount-ids
+  (testing "rf2-3ymg — an Epoch panel and a Machine Inspector displaying the
+            SAME machine cascade, both mounted with NO opts, compose disjoint
+            cascade mount-ids. They render that cascade through one shared
+            `machine-cascade-mini-pipeline` off one
+            `projection/machine-cascade-rows`, so before the repair both
+            emitted `epoch/machine-cascade-transition-delta/<step>` for the
+            same step and shared one lifecycle entry, one ResizeObserver and
+            one width slot across two DIFFERENT panels.
+
+            NO `:instance-id` is passed, deliberately: which panel is
+            rendering is statically known, a caller embedding one of each
+            cannot see this collision, and the Machine Inspector is the guest
+            in the Epoch panel's id namespace — so it names itself."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_       (setup!)
+            epoch   (mount-epoch! nil)
+            machine (mount-machines! nil)]
+        (try
+          (let [cas-e (cascade-mount-ids (:container epoch))
+                cas-m (cascade-mount-ids (:container machine))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (some? (.querySelector (:container machine)
+                                       "[data-testid=\"rf-xray-machine-event-handler-mini-pipeline\"]"))
+                "control: the Machine Inspector committed the SHARED
+                 mini-pipeline host, so an empty intersection below is
+                 separation and not a panel that painted an empty state")
+            (is (seq cas-e)
+                (str "control: the Epoch panel committed cascade inspectors "
+                     "too — both surfaces are rendering the shared cascade, "
+                     "which is what makes the collision reachable. epoch="
+                     (pr-str cas-e)))
+            (is (seq cas-m)
+                (str "control: and so did the Machine Inspector. machines="
+                     (pr-str cas-m)))
+
+            ;; ---- the claim ---------------------------------------------
+            (is (nil? (some (set cas-e) cas-m))
+                (str "no cascade mount-id is shared between the two panels, "
+                     "with neither caller having named anything. epoch="
+                     (pr-str cas-e) " machines=" (pr-str cas-m)))
+            (is (every? #(string/includes? % "machine-inspector") cas-m)
+                (str "and the Machine Inspector's cascade ids say WHICH panel "
+                     "rendered them — it is a guest in the Epoch panel's id "
+                     "namespace and names itself. machines=" (pr-str cas-m))))
+          (finally
+            (unmount! machine)
+            (unmount! epoch)))))))
+
+;; ===========================================================================
+;; W4 — the LOGICAL identity must NOT move
+;; ===========================================================================
+
+(deftest two-named-epoch-mounts-share-their-disclosure-identity
+  (testing "rf2-3ymg — the bound on this repair, as a row. Naming two mounts
+            qualifies the PHYSICAL identity only: the `:site-id` that keys
+            expansion and zoom (rf2-pvsxs) is IDENTICAL across the two panels,
+            so two views of the same epoch still open and close together and
+            an operator's expansion choices still survive a tab
+            leave-and-return. A repair that qualified the site-id too would
+            pass W1, W2 and W3 and silently change this."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            left  (mount-epoch! {:instance-id "left"})
+            right (mount-epoch! {:instance-id "right"})]
+        (try
+          (let [sites-l (site-ids (:container left))
+                sites-r (site-ids (:container right))]
+            (is (seq sites-l)
+                (str "control: the left mount committed a site-id at all — "
+                     "all thirteen sites pass one, so an equality below is a "
+                     "measurement rather than two empty vectors agreeing. "
+                     "left=" (pr-str sites-l)))
+            (is (= sites-l sites-r)
+                (str "the LOGICAL identity is shared across the two mounts, "
+                     "deliberately. left=" (pr-str sites-l)
+                     " right=" (pr-str sites-r)))
+            (is (some? (.querySelector (:container right)
+                                       "[data-testid=\"rf-xray-epoch-dispatch-event\"]"))
+                "and the panel's own row testids are untouched by the
+                 qualifier — they are the STEP's identity, not the
+                 inspector's"))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W5 — the negative control: unnamed Epoch mounts collide, and are unchanged
+;; ===========================================================================
+
+(deftest two-unnamed-epoch-mounts-still-collide
+  (testing "rf2-3ymg — the defect verbatim, kept as a row. Two standalone
+            Epoch mounts with NO `:instance-id` present the SAME mount-ids,
+            which is what makes W1's disjointness a measurement rather than a
+            coincidence; and the ids they present carry no instance segment at
+            all, so every existing single-mount call site composes exactly
+            what it always did."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup!)
+            a     (mount-epoch! nil)
+            b     (mount-epoch! {})
+            named (mount-epoch! {:instance-id "left"})]
+        (try
+          (let [ids-a (mount-ids (:container a))
+                ids-b (mount-ids (:container b))
+                ids-n (mount-ids (:container named))]
+            (is (seq ids-a)
+                "control: both unnamed mounts committed widgets")
+            (is (= ids-a ids-b)
+                (str "two unnamed mounts present the SAME ids — so the "
+                     "instrument W1 uses CAN see a collision, and its "
+                     "disjointness is a measurement rather than silence. a="
+                     (pr-str ids-a)))
+            (is (some #(= "epoch/dispatch-event" %) ids-a)
+                (str "and they are byte-for-byte the ids this panel composed "
+                     "before rf2-3ymg — the DISPATCH step's is a CONSTANT, "
+                     "which is the sharpest statement of both halves: it "
+                     "collides between two mounts, and it must not move for "
+                     "one. a=" (pr-str ids-a)))
+            (is (= (count ids-a) (count ids-n))
+                (str "a named mount commits the same widgets, differing only "
+                     "in what they are called. unnamed=" (pr-str ids-a)
+                     " named=" (pr-str ids-n)))
+            (is (nil? (some (set ids-a) ids-n))
+                (str "and no id survives from the unnamed pair to the named "
+                     "mount — naming qualifies every one of them. unnamed="
+                     (pr-str ids-a) " named=" (pr-str ids-n)))
+            (is (= ids-a (mount-ids (:container a)))
+                "re-reading the same container is stable — these are
+                 identities, not per-render nonces"))
+          (finally
+            (unmount! named)
+            (unmount! b)
+            (unmount! a)))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
@@ -104,6 +104,7 @@
             [re-frame.core :as rf]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.panels :as panels]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -179,10 +180,25 @@
   The Machine Inspector needs the registered-machines / definitions
   overrides to paint its focused-event section at all; the Epoch panel needs
   neither and reads the same history and focus. Both panels default to the
-  `:rf/xray` frame, which is what makes the collision reachable."
+  `:rf/xray` frame, which is what makes the collision reachable.
+
+  `ensure-xray-frame!` RUNS FIRST, BEFORE the seeding, and that ordering is
+  a measured requirement rather than tidiness. These rows mount through the
+  PUBLIC facades, and `panels/render-panel!` routes every mount through
+  `ensure-xray-handlers-installed!` → `mount/ensure-xray-frame!`, whose
+  FIRST-MOUNT HOOK TABLE (`::seed-trace-and-target-frame`,
+  `::reset-transient-filters`, `::hydrate-static-mode`, …) writes the very
+  slots seeded here. Seeded first and mounted second, those hooks land ON
+  TOP and both panels paint an empty state — measured: every `mount-ids`
+  read came back `[]` with the panel roots committed, so the controls fired
+  rather than the claims. `ensure-xray-frame!` is idempotent, so running it
+  here leaves the facade's own call a no-op and the seed is what the panels
+  read. The sibling suites do not meet this because they mount the registry
+  head under a `frame-provider` directly and never reach the facade."
   []
   (registry/register-xray-handlers!)
   (xray-test-support/install-test-overrides!)
+  (mount/ensure-xray-frame! :rf/xray)
   (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
                      [machine-id]]
                     {:frame :rf/xray})

--- a/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs
@@ -499,17 +499,27 @@
             ignored key, so every other mount fn must keep delivering a bare
             element even when its caller sets the opt.
 
-            rf2-pua3 moved `mount-trace!` from the second group to the first —
-            `trace/Panel` now reads `:instance-id` — so the row that used to
-            name it here names `mount-epoch-panel!` instead, and the trace
-            half is asserted in [[mount-trace-instance-id-reaches-the-boundary]]
-            below. A panel is picked here for being a CURRENT member of the
-            no-prop group, not for being a permanent one."
+            A panel is picked here for being a CURRENT member of the no-prop
+            group, not for being a permanent one, so the pick MOVES as panels
+            migrate. It has moved twice:
+
+              - rf2-pua3 moved `mount-trace!` to the first group, and the
+                trace half is asserted in
+                [[mount-trace-instance-id-reaches-the-boundary]] below;
+              - rf2-3ymg then moved `mount-epoch-panel!` AND
+                `mount-machine-inspector!`, whose halves are asserted in
+                [[mount-epoch-panel-instance-id-reaches-the-boundary]] and
+                [[mount-machine-inspector-instance-id-reaches-the-boundary]].
+
+            So the pick is now `mount-reactive-panel!`, and it is a sharper
+            witness than either predecessor: `reactive-panel/Panel-bridge` is
+            declared 0-arity ONLY, so a props map here is the arity error this
+            row names rather than a silently ignored key."
     (let [[capture _ render-stub] (make-render-stub)]
       (with-redefs [rf.substrate.adapter/render render-stub]
-        (panels/mount-epoch-panel! :mount-point {:instance-id "left"})
-        (is (= [epoch-panel/Panel-bridge] (delivered-element capture))
-            "the epoch mount delivers its view with no props")))))
+        (panels/mount-reactive-panel! :mount-point {:instance-id "left"})
+        (is (= [reactive-panel/Panel-bridge] (delivered-element capture))
+            "the reactive mount delivers its view with no props")))))
 
 (defn- trace-delivered-by
   "Mount the Trace panel through the public facade with `opts`; return the
@@ -556,6 +566,114 @@
         "opts carrying no instance name deliver it too")
     (is (= {} (crossed (trace-delivered-by nil)))
         "and the bridge's 0-arity mounts the boundary with no props")))
+
+(defn- epoch-delivered-by
+  "Mount the Epoch panel through the public facade with `opts`; return the
+  element it delivered to the substrate."
+  [opts]
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [rf.substrate.adapter/render render-stub]
+      (panels/mount-epoch-panel! :mount-point opts))
+    (delivered-element capture)))
+
+(deftest mount-epoch-panel-instance-id-reaches-the-boundary
+  (testing "rf2-3ymg — `mount-epoch-panel!`'s `:instance-id` opt reaches the
+            Fresco boundary's props, across the real `Panel-bridge`. This is
+            the mount door onto the prop the panel now reads: a caller that
+            MOUNTS passes opts and never props, so before this the standalone
+            embed could not name an instance at all.
+
+            The DOM-level claim — that naming two mounts actually separates
+            their inspector lifecycle and width — is
+            `panels/epoch_machine_mount_instance_id_dom_cljs_test`'s. This row
+            is only that the opt survives the facade and the crossing, which
+            is the half a DOM row cannot localise when it fails."
+    (is (= {:instance-id "left"}
+           (crossed (epoch-delivered-by {:instance-id "left"})))
+        "the opt crosses the bridge and arrives as a prop")
+    (is (= {:instance-id "left/epoch"}
+           (crossed (epoch-delivered-by {:instance-id :left/epoch})))
+        "and a KEYWORD keeps its namespace — rf2-4bsq: `[:>]` would convert it
+         with `cljs.core/name` and drop the namespace, so `:left/epoch` and
+         `:right/epoch` would both arrive as \"epoch\" and compose one
+         `epoch/epoch/dispatch-event`, restoring the very collision this
+         removes. The bridge tokenises BEFORE the crossing for that reason")
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-epoch-panel! :mount-point
+                                   {:frame :my-app/cart :instance-id "right"})
+        (is (= {:frame :my-app/cart} (second (captured-tree capture)))
+            "and it composes with `:frame` rather than replacing it — the
+             frame-provider still wraps the frame the host named")))
+    (is (= [epoch-panel/Panel-bridge] (epoch-delivered-by nil))
+        "an UNNAMED epoch mount delivers the bare `[Panel-bridge]` element it
+         always delivered, not `[Panel-bridge {}]` — the shape the shell's
+         `[(:panel tab)]` and every standalone call site in this tree take
+         today, and what keeps their composed ids byte-for-byte unchanged")
+    (is (= [epoch-panel/Panel-bridge] (epoch-delivered-by {:frame :my-app/cart}))
+        "opts carrying no instance name deliver it too")
+    (is (= {} (crossed (epoch-delivered-by nil)))
+        "and the bridge's 0-arity mounts the boundary with no props")
+    (is (= {} (crossed (epoch-delivered-by {:instance-id ""})))
+        "a BLANK string tokenises to nil and mounts with no props, exactly as
+         naming no instance does — the facade passes it through (the empty
+         string is truthy), so it is the tokeniser that has to refuse it")))
+
+(defn- machine-inspector-delivered-by
+  "Mount the Machine Inspector through the public facade with `opts`; return
+  the element it delivered to the substrate."
+  [opts]
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [rf.substrate.adapter/render render-stub]
+      (panels/mount-machine-inspector! :mount-point opts))
+    (delivered-element capture)))
+
+(deftest mount-machine-inspector-instance-id-reaches-the-boundary
+  (testing "rf2-3ymg — `mount-machine-inspector!`'s `:instance-id` opt reaches
+            the Fresco boundary's props, across the real `Panel-bridge`.
+
+            THIS PANEL'S CONTRACT DIFFERS FROM EVERY SIBLING'S, which is why
+            it gets its own row rather than riding on the epoch one above.
+            Element 2 renders through `epoch-view/machine-cascade-mini-
+            pipeline`, the SHARED renderer the Epoch panel's handler step uses
+            (rf2-g2axio), so this panel composes ids in the EPOCH panel's id
+            namespace. `machine-inspector/instance-token` therefore NEVER
+            answers nil: it names the panel itself, and a caller's token rides
+            BELOW that. The rows below pin both halves of that."
+    (is (= {:instance-id "machine-inspector"}
+           (crossed (machine-inspector-delivered-by nil)))
+        "AN UNNAMED MOUNT IS THE INTERESTING ONE — it crosses carrying this
+         panel's OWN name, not `{}`. That is the cross-panel half of rf2-3ymg
+         fixed with no caller action, because which panel is rendering is
+         statically known and an embedder mounting one Epoch panel and one
+         Machine Inspector over the same cascade cannot see the collision to
+         work around it. Every sibling panel answers nil here")
+    (is (= [machine-inspector/Panel-bridge] (machine-inspector-delivered-by nil))
+        "the DELIVERED element is still the bare `[Panel-bridge]` it always
+         was, though — what changed is what the bridge mounts the boundary
+         with, not what the facade hands the substrate")
+    (is (= {:instance-id "machine-inspector/left"}
+           (crossed (machine-inspector-delivered-by {:instance-id "left"})))
+        "a caller's name rides BELOW the panel's own, so two standalone
+         Machine Inspectors are distinct AND one named `left` cannot collide
+         with an Epoch panel named `left` either")
+    (is (= {:instance-id "machine-inspector/left/machines"}
+           (crossed (machine-inspector-delivered-by {:instance-id :left/machines})))
+        "and a KEYWORD keeps its namespace — rf2-4bsq, as for every other
+         bridge that tokenises before the crossing")
+    (is (= {:instance-id "machine-inspector/left"}
+           (crossed (machine-inspector-delivered-by
+                      {:instance-id "machine-inspector/left"})))
+        "the tokeniser is IDEMPOTENT on its own output, which is what makes
+         the boundary's second call after the crossing a no-op rather than a
+         `machine-inspector/machine-inspector/left`")
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [rf.substrate.adapter/render render-stub]
+        (panels/mount-machine-inspector!
+          :mount-point {:frame :my-app/cart :instance-id "right"})
+        (is (= {:frame :my-app/cart} (second (captured-tree capture)))
+            "and it composes with `:frame` rather than replacing it — the
+             frame-provider still wraps the frame the host named")))))
 
 ;; ---- contract — idempotency under repeat mount ------------------------
 


### PR DESCRIPTION
## THE ONE RED IS CLEARED — the node lane is green

This branch carried one known node-lane failure the original author was fenced out of
repairing. The fence has lifted and the repair has landed; `npm run test:cljs` is
**captured exit 0**, 11730 tests / 58658 assertions, 0 failures, 0 errors.

`tools/xray/test/day8/re_frame2_xray/panels_mount_cljs_test.cljs` carried
`mount-fns-without-an-instance-name-deliver-exactly-what-they-did`, which asserted that
`mount-epoch-panel!` was a **current member of the no-prop group**. This change moves it
out, exactly as rf2-pua3 moved `mount-trace!` out, so the row was **superseded rather than
wrong** — its own docstring anticipated the move ("A panel is picked here for being a
CURRENT member of the no-prop group, not for being a permanent one").

**The red was reproduced before it was repaired**, not taken on the previous report:
`npm run test:cljs` captured exit **1**, 11728 tests / 58645 assertions, exactly 1 failure
at `panels_mount_cljs_test.cljs:511:13` — the row named above and nothing else.

### What the repair does

**It re-points the row rather than reverting the source.** The move out of the no-prop
group is the feature; the row is not weakened into something that asserts nothing.

The pick is now `mount-reactive-panel!`, and it is a **sharper witness than either
predecessor**: `reactive-panel/Panel-bridge` is declared **0-arity only**, so a props map
there is the arity error the row's own docstring names, rather than a silently ignored key
that a Fresco boundary would destructure away. The row still bites for a real panel, and
the docstring now records the full lineage of the pick (trace → epoch → reactive) so the
next migration knows where to look.

### And the two boundary rows — added, deliberately, not as duplication

The previous author called these *ideal*. They are worth having, and the in-tree precedent
says why: `mount-trace-instance-id-reaches-the-boundary`'s own docstring states that the
DOM-level claim belongs to the DOM suite while **"this row is only that the opt survives
the facade and the crossing, which is the half a DOM row cannot localise when it fails."**
The new browser suite on this branch witnesses the composed *effect*; these rows say which
half broke — the facade, or the Reagent crossing.

`mount-machine-inspector-instance-id-reaches-the-boundary` additionally pins a claim that
**nothing else in the tree pins**: an UNNAMED Machine Inspector mount now crosses as
`{:instance-id "machine-inspector"}` rather than `{}`, because its element 2 renders
through the Epoch panel's shared cascade pipeline and so composes into the Epoch panel's id
namespace. That is this change's cross-panel half, fixed with no caller action — and it is
precisely the behaviour this PR's own description flags as changing what an unnamed Machine
Inspector composes. It also pins that the *delivered* element is still the bare
`[Panel-bridge]` it always was, and that the tokeniser is idempotent on its own output, on
which the bridge-then-boundary double call depends.

Scope held: **one test file, 127 insertions / 9 deletions.** No source file was touched by
the repair.

---

## What was wrong

Thirteen `ei/edn-inspector-view` heads in `panels/epoch/view.cljs` composed a `:mount-id`
from a **logical site**: `"epoch/dispatch-event"` is a constant, and the machine cascade's
three are a role plus a step ordinal. That separates roles *within* one panel — the question
rf2-k97c.3 was answering — and is silent on a different one: which of two panels on screen
is this?

It matters because the string is physical. The widget keys its per-mount store by
`[frame-id mount-id]`, `container-ref-for` memoises the ref callback on that key and
installs a ResizeObserver only when the entry has none, and `release-mount!` disconnects the
entry and clears the measured-width slot — keyed by the bare `mount-id` — when **either**
holder detaches. Two mounts sharing an id therefore do not merely look alike: the second
installs no observer at all, and the first to go takes the survivor's observer and width
with it.

## The reproduction came first

The witness was written and **committed against the unrepaired tree** and run before
anything was fixed. `npm run test:browser`, captured exit **1**: 9 failures, 0 errors, on an
otherwise-green 980-test / 5485-assertion run, all 9 in the new namespace.

* Two named Epoch mounts both committed `["epoch/dispatch-event"
  "epoch/machine-cascade-transition-delta/1"]`. Byte-identical.
* An Epoch panel and a Machine Inspector, **with neither caller naming anything**, both
  committed `["epoch/machine-cascade-transition-delta/1"]` — the cross-panel half, over the
  shared mini-pipeline, verbatim.
* Both width writes landed on one key (`(not (= 2 1))`), and after unmounting the sibling
  the **survivor's** store entry read nil — `(not (contains? nil :observer))`. That is the
  half a distinctness-only witness passes straight over.

So the bead's data-flow argument held in full, including the part it was honest about never
having executed.

**One fixture finding on the way, and it was a false green in the making.** The first run
read `[]` from every container with both panel roots committed — the controls fired rather
than the claims. Those rows mount through the *public facades*, and `render-panel!` routes
every mount through `ensure-xray-handlers-installed!` → `mount/ensure-xray-frame!`, whose
first-mount hook table writes the very slots the fixture seeds. Seeded first and mounted
second, the hooks land on top and both panels paint an empty state. The sibling boundary
suites never meet this because they mount the registry head under a `frame-provider` and
never reach the facade. Fixed by calling the (idempotent) `ensure-xray-frame!` before the
seeding.

## The shape, and it is a FOURTH one

**One qualifier, on the `:mount-id` alone.** All thirteen sites pass a stable `:site-id`,
and the widget's `effective-id` is `(or site-id mount-id)`, so expansion and zoom are keyed
`[panel-id site-id path]` and never read the mount-id. That much it shares with Trace, and a
row pins the bound.

What it does **not** share is where the qualifier comes from, because there are two
collisions here rather than one:

* **Two Epoch panels in one frame** — two mounts of one panel, which nothing inside can tell
  apart. The **caller** names them, through the optional `:instance-id` the three shipped
  panels already take, tokenised before the Reagent crossing since `cljs.core/name` drops a
  keyword's namespace (rf2-4bsq). Unnamed — every call site in this tree today — every id is
  byte-for-byte what it was.

* **An Epoch panel and a Machine Inspector** — two *different* panels, sharing one
  `machine-cascade-mini-pipeline` off one `machine-cascade-rows`, which is rf2-g2axio's whole
  point. This is **not the caller's to fix**: which panel is rendering is statically known,
  and an embedder mounting one of each cannot see the collision to work around it. So
  `machine-inspector/instance-token` never answers nil — it names itself, and a caller's
  `:instance-id` rides below it (`machine-inspector/left`).

That second decision is the one deliberate departure from the brief's "minimal caller-owned
qualifier" framing, and it is the reason the bead's own sharpest case ("*more sharply*, an
Epoch panel and a Machine Inspector...") is fixed by default rather than only for callers
who knew to ask. It does change what an **unnamed** Machine Inspector composes — its cascade
inspector `:mount-id`s and therefore the `rf-xray-edn-inspector-*` container testids derived
from them. No test pins those (checked), and the node lane now pins the crossing itself. The
shared cascade-row testids the extraction promised would stay identical on both surfaces are
untouched.

## Bound

Preserved byte-for-byte: expansion, zoom, every step's own testids, the shared cascade-row
testids, the React keys, and every id composed by an unnamed Epoch mount. No identity
framework; no widening of the migration. `views/edn_inspector.cljs` and
`views/edn_widget.cljs` are untouched — the inspector has supported a caller-supplied
per-mount identity since rf2-d2aj; what was missing was a public way for these two callers
to supply one.

Threaded as an ordinary argument — through the `ctx` map the panel already threads, and as a
trailing parameter below it. **Not a dynamic var**: `machine-cascade-view` and the
violation/error blocks build children inside `for` and `map-indexed`, whose lazy seqs are
realised by the renderer *after* the boundary body has returned and any `binding` has
popped, so an ambient value would read nil for exactly the rows that carry the most
inspectors.

## Quality gates

| Gate | Captured exit | Result |
| --- | --- | --- |
| `npm run test:cljs` — compile phase (repair) | **0** | 1963 files, 0 warnings. Config path named this worktree |
| `npm run test:cljs` — run phase (repair) | **0** | **11730 tests, 58658 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (pre-repair, reproduction) | **1** | 11728 tests, 58645 assertions, 1 failure — the superseded row, and nothing else |
| `python scripts/check_retired_spellings.py` | **0** | pass |
| `python scripts/check_retired_spellings.py` (SABOTAGED) | **1** | named this exact test file and the planted line — the gate demonstrably reads `tools/xray/test/**` |
| `python scripts/check_require_alias_dialect.py` | **0** | pass |
| `python scripts/check_flattened_lists.py` | **0** | pass |
| `python scripts/check_view_lifetime_residue.py` | **0** | pass |
| `python scripts/check_thrown_error_messages.py` | **0** | pass |
| `python scripts/check_architecture_census.py` | **0** | pass |
| `python scripts/check_fast_pr_gap.py --brief` | **0** | report, not a suite — read to learn what CI still owns |
| `npm run test:browser` (pre-fix, witness only) | **1** | 9 failures / 0 errors in the new namespace, rest of tree green — the reproduction |
| `npm run test:browser` (post-fix) | **0** | 980 tests, 5485 assertions, 0 failures, 0 errors. Port 8151 |
| `scripts/check-no-hardcoded-paths.sh` | **0** | pass |
| `scripts/check-ai-tracking-ratchet.sh` | **0** | pass |

**Every number above is a captured exit code** read back from its own `.exit` file, never a
figure reported about the run by something else.

**Lane discrimination, by both routes the gate affords.** The compile phase prints its
config path, and that line named this worktree's `shadow-cljs.edn` — so the run read this
tree and not a sibling's. Independently, the node lane is proven to have graded the changed
source by its own counts: the reproduction ran 11728 tests / 58645 assertions with the row
red, and the repair ran **11730 / 58658** — exactly +2 deftests and +13 assertions, which is
precisely what the two new rows add, with the failure gone. That is positive evidence the
runtime observed the edit, not merely that the source changed.

**The ratchet was proven to bite rather than assumed to.** `check_retired_spellings.py` was
run against a planted violation in this very file and came back exit **1** naming the file
and the planted line; the plant's match count was read as 1 *before* the run, and the
restore was verified by git blob hash against the committed object (identical), with a
residue scan reading 0. The gate was not re-run after the restore because the hash proves
the file is byte-identical to the state already graded green.

**The browser lane was not re-run for this repair**, and that is deliberate per the gate time
box: it was green on the previous head, and this repair is node-lane-only — one test file,
no DOM surface, no source file. CI is the evidence for it on the new head.

**Not rebased.** Trunk has moved 32 commits since this branch's merge base, and **none of
them touches any of this branch's five files**, so there is no conflict and nothing to
revert. The branch-vs-merge-base diff was read for silent reverts as well as conflicts; the
repair commit is one file, additive, 127 insertions / 9 deletions.

**Everything else is left to CI**, per the gate time box: the full matrix, the fast-PR
spine, the docs and lint lanes, the Xray feature-matrix gate and the adapter smokes. Each
heavy lane above was run once.
