### PR TITLE
test: census of document-guarded rows that execute in neither lane (rf2-6ppy)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
@@ -4,10 +4,15 @@
   Covers:
 
   - `record` pure helper — prepend, dedup, cap.
-  - `load` / `save!` localStorage round-trip (degrades silently in
-    Node test runtimes where window.localStorage is absent — the JVM
-    fixture path is exercised by the CLJC `sources` tests).
-  - `sanitise` drops non-keyword entries from a malformed payload."
+  - `load` on an empty slot — the storage-free fallback.
+  - `sanitise` drops non-keyword entries from a malformed payload.
+
+  The `load` / `save!` localStorage ROUND-TRIP lives in the sibling
+  `day8.re-frame2-xray.palette.recents-dom-cljs-test` (rf2-6ppy). It
+  needs a real `window.localStorage`, which this lane does not have;
+  guarding it here on `(exists? js/window)` meant it ran in NO lane,
+  because `:browser-test` only loads namespaces ending
+  `-dom-cljs-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-xray.palette.recents :as recents]))
 
@@ -41,28 +46,14 @@
   (is (= [:foo] (recents/record [:foo] nil))
       "nil command-id does not bump the list"))
 
-;; ---- save! / load round-trip --------------------------------------------
+;; ---- load without storage -----------------------------------------------
 ;;
-;; Node test runtimes don't simulate `window.localStorage` — the round-
-;; trip tests gate on `js/window` so they cover the browser path when
-;; the runtime provides it and silently skip otherwise. The pure
-;; `record` / `sanitise` tests above cover the algorithm regardless.
-
-(deftest save-load-round-trip
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (recents/save! [:foo :bar])
-    (is (= [:foo :bar] (recents/load))
-        "browser-backed round-trip preserves the recents vector
-         (most-recent-first, capped at max-recents)")))
+;; Node test runtimes don't provide `window.localStorage`, so only the
+;; storage-free fallback is assertable here. The round-trip that needs
+;; real storage is in `recents-dom-cljs-test`; it used to sit below,
+;; gated on `js/window`, where it executed in neither lane (rf2-6ppy).
 
 (deftest load-empty-slot-returns-empty-vector
   (recents/clear!)
   (is (= [] (recents/load))
       "empty / unreachable storage → empty vector (never nil)"))
-
-(deftest save-caps-at-max
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (recents/save! [:a :b :c :d :e])
-    (let [loaded (recents/load)]
-      (is (<= (count loaded) recents/max-recents)
-          "save! caps the persisted list at max-recents"))))

--- a/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
@@ -9,10 +9,17 @@
 
   The `load` / `save!` localStorage ROUND-TRIP lives in the sibling
   `day8.re-frame2-xray.palette.recents-dom-cljs-test` (rf2-6ppy). It
-  needs a real `window.localStorage`, which this lane does not have;
-  guarding it here on `(exists? js/window)` meant it ran in NO lane,
-  because `:browser-test` only loads namespaces ending
-  `-dom-cljs-test`."
+  needs a real `window.localStorage`, which this lane does not have.
+  Sitting HERE it executed in NO lane — skipped under `:node-test` for
+  want of storage, and never loaded by `:browser-test`, whose
+  `:ns-regexp` is `.*-dom-cljs-test$`.
+
+  The FILE NAME was the defect, not the guard, and the sibling still
+  carries one. `:node-test`'s `:ns-regexp` is `cljs-test$` — a bare
+  SUFFIX match that `-dom-cljs-test` satisfies too — so a DOM-tagged
+  file runs on BOTH lanes. The move ADDED the browser lane rather than
+  removing this one, and the sibling's `ls/available?` guard is what
+  keeps its node run inert."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [day8.re-frame2-xray.palette.recents :as recents]))
 
@@ -51,7 +58,11 @@
 ;; Node test runtimes don't provide `window.localStorage`, so only the
 ;; storage-free fallback is assertable here. The round-trip that needs
 ;; real storage is in `recents-dom-cljs-test`; it used to sit below,
-;; gated on `js/window`, where it executed in neither lane (rf2-6ppy).
+;; where this lane skipped it and the browser build never loaded it, so
+;; it executed in neither (rf2-6ppy). Moving it did NOT take it off this
+;; lane — `:node-test`'s `cljs-test$` selector loads `-dom-cljs-test`
+;; files too — it added the browser lane, and the guard it kept there is
+;; what keeps its node pass honest.
 
 (deftest load-empty-slot-returns-empty-vector
   (recents/clear!)

--- a/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs
@@ -13,7 +13,7 @@
   guarding it here on `(exists? js/window)` meant it ran in NO lane,
   because `:browser-test` only loads namespaces ending
   `-dom-cljs-test`."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [day8.re-frame2-xray.palette.recents :as recents]))
 
 (use-fixtures :each

--- a/tools/xray/test/day8/re_frame2_xray/palette/recents_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/recents_dom_cljs_test.cljs
@@ -4,22 +4,38 @@
 
   WHY A SEPARATE NAMESPACE. The sibling
   `day8.re-frame2-xray.palette.recents-cljs-test` holds the pure `record`
-  / `sanitise` algebra, which needs no host storage and belongs on the
-  fast `:node-test` lane. The `save!` / `load` round-trip needs a real
-  `window.localStorage`, which the node lane does not provide.
+  / `sanitise` algebra, which needs no host storage. The `save!` / `load`
+  round-trip needs a real `window.localStorage`, and only a namespace
+  ending `-dom-cljs-test` is ever loaded by the `:browser-test` build,
+  whose `:ns-regexp` is `.*-dom-cljs-test$`. Sitting in the sibling file
+  these rows executed in NEITHER lane: skipped under `:node-test` for
+  want of storage, and never loaded by `:browser-test` at all. The file's
+  LOCATION was the defect. The guard was not.
 
-  Guarding those rows in the node file — `(when (and (exists? js/window)
-  (.-localStorage js/window)) ...)` — made them execute in NEITHER lane:
-  skipped under `:node-test` for want of storage, and never loaded by
-  `:browser-test`, whose `:ns-regexp` is `.*-dom-cljs-test$`. A namespace
-  must end `-dom-cljs-test` to reach the browser build at all, so the two
-  round-trip rows live here, UNGUARDED, and run against real
-  localStorage.
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does. So the node
+  build loads this namespace too, and the overlap is deliberate:
+  `implementation/shadow-cljs.edn` records above `:browser-test` that the
+  DOM-tagged files run on BOTH targets so their cross-runtime asserts
+  keep firing in Node. Moving a row here therefore ADDS the browser lane;
+  it does not take the row off the node one. `ls/available?` is what
+  keeps the node run inert — without it, node executes an unguarded
+  round-trip against storage it does not have and `load` returns `[]`.
 
-  These assertions had never executed before this namespace existed. A
-  failure here is therefore evidence about `recents/save!` / `recents/load`
-  arriving for the first time, not a regression introduced by the move."
+  THE SKIP BRANCH ASSERTS RATHER THAN VANISHING. A bare `(when ...)` body
+  would leave the node lane holding a deftest with ZERO assertions, which
+  is the hollow shape rf2-6ppy exists to remove — relocated, not fixed.
+  The marker row keeps the skip visible in the node summary. Same shape
+  as the `browser?` branches in
+  `day8.re-frame2-xray.palette.empty-row-frame-context-dom-cljs-test`.
+
+  These assertions had never executed in ANY lane before this namespace
+  existed. A failure here is evidence about `recents/save!` /
+  `recents/load` arriving for the first time, not a regression introduced
+  by the move."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [day8.re-frame2-xray.local-storage :as ls]
             [day8.re-frame2-xray.palette.recents :as recents]))
 
 (use-fixtures :each
@@ -27,13 +43,23 @@
    :after  (fn [] (recents/clear!))})
 
 (deftest save-load-round-trip
-  (recents/save! [:foo :bar])
-  (is (= [:foo :bar] (recents/load))
-      "browser-backed round-trip preserves the recents vector
-       (most-recent-first, capped at max-recents)"))
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (recents/save! [:foo :bar])
+      (is (= [:foo :bar] (recents/load))
+          "browser-backed round-trip preserves the recents vector
+           (most-recent-first, capped at max-recents)"))))
 
 (deftest save-caps-at-max
-  (recents/save! [:a :b :c :d :e])
-  (let [loaded (recents/load)]
-    (is (<= (count loaded) recents/max-recents)
-        "save! caps the persisted list at max-recents")))
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (recents/save! [:a :b :c :d :e])
+      (let [loaded (recents/load)]
+        ;; `=` rather than `<=`: a silently no-op write (swallowed quota
+        ;; or SecurityError — see the `local-storage` seam) leaves `load`
+        ;; returning `[]`, and `<=` passes on that. The cap is exact —
+        ;; five saved, `max-recents` kept.
+        (is (= recents/max-recents (count loaded))
+            "save! caps the persisted list at max-recents")))))

--- a/tools/xray/test/day8/re_frame2_xray/palette/recents_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/recents_dom_cljs_test.cljs
@@ -1,0 +1,39 @@
+(ns day8.re-frame2-xray.palette.recents-dom-cljs-test
+  "Browser-lane half of the palette recents persistence tests (rf2-ybjkx),
+  promoted out of `recents-cljs-test` under rf2-6ppy.
+
+  WHY A SEPARATE NAMESPACE. The sibling
+  `day8.re-frame2-xray.palette.recents-cljs-test` holds the pure `record`
+  / `sanitise` algebra, which needs no host storage and belongs on the
+  fast `:node-test` lane. The `save!` / `load` round-trip needs a real
+  `window.localStorage`, which the node lane does not provide.
+
+  Guarding those rows in the node file — `(when (and (exists? js/window)
+  (.-localStorage js/window)) ...)` — made them execute in NEITHER lane:
+  skipped under `:node-test` for want of storage, and never loaded by
+  `:browser-test`, whose `:ns-regexp` is `.*-dom-cljs-test$`. A namespace
+  must end `-dom-cljs-test` to reach the browser build at all, so the two
+  round-trip rows live here, UNGUARDED, and run against real
+  localStorage.
+
+  These assertions had never executed before this namespace existed. A
+  failure here is therefore evidence about `recents/save!` / `recents/load`
+  arriving for the first time, not a regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+            [day8.re-frame2-xray.palette.recents :as recents]))
+
+(use-fixtures :each
+  {:before (fn [] (recents/clear!))
+   :after  (fn [] (recents/clear!))})
+
+(deftest save-load-round-trip
+  (recents/save! [:foo :bar])
+  (is (= [:foo :bar] (recents/load))
+      "browser-backed round-trip preserves the recents vector
+       (most-recent-first, capped at max-recents)"))
+
+(deftest save-caps-at-max
+  (recents/save! [:a :b :c :d :e])
+  (let [loaded (recents/load)]
+    (is (<= (count loaded) recents/max-recents)
+        "save! caps the persisted list at max-recents")))


### PR DESCRIPTION
Census for rf2-6ppy, plus the smallest convincing repair. Derived at trunk `dbf04ed509`.

## The premise holds, and it is wider than the item states

Both halves check out at source:

- `implementation/shadow-cljs.edn` — `:node-test` has `:ns-regexp "cljs-test$"`; `:browser-test` has
  `:ns-regexp ".*-dom-cljs-test$"`. So `-dom-cljs-test` namespaces run in BOTH lanes, and a plain
  `-cljs-test` namespace runs on node ONLY. The suffix rule is real, and it is a NAMESPACE rule that
  happens to track filenames (no ns/filename disagreement anywhere in the tree).
- No DOM shim on node. `jsdom` and `happy-dom` appear in no dependency list — every tracked mention is
  prose asserting their absence. `node -e` on this runtime reports `document: undefined`,
  `window: undefined`, `localStorage: undefined`.

The only other browser-lane builds are `:browser-test-schemas-boundary-prod` (`-boundary-prod-test$`)
and `:browser-test-prod-elision` (`-elision-prod-test$`); no namespace below matches either.

**What differs from the item: the guard has a second spelling, and it is the larger half.** Besides
`(when (exists? js/document) …)`, eleven files route the same check through a locally-defined
`(browser?)` predicate — `(and (exists? js/window) (.-localStorage js/window))` and variants. Those
files are invisible to a census keyed on `exists? js/document`. Counting both spellings takes the
census from 7 files to 16.

Several of those predicates carry a docstring stating the author's intent explicitly — *"Node-test (the
shadow `:node-test` target) returns false; browser-test returns true."* Browser-test never loads the
file, so the second half was never true.

## The census — 16 files, 106 guarded assertions, executing in no lane

Namespace does not end `-dom-cljs-test`, so `:browser-test` never loads it; the guard is false on node.

| File | Guarded | of total | Guard spelling |
| --- | ---: | ---: | --- |
| `tools/story/test/re_frame/story/ui/toolbar_persistence_cljs_test.cljs` | 20 | 20 | `browser?` |
| `tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs` | 12 | 23 | `exists?` |
| `tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs` | 11 | 48 | `exists?` |
| `tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs` | 9 | 70 | `browser?` |
| `tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs` | 9 | 72 | `exists?` |
| `tools/story/test/re_frame/story/backgrounds_test.cljc` | 6 | 47 | `browser?` |
| `tools/story/test/re_frame/story/viewport_test.cljc` | 6 | 51 | `browser?` |
| `tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs` | 6 | 22 | `exists?` |
| `tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc` | 5 | 108 | `browser?` |
| `tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc` | 5 | 50 | `browser?` |
| `tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs` | 5 | 77 | `exists?` |
| `tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc` | 3 | 20 | `browser?` |
| `tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc` | 3 | 20 | `browser?` |
| `tools/story/test/re_frame/story_help_cljs_test.cljs` | 3 | 8 | `browser?` |
| `tools/xray/test/day8/re_frame2_xray/palette/recents_cljs_test.cljs` | 2 | 9 | `exists?` | 
| `tools/story/test/re_frame/story/xray_preset_cljs_test.cljs` | 1 | 34 | `exists?` |

`resize_handle_cljs_test.cljs`, the known-positive control, appears — read and counted, not edited
(PR #9677 owns it).

Three entries are worse than the row count suggests:

- **`toolbar_persistence_cljs_test.cljs` is entirely hollow** — 20 of 20 assertions guarded. The whole
  namespace, a "CLJS-side regression net for toolbar mode persistence across reload (rf2-jpi7n)",
  executes zero assertions in any lane.
- **`backgrounds_test.cljc` and `viewport_test.cljc` are dead one level further out.** Their namespaces
  (`re-frame.story.backgrounds-test`, `re-frame.story.viewport-test`) do not end `cljs-test` either, so
  `:node-test` does not select them at all and `:browser-test` does not match them. Their storage rows
  sit inside `#?(:cljs …)`, which the JVM lane never reads. The `(browser?)` guard is not what kills
  these — they would still run nowhere without it.

