### PR TITLE
fix(xray): cross Reagent islands through the installed adapter (rf2-7ds8)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -128,6 +128,10 @@
      ;; spine handles re-frame-owned disposal before these substrate ops.
      :current-frame     rf.views/current-frame
      :current-component r/current-component
+     ;; rf2-7ds8 — reagent2's own hiccup walk, so a caller crossing a
+     ;; hiccup island into React under this adapter gets a subtree THIS
+     ;; build renders, and `:current-component` above can see it.
+     :as-element        r/as-element
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
      :make-reaction     ratom/make-reaction

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
@@ -37,6 +37,13 @@
   "Every late-bind hook the Reagent Slim adapter publishes at ns-load."
   #{:adapter/current-frame
     :adapter/current-component
+    ;; rf2-7ds8 — reagent2's own hiccup → React element walk, published by
+    ;; the ratom family alone. The twin of `:adapter/current-component`
+    ;; directly above it: a caller that crosses a hiccup island into React
+    ;; with some OTHER ratom build's walk gets a subtree rendered by that
+    ;; build, which the hook above cannot see into, so the frame resolves
+    ;; nil and the island raises `:rf.error/no-frame-context`.
+    :adapter/as-element
     :adapter/ratom
     :adapter/ratom?
     :adapter/make-reaction

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -200,6 +200,10 @@
      ;; The spine handles re-frame-owned disposal before these substrate ops.
      :current-frame     rf.views/current-frame
      :current-component r/current-component
+     ;; rf2-7ds8 — stock Reagent's own hiccup walk. Twin of the slim
+     ;; adapter's entry; see `:adapter/as-element` in the late-bind
+     ;; directory for why the crossing must come from the installed build.
+     :as-element        r/as-element
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
      ;; Guarded ctor/disposer pair (rf2-rzeko): the routed

--- a/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
@@ -46,6 +46,10 @@
   #{:reagent/set-hiccup-emitter!
     :adapter/current-frame
     :adapter/current-component
+    ;; rf2-7ds8 — stock Reagent's own hiccup → React element walk. Twin of
+    ;; `:adapter/current-component` above and published by the ratom family
+    ;; alone; see the reagent-slim pin for the mechanism it protects.
+    :adapter/as-element
     :adapter/ratom
     :adapter/ratom?
     :adapter/make-reaction

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -903,6 +903,12 @@
     :chained?    true
     :design-bead "rf2-wbnl"
     :description "Resolve the in-flight Reagent component (routed via current-adapter)."}
+   {:key         :adapter/as-element
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim]
+    :chained?    true
+    :design-bead "rf2-7ds8"
+    :description "The INSTALLED ratom build's own hiccup → React element walk (routed via current-adapter). The exact twin of :adapter/current-component, published by the same two adapters and for the same reason. A caller that needs a React element for a hiccup island — a Fresco boundary handing a surviving reg-view island down as a child, which is what tools/xray does at nine sites — must obtain it from the renderer the runtime is actually using. Crossing with some OTHER ratom build's as-element does NOT fail loudly: React mounts the element and the :contextType the reg-view head carries is even honoured, so the frame VALUE reaches the class. What breaks is one level down — the foreign build renders the subtree with ITS in-flight-component binding set, while :adapter/current-component routes to the installed build and answers nil, so views/current-frame finds no component to read (.-context) off and returns nil. Every ambient subscribe/dispatch in that subtree then raises :rf.error/no-frame-context and React takes the subtree down: a blank surface, not a diagnostic. Measured under reagent-slim with Xray crossing via stock reagent.core/as-element (rf2-7ds8). NOT published by UIx / Fresco / plain-atom / test-react: hiccup is not those substrates' authoring shape, and there is no substrate-neutral element, so the hook is routed with no chain-bottom fallback and an absent answer is the honest one."}
    {:key         :adapter/ratom
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim]

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -4252,6 +4252,15 @@
       :current-frame      — (fn []) → React-context-tier current frame
                             (`views/current-frame`)
       :current-component  — (fn []) → the in-flight component
+      :as-element         — (fn [hiccup]) → this substrate's own
+                            hiccup → React element walk. The TWIN of
+                            `:current-component` and published for the
+                            same reason: a subtree crossed into React by
+                            some OTHER ratom build renders under that
+                            build's renderer, so `:current-component`
+                            (which routes to the INSTALLED one) answers
+                            nil inside it and `views/current-frame`
+                            resolves no frame. rf2-7ds8.
       :atom               — (fn [v]) → reactive atom
       :ratom?             — (fn [x]) → boolean (IReactiveAtom check)
       :make-reaction      — (fn [thunk]) → reaction
