### PR TITLE
feat(xray): the filter edit popup becomes a Fresco boundary (rf2-d9ln)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/filters.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters.cljs
@@ -2,17 +2,19 @@
   "Facade for Xray's IN/OUT auto-filter subsystem.
 
   Per the canonical Xray panel-facade pattern (mirrored from
-  `palette.cljs`): the facade owns the `reg-view` Modal wrapper for
-  the edit popup + an `install!` fn that wires every filter-side
-  registration through the Xray registry.
+  `palette.cljs`): the facade owns the Modal wrapper for the edit
+  popup + an `install!` fn that wires every filter-side registration
+  through the Xray registry.
 
   ## What lives here
 
-  - `Modal` — `reg-view` mounting the edit popup. Mounted at the
+  - `ModalView` — the `rf.fresco/defview` BOUNDARY for the edit popup.
+    Short-circuits to nil when `:rf.xray/edit-popup-open?` is false.
+  - `Modal` — the public callable the shell mounts as a hiccup head,
+    an `as-component` bridge over [[ModalView]]. Mounted at the
     shell-view root so the popup overlays the chrome and panels;
-    short-circuits to nil when `:rf.xray/edit-popup-open?` is false.
-    Mounting at the shell root also keeps the popup's subscribes
-    inside the `:rf/xray` frame-provider's React context.
+    mounting there also keeps the popup's reads inside the `:rf/xray`
+    frame-provider's React context.
   - `install!` — orchestrator that installs the subs / events / fxs
     + the persistence fx. It does NOT hydrate on load: the transient
     pills reset every load and the host seed lands via `mount.cljs`'s
@@ -29,6 +31,7 @@
   - localStorage round-trip is in `filters/persistence.cljs`."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.filters.error-override :as error-override]
@@ -57,37 +60,101 @@
 
 ;; ---- Modal --------------------------------------------------------------
 