## Three buckets, as asked

**(1) Genuinely dead, asserting something nothing else covers — all 16.** Every guarded row I read
asserts a storage or DOM round-trip whose unguarded siblings reach only the storage-free fallback path
(`load` on an empty slot returning `[]`, defaults when the slot is absent). The write-through, the
cap-at-max, the reload-survives and the hydrate-from-storage properties exist only in the dead rows.
Checked for duplication where two files looked like candidates: `backgrounds_test.cljc` covers
`save-to-storage!`/`load-from-storage` while `backgrounds_switcher_cljs_test.cljc` covers `hydrate!`
seeding — distinct properties, both dead.

**(2) Dead but covered elsewhere — none found.** I looked for this bucket specifically and it is empty.
The nearest candidate inverts into something worse: `xray_preset_cljs_test.cljs`'s single guarded row is
a *precondition* — `(when (exists? js/document) (xray-keybinding/attach!) (is (true? (attached?))))`.
Because it never runs, `attach!` never runs either, so the unguarded sibling two lines below,
`(is (false? (xray-keybinding/attached?)) "wire-cross-host! removed the listener")`, passes vacuously —
nothing was ever attached. A dead row hollowing a live one.

**(3) Guards correct as they stand.** 32 further files carry the same guards inside `-dom-cljs-test`
namespaces; the browser build loads those, so the guards do their job. Two special cases worth recording
so a later sweep does not misfile them:

- `implementation/core/test/re_frame/adapter/react_shared_suite.cljs` guards rows on `(browser?)` but is
  a parameterised suite namespace, not a test namespace. It is required by `-dom-cljs-test` files
  (`uix_use_sub_dom_cljs_test`, `uix_after_render_dom_cljs_test`, and others), so its guarded bodies do
  execute in the browser lane. Correct as-is.
- `tools/xray/test/day8/re_frame2_xray/acceptance/test_helpers/criteria.cljs` uses `(if-not (browser?) …)`
  — the inverted form, selecting the node path deliberately.

A near-miss worth noting: `keybinding_cljs_test.cljs` installs a real `js/document` stub via
`set! js/document` on `goog.global`, which would make neighbouring `exists?` guards true. It restores or
`js-delete`s the slot in a `finally`, so it does not leak and the guards above stay false.

## The repair in this change — smallest convincing, one file

`day8.re-frame2-xray.palette.recents-cljs-test`'s two localStorage round-trip rows move into a new
`recents_dom_cljs_test.cljs`, which the browser build does load. The storage-free `load`-on-empty-slot
row stays on the node lane.

**They keep their storage guard, and that is the whole point of the shape.** A first pass moved them
UNGUARDED, on the belief that a `-dom-cljs-test` namespace runs in the browser lane only. It does not —
the census two sections above says so in its own words, and `implementation/shadow-cljs.edn` says it in
terms: `:node-test`'s `:ns-regexp` is `cljs-test$`, a bare SUFFIX match that `-dom-cljs-test` satisfies
exactly as `-cljs-test` does, and the comment above `:browser-test` records the overlap as deliberate,
so DOM-tagged files keep firing their cross-runtime asserts in Node. The move therefore ADDS the browser
lane; it never removed the node one. Unguarded, node ran a localStorage round-trip in a runtime with no
localStorage, `load` returned `[]`, and `CLJS (shadow-cljs :node-test)` went red.

