### PR TITLE
test(xray): W1's island row selects a node the island emits (rf2-q6n3)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -19,6 +19,10 @@
                                     OWN sub-cache rather than off the DOM
     6 CLEAN TEARDOWN              — W3
 
+  W4 answers no epic criterion. It is the CONTROL under W1's island row: it
+  mounts the panel's own tree with the island child removed and shows the
+  island assertion failing while the wrapper assertions still pass.
+
   Criteria 3 and 5 have no row here for the reasons the Epoch panel's sibling
   suite sets out: criterion 5 is structural and identical for every boundary
   in this migration, and `static/flows/panel_fresco_boundary_dom_cljs_test`
@@ -43,6 +47,13 @@
   spelling. That is not a detail a node-lane row can witness: under
   `identity` the island is a no-op and the tree looks the same either way.
   Here, a missing or wrong island does not paint at all.
+
+  SELECT THE ISLAND BY A NODE THE ISLAND EMITS (rf2-q6n3). That is
+  `rf-xray-machine-canvas-host`, `Chart`'s own root. It is NOT
+  `rf-xray-machine-focused-event-chart`, which `machine_inspector` emits two
+  levels ABOVE its `as-child` call and which therefore survives the whole
+  Chart subtree being absent — W1 claimed the island on that marker until
+  rf2-q6n3, and W4 is the standing demonstration of why it could not.
 
   ## The mount is the SHELL's mount, taken from the registry
 
@@ -79,9 +90,18 @@
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.machines]
             [re-frame.test-support :as rf.test-support]
+            ;; W4 only. `r/as-element` is the island spelling [[Panel]] hands
+            ;; down, and W4's control is that same call with the ONE argument
+            ;; swapped — so the test needs the production spelling verbatim.
+            [reagent.core :as r]
+            ;; W4 only, and it is the one place this file names a panel var
+            ;; rather than reaching through the registry: `panel-tree` IS the
+            ;; seam the island rides on, so the control has to call it.
+            [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
@@ -242,8 +262,27 @@
 (defn- focused-section? [container]
   (some? (q container "[data-testid=\"rf-xray-machine-focused-event\"]")))
 
-(defn- chart-node [container]
+(defn- chart-wrapper-node
+  "The chart WRAPPER — a `:div` `machine_inspector` itself emits above the
+  island (`panels/machine_inspector.cljs`, ELEMENT 3). Its presence says the
+  focused-event section reached element 3 and took the has-definition arm,
+  and it says NOTHING WHATEVER about the island: `machine_inspector` emits
+  this node and a second styling wrapper BEFORE the `as-child` call, so it is
+  committed even when `as-child` answers nil and the entire Chart subtree is
+  absent. [[w4-the-island-selector-discriminates-and-the-wrapper-does-not]]
+  demonstrates exactly that, which is why this is not a claim about the
+  island and must never be written as one again (rf2-q6n3)."
+  [container]
   (q container "[data-testid=\"rf-xray-machine-focused-event-chart\"]"))
+
+(defn- island-node
+  "The ISLAND — `machine-canvas/Chart`'s OWN root div. `Chart` emits
+  `:data-testid` from its `testid` prop, whose `:or` default is this literal
+  (`panels/machine_canvas.cljs`), and `machine_inspector`'s `as-child` call
+  site passes no `:testid`, so this marker IS Chart's root here. Nothing but
+  `Chart` running can put this node in the DOM."
+  [container]
+  (q container "[data-testid=\"rf-xray-machine-canvas-host\"]"))
 
 (defn- cache-of
   "The frame's live sub-cache map. Not `some->`-guarded: a nil here means the
@@ -296,14 +335,30 @@
                `panel-tree` rather than painting an empty shell")
 
           ;; ---- the island, which only a real commit can witness -----------
-          (is (some? (chart-node container))
-              "THE ISLAND MOUNTED. `machine-canvas/Chart` is still an
-               `rf/reg-view`, which Fresco's codec grades `:invalid` in head
-               position down the identical arm a plain `defn` takes — so this
-               subtree reaches the DOM only because the boundary hands
-               `r/as-element` down as the `as-child` spelling. Under the node
-               lane's `identity` the island is a no-op and this claim cannot
-               be made at all.")
+          ;;
+          ;; TWO ROWS, AND THE ORDER IS THE POINT (rf2-q6n3). Until this
+          ;; commit there was ONE row here, selecting the WRAPPER and
+          ;; claiming the island. `machine_inspector` emits that wrapper
+          ;; itself, two levels above its `as-child` call, so the row was
+          ;; true of a tree with no island in it at all — it restated what
+          ;; the `focused-section?` row above already establishes. The
+          ;; wrapper row is kept because it IS a real witness of its own
+          ;; claim; what changed is the sentence attached to it.
+          (is (some? (chart-wrapper-node container))
+              "the focused-event section reached ELEMENT 3 and took the
+               has-definition arm, so it emitted the chart WRAPPER. This is a
+               claim about `machine_inspector`'s own markup and no more: the
+               wrapper sits above the `as-child` call and survives the island
+               being absent, which is W4's subject.")
+          (is (some? (island-node container))
+              "THE ISLAND MOUNTED — `machine-canvas/Chart`'s OWN root div,
+               below the migration seam. `Chart` is still an `rf/reg-view`,
+               which Fresco's codec grades `:invalid` in head position down
+               the identical arm a plain `defn` takes, so this node reaches
+               the DOM only because the boundary hands `r/as-element` down as
+               the `as-child` spelling and Reagent expanded the head. Under
+               the node lane's `identity` the island is a no-op and this
+               claim cannot be made at all.")
 
           ;; ---- criterion 4: the reads are where the tree said they'd be ----
           (doseq [query-v boundary-reads]
@@ -447,3 +502,142 @@
                                "and the second unmount releases them too")))
             (.catch (fn [e] (is false (str "poll timed out: " (.-message e))) nil))
             (.then (fn [_] (done))))))))