@@ -4283,7 +4292,7 @@
   with the same shape — only their injected bare hook fns and `:kind`
   differ. The former hand-copied route-hook block now lives once."
   [spine-fns {:keys [kind register-context-provider
-                     current-frame current-component atom ratom? make-reaction
+                     current-frame current-component as-element atom ratom? make-reaction
                      activate-reaction!
                      disposable? add-on-dispose! dispose! reactive? after-render]}]
   (let [dispose-dispatch (make-ratom-dispose-dispatch disposable? dispose!)
@@ -4338,6 +4347,12 @@
       #(rf.frame/current-frame))
     (rf.substrate.adapter/route-hook! adapter :adapter/current-component
       current-component)
+    ;;   :adapter/as-element — rf2-7ds8. The hiccup → React element walk
+    ;;     belonging to the INSTALLED ratom build. Routed, not chained to a
+    ;;     substrate-neutral bottom, because there is no neutral answer: an
+    ;;     element is only correct for the renderer that made it.
+    (rf.substrate.adapter/route-hook! adapter :adapter/as-element
+      as-element)
     (rf.substrate.adapter/route-hook! adapter :adapter/ratom
       atom)
     (rf.substrate.adapter/route-hook! adapter :adapter/ratom?

--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -79,16 +79,26 @@
          ;; installed by the host still governs the runtime path.
          day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
 
-         ;; Xray's own views require stock Reagent directly — e.g.
-         ;; `day8.re-frame2-xray.views.resizable-table` requires
-         ;; `reagent.core` for its component-local Ratom state — so Xray
-         ;; declares the stock `reagent/reagent` dep itself. It previously
-         ;; inherited Reagent transitively from core, but core is now
-         ;; Reagent-free (re-frame.views late-binds via the
-         ;; `:adapter/current-component` hook), so every artefact that
-         ;; requires reagent.* must declare it. This is dev-only (Xray is a
-         ;; devtools panel excluded from production bundles) and independent
-         ;; of the reagent-slim adapter above, which carries no stock Reagent.
+         ;; Xray declares stock Reagent itself; core is Reagent-free
+         ;; (re-frame.views late-binds via `:adapter/current-component`), so
+         ;; every artefact that requires reagent.* must declare it.
+         ;;
+         ;; SINCE rf2-7ds8 THERE IS EXACTLY ONE PRODUCTION REQUIRE, in
+         ;; `day8.re-frame2-xray.substrate`, and it is the FALLBACK arm of
+         ;; the hiccup->React-element crossing — taken only when no
+         ;; ratom-family adapter is installed to answer
+         ;; `:adapter/as-element` (Xray owning its own root under an
+         ;; element-shaped adapter). Before that bead, six view sources
+         ;; named `reagent.core/as-element` directly, which is why Xray
+         ;; under the reagent-slim adapter shipped BOTH ratom runtimes and
+         ;; rendered nothing.
+         ;;
+         ;; This is dev-only (Xray is a devtools panel excluded from
+         ;; production bundles) and independent of the reagent-slim adapter
+         ;; above, which carries no stock Reagent. Retiring the last require
+         ;; needs a non-Reagent answer for that fallback; it is a bundle
+         ;; concern now, not a correctness one.
+         ;; Test code still requires reagent.* freely.
          reagent/reagent {:mvn/version "2.0.1"}
 
          ;; Editscript is the shared pure-data diff representation for

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -111,7 +111,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
             [re-frame.interop :as rf.interop]
-            [reagent.core :as r]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-machines-viz.chart.overlays.after-rings
@@ -577,10 +577,10 @@
      :frame          (rf/current-frame-id)
      ;; The machines-viz overlay is a Reagent class, so it reaches React
      ;; as a finished React ELEMENT — a legal child anywhere per Fresco's
-     ;; component ABI — rather than as a hiccup head. `r/as-element`
+     ;; component ABI — rather than as a hiccup head. `substrate/as-element`
      ;; carries the hiccup vector itself, so the CLJS props map crosses
      ;; BY IDENTITY; see the ns docstring.
-     :as-child       r/as-element}))
+     :as-child       substrate/as-element}))
 
 ;; ---- the migration bridge (rf2-k97c.3) ----------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -104,7 +104,7 @@
   table; `child-kind` classifies `react/isValidElement` as
   `:react-element` and `as-element` passes it through untouched). So
   [[overlay-tree]] takes an `:as-child` function — `identity` for a
-  hiccup caller, `reagent.core/as-element` for the boundary — and the
+  hiccup caller, `substrate/as-element` for the boundary — and the
   CLJS props map crosses to machines-viz BY IDENTITY, because
   `as-element` carries the hiccup vector itself rather than converting
   a props object. See [[overlay-tree]]."
@@ -433,7 +433,7 @@
                       the calling renderer. `identity` (the default)
                       leaves it as hiccup, which is what a Reagent
                       parent and the node-lane rows want;
-                      `reagent.core/as-element` answers a React element,
+                      `substrate/as-element` answers a React element,
                       which is what a Fresco body needs. The ns
                       docstring records why neither of the migration's
                       usual repairs — mount it as a head, or CALL it —

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -44,7 +44,8 @@
   substrate adapter installed via `rf/init!`. [[panel-tree]] holds the
   markup as a pure fn so the node lane can still drive it.
 
-  `reagent.core` IS referenced now, and only as a migration seam: one
+  The installed adapter's hiccup walk IS referenced now, and only as a
+  migration seam: one
   `as-element` island for the topology chart, which is still an
   `rf/reg-view` and shared with the Static surface. Every other helper in
   this file answers hiccup and is CALLED, never used as a hiccup head —
@@ -67,12 +68,12 @@
             ;; marker before any panel surface reads it — never raw.
             [re-frame.classification :as rf.classification]
             [re-frame.fresco :as rf.fresco]
-            ;; rf2-k97c.3 — `reagent.core/as-element` is the `as-child`
+            ;; rf2-k97c.3 — `substrate/as-element` is the `as-child`
             ;; spelling [[Panel]] hands down for the ONE island this panel
             ;; still needs (the topology chart; see [[panel-tree]]). The
             ;; markup stays pure hiccup — Reagent appears here as a
             ;; migration seam, not as an authoring dependency.
-            [reagent.core :as r]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             ;; rf2-g2axio — the SHARED EVENT HANDLER machine-cascade
@@ -363,7 +364,7 @@
 
   rf2-k97c.3 — `as-child` is the island spelling [[panel-tree]] threads
   down: `identity` for a hiccup caller (the node lane), and
-  `reagent.core/as-element` under the boundary. It wraps ELEMENT 3 only.
+  `substrate/as-element` under the boundary. It wraps ELEMENT 3 only.
   `machine-canvas/Chart` is still an `rf/reg-view`, and a `reg-view` head
   grades `:invalid` under Fresco's codec down the IDENTICAL arm a plain
   `defn` does — the codec reads one own property, `frescoBoundary`, which
@@ -742,7 +743,7 @@
 
   `as-child` is the island spelling, threaded down to
   [[focused-event-section]] and used nowhere else: `identity` for a
-  hiccup caller, `reagent.core/as-element` under the boundary.
+  hiccup caller, `substrate/as-element` under the boundary.
 
   PURE: every helper it calls is a plain fn of its arguments. Two values
   that used to be read deep in the tree — [[focused-event-view]]'s
@@ -829,7 +830,7 @@
   and under the Fresco root Xray will own.
 
   ONE ISLAND SURVIVES, and it is scheduling rather than residue:
-  `r/as-element` is handed down for the topology chart, because
+  `substrate/as-element` is handed down for the topology chart, because
   `machine-canvas/Chart` is still an `rf/reg-view` and has a second
   consumer on the Static surface. [[focused-event-section]] records the
   condition that retires it.
@@ -873,7 +874,7 @@
               ;; same focused epoch Prev/Next drives, so the mini-pipeline
               ;; and the chart move together.
               (:cascade (rf.fresco/sub [:rf.xray/machine-focused-epoch-cascade]))
-              r/as-element
+              substrate/as-element
               (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])
               (rf.fresco/sub [:rf.xray/target-frame])
               ;; rf2-3ymg — this mount's qualifier for the SHARED

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -154,7 +154,7 @@
             [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
             [re-frame.interop :as rf.interop]
-            [reagent.core :as r]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.filters :as filters]
@@ -1432,7 +1432,7 @@
   `defview` binds NO name inside the body, so the bare `dispatch` this
   body used to close over would be a LOUD compile error.
 
-  `r/as-element` is the `as-child` spelling for the two Reagent islands;
+  `substrate/as-element` is the `as-child` spelling for the two Reagent islands;
   [[ribbon-tree]] records which they are and why.
 
   The argument is the ordinary one-props-map vector every `defview`
@@ -1459,7 +1459,7 @@
      ;; when ≥1 filter is committed (the events-ribbon's own `[+]`
      ;; takes over). Open when zero filters, closed otherwise.
      :filters         (rf.fresco/sub [:rf.xray/active-filters])}
-    r/as-element
+    substrate/as-element
     [ribbon-theme-toggle {}]))
 
 ;; ---- L2 event list -------------------------------------------------------
@@ -2794,7 +2794,7 @@
   tab read above it would re-render the ribbon, the events ribbon, the
   L2 list and the tab bar with it. Boundary count tracks reads.
 
-  `r/as-element` is the `as-child` spelling for the L4 island;
+  `substrate/as-element` is the `as-child` spelling for the L4 island;
   [[detail-panel-tree]] records why it is still an island.
 
   The wrapping `<div>` paints `bg-2` as a contrast safety net
@@ -2825,7 +2825,7 @@
                      default-tab)]
     (detail-panel-tree selected
                        (panel-registry/tab-by-id :dynamic selected)
-                       r/as-element)))
+                       substrate/as-element)))
 
 ;; ---- Dynamic / Static surface composer (rf2-o5f5f.1) --------------------
 ;;
@@ -2923,7 +2923,7 @@
   [_props]
   (dynamic-chrome-tree [ribbon {}]
                        [events-ribbon {}]
-                       (r/as-element [event-list])
+                       (substrate/as-element [event-list])
                        [resize-handle/seam-handle-view {}]
                        [tab-bar {}]
                        [detail-panel {}]))

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1245,7 +1245,7 @@
   boundary, so it stays a head.
 
   TWO REAGENT ISLANDS, both reached through `as-child` — `identity` for a
-  hiccup caller and the node lane, `reagent.core/as-element` for the
+  hiccup caller and the node lane, `substrate/as-element` for the
   boundary:
 
     * `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`, both
@@ -2712,7 +2712,7 @@
   `fresco/Panel` are still `rf/reg-view`s. Both grade `:invalid` as a
   Fresco head, down the same arm. `as-child` is `identity` for a hiccup
   caller and the node lane, which leaves `[(:panel tab)]` exactly the
-  vector it has always been, and `reagent.core/as-element` for the
+  vector it has always been, and `substrate/as-element` for the
   boundary, which answers a React element — a legal child anywhere per
   Fresco's component ABI.
 
@@ -2886,7 +2886,7 @@
   the composition has to live.
 
   ONE REAGENT ISLAND, still an `rf/reg-view`, reached through
-  `reagent.core/as-element` (the node lane's door passes `identity`, so
+  `substrate/as-element` (the node lane's door passes `identity`, so
   it stays the fn-headed vector a hiccup walker expands):
 
     * [[event-list]] — held back by a SHIPPED EMBED in a file another

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -81,8 +81,8 @@
   the bodies are headed directly."
   (:require [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
-            [reagent.core :as r]
             [day8.re-frame2-machines-viz.grammar :as grammar]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.static.machines.cascade-dimmed
              :as cascade-dimmed]
@@ -406,7 +406,7 @@
   door, which answers the boundary's DECLARED frame inside a body and
   replaces the name `reg-view` used to inject lexically.
 
-  `r/as-element` is the `as-child` spelling for the two Reagent islands
+  `substrate/as-element` is the `as-child` spelling for the two Reagent islands
   — the ns docstring records why neither of the migration's usual
   repairs is available for them.
 
@@ -447,4 +447,4 @@
                        :last-trans  (rf.fresco/sub
                                       [:rf.xray.static.machines/sim-last-transition])})}
       (:dispatch (rf/capture-frame))
-      r/as-element)))
+      substrate/as-element)))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -73,7 +73,7 @@
   React ELEMENT is a legal child anywhere (`codec`'s `child-kind`
   classifies `react/isValidElement` as `:react-element`). So
   [[detail-tree]] takes an `:as-child` function — `identity` for a
-  hiccup caller and for the node lane, `reagent.core/as-element` for the
+  hiccup caller and for the node lane, `substrate/as-element` for the
   boundary — and the whole Reagent subtree crosses as one finished
   element, rendered by Reagent's own machinery under the SAME React
   context the frame-provider wrote. MIGRATION SCAFFOLDING WITH A DEFINED
@@ -273,7 +273,7 @@
   `as-child` is how the two REAGENT ISLANDS are spelled for the calling
   renderer — see the ns docstring. `identity` (the node lane, and any
   Reagent caller) leaves each body as a fn-headed hiccup vector, which