rf2-6ppy's goal is untouched: the rows go from executing in **no** lane to executing in the **browser**
lane. The file's LOCATION was the defect; the guard never was.

Three details of the restored shape:

- **The guard is `ls/available?`** — the shared `local-storage` seam that exists to be the one place
  Xray spells this test (rf2-jkake.24) — rather than a fresh copy of the
  `(and (exists? js/window) (.-localStorage js/window))` trio that seam retired.
- **The skip branch asserts rather than vanishing.** A bare `(when …)` body leaves the node lane holding
  a deftest with ZERO assertions, which is the hollow shape this item exists to remove — relocated
  rather than fixed. The marker row keeps the skip visible in the node summary. Same shape as the
  `browser?` branches in `palette.empty-row-frame-context-dom-cljs-test`.
- **`save-caps-at-max` tightens from `<=` to `=`.** Five saved against a cap of three is exact, and
  `<=` passes on `[]` — so inside its own lane that row would have stayed hollow if a write ever
  silently no-opped (swallowed quota or `SecurityError`), which is this item's subject arriving a
  second time.

`:node-test`'s `ns-regexp` was deliberately NOT narrowed to exclude `-dom-cljs-test`. That would move
every DOM-tagged namespace in the repo across lanes at once — a repo-wide behaviour change smuggled in
as a test fix. The overlap is deliberate and stays. Nor were the failing rows deleted or weakened to
pass on node.