-(rf/reg-view Modal
-  "The edit popup. Renders only when `:rf.xray/edit-popup-open?` is
-  true; closed-state is a single subscribe + a `when`.
-  `reg-view`-registered so the body's subscribes route through the
-  React-context tier to `:rf/xray`.
+(rf.fresco/defview ^:private ModalView
+  "The filter edit popup's root — a FRESCO BOUNDARY (rf2-d9ln), not an
+  `rf/reg-view`. Renders only when `:rf.xray/edit-popup-open?` is true;
+  closed-state is one read plus a `when`.
 
-  Threads the reg-view-injected frame-aware `dispatch`
-  into `popup-view` so deferred `:on-*` handlers land on the
-  surrounding instance frame, not a `{:frame :rf/xray}` literal.
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref and no reaction owned by the installed
+  adapter. The FRAME they resolve against comes from React context,
+  which the enclosing frame boundary writes; `rf/frame-provider` and
+  `rf.fresco/frame-provider` write the SAME context, so this resolves
+  `:rf/xray` identically under today's Reagent-rendered shell and under
+  the Fresco root Xray will own.
 
-  ## rf2-k97c.3 — STILL AN `rf/reg-view`, AND THAT IS THE DECISION
+  THE THREE INNER READS SIT INSIDE THE OPEN-GATE `when` DELIBERATELY.
+  `rf.fresco/sub` is legal anywhere in a body and records its edge where
+  the read happens (HD-002), so a CLOSED popup holds ONE subscription,
+  not four — the same short-circuit the `reg-view` era got by not
+  calling `popup-view` at all, expressed in the collector's own terms.
 
-  Not an oversight, and not a half-done migration. This is one of the
-  seven shell-root modals `shell-view` mounts, and `shell-view` is
-  still an `rf/reg-view` — a Reagent tree — because severing Xray's
-  paint from the installed adapter's `:render` is the parent epic's
-  coupling (1) and a LATER slice. A `defview` mints a React function
-  component, which is not a legal hiccup head in a Reagent tree, so
-  migrating this Modal today would mean either an `as-component` bridge
-  with nothing above it to justify one, or an edit to `shell.cljs` that
-  the four sibling chrome satellites would each need too.
+  THEY ARE READ HERE RATHER THAN IN `popup-view`, AND THAT HOIST IS
+  LOAD-BEARING. `rf.fresco/sub` refuses outside a boundary render
+  (`:rf.error/fresco-sub-outside-render`), so a read-performing helper
+  becomes uncallable from every non-render lane the moment its reads
+  migrate — and `popup-view` has direct callers in two node-lane
+  suites. Taking values instead keeps it callable from anywhere, which
+  is what gives the node lane a door onto the SHIPPED tree. Same hoist,
+  and the same reason, as `settings/view/popup-tree`.
 
-  The later slice owns the choice and has two live options on record —
-  migrate these modals, or island them behind `as-child`. Whichever it
-  picks, the subtree below here is already ready: `popup-view` is
-  CALLED rather than headed, and every plain-fn head inside it has been
-  inlined, so nothing under this Modal is a `:invalid` head waiting to
-  fire."
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's declared frame inside a body and replaces
+  the `dispatch` the `reg-view` body injected lexically (rf2-nesy9;
+  `defview` binds no name). Every deferred `:on-*` handler in the tree
+  below closes over it, so an edit landing after render scope has
+  unwound still reaches the surrounding instance frame rather than a
+  `{:frame :rf/xray}` literal.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. The shell mounts this with none, so it is destructured away."
+  [_props]
+  (when (rf.fresco/sub [:rf.xray/edit-popup-open?])
+    (edit-popup/popup-view
+      (:dispatch (rf/capture-frame))
+      {:trigger     (rf.fresco/sub [:rf.xray/edit-popup-trigger])
+       :draft       (rf.fresco/sub [:rf.xray/edit-popup-draft])
+       :positioning (rf.fresco/sub [:rf.xray/modal-positioning])})))
+
+;; ---- the migration bridge (rf2-d9ln) ------------------------------------
+;;
+;; Xray's shell is still a `reg-view` tree rendered by the installed
+;; adapter, and `shell.cljs` mounts this popup as a hiccup head —
+;; `[filters/Modal]` at the shell-view root. `defview`'s contract is that
+;; a boundary is mounted as `[head props]` inside a Fresco body or
+;; through `as-component` from OUTSIDE, never as a hiccup render fn in a
+;; Reagent tree.
+;;
+;; `rf.fresco/as-component` is Fresco's own outward door for exactly
+;; this: it answers a real React component for a boundary, which a React
+;; parent mounts UNDER THE FRAME IT IS ALREADY IN, taking the frame from
+;; React context rather than from a second root. So there is no second
+;; root here, no adapter-kind branch, and no props ABI — and, the point
+;; of rf2-d9ln, NO `shell.cljs` EDIT. The docstring this replaced said
+;; migrating would need one; `cancellation-cascade/Popover`,
+;; `spine-filters/Modal`, `palette/Modal` and `settings-popup/Modal` had
+;; already shipped through this same bridge without touching it.
+;;
+;; THIS IS SCAFFOLDING WITH A DEFINED END. When `mount.cljs` owns a
+;; Fresco root and `shell-view` is itself a boundary, it heads
+;; [[ModalView]] directly, `[:>]` goes, and both defs below are deleted.
+
+(def ^:private Modal-component
+  "The React component [[ModalView]] presents as, for a non-Fresco
+  parent. Declared once at top level beside the view, as
+  `rf.fresco/as-component`'s contract requires — deriving it per render
+  would mint a new component type every time and remount the popup on
+  each shell render, losing the pattern input's focus and caret with it."
+  (rf.fresco/as-component ModalView))
+
+(defn Modal
+  "The edit popup's public callable — what `shell.cljs` mounts as a
+  hiccup head at the shell-view root.
+
+  Since rf2-d9ln it is the migration bridge rather than the view:
+  Reagent-shaped hiccup interoping to the React component [[ModalView]]
+  presents as. The shell's enclosing `rf/frame-provider` is what puts
+  the instance frame in React context for it.
+
+  The open/closed gate is inside [[ModalView]], so this is always
+  mounted and renders nothing while the popup is closed — the same
+  shape a mounted `reg-view` returning nil had.
+
+  Callers wanting the MARKUP as data — the node-lane rows — build it
+  from `edit-popup/popup-view` with the reads' values instead; this
+  returns an interop vector, not a tree to walk."
   []
-  (when @(rf/subscribe [:rf.xray/edit-popup-open?])
-    (edit-popup/popup-view dispatch)))
+  [:> Modal-component {}])
 
 ;; ---- hydration ---------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/edit_popup.cljs
@@ -46,8 +46,7 @@
   The view reads the trigger payload from `:rf.xray/edit-popup-pill`
   and the draft from `:rf.xray/edit-popup-draft` (a working copy the
   user mutates without affecting the live filter slot)."