-  is exactly what it has always been; `reagent.core/as-element` (the
+  is exactly what it has always been; `substrate/as-element` (the
   boundary) answers a React element, a legal child anywhere per Fresco's
   component ABI. The Instances and Cascade arms are pure keyword hiccup
   and cross unchanged either way."

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -74,7 +74,7 @@
 
   ## Pure hiccup, and the ONE Reagent reference
 
-  The markup is still pure hiccup. `reagent.core/as-element` appears in
+  The markup is still pure hiccup. `substrate/as-element` appears in
   exactly one place — [[Panel]]'s `as-child` argument — and is the
   migration seam [[panel-tree]] documents, not a view-layer dependency."
   (:require [re-frame.core :as rf]
@@ -179,7 +179,7 @@
   says a React ELEMENT is a legal child anywhere, reached through an
   `as-child` seam. `identity` for a hiccup caller and the node lane,
   which leaves the browse list exactly the fn-headed vector it has
-  always been; `reagent.core/as-element` for the boundary, which answers
+  always been; `substrate/as-element` for the boundary, which answers
   a React element Fresco splices in as a child.
 
   THE SIMULATE-URL HEADER IS CALLED, NOT HEADED — it always was — and it

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -79,7 +79,7 @@
   migration seam [[panel-tree]] documents, not a view-layer dependency."
   (:require [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
-            [reagent.core :as r]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.routing-helpers :as h]
             [day8.re-frame2-xray.static.routes.browse-list :as browse-list]
@@ -238,7 +238,7 @@
   inside your body, so the bare `dispatch` this body used to close over
   would be a LOUD compile error, which is the good failure.
 
-  `r/as-element` is the `as-child` spelling for the browse-list island —
+  `substrate/as-element` is the `as-child` spelling for the browse-list island —
   [[panel-tree]] records the census that makes it necessary.
 
   The argument is the ordinary one-props-map vector every `defview`
@@ -254,7 +254,7 @@
                  :sim-open   sim-open
                  :routes-map routes-map}
                 (:dispatch (rf/capture-frame))
-                r/as-element)))
+                substrate/as-element)))
 
 ;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -104,7 +104,7 @@
 
   TWO REAGENT ISLANDS REMAIN, both reached through an `as-child`
   seam — `identity` for a hiccup caller and the node lane,
-  `reagent.core/as-element` for a boundary:
+  `substrate/as-element` for a boundary:
 
     * the L1 ribbon's `frame-switcher/frame-switcher-view` and
       `mode-pill/mode-pill`, both still `rf/reg-view`s. The Dynamic
@@ -297,7 +297,7 @@
   `as-child` is `identity` for a hiccup caller (the node lane, and any
   Reagent caller), which leaves each island a fn-headed hiccup vector
   exactly as it has always been; the boundary passes
-  `reagent.core/as-element`, which answers a React element — a legal
+  `substrate/as-element`, which answers a React element — a legal
   child anywhere per Fresco's component ABI.
 
   PURE: `ribbon-right-icons` is CALLED rather than headed, and answers
@@ -507,7 +507,7 @@
   PR #9648). A plain fn grades `:invalid` as a Fresco head, so the
   island stands. `as-child` is `identity` for a hiccup caller and the
   node lane, which leaves `[(:panel tab)]` exactly the vector it has
-  always been, and `reagent.core/as-element` for the boundary, which
+  always been, and `substrate/as-element` for the boundary, which
   answers a React element — a legal child anywhere per Fresco's
   component ABI, and the crossing every Static panel's own bridge
   comment already describes.

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -156,7 +156,7 @@
     - Interceptors — lens"
   (:require [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]
-            [reagent.core :as r]
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.mode-pill :as mode-pill]
@@ -363,7 +363,7 @@
   The argument is the ordinary one-props-map vector every `defview`
   takes. [[surface]] mounts it with none, so it is destructured away."
   [_props]
-  (ribbon-tree (:dispatch (rf/capture-frame)) r/as-element))
+  (ribbon-tree (:dispatch (rf/capture-frame)) substrate/as-element))
 
 ;; ---- L3 tab bar (Static) ------------------------------------------------
 
@@ -564,7 +564,7 @@
                      default-tab)]
     (detail-panel-tree selected
                        (panel-registry/tab-by-id :static selected)
-                       r/as-element)))
+                       substrate/as-element)))
 
 ;; ---- Static surface ------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/substrate.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/substrate.cljs
@@ -35,17 +35,34 @@
   island is rendered by the same build whose in-flight component the frame
   resolver consults, whichever ratom-family adapter the host installed.
 
-  ## Why it fails loud rather than returning nil
+  ## The fallback, and why it is NOT dead code
 
-  There is no substrate-neutral React element — an element is only correct
-  for the renderer that made it — so `:adapter/as-element` is published by
-  the ratom family ALONE and is deliberately routed with no chain-bottom
-  fallback. A nil-returning door would hand React a nil child, paint
-  nothing, and look exactly like the defect this namespace exists to
-  remove. `mount.cljs` already refuses the element-shaped substrates
-  before any of this runs, so reaching here with no walk published is a
-  wiring fault and is reported as one."
-  (:require [re-frame.error     :as rf.error]
+  `:adapter/as-element` is published by the ratom family ALONE — there is
+  no substrate-neutral React element, an element being correct only for
+  the renderer that made it — and it is ROUTED, so it answers only while
+  its own adapter is the installed one and returns nil otherwise.
+
+  That nil is reachable, and the reachable case is a REAL one rather than
+  a defensive flourish: Xray can own its own React root, and the
+  acceptance harness mounts the Static surface through Fresco's root with
+  **UIx** installed as the application adapter. The installed adapter is
+  then not ratom-family, no walk answers, and the island still has to
+  reach React — Fresco's codec passes an already-built React element
+  through untouched, which is what made this work before rf2-7ds8 named
+  the walk statically.
+
+  So the door PREFERS the installed ratom walk and falls back to stock
+  Reagent's, which is byte-for-byte the behaviour every one of these
+  crossings had before. The fallback cannot mask the defect it was
+  written for: under reagent-slim the routed hook answers, so the
+  fallback is never reached, and `w1-as-element-door-is-the-installed-
+  builds-walk` pins that it is reagent2's walk that answers rather than
+  this one.
+
+  `mount.cljs` independently refuses the element-shaped substrates for
+  the public `open!`, so a production Xray only ever mounts on a
+  ratom-family adapter and only ever takes the first arm."
+  (:require [reagent.core       :as stock]
             [re-frame.late-bind :as rf.late-bind]))
 
 (defn as-element
@@ -56,18 +73,12 @@
   its surviving Reagent islands. Pass `identity` instead from a plain
   hiccup caller or the node lane, where the island stays a vector.
 
-  Raises `:rf.error/no-substrate-as-element` when the installed adapter
-  publishes no walk — see the namespace docstring for why that is not a
-  nil return."
+  Falls back to stock Reagent's walk when no ratom-family adapter is
+  installed to answer — see the namespace docstring for why that case is
+  real and why the fallback cannot mask the defect."
   [hiccup]
-  (if-let [walk (rf.late-bind/get-fn-cached :adapter/as-element)]
-    (walk hiccup)
-    (rf.error/throw-error!
-      :rf.error/no-substrate-as-element
-      'day8.re-frame2-xray.substrate/as-element
-      (str "The installed substrate adapter publishes no hiccup → React "
-           "element walk (:adapter/as-element), so Xray cannot cross a "
-           "Reagent island into a Fresco boundary. The ratom-family "
-           "adapters (Reagent / reagent-slim) publish one; install one of "
-           "those via (rf/init! ...) before opening Xray.")
-      {:recovery :install-ratom-adapter})))
+  (let [walk     (rf.late-bind/get-fn-cached :adapter/as-element)
+        installed (when walk (walk hiccup))]
+    (if (some? installed)
+      installed
+      (stock/as-element hiccup))))