+
+;; ===========================================================================
+;; W4 — the island selector discriminates, and the wrapper selector does not
+;; ===========================================================================
+
+;; THE CONTROL IS `Panel`'s OWN BODY WITH ONE ARGUMENT SWAPPED.
+;;
+;; `machine-inspector/panel-tree` takes the island spelling as a PARAMETER —
+;; `r/as-element` under the boundary, `identity` for the node lane — and
+;; threads it to exactly one call site, `focused-event-section`'s
+;; `(as-child [machine-canvas/Chart …])`. An island-less tree is therefore
+;; that same fn with `(constantly nil)` in that one argument: not a hand-built
+;; fixture resembling the panel, but the production tree builder emitting the
+;; production wrapper through the production seam. Both halves below come from
+;; the same fn over the same seeded state, so `as-child` is the ONLY variable
+;; between them.
+;;
+;; IT IS HOSTED IN A REAL BOUNDARY rather than in a bare Reagent tree, and
+;; that is load-bearing rather than ceremony: `panel-tree`'s ELEMENT 2 reaches
+;; the shared mini-pipeline, whose EDN-widget heads are Fresco boundaries.
+;; Reagent mints its own component for a fn head and CALLS it during Reagent's
+;; render, which is not a React function-component render, so the boundary's
+;; first hook throws, React swallows the render throw, and that subtree
+;; silently commits nothing. `machine_epochs_always_round_dom_cljs_test`
+;; records the same fact from the other side and hosts its subject this way.
+;;
+;; The spelling arrives through an atom rather than through props because only
+;; an EMPTY props map survives the `[:>]` crossing intact.
+
+(defonce ^:private !island-spelling
+  (atom nil))
+
+(rf.fresco/defview IslandProbe
+  "[[Panel]]'s body — the same five queries through the same collector, the
+  same `panel-tree` call — with the island spelling read from
+  [[!island-spelling]] rather than hard-coded to `r/as-element`. Takes the
+  ordinary one-props-map argument every `defview` takes and reads nothing
+  from it."
+  [_props]
+  (machine-inspector/panel-tree
+    (rf.fresco/sub data-q)
+    (rf.fresco/sub records-q)
+    (:cascade (rf.fresco/sub cascade-q))
+    @!island-spelling
+    (rf.fresco/sub fit-q)
+    (rf.fresco/sub frame-q)))
+
+(def ^:private IslandProbe-component
+  "The React component [[IslandProbe]] presents as, for the Reagent root
+  below. Declared ONCE at top level, as `rf.fresco/as-component` requires."
+  (rf.fresco/as-component IslandProbe))
+
+(defn- mount-probe!
+  "Mount [[IslandProbe]] with `as-child` as its island spelling, inside the
+  `frame-provider` the real shell wraps every panel in. Committed
+  synchronously, as [[mount-panel!]] is and for the same reason."
+  [as-child]
+  (reset! !island-spelling as-child)
+  (let [container (.createElement js/document "div")
+        root      (rdc/create-root container)]
+    (.appendChild (.-body js/document) container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render root [rf/frame-provider {:frame :rf/xray}
+                          [:> IslandProbe-component {}]])))
+    {:container container :root root}))
+
+(deftest w4-the-island-selector-discriminates-and-the-wrapper-does-not
+  (testing "rf2-q6n3 — with the island child removed, the
+            `rf-xray-machine-focused-event-chart` wrapper is STILL COMMITTED
+            while the `rf-xray-machine-canvas-host` island is GONE. That
+            asymmetry is the whole row. It is what makes W1's island
+            assertion a claim about the island, and it is the standing
+            demonstration that the assertion W1 used to carry — which
+            selected the wrapper — could not have failed on an absent island
+            and therefore never made the claim its docstring stated."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup!)
+        (seed-machines!)
+        (set-history! fixture-history)
+        (focus-epoch! 1)
+        (let [!live (atom (mount-probe! r/as-element))
+              !dark (atom nil)
+              drop! (fn [a]
+                      (when-let [{:keys [root container]} @a]
+                        (reset! a nil)
+                        (teardown! root container)))]
+          (-> (rf.test-support/poll-until
+                #(some? (island-node (:container @!live)))
+                {:label "the probe committed Chart's own canvas host"})
+              (.then
+                (fn [_]
+                  ;; ---- the island is really there when it is there --------
+                  (is (= "rf-xray-machine-canvas-host"
+                         (some-> (island-node (:container @!live))
+                                 (.getAttribute "data-testid")))
+                      "NON-VACUITY: handed the production spelling
+                       `r/as-element`, the probe commits `machine-canvas/
+                       Chart`'s own root. So this harness CAN produce an
+                       island, and the absence asserted below is a real
+                       absence rather than a harness that never renders one.
+                       Compared against the marker written out in full, so a
+                       nil node cannot agree with a nil expectation.")
+                  (is (some? (chart-wrapper-node (:container @!live)))
+                      "and the wrapper is committed here too, exactly as in
+                       W1 — which is what makes the pair below a controlled
+                       comparison rather than two unrelated trees")
+                  (drop! !live)
+                  ;; ---- now take the island away, and only the island -----
+                  (reset! !dark (mount-probe! (constantly nil)))
+                  (settle)))
+              (.then
+                (fn [_]
+                  (let [container (:container @!dark)]
+                    (is (nil? (island-node container))
+                        "THE ISLAND IS GONE. `as-child` answered nil, so
+                         `machine-canvas/Chart` never ran and nothing in the
+                         committed DOM carries its root marker. Asserted
+                         after a full settling window, so the absence is a
+                         decision and not a race.")
+                    (is (some? (chart-wrapper-node container))
+                        "AND THE WRAPPER IS STILL STANDING. This is the
+                         rf2-q6n3 defect stated as a passing assertion:
+                         `machine_inspector` emits
+                         `rf-xray-machine-focused-event-chart` two levels
+                         ABOVE its `as-child` call, so a row selecting that
+                         marker reads GREEN over a tree with no island in it
+                         at all. The island claim cannot be made with this
+                         node, and W1 no longer makes it."))))
+              (.catch (fn [e]
+                        (is false (str "W4 never settled: " (.-message e)))
+                        nil))
+              (.then (fn [_]
+                       (drop! !live)
+                       (drop! !dark)
+                       (reset! !island-spelling nil)
+                       (done)))))))))


### PR DESCRIPTION
## rf2-q6n3 — W1's island row selects a node the island emits

The Machine Inspector's Fresco-boundary suite claimed its surviving Reagent
chart island had mounted, on the presence of
`rf-xray-machine-focused-event-chart`. That marker is emitted by
`panels/machine_inspector.cljs` itself, on a wrapper **two levels above** its
`as-child` call — so it is committed even when `as-child` answers nil and the
entire `machine-canvas/Chart` subtree is absent. W1's strongest-sounding row
therefore only restated what its own `focused-section?` row already
establishes.

Verified at source before changing anything: `machine_inspector.cljs` emits
the marker on the wrapper, then a second styling wrapper, then calls
`as-child`; `machine_canvas.cljs` gives `Chart`'s `testid` prop an `:or`
default of `rf-xray-machine-canvas-host` and emits it on Chart's own root; and
the `as-child` props block at the call site passes **no** `testid`, so that
default is the live marker here.

### What changed

One file: `tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs`.

* **The island row now selects `rf-xray-machine-canvas-host`** — `Chart`'s own
  root div, below the migration seam. Nothing but `Chart` running can put that
  node in the DOM.
* **The wrapper row is kept, with a corrected sentence.** It is a real witness
  that the focused-event section reached element 3 and took the
  has-definition arm. It is not, and never was, a witness of the island. This
  is a correction rather than a deletion.
* **W4 is the new negative control**, and the asymmetry is the deliverable.

### W4 — the control

`machine-inspector/panel-tree` takes the island spelling as a *parameter*
(`r/as-element` under the boundary, `identity` for the node lane) and threads
it to exactly one call site. So an island-less tree is that same production fn
with `(constantly nil)` in that one argument — the production tree builder,
the production wrapper markup, the production seam. Both halves render from
the same fn over the same seeded state; `as-child` is the only variable.

| | `rf-xray-machine-focused-event-chart` | `rf-xray-machine-canvas-host` |
| --- | --- | --- |
| island present (`r/as-element`) | present | present |
| island absent (`(constantly nil)`) | **present** | **absent** |

The bottom-left cell is the defect, stated as a passing assertion: a row
selecting the wrapper reads green over a tree with no island in it.

Three properties, all deliberate:

* The subject is hosted in a **real Fresco boundary**, not a bare Reagent
  tree. `panel-tree`'s element 2 reaches the shared mini-pipeline, whose
  EDN-widget heads are Fresco boundaries; Reagent would call them during its
  own render, the first hook would throw, React would swallow it, and that
  subtree would silently commit nothing.
  `machine_epochs_always_round_dom_cljs_test` records the same fact and hosts
  its subject the same way.
* Assertions compare against **written-out literals**, never against a value
  derived from the same read — so the two sides cannot agree with each other
  by both going nil under a revert.
* The absence is asserted **after a full settling window**, not in the
  mounting turn, so it is a decision and not a race. The positive half is
  polled for and doubles as the non-vacuity control: it proves the harness can
  produce an island at all.

### The other two files that select the same marker — reported, not touched

`rf-xray-machine-focused-event-chart` is selected in three test files. Both
others are **correct** and were left alone:

* `panels/machine_inspector_view_cljs_test.cljs` — a node-lane suite walking
  pure hiccup. It says "the section renders the topology chart" and reads
  `data-from-highlight-id` / `data-to-highlight-id` off that node. Those are
  wrapper attributes and wrapper claims.
* `panels/epoch/machine_epochs_always_round_dom_cljs_test.cljs` — says "the
  focused-event chart **wrapper** rendered" in so many words, and reads
  `data-fired-edge-ids` off it. Also a wrapper attribute.

Neither carries the false claim.

### Verified by hand

Anchors and the table's column counts in this body checked by hand. No link,
slug or site gate has this path in its roots, so none was nominated.

## Quality gates

Every number below is the exit code captured on the runner's own command line
and read back from its `.exit` file, never a figure reported about the run.
Both heavy lanes were split so the run phase is gated on the compile phase's
captured exit rather than chained to it.

| Gate | Captured exit | Result |
| --- | --- | --- |
| `shadow-cljs compile browser-test` | **0** | 1066 files, 1065 compiled, 5 warnings |
| `serve-and-run-browser-tests.cjs` (port 8175) | **0** | 991 tests, 5583 assertions, **0 failures, 0 errors** |
| browser lane, **sabotage control** | **1** | 991 tests, 5583 assertions, **1 failure**, 0 errors |
| `compile-node-test.cjs node-test` | **0** | 1966 files, 1965 compiled, 0 warnings |
| `node out/node-test.js` | **0** | 11739 tests, 58662 assertions, **0 failures, 0 errors** |
| `check_require_alias_dialect.py --self-test` / `--verbose` | **0** | 79 self-tests; 2868 files, 11315 edges, 0 non-canonical, every surface at or under its floor |
| `check_retired_spellings.py --self-test --verbose` / `--verbose` | **0** | 1057 + 4660 files scanned, none found |
| `check_test_lane_bijection.py --self-test` / `--verbose` | **0** | 1638 test-defining files, 45 lanes, every file selected |
| `clj-kondo --parallel --fail-level error --lint tools/xray` | **0** | errors 0; 141 warnings, all pre-existing, **0 in the changed file** |
| `clojure -M:splint --fail-on-errors ../tools` | **0** | 1049 files, 1466 style warnings, no errors |
| `python scripts/check_fast_pr_gap.py --brief` | **0** | report only — names 101 required checks this spine does not decide |

The 5 browser-compile warnings are pre-existing `:infer-warning`s in
`implementation/fresco/test/re_frame/fresco/login_server_crossing_ssr_dom_cljs_test.cljs`,
a file this change does not touch.

**The sabotage control is the row that matters.** The clean run is only
evidence if the new assertions actually execute in that lane. Flipping W4's
island-absence assertion from `nil?` to `some?` — a one-token plant on a
single line, match count read as exactly 1 before running — recompiled (3
files, captured exit 0, so the artefact is the planted one and not a stale
build) and the lane came back **captured exit 1** with exactly one failure,
naming `w4-the-island-selector-discriminates-and-the-wrapper-does-not` at the
planted line. Test and assertion counts were identical to the clean run
(991 / 5583), so the plant was scoped and aborted no namespace. That red also
discriminates the worktree: the fault existed only in this checkout, so a run
that had wandered into a sibling's would have come back green.

The plant was restored and the restore verified against the committed object
rather than by reading a diff: `git hash-object` in its default form
reproduces the committed blob id exactly, and `git diff --quiet HEAD` — a
second, independent instrument — exits 0.

Both lanes also printed their root, and both named this worktree's
`shadow-cljs.edn` and `out/browser-test`.

### Gates not run, and why

* **`scripts/test-fast-pr.sh`** — not nominated. It tiers itself on the
  changed-surface classifier and would double-run the two lanes above.
* **Link, slug and site gates** (`check_doc_slugs.py`,
  `check_readme_links.py --ci`, `mkdocs build --strict`) — the diff is one
  `.cljs` test file, which is outside every one of their roots. Running one
  would return a green that inspected nothing that changed.
* **Bundle isolation** — its subject is a compiled production example bundle
  and needs a `shadow-cljs release` build. A test file never ships in one, so
  the gate cannot reach this path.
* **`api-manifest`** — armed by the lint surface, but its subject is
  `tools/xray/spec/API.md` against `ns-publics` of *src*. This diff moves no
  public name.
* Everything else in the required matrix is CI's, and CI grades it in
  parallel on this push.