-  (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
+  (:require [day8.re-frame2-xray.theme.modal-chrome :as modal-chrome]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
 
@@ -211,34 +210,45 @@
      (case mode :in "Show only matching events" :out "Hide matching events")]))
 
 (defn popup-view
-  "The popup body. Caller (`filters/Modal`) gates the mount on
-  `:rf.xray/edit-popup-open?`.
+  "The popup body, as a PURE function of `dispatch` and the values
+  `filters/ModalView` reads. The caller gates the mount on
+  `:rf.xray/edit-popup-open?` — this fn assumes it is open and always
+  renders.
 
-  `dispatch` is the frame-aware dispatcher injected by the
-  `filters/Modal` `reg-view` body — every deferred handler routes
+  `dispatch` is the frame-aware dispatcher the boundary captured with
+  `(:dispatch (rf/capture-frame))` — every deferred handler routes
   through it so the edit lands on the surrounding instance frame, not
-  a `{:frame :rf/xray}` literal.
+  a `{:frame :rf/xray}` literal. The node-lane doors pass `rf/dispatch`
+  under `rf/with-frame`.
 
-  ## rf2-k97c.3 — the three reads are STILL AMBIENT, deliberately
+  ## rf2-d9ln — THE THREE READS WERE AMBIENT, AND ARE NOW HOISTED
 
-  `filters/Modal` above is still an `rf/reg-view` mounted from
-  `shell-view`, which is itself still an `rf/reg-view` — a Reagent
-  tree — so the reads below are `@(rf/subscribe …)` resolving through
-  the React-context tier, exactly as they always have been. They do NOT
-  become `rf.fresco/sub`: that call is legal only inside a `defview`
-  body and would raise `:rf.error/fresco-sub-outside-render` here, and
-  it would also break the two suites that drive this fn directly
-  (`modals_aria_cljs_test`, `filters/edit_popup_cljs_test`).
+  They used to be `@(rf/subscribe …)` performed here, because
+  `filters/Modal` was an `rf/reg-view` in a Reagent tree. Since
+  `filters/ModalView` became a Fresco boundary they are read there,
+  through `rf.fresco/sub`, and handed down as `data`:
 
-  What DID change is the head shape: every plain-fn head inside this
-  subtree is now a call, so whichever way the later slice resolves
-  `filters/Modal` — migrated to a boundary, or islanded behind
-  `as-child` — this file needs no further repair."
-  [dispatch]
-  (let [trigger     @(rf/subscribe [:rf.xray/edit-popup-trigger])
-        draft       @(rf/subscribe [:rf.xray/edit-popup-draft])
-        positioning @(rf/subscribe [:rf.xray/modal-positioning])
-        mode        (or (:mode draft) :in)
+      {:trigger     — `:rf.xray/edit-popup-trigger` (what opened it)
+       :draft       — `:rf.xray/edit-popup-draft` (pattern + mode)
+       :positioning — `:rf.xray/modal-positioning` (fixed / absolute)}
+
+  THE HOIST IS NOT TASTE. `rf.fresco/sub` refuses outside a boundary
+  render (`:rf.error/fresco-sub-outside-render`), so a read-performing
+  helper becomes uncallable the moment its reads migrate — and this fn
+  has direct callers outside any React commit, in `modals_aria_cljs_test`
+  and `filters/edit_popup_cljs_test`. A pure fn needs neither a render
+  window nor `subscribe-once`, so hoisting keeps every lane open. Same
+  hoist, and the same reason, as `settings/view/popup-tree`.
+
+  The predecessor of this docstring predicted this file would need no
+  further repair whichever way the Modal resolved. That was wrong in one
+  respect — the reads had to move — and right in the one it was really
+  about: every plain-fn head inside this subtree is a CALL, so nothing
+  below here was an `:invalid` head when the boundary landed.
+
+  PURE: every helper it calls is a plain fn of its arguments."
+  [dispatch {:keys [trigger draft positioning]}]
+  (let [mode        (or (:mode draft) :in)
         editing?    (= :pill (:source trigger))
         title       (case (:source trigger)
                       :pill    "Edit filter"
@@ -284,10 +294,11 @@
        ;; rf2-k97c.3 — `mode-radio` is CALLED, not headed. It answers
        ;; hiccup, its subtree is head-free (`[:label …]` over
        ;; `[:input …]`), and it reads nothing, so the ruled HD-016
-       ;; repair is to inline it. It costs nothing today — `filters/
-       ;; Modal` above is still an `rf/reg-view`, where a plain-fn head
-       ;; is legal — and it is what lets that Modal become a boundary
-       ;; later without this file being re-opened. See [[popup-view]].
+       ;; repair is to inline it. That repair is what let `filters/
+       ;; ModalView` become a Fresco boundary (rf2-d9ln) without this
+       ;; subtree carrying an `:invalid` head: a plain-fn head is legal
+       ;; in a Reagent tree and an error in a Fresco one, and there is
+       ;; no longer one here to raise. See [[popup-view]].
        [:div {:style (radio-row-style)}
         (mode-radio dispatch {:mode :in :current-mode mode})
         (mode-radio dispatch {:mode :out :current-mode mode})]]

--- a/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_cljs_test.cljs
@@ -7,15 +7,23 @@
    - save-edit-popup mutates :active-filters and closes the popup
    - delete-edit-popup drops the pill and closes
    - close-edit-popup discards the draft
-   - hide-event-type (right-click row path) pre-populates OUT mode"
+   - hide-event-type (right-click row path) pre-populates OUT mode
+
+  ## Where the rendered tree comes from (rf2-d9ln)
+
+  `filters/Modal` is a Fresco boundary behind an `as-component` bridge,
+  so calling it answers the `[:>]` interop head rather than a tree to
+  walk. The rows below drive `test-helpers.modal-trees/edit-popup-tree`,
+  which reproduces `filters/ModalView`'s gate and its three reads in the
+  same order — so what they assert on is still the SHIPPED hiccup."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
-            [day8.re-frame2-xray.filters :as filters]
             [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.modal-trees :as modal-trees]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (use-fixtures :each
@@ -276,7 +284,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/open-edit-popup {:source :add :mode :in}])
     (rf/with-frame :rf/xray
-      (let [rendered (filters/Modal)
+      (let [rendered (modal-trees/edit-popup-tree rf/dispatch)
             backdrop (rf.test-helpers/find-by-testid rendered "rf-xray-edit-popup-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
@@ -293,7 +301,7 @@
     (frame-dispatch [:rf.xray/open-edit-popup {:source :add :mode :in}])
     (frame-dispatch [:rf.xray/set-modal-positioning :absolute])
     (rf/with-frame :rf/xray
-      (let [rendered (filters/Modal)
+      (let [rendered (modal-trees/edit-popup-tree rf/dispatch)
             backdrop (rf.test-helpers/find-by-testid rendered "rf-xray-edit-popup-backdrop")
             style    (:style (second backdrop))]
         (is (some? backdrop))
@@ -320,7 +328,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/open-edit-popup {:source :add :mode :in}])
     (rf/with-frame :rf/xray
-      (let [rendered (filters/Modal)]
+      (let [rendered (modal-trees/edit-popup-tree rf/dispatch)]
         ;; Kept surfaces.
         (is (some? (rf.test-helpers/find-by-testid rendered "rf-xray-edit-popup-mode-in"))
             "Mode IN radio present")
@@ -366,7 +374,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/open-edit-popup {:source :add :mode :in}])
     (rf/with-frame :rf/xray
-      (let [rendered     (filters/Modal)
+      (let [rendered     (modal-trees/edit-popup-tree rf/dispatch)
             strings      (all-strings rendered)
             placeholders (placeholder-values rendered)]
         (is (contains? strings "Filter events")
@@ -397,7 +405,7 @@
                      {:source :pill :mode :in :idx 0
                       :pill {:pattern :auth/*}}])
     (rf/with-frame :rf/xray
-      (let [strings (all-strings (filters/Modal))]
+      (let [strings (all-strings (modal-trees/edit-popup-tree rf/dispatch))]
         (is (contains? strings "Edit filter")
             "title is 'Edit filter' on the :pill source")
         (is (contains? strings "Apply")
@@ -411,7 +419,7 @@
     (xray-setup!)
     (frame-dispatch [:rf.xray/hide-event-type :user/mouse-move])
     (rf/with-frame :rf/xray
-      (let [strings (all-strings (filters/Modal))]
+      (let [strings (all-strings (modal-trees/edit-popup-tree rf/dispatch))]
         (is (contains? strings "Add filter for this event")
             "title is 'Add filter for this event' on the :context source")
         (is (contains? strings "Add filter")

--- a/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/edit_popup_fresco_boundary_dom_cljs_test.cljs
@@ -1,0 +1,321 @@
+(ns day8.re-frame2-xray.filters.edit-popup-fresco-boundary-dom-cljs-test
+  "Real-DOM witnesses for the filter edit-popup bridge — `filters/Modal`
+  (rf2-d9ln), the last shell-root modal to become a Fresco boundary.
+
+  ## The gap this file closes
+
+  rf2-d9ln turned `filters/Modal` into a BOUNDARY behind its existing
+  public bridge name. Its production observation changed — three ambient
+  `@(rf/subscribe …)` reads inside `popup-view` became `rf.fresco/sub`
+  calls in the boundary — and so did its dispatch, which is now captured
+  with `(:dispatch (rf/capture-frame))` rather than injected lexically by
+  `reg-view`. But every node-lane row that moved with it drives a
+  test-owned copy of the gate and the reads through
+  `test-helpers.modal-trees/edit-popup-tree`, calling the pure
+  `popup-view` directly. Nothing mounts the bridge and nothing executes
+  the boundary, so a broken real gate or a nil boundary body would leave
+  the whole node lane green.
+
+  This file is the missing half, and it is the edit-popup sibling of
+  `spine_filters_fresco_boundary_dom_cljs_test` (rf2-3du3), which closed
+  exactly this gap for the two spine-filter bridges:
+
+    W1  Modal mounts as the shell's own hiccup head, its gate reads
+        `:rf.xray/edit-popup-open?` TRUE, and the boundary body commits
+        the real dialog DOM — with a CLOSED instance beside it proving
+        the gate is a gate rather than an unconditional paint.
+
+    W2  The header ✕, clicked from OUTSIDE any render scope, lands on the
+        frame the enclosing `frame-provider` named — not on a second live
+        instance, and not on a `{:frame :rf/xray}` literal — and the
+        surface then repaints from the boundary's OWN subscription.
+
+  ## Why the node lane cannot make either claim
+
+  `expand-tree` INVOKES a fn head, so `[Modal]` and `(Modal)` expand to
+  the same value and the node lane is structurally blind to head
+  legality. It is blind twice over here: the door it drives passes the
+  boundary's reads in as ARGUMENTS, so the gate and the `rf.fresco/sub`
+  calls that are the actual subject of rf2-d9ln never run at all. Only a
+  committed DOM can answer, which is why these rows are `-dom-cljs-test`.
+
+  ## The mount is the SHELL's mount
+
+  `shell.cljs` mounts this bridge as a plain hiccup HEAD inside the
+  shell's `[rf/frame-provider {:frame frame-id}]` (`:3161`). [[mount!]]
+  does exactly that and nothing else — no wrapper, no second call. Every
+  assertion after the mount reads `container.querySelector…`, i.e. the
+  DOM React committed on its own.
+
+  ## Frames: two private ones, and NEVER `:rf/xray`
+
+  `:rf/xray` is the production singleton, shared with every other suite
+  on the page, so a control frame named `:rf/xray` could be moved by a
+  neighbour between the mount and the assertion. Both frames here are
+  private to this ns. That also makes W2 a direct witness for rf2-nesy9's
+  frame-CARRYING dispatch: under a `{:frame :rf/xray}` literal the
+  mounted frame below would never close and W2 would redden.
+
+  ## Substrate: the Reagent adapter, deliberately
+
+  The family Xray already supports, because the claim is that the
+  boundary is INDIFFERENT to it. `:ambient-frame nil` is load-bearing:
+  tier 1 of the frame resolver is the dynamic var, so an ambient frame
+  would SHADOW the React-context tier W2 is about, and that row would
+  pass while measuring nothing.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where every row short-circuits
+  through [[browser?]] and reports the skip rather than passing silently."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.core :as rf]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.filters :as filters]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; ---- frames --------------------------------------------------------------
+
+(def ^:private instance-frame
+  "The Xray instance this suite mounts. A NAMED NON-DEFAULT frame, per
+  the ns docstring — the shape `shell-view`'s `:frame-id` opt ships."
+  ::instance)
+
+(def ^:private competing-frame
+  "A SECOND live Xray instance — W2's competing-frame control. A close
+  performed in the mounted instance must move nothing here. It is opened
+  too, so the control is demonstrably READABLE: an assertion that this
+  frame is still open has to be able to fail."
+  ::competing)
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about;
+                      ;; a neighbour's boundary left in the entry cache
+                      ;; would make these rows read a residue that is not
+                      ;; this suite's.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- settle
+  "A promise resolving once every render pipeline on the page has had a
+  real chance to commit — two animation frames and a macrotask. A Fresco
+  boundary is NOT in Reagent's render queue (its update is scheduled by
+  the collector through React), so draining Reagent's queue would commit
+  nothing of this boundary's and would read a DOM that has not moved."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (js/requestAnimationFrame
+        (fn [_]
+          (js/requestAnimationFrame
+            (fn [_] (js/setTimeout resolve 20))))))))
+
+;; ---- setup / seeding, through the PRODUCTION events ----------------------
+;;
+;; Every seed below dispatches a real registered `:rf.xray/*` event. There
+;; is no `-for-test` override seam in this subsystem and none is wanted:
+;; the open state the boundary gates on is exactly what the shell's own
+;; pill and right-click handlers produce.
+
+(defn- setup!
+  "Register Xray's handlers — which fans out to `filters/install!`, the
+  source of every sub and event below — and make the two frames."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id instance-frame})
+  (rf/make-frame {:id competing-frame})
+  nil)
+
+(defn- open-popup! [frame]
+  (rf/dispatch-sync [:rf.xray/open-edit-popup {:source :add :mode :in}]
+                    {:frame frame}))
+
+(defn- mount!
+  "Mount `views` as plain hiccup HEADS inside a `frame-provider` scoping
+  `frame` — the exact shape `shell.cljs` uses at `:3161`. Committed
+  synchronously: React 19's `root.render` is otherwise async and the
+  first assertion would run against an empty container."
+  [frame views]
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root (into [rf/frame-provider {:frame frame}]
+                               (map vector views)))))
+    {:container container :root root}))
+
+(defn- teardown!
+  "Unmount inside `flushSync` so React's cleanup effects — which is where
+  the collector releases a boundary's reads — have RUN by the time the
+  next line runs. A bare `.unmount` schedules them."
+  [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+;; ---- readers --------------------------------------------------------------
+;;
+;; EVERY DOM ACCESSOR HERE IS NIL-TOLERANT, AND THAT IS A REQUIREMENT
+;; RATHER THAN A COURTESY. These rows exist to redden when the boundary
+;; stops painting, so the absent-node case is their EXPECTED failure mode
+;; — and `shadow.test` runs the whole browser lane, and the closing
+;; summary, inside ONE `cljs.test/run-block` with no try/catch. A bare
+;; `(.click nil)` therefore does not fail a row: it throws uncaught,
+;; aborts the run, and every namespace scheduled after this one never
+;; executes, with no cljs.test summary at all (rf2-u0j8).
+
+(defn- q [container sel] (some-> container (.querySelector sel)))
+
+(defn- testid-sel [id] (str "[data-testid=" (pr-str id) "]"))
+
+(defn- dialog-node   [c] (q c (testid-sel "rf-xray-edit-popup-dialog")))
+(defn- backdrop-node [c] (q c (testid-sel "rf-xray-edit-popup-backdrop")))
+(defn- pattern-node  [c] (q c (testid-sel "rf-xray-edit-popup-pattern")))
+(defn- mode-in-node  [c] (q c (testid-sel "rf-xray-edit-popup-mode-in")))
+(defn- close-btn     [c] (q c (testid-sel "rf-xray-edit-popup-close")))
+
+(defn- click!
+  "Click `node`, or do nothing when it is absent, answering whether there
+  was anything to click. See the nil-tolerance note above."
+  [node]
+  (when (some? node)
+    (.click node))
+  (some? node))
+
+(defn- open-of
+  "The frame's OWN `:edit-popup-open?` app-db slot, read through the
+  public value accessor.
+
+  This is an INDEPENDENT INSTRUMENT on purpose: it does not go through
+  the sub layer the boundary reads, so a boundary that read nothing and a
+  reader that read nothing cannot agree with each other."
+  [frame-id]
+  (:edit-popup-open? (rf/app-db-value frame-id)))
+
+;; ===========================================================================
+;; W1 — the bridge mounts, the gate is real, and the boundary paints
+;; ===========================================================================
+
+(deftest w1-edit-popup-bridge-mounts-and-paints-behind-a-real-gate
+  (testing "rf2-d9ln — `filters/Modal` mounted as the shell's hiccup head
+            commits the real edit-popup DOM, which is the claim no
+            node-lane row can make: the door it drives is handed the
+            boundary's reads as arguments, so neither the gate nor the
+            `rf.fresco/sub` calls ever run there. A CLOSED instance
+            mounted the same way paints nothing, which is what makes the
+            open half evidence about the GATE rather than about an
+            unconditional body."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; ---- the CLOSED half, first: the gate must really gate --------
+        (let [{:keys [container root]} (mount! competing-frame [filters/Modal])]
+          (is (nil? (dialog-node container))
+              "a mounted bridge over a CLOSED popup commits NO dialog —
+               the boundary's `when` short-circuited on a false
+               `:rf.xray/edit-popup-open?`, exactly as the mounted
+               `reg-view` returning nil did")
+          (is (nil? (backdrop-node container))
+              "and no backdrop either, so nothing of the body painted")
+          (teardown! root container))
+
+        ;; ---- the OPEN half -------------------------------------------
+        (open-popup! instance-frame)
+        (let [{:keys [container root]} (mount! instance-frame [filters/Modal])]
+          (is (some? (dialog-node container))
+              "the popup committed a real dialog under React — the Fresco
+               boundary behind the public bridge name really ran its body
+               and its gate read TRUE")
+          (is (some? (backdrop-node container))
+              "and the backdrop committed alongside it, so the boundary
+               rendered the whole `modal-chrome` scaffold rather than its
+               first child")
+          (is (some? (pattern-node container))
+              "the pattern input is real DOM — the subtree BELOW the
+               boundary rendered too, which is what says every plain-fn
+               head inside `popup-view` is a CALL and not an `:invalid`
+               head (the inlining rf2-k97c.3 did, now load-bearing)")
+          (is (some? (mode-in-node container))
+              "and so are the mode radios, reached through `mode-radio`,
+               the called helper that comment is about")
+          (teardown! root container))
+        (done)))))
+
+;; ===========================================================================
+;; W2 — the captured dispatch reaches the NAMED frame, and the surface is live
+;; ===========================================================================
+
+(deftest w2-edit-popup-close-lands-on-the-named-frame-and-repaints
+  (testing "rf2-d9ln — the header ✕ inside the mounted boundary, clicked
+            from OUTSIDE any render scope, closes the popup on the frame
+            the enclosing `frame-provider` named while a second live
+            instance stays open. Under the `{:frame :rf/xray}` literal
+            the `reg-view` era's lexical `dispatch` would have produced,
+            the mounted frame would never close. The surface then
+            repaints from the boundary's OWN subscription, which is the
+            liveness half."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        ;; Both instances are opened BEFORE the mount, so the negative
+        ;; half below is measured with an instrument demonstrably able to
+        ;; see this slot move.
+        (open-popup! competing-frame)
+        (open-popup! instance-frame)
+        (is (true? (open-of instance-frame))
+            "PRE-CONDITION: the mounted instance is open")
+        (is (true? (open-of competing-frame))
+            "PRE-CONDITION: the competing instance is open, so the
+             control below can fail")
+        (let [{:keys [container root]} (mount! instance-frame [filters/Modal])]
+          (is (some? (dialog-node container))
+              "PRE-CONDITION: the boundary painted, so there is a ✕ to
+               click")
+          (is (true? (click! (close-btn container)))
+              "the header ✕ is real DOM and was clicked")
+          (-> (settle)
+              (.then
+                (fn [_]
+                  (is (false? (open-of instance-frame))
+                      "the close landed on the MOUNTED instance's frame —
+                       the dispatcher the boundary captured with
+                       `(:dispatch (rf/capture-frame))` carries the frame
+                       the `frame-provider` named")
+                  (is (true? (open-of competing-frame))
+                      "and moved NOTHING on the second live instance, so
+                       the dispatch was frame-CARRYING rather than
+                       broadcast")
+                  (is (nil? (dialog-node container))
+                      "the surface repainted itself away — the boundary
+                       re-rendered from its OWN `rf.fresco/sub` on
+                       `:rf.xray/edit-popup-open?`, which is the liveness
+                       this file exists to witness")
+                  (teardown! root container)
+                  (done)))
+              (.catch
+                (fn [e]
+                  (is false (str "settle/assert threw: " e))
+                  (teardown! root container)
+                  (done)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/modals_aria_cljs_test.cljs
@@ -22,7 +22,9 @@
        `test-helpers.modal-trees/settings-popup-tree` since rf2-k97c.3 —
        the popup's root is a Fresco boundary and no longer a callable)
     2. Mute manager    (`spine-filters/dialog-tree`)
-    3. Filter edit-popup (`filters/edit-popup/popup-view`)
+    3. Filter edit-popup (`filters/edit-popup/popup-view`, driven
+       through `test-helpers.modal-trees/edit-popup-tree` since rf2-d9ln —
+       the popup's root is a Fresco boundary and no longer a callable)
     4. Cancellation-cascade popover — exercised via its `popover-tree`
        (it renders a [:div {:role \"dialog\" ...}]); since rf2-k97c.3 the
        view itself is a Fresco boundary, so the tree fn is the door
@@ -36,7 +38,6 @@
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
             [re-frame.test-helpers :as rf.test-helpers]
-            [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.panels.app-db-segment-inspector
              :as segment-inspector]
             [day8.re-frame2-xray.panels.cancellation-cascade
@@ -177,7 +178,7 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/open-edit-popup
                        {:source :add :mode :in :pill {}}]))
-  (let [tree (rf/with-frame :rf/xray (edit-popup/popup-view rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (modal-trees/edit-popup-tree rf/dispatch))]
     (assert-dialog-contract! tree "rf-xray-edit-popup-dialog"
                              "Filter edit-popup")))
 
@@ -290,7 +291,7 @@
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/open-edit-popup
                        {:source :add :mode :in :pill {}}]))
-  (let [tree (rf/with-frame :rf/xray (edit-popup/popup-view rf/dispatch))]
+  (let [tree (rf/with-frame :rf/xray (modal-trees/edit-popup-tree rf/dispatch))]
     (assert-dialog-focus-ref! tree "rf-xray-edit-popup-dialog"
                               "Filter edit-popup")))
 

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/modal_trees.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/modal_trees.cljs
@@ -54,6 +54,7 @@
   `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
   bodies had, and the same one every existing caller already satisfies."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.filters.edit-popup :as edit-popup]
             [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
             [day8.re-frame2-xray.settings.view :as settings-view]))
 
@@ -110,3 +111,33 @@
   ([dispatch]
    (when @(rf/subscribe [:rf.xray/editor-hint-open?])
      (editor-hint/toast-view dispatch))))
+
+;; ---- Filter edit popup (rf2-d9ln) ----------------------------------------
+
+(defn edit-popup-tree
+  "The filter edit-popup's hiccup, read the way `filters/ModalView` reads
+  it — the gate first, then the same three subs in the same order.
+
+  Answers `nil` when `:rf.xray/edit-popup-open?` is false, which is the
+  boundary's own short-circuit reproduced rather than approximated.
+
+  `dispatch` defaults to `(:dispatch (rf/capture-frame))`, the SAME door
+  the boundary uses, so a handler a row pulls off the tree and fires
+  later carries the frame the shipped one does. The explicit arity is for
+  rows that want to pass a recording double.
+
+  THE THREE NON-GATE READS ARE HOISTED, which is why this door exists —
+  `filters/edit-popup/popup-view` performed them itself until rf2-d9ln.
+  It could not keep doing so: an ambient `@(rf/subscribe …)` is REFUSED
+  inside a boundary render (`:rf.error/ambient-frame-refused`, and the
+  refusing extent reaches a parens-called helper), while `rf.fresco/sub`
+  refuses OUTSIDE one. One read cannot serve both lanes, so the boundary
+  reads and `popup-view` is pure of its arguments."
+  ([] (edit-popup-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (when @(rf/subscribe [:rf.xray/edit-popup-open?])
+     (edit-popup/popup-view
+       dispatch
+       {:trigger     @(rf/subscribe [:rf.xray/edit-popup-trigger])
+        :draft       @(rf/subscribe [:rf.xray/edit-popup-draft])
+        :positioning @(rf/subscribe [:rf.xray/modal-positioning])}))))


### PR DESCRIPTION
`filters/Modal` was the last shell-root modal in Xray still registered as an `rf/reg-view`, kept that way by a docstring whose load-bearing claim was false.

## What the docstring claimed, and why it is wrong

It said migrating this Modal would need "either an `as-component` bridge with nothing above it to justify one, or an edit to `shell.cljs` that the four sibling chrome satellites would each need too."

The second half is refuted by the file that mounts it:

| shell.cljs | mount | shape |
|---|---|---|
| 3154 | `[palette/Modal]` | bridged boundary |
| 3161 | `[filters/Modal]` | **this PR's subject** |
| 3166 | `[settings-popup/Modal]` | bridged boundary |
| 3183 | `[cancellation-cascade/Popover]` | bridged boundary |
| 3193 | `[spine-filters/Modal]` | bridged boundary |
| 3199 | `[spine-filters/RowContextMenu]` | bridged boundary |

Five bridged boundaries already mount from that same block and none required a `shell.cljs` edit. **This PR does not touch `shell.cljs` either.** A census of the tree reads 43 `defview` boundaries against 8 remaining `reg-view`s, and none of the eight is a shell-root modal once this lands.

The FIRST half of the claim stands — a `defview` really is not a legal hiccup head in a Reagent tree. It is the inference from it that does not survive: keeping the public name a callable bridge and making the boundary private behind it costs no caller anything.

## The read-hoist is load-bearing, not tidying

`popup-view` performed its own three `@(rf/subscribe …)` reads. Both directions are closed:

- an ambient `@(rf/subscribe …)` is **refused inside** a boundary render (`:rf.error/ambient-frame-refused`), and the refusing extent reaches a parens-called helper too — so leaving the reads where they were would have raised on the popup's first open, not merely gone stale;
- `rf.fresco/sub` refuses **outside** a boundary render (`:rf.error/fresco-sub-outside-render`), and `popup-view` has direct callers in two node-lane suites that run in no React commit.

One read cannot serve both lanes, so the boundary reads and `popup-view` becomes a pure fn of `dispatch` plus the three values — the same hoist, for the same recorded reason, as `settings/view/popup-tree` and `spine-filters/dialog-tree`. The reads stay inside the open-gate `when`, so a closed popup still holds one subscription rather than four. `edit_popup.cljs` no longer requires `re-frame.core` at all.

## The node lane cannot grade this, so there are DOM witnesses

`expand-tree` INVOKES a fn head, so `[Modal]` and `(Modal)` expand identically and no node-lane row can see head legality; and the door those rows drive is handed the boundary's reads as arguments, so neither the gate nor the `rf.fresco/sub` calls execute there. `filters/edit_popup_fresco_boundary_dom_cljs_test.cljs` is the missing half, modelled on `spine_filters_fresco_boundary_dom_cljs_test` (rf2-3du3): W1 mounts the bridge at a named non-default frame and asserts the real dialog DOM behind a gate proven real by a closed instance beside it; W2 clicks the header ✕ from outside any render scope and asserts it lands on the mounted frame while a second live instance stays open, then repaints from the boundary's own subscription.

## Quality gates

Every exit code below is quoted from this worker's own captured `.exit` file, not from a harness report — the two disagreed once during this run (see the sabotage row).

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:cljs` (node lane) | **0** | 11726 tests, 58643 assertions, 0 failures, 0 errors |
| `npx shadow-cljs compile browser-test` | **0** | compile split from the serve step deliberately, so a failed compile cannot leave the serve step running a stale artefact |
| `BROWSER_TEST_PORT=8159 node scripts/serve-and-run-browser-tests.cjs` | **0** | 980 tests, 5504 assertions, 0 failures, 0 errors; log names this worktree as the served root |
| **Sabotage** — boundary gate forced false, recompiled, re-run | **1** | 7 failures, every one in the two new rows (4 in W1's open half, 3 in W2); W1's closed-half assertions correctly stayed green, and the rows FAILED rather than crashing, so the lane still printed its summary. Source restored and verified against the committed blob object, with `git diff --quiet HEAD` as a second instrument |
| `python scripts/check_retired_spellings.py` | **0** | ratchet over the paths this PR touches; its `--self-test` fixture witness also exit **0**, so the pass is not vacuous |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | ratchet whose subject this PR moves — one require alias added, two removed. 2866 files, 11303 re-frame require edges, 0 non-canonical, every surface at or under its floor; `--self-test` exit **0** |
| `python scripts/check_fast_pr_gap.py --brief` | report | run to LEARN what CI still owns: 101 required checks no local spine decides |

**Skipped, with reasons.** `clj-kondo`, `splint` and `eslint` were not run locally — `lint.yml` owns them and runs them unconditionally on this diff; the require-alias ratchet above is the one lint-family gate whose subject this PR actually moves, and it was run. `scripts/test-fast-pr.sh` was deliberately not nominated: it tiers itself on the changed-surface classifier, so naming it beside the per-artefact lane double-runs the work, and a green spine is compatible with a red required check.

The branch was rebased onto trunk after the gates ran. The shared fixture (`make-reset-runtime-fixture`), `xray/test_support` and the Fresco collector are all unchanged across that rebase, and no trunk commit in the interval touched any file this PR edits, so the greens above still describe this code — CI re-runs the matrix on the new base regardless.