--- a/tools/xray/src/day8/re_frame2_xray/substrate.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/substrate.cljs
@@ -1,0 +1,73 @@
+(ns day8.re-frame2-xray.substrate
+  "Xray's door to the INSTALLED substrate adapter's hiccup → React element
+  walk (rf2-7ds8).
+
+  ## Why this exists
+
+  Xray's shell is hiccup, and several of its views are now FRESCO
+  BOUNDARIES. A boundary body may hand a surviving `rf/reg-view` island
+  down to React as a child, and Fresco's component ABI wants a React
+  ELEMENT there rather than a fn-headed hiccup vector. Producing that
+  element is a per-substrate act, and the boundaries take the spelling as
+  an `as-child` PARAMETER precisely so it can vary: a plain hiccup caller
+  (and the node lane) passes `identity`, leaving the island the vector it
+  has always been; a boundary passes this fn.
+
+  Until rf2-7ds8 the boundaries passed `reagent.core/as-element` — STOCK
+  Reagent's walk, named statically. Under the **reagent-slim** adapter
+  that is the wrong runtime, and the way it is wrong is quiet:
+
+    * React mounts the element perfectly well, and the `:contextType` the
+      `reg-view` head carries is honoured, so the frame keyword genuinely
+      reaches the mounted class.
+    * But the subtree is rendered by STOCK Reagent, which binds STOCK
+      Reagent's in-flight-component slot — while `:adapter/current-
+      component` routes to the INSTALLED adapter, i.e. `reagent2`, and so
+      answers nil inside that subtree.
+    * `re-frame.views.provider/current-frame` reads `(.-context cmp)` off
+      that component. With no component it returns nil, and every ambient
+      `subscribe` / `dispatch` beneath raises
+      `:rf.error/no-frame-context`.
+    * The raise happens in React's render phase, so React unmounts the
+      subtree. The developer gets a BLANK Xray, not a diagnostic.
+
+  Reading the walk off the installed adapter removes the whole class: the
+  island is rendered by the same build whose in-flight component the frame
+  resolver consults, whichever ratom-family adapter the host installed.
+
+  ## Why it fails loud rather than returning nil
+
+  There is no substrate-neutral React element — an element is only correct
+  for the renderer that made it — so `:adapter/as-element` is published by
+  the ratom family ALONE and is deliberately routed with no chain-bottom
+  fallback. A nil-returning door would hand React a nil child, paint
+  nothing, and look exactly like the defect this namespace exists to
+  remove. `mount.cljs` already refuses the element-shaped substrates
+  before any of this runs, so reaching here with no walk published is a
+  wiring fault and is reported as one."
+  (:require [re-frame.error     :as rf.error]
+            [re-frame.late-bind :as rf.late-bind]))
+
+(defn as-element
+  "Convert `hiccup` to a React element through the INSTALLED substrate
+  adapter's own walk (`:adapter/as-element`).
+
+  This is the `as-child` spelling every Xray Fresco boundary passes for
+  its surviving Reagent islands. Pass `identity` instead from a plain
+  hiccup caller or the node lane, where the island stays a vector.
+
+  Raises `:rf.error/no-substrate-as-element` when the installed adapter
+  publishes no walk — see the namespace docstring for why that is not a
+  nil return."
+  [hiccup]
+  (if-let [walk (rf.late-bind/get-fn-cached :adapter/as-element)]
+    (walk hiccup)
+    (rf.error/throw-error!
+      :rf.error/no-substrate-as-element
+      'day8.re-frame2-xray.substrate/as-element
+      (str "The installed substrate adapter publishes no hiccup → React "
+           "element walk (:adapter/as-element), so Xray cannot cross a "
+           "Reagent island into a Fresco boundary. The ratom-family "
+           "adapters (Reagent / reagent-slim) publish one; install one of "
+           "those via (rf/init! ...) before opening Xray.")
+      {:recovery :install-ratom-adapter})))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
@@ -1,0 +1,223 @@
+(ns day8.re-frame2-xray.static.shell-reagent-slim-crossing-dom-cljs-test
+  "rf2-7ds8 — Xray's Fresco boundaries must cross their surviving Reagent
+  islands through the INSTALLED ratom build, and this suite measures that
+  under **reagent-slim**, the adapter the defect was found on.
+
+  ## The defect these rows stand over
+
+  Xray's boundaries take the hiccup->React-element crossing as an
+  `as-child` PARAMETER. Nine sites across six sources passed
+  `reagent.core/as-element` — STOCK Reagent's walk, named statically.
+  Under reagent-slim the installed build is `reagent2`, and the mismatch
+  is quiet rather than loud:
+
+    * React mounts the element, and the `:contextType` the `reg-view`
+      head carries IS honoured — `reagent2.impl.component` reads
+      `(:contextType (meta f))` exactly as stock's `fn-to-class` does —
+      so the frame keyword genuinely reaches the mounted class.
+    * But the foreign build renders the subtree with ITS
+      in-flight-component slot bound, while `:adapter/current-component`
+      routes to the INSTALLED build and answers nil inside it.
+    * `re-frame.views.provider/current-frame` reads `(.-context cmp)` off
+      that component, finds none, and returns nil — so every ambient
+      `subscribe` / `dispatch` beneath raises
+      `:rf.error/no-frame-context`, in React's RENDER phase, and React
+      takes the subtree down. A blank Xray, not a diagnostic.
+
+  ## Two rows, and they fail in different registers ON PURPOSE
+
+  W1 is the DURABLE PIN. It reads the door itself and needs no DOM, so a
+  regression reds ONE row with a precise message. W2 is the PAINT
+  witness — the only thing that proves a developer on reagent-slim sees
+  a shell rather than a blank panel — and it can only be had from a real
+  React commit.
+
+  ## Why W2 mounts under `h/error-boundary`, which is not decoration
+
+  rf2-7ds8's own bead argued this defect could not be pinned at all:
+  reproducing it needs an UNCAUGHT RENDER-PHASE THROW, and the browser
+  runner fails any run carrying an uncaught `pageerror` independently of
+  the `cljs.test` summary — so a naive pin would red the whole lane for
+  every unrelated suite and make one real defect look like a broken
+  runner. That reasoning is sound about a NAKED mount and is answered
+  rather than contradicted here: an error boundary above the crossing
+  makes the throw a HANDLED one, so a regression reddens this row on its
+  own message and every neighbouring namespace still runs. The bead's
+  conclusion was right for the instrument it had in mind.
+
+  ## Test target
+
+  The ns ends in `-dom-cljs-test`, so it runs under the `:browser-test`
+  build (real DOM + React via Chromium). The `:node-test` build's regex
+  also matches, so it LOADS under Node — where W2 short-circuits through
+  [[browser?]] and reports the skip rather than passing silently. W1
+  needs no DOM and runs in both."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent2.core :as slim]
+            [reagent2.dom.client :as slim-dom]
+            [reagent.core :as stock]
+            ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]
+            [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
+            [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.shell :as static-shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture
+    {:adapter       rf.adapter.reagent-slim/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (xray-test-support/reset-all!)
+                      ;; Fresco's collector tables are process-global
+                      ;; `defonce`s the core fixture knows nothing about; a
+                      ;; neighbour's boundary left in the entry cache would
+                      ;; make this suite read a residue that is not its own.
+                      (rf.fresco.impl.collector/reset-runtime!))}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns but has no `js/document` to mount React into."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ===========================================================================
+;; W1 — the crossing door is the INSTALLED build's walk
+;; ===========================================================================
+
+(deftest w1-as-element-door-is-the-installed-builds-walk
+  (testing "rf2-7ds8 — with reagent-slim installed, `:adapter/as-element`
+            resolves to reagent2's hiccup walk and NOT to stock
+            Reagent's.
+
+            BOTH HALVES ARE COMPARED TO LITERALS, and that is the whole
+            point of the row's shape. A door checked against a value
+            derived from the same lookup agrees with itself when the
+            subject is broken — both sides go nil, they match, and the
+            row goes green ON the defect. `reagent2.core/as-element` and
+            `reagent.core/as-element` are two distinct vars named
+            independently of anything this row reads, so the positive and
+            the negative cannot degrade together."
+    (let [door (rf.late-bind/get-fn-cached :adapter/as-element)]
+      (is (some? door)
+          "reagent-slim publishes :adapter/as-element (a nil door would make
+           both comparisons below vacuous, so this is asserted first)")
+      (is (identical? door slim/as-element)
+          "the door IS reagent2's walk — the build whose in-flight component
+           :adapter/current-component routes to, which is what lets
+           views/current-frame read a frame off it")
+      (is (not (identical? door stock/as-element))
+          "the door is NOT stock Reagent's walk. This is the defect itself:
+           stock's walk renders the island under a build the installed
+           adapter cannot see into, so the frame resolves nil and the
+           subtree raises :rf.error/no-frame-context"))))
+
+;; ===========================================================================
+;; W2 — the Static ribbon's Reagent island actually PAINTS under slim
+;; ===========================================================================
+
+(def ^:private caught
+  "The error `h/error-boundary` caught below this row's crossing, or nil.
+  Non-nil is the defect returning: the island raised in React's render
+  phase and React took the subtree down."
+  (atom nil))
+
+(rf.fresco/defview guarded-ribbon
+  "The Static L1 ribbon under an error boundary, so a render-phase raise
+  from the crossing is HANDLED — this row reddens on its own message
+  instead of aborting the lane for every other namespace on the page.
+  See the ns docstring."
+  [_props]
+  [rf.fresco/error-boundary
+   {:on-error (fn [error] (reset! caught error))
+    :fallback [:div {:data-testid "rf-slim-crossing-fallback"}]}
+   [static-shell/ribbon {}]])
+
+(def ^:private guarded-component
+  "The React component [[guarded-ribbon]] presents as. Declared once at
+  top level, as `rf.fresco/as-component`'s contract requires — deriving
+  it per render would mint a new component type every time and remount
+  the subtree under test."
+  (rf.fresco/as-component guarded-ribbon))
+
+(defn- setup!
+  "Register Xray's handlers — which is what registers the sub family the
+  ribbon's islands read — and make the frame the tree names."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  nil)
+
+(defn- mount-ribbon!
+  "Mount the guarded ribbon through REAGENT-SLIM's own client root, under
+  a `frame-provider` scoping `:rf/xray`. Committed synchronously —
+  React 19's `root.render` is otherwise async and the assertions would
+  read an empty container."
+  []
+  (let [container (.createElement js/document "div")
+        root      (slim-dom/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (slim-dom/render root [rf/frame-provider {:frame :rf/xray}
+                               [:> guarded-component {}]])))
+    {:container container :root root}))
+
+(defn- teardown! [root container]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (.remove container))
+
+(defn- testid
+  "The committed node carrying `id`, or nil. Every reader below goes
+  through this and is `some?`-tested rather than dereferenced, so a
+  regression that empties the chrome reddens the row instead of throwing
+  a TypeError out of `cljs.test/run-block` — which has no try/catch and
+  would take the whole browser lane down with no summary."
+  [container id]
+  (some-> container (.querySelector (str "[data-testid=\"" id "\"]"))))
+
+(deftest w2-ribbon-reagent-island-paints-under-reagent-slim
+  (testing "rf2-7ds8 — under reagent-slim the Static L1 ribbon's Reagent
+            island commits to the DOM, which it can only do if the
+            boundary crossed it through the installed build AND the frame
+            resolved beneath it.
+
+            `frame-switcher-view` is a `reg-view` whose body makes an
+            ambient read. Its node therefore exists ONLY when
+            views/current-frame found a component to read a frame off —
+            so the node's presence is the frame-context claim, not merely
+            a paint claim."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (reset! caught nil)
+        (setup!)
+        (let [{:keys [container root]} (mount-ribbon!)]
+          ;; The ribbon's own chrome — present even if the islands are gone,
+          ;; so it separates "the boundary painted nothing at all" from "the
+          ;; boundary painted but its island was taken down".
+          (is (some? (testid container "rf-xray-static-ribbon"))
+              "the Static ribbon boundary committed its own chrome")
+          (is (nil? @caught)
+              (str "no render-phase error reached the boundary above the "
+                   "crossing. A :rf.error/no-frame-context here is rf2-7ds8 "
+                   "returning: the island was crossed by a build the "
+                   "installed adapter cannot see into. Caught: "
+                   (pr-str @caught)))
+          (is (nil? (testid container "rf-slim-crossing-fallback"))
+              "the error boundary did NOT swap in its fallback")
+          (is (some? (testid container "rf-xray-ribbon-frame"))
+              (str "frame-switcher-view — a reg-view island the ribbon "
+                   "crosses through its as-child seam — is committed under "
+                   "reagent-slim. This is the node the defect removed"))
+          (is (some? (testid container "rf-xray-ribbon-frame-picker"))
+              "the island rendered its frame picker, so its ambient read ran
+               rather than raising")
+          (teardown! root container)
+          (done))))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
@@ -93,30 +93,54 @@
 
 (deftest w1-as-element-door-is-the-installed-builds-walk
   (testing "rf2-7ds8 — with reagent-slim installed, `:adapter/as-element`
-            resolves to reagent2's hiccup walk and NOT to stock
-            Reagent's.
+            walks hiccup the way reagent2 does and NOT the way stock
+            Reagent does.
 
-            BOTH HALVES ARE COMPARED TO LITERALS, and that is the whole
-            point of the row's shape. A door checked against a value
-            derived from the same lookup agrees with itself when the
-            subject is broken — both sides go nil, they match, and the
-            row goes green ON the defect. `reagent2.core/as-element` and
-            `reagent.core/as-element` are two distinct vars named
-            independently of anything this row reads, so the positive and
-            the negative cannot degrade together."
-    (let [door (rf.late-bind/get-fn-cached :adapter/as-element)]
+            IT IS MEASURED BY EFFECT RATHER THAN BY IDENTITY, and that is
+            a finding rather than a convenience: `route-hook!` wraps the
+            published fn so the chain can pick the INSTALLED adapter at
+            call time, so the door is a `routed-hook` object and an
+            `identical?` row against the raw var fails on a perfectly
+            healthy wiring. What the crossing needs is not that var but
+            its BEHAVIOUR, so that is what is read.
+
+            THE DISCRIMINATOR IS THE COMPONENT TYPE REACT RECEIVES for a
+            fn head, and all three readings go through the SAME `probe`
+            fn ON PURPOSE. Each build caches the class it mints on the fn
+            object under its own property — stock on `.-cljsReactClass`,
+            reagent2 on `.-cljsReagentClass-fn` — so one fn can carry
+            both and the two answers stay independent. Using a fresh fn
+            per build instead would make the negative trivially true (two
+            fns always mint two classes) and it would prove nothing.
+
+            BOTH HALVES COMPARE TO LITERALS. `reagent2.core/as-element`
+            and `reagent.core/as-element` are two distinct vars named
+            independently of anything the door resolves, so the positive
+            and the negative cannot degrade together — a door checked
+            only against a value derived from the same lookup agrees with
+            itself when the subject is broken and goes green ON the
+            defect."
+    (let [door  (rf.late-bind/get-fn-cached :adapter/as-element)
+          probe (fn probe-view [] [:div {:data-testid "rf-slim-crossing-probe"}])]
       (is (some? door)
           "reagent-slim publishes :adapter/as-element (a nil door would make
            both comparisons below vacuous, so this is asserted first)")
-      (is (identical? door slim/as-element)
-          "the door IS reagent2's walk — the build whose in-flight component
-           :adapter/current-component routes to, which is what lets
-           views/current-frame read a frame off it")
-      (is (not (identical? door stock/as-element))
-          "the door is NOT stock Reagent's walk. This is the defect itself:
-           stock's walk renders the island under a build the installed
-           adapter cannot see into, so the frame resolves nil and the
-           subtree raises :rf.error/no-frame-context"))))
+      (when (some? door)
+        ;; Stock runs FIRST and on this same fn, so if the two builds ever
+        ;; collided on one cache property the negative below would catch it
+        ;; rather than read a reassuring pass.
+        (let [via-stock (stock/as-element [probe])
+              via-door  (door [probe])
+              via-slim  (slim/as-element [probe])]
+          (is (identical? (.-type via-door) (.-type via-slim))
+              "the door mints the component type REAGENT2 mints — the build
+               whose in-flight component :adapter/current-component routes
+               to, which is what lets views/current-frame read a frame off it")
+          (is (not (identical? (.-type via-door) (.-type via-stock)))
+              "the door does NOT mint stock Reagent's type. That is the defect
+               itself: stock's walk renders the island under a build the
+               installed adapter cannot see into, so the frame resolves nil
+               and the subtree raises :rf.error/no-frame-context"))))))
 
 ;; ===========================================================================
 ;; W2 — the Static ribbon's Reagent island actually PAINTS under slim


### PR DESCRIPTION
## What and why

Xray does not render under **reagent-slim** — one of the three adapters
`implementation/adapters/README.md` says ship today.
`frame-switcher/frame-switcher-view` raises `:rf.error/no-frame-context` in
React's render phase and React takes the subtree down, so the developer gets a
blank surface rather than a diagnostic. `mount.cljs`'s
`unsupported-substrate-diagnostic` meanwhile tells them the shell renders
"through the ratom-family adapters (Reagent / reagent-slim)" — the product
advertises the support it lacks. This makes that sentence true.

## The mechanism, established at source

Xray's Fresco boundaries take the hiccup→React-element crossing as an
`as-child` **parameter** (a plain hiccup caller and the node lane pass
`identity`). Nine sites across six sources passed `reagent.core/as-element` —
stock Reagent's walk, named statically.

Under reagent-slim the installed build is `reagent2`, and the mismatch is quiet
rather than loud:

* React mounts the element fine, and the `:contextType` the `reg-view` head
  carries **is** honoured — `reagent2.impl.component` reads `(:contextType
  (meta f))` exactly as stock's `fn-to-class` does — so the frame keyword
  genuinely reaches the mounted class.
* But the subtree is rendered by the **foreign** build, which binds *its*
  in-flight-component slot, while `:adapter/current-component` routes to the
  **installed** build and answers nil inside it.
* `re-frame.views.provider/current-frame` reads `(.-context cmp)` off that
  component. No component → nil → every ambient `subscribe` / `dispatch`
  beneath raises.

So the fault is not "the crossing resolves nothing"; it is that the crossing
resolves to a renderer the frame resolver cannot see into. The sabotage run
below reproduces exactly that error.

## The fix

Publish **`:adapter/as-element`** — the installed ratom build's own hiccup walk
— as a routed late-bind hook. It is the exact twin of
`:adapter/current-component`, published by the same two adapters, and the
twinning is the argument: the crossing must come from the build whose in-flight
component the frame resolver consults.

`day8.re-frame2-xray.substrate/as-element` is the single door all nine sites now
use. It **prefers** the installed ratom walk and falls back to stock Reagent's.
The fallback is not defensive padding — Xray can own its own React root, and the
acceptance harness mounts the Static surface through Fresco's root with **UIx**
installed, where no ratom walk answers. My first cut omitted that fallback and
broke exactly those rows; see the gates table.

The fallback cannot mask the defect: under reagent-slim the routed hook answers,
so it is never reached, and W1 pins that it is reagent2's walk that answers.

## Quality gates

Every gate below is quoted from **its own captured `.exit` file**, not from the
harness's report of the same run — those disagreed on three of these runs, the
harness saying `0` against a captured `1` each time.

| Gate | Captured exit | Result |
|---|---|---|
| `npm run test:browser` (final, on the rebased base) | **0** | 999 tests / 5615 assertions, 0 failures, 0 errors. Port **8163**, serving from this worktree. |
| `npm run test:browser` — **sabotage control** | **1** | 5 failures, **all five in W2 and nowhere else**; lane still completed with a full summary. |
| `npm run test:reagent-slim:smoke` | **0** | 1 smoke, 0 failures. Build root printed = this worktree. |
| `npm run test:cljs` (node lane) | **1**, then repaired | Ran once; both failures fixed (see below). **Not re-run** on the final base — left to CI. |
| `check_retired_spellings`, `check_retired_composition_vocab`, `check_retired_image_keys`, `check-ai-tracking-ratchet` | **0** each | Ratchets covering the touched paths. Run, but not fault-planted. |
| `python scripts/check_fast_pr_gap.py --brief` | **0** | A report, not a suite: 101 required checks this spine does not decide. |

**The node lane's two failures were both real and both repaired.** (1) The
reagent-slim adapter pins its published hook set and cross-checks it against the
late-bind directory for *equality*, so publishing a hook without pinning it is a
red — both ratom pins now carry `:adapter/as-element`. (2) W1 compared the door
by `identical?` against the raw var, but `route-hook!` *wraps* the published fn
so the chain can pick the installed adapter at call time; the row now measures
behaviour instead. W1 is verified green — the ns runs in both builds and W1 needs
no DOM, so the browser lane grades it.

**Left to CI:** the node lane on the final base, lint, docs, and the rest of the
matrix.

### The failing-first evidence

Forcing the stock arm (a one-line plant, restored and verified by blob hash)
reproduced the bead's defect precisely: `:rf.error/no-frame-context` caught by
the boundary, the fallback swapped in, and both the ribbon chrome and the
`frame-switcher-view` island gone.

**This also answers the bead's claim that the defect could not be pinned.** That
claim was right about a *naked* mount — an uncaught render-phase throw reds the
whole browser lane independently of the `cljs.test` summary. W2 mounts under
`h/error-boundary`, which makes the throw a handled one: under the plant it
failed 5 rows and the lane still ran all 992 tests to a full summary.

## Related but deliberately untouched

* **The UIx inversion.** UIx is refused by the public `open!` denylist yet paints
  through Xray's own React root. Retiring that denylist is `rf2-k97c.4`,
  sequenced behind `rf2-k97c.3`. The refusal path is untouched.
* **`tools/xray` keeps its stock `reagent/reagent` dep** — now for exactly one
  production require, the fallback arm. So a reagent-slim page carrying Xray
  still ships both ratom runtimes. That is a **bundle** concern now rather than a
  correctness one; retiring it needs a non-Reagent answer for the Fresco-root
  path. The dep's comment is corrected rather than removed — it named a reason
  that had already gone stale.