Both files' prose asserted the rows had moved off the node lane. Corrected in the same commit: a
docstring giving a false mechanism is worse than none, because the next reader repeats it.

**These two assertions had never executed in any lane before this change.** They now execute in the
browser lane, and that is shown by measurement rather than by a green — see the asymmetry evidence
under Quality gates.


## The remaining 15 files are NOT repaired here, deliberately

The repair is a convention call, and the item says to hand one back rather than make it. There are three
available shapes, and the repo already uses two of them:

1. **Move to a `-dom-cljs-test` namespace** — what this change does. Costs the fast lane.
2. **Install a host stub so the row runs on node.** This repo's own precedent:
   `url_state_cljs_test.cljs` documents exactly this defect in prose at its popstate section — *"the old
   test wrapped its whole body in `(when (browser?) …)` and executed ZERO assertions under
   `npm run test:cljs` — a vacuous pass"* — and fixes it by installing a `js/globalThis` window stub.
   The routing suites do the same. Cheaper and faster than (1), but it tests against a fake.
3. **Delete the rows** where the property is not worth a lane. Not applicable to anything found.

Which of (1) and (2) applies is per-property — real localStorage semantics versus a fake — and is yours
to set. The 15 remaining files and their row counts are in the table above.

There may also be a case for a lint or classifier rule that fails a build when a namespace not ending
`-dom-cljs-test` guards assertions on `js/document` / `js/window`, since this defect is invisible from
every direction and recurred across 16 files and two spellings. Flagging, not filing.

## Quality gates

Both lanes were run locally this time — the first pass skipped them for the time box, and the node lane
is where the defect above surfaced.

| Gate | Result | Counts |
| --- | --- | --- |
| `npm run test:cljs` (node lane — the lane that was red) | **PASS** — captured exit `0` | Ran 11723 tests containing 58642 assertions; 0 failures, 0 errors |
| `npm run test:browser` (browser lane, `BROWSER_TEST_PORT=8171`) — run WITH a deliberate plant | **RED BY DESIGN** — captured exit `1` | Ran 977 tests containing 5460 assertions; exactly 1 failure, and it is the plant |
| Focused node run of the new namespace, `node out/node-test.js --test=day8.re-frame2-xray.palette.recents-dom-cljs-test` | **PASS** — captured exit `0` | Ran 2 tests containing 2 assertions; 0 failures, 0 errors |
| `clj-kondo --lint` (both changed files, re-run over the current bytes) | **PASS** — captured exit `0` | 0 errors, 0 warnings |
| `python scripts/check_retired_spellings.py` | **PASS** — captured exit `0` | repo-wide; 0 violations |
| `python scripts/check_fast_pr_gap.py --brief` | report, not a suite | names 101 required checks no local spine decides |

Earlier rows from the first pass — paren/form balance, the census re-run, `check-commit-attribution.sh`
and `check-beads-pr-boundary.sh` — still hold; this commit touches the same two files and adds no
tracker-database path. `clj-kondo` was re-run rather than carried over, because its earlier green
described bytes this commit changed.

### The asymmetry, shown rather than asserted

A green node lane is on its own consistent with the rows having been **deleted**, which is the failure
mode this item is about. So both halves were measured:

- **Executed in the browser lane.** With `save-load-round-trip`'s expected value deliberately altered to
  `[:foo :bar :planted-rf2-6ppy]`, the browser lane returned exactly one failure, at
  `recents_dom_cljs_test.cljs:50`, reporting `actual: (not (= [:foo :bar :planted-rf2-6ppy] [:foo :bar]))`.
  That `[:foo :bar]` is `(recents/load)` reading back what `save!` wrote — so the real branch ran against
  real `localStorage`, not the skip branch. The unplanted `save-caps-at-max` passed, and the other 976
  tests passed, so the single red is the plant and nothing else.
- **Skipped on the node lane.** The same namespace runs in the node bundle — the focused run above
  reports 2 tests, so `:node-test` does load a `-dom-cljs-test` namespace — and reports 0 failures. Had
  the real branch run there, `(= [:foo :bar] (recents/load))` would have failed, because node has no
  `localStorage`. The two assertions it counts are the skip markers.
- **The plant was reverted and the revert verified by content hash**, not by reading a diff: the file's
  blob hash returned to the committed `04fbac8648dc451ba9eeb6ef1fd63113c32baafa`, with a second
  instrument (`git diff --quiet HEAD`) agreeing at exit 0, and 0 occurrences of the plant sentinel
  remaining. The plant never left the working tree and is in no commit.
- The focused-run instrument was itself controlled both ways: a nonexistent namespace returns an
  explicit `no tests matched` error, and the sibling node-lane namespace returns its 5 tests / 7
  assertions.

Left to CI, declared rather than skipped silently:

- **A clean, unplanted browser-lane run.** The local browser run was spent on the sabotage, which is the
  evidence CI cannot produce; CI's own `cljs-browser` job supplies the clean green on this push.
- **The rest of the required matrix** — the JVM artefact lanes, bundle-isolation, examples-compile and
  the other jobs `check_fast_pr_gap.py` enumerates. None is decided by any local run.
- **`mkdocs build --strict` and the link/anchor gates** — no path under `docs/`, `spec/`, `migration/`
  or any README changed, so they are not this diff's gates.
