### PR TITLE
test: revive the remaining never-executed test rows (rf2-r51p)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/persistence_cljs_test.cljs
@@ -1,11 +1,24 @@
 (ns day8.re-frame2-xray.filters.persistence-cljs-test
-  "localStorage round-trip tests for the filter persistence layer
-  (rf2-ak4ms).
+  "Host-free tests for the filter persistence layer (rf2-ak4ms): the
+  `->edn` / `<-edn` algebra, the `configure!` plumbing and the
+  seed-fallback hydration paths.
 
-  These tests run in the node-runtime CLJS suite. localStorage exists
-  in `npm run test:cljs`'s shadow-cljs node-target via the
-  `dom-storage` polyfill the test-support harness installs; absence
-  is also exercised via the storage-available? guard."
+  THE REAL-STORAGE ROWS LIVE IN THE DOM SIBLING. `save!` / `load`
+  round-trips, per-instance storage-key isolation and the
+  write-through assertions moved to
+  `day8.re-frame2-xray.filters.persistence-dom-cljs-test` under
+  rf2-r51p, because only a namespace ending `-dom-cljs-test` is loaded
+  by the `:browser-test` build.
+
+  THIS DOCSTRING USED TO CLAIM localStorage EXISTED HERE, AND IT DID
+  NOT. The previous wording said localStorage exists under `npm run
+  test:cljs` \"via the `dom-storage` polyfill the test-support harness
+  installs\". No such polyfill is installed and no such package is
+  depended on — `implementation/package.json` lists no `dom-storage`,
+  no `jsdom` and no `happy-dom` in any dependency list. The rows those
+  words justified were guarded by `(and (exists? js/window)
+  (.-localStorage js/window))`, which is FALSE on node, so they
+  executed in neither lane until rf2-r51p moved them."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
@@ -40,9 +53,8 @@
   (rf/with-frame :rf/xray
     @(rf/subscribe q)))
 
-(defn- frame-dispatch [ev]
-  (rf/with-frame :rf/xray
-    (rf/dispatch-sync ev)))
+;; `frame-dispatch` went with the write-through rows to the dom sibling —
+;; every remaining test here reads, none dispatches.
 
 ;; -------------------------------------------------------------------------
 ;; (1) ->edn / <-edn round-trip
@@ -93,12 +105,18 @@
 ;; (2) save! / load round-trip (depends on localStorage being available)
 ;; -------------------------------------------------------------------------
 
-(deftest save-and-load-round-trip
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (let [filters {:in  [{:pattern :auth/*}]
-                   :out [{:pattern :mouse-move}]}]
-      (persistence/save! filters)
-      (is (= filters (persistence/load))))))
+;; The real-storage rows that lived here — `save-and-load-round-trip`,
+;; `custom-storage-key-isolates-per-instance`,
+;; `hydration-prefers-localstorage-over-seed`,
+;; `add-filter-persists-to-localstorage` and
+;; `remove-filter-persists-to-localstorage` — moved to
+;; `day8.re-frame2-xray.filters.persistence-dom-cljs-test` under
+;; rf2-r51p. Each was wrapped in `(when (and (exists? js/window)
+;; (.-localStorage js/window)) ...)`, which is FALSE under `:node-test`,
+;; while `:browser-test`'s `.*-dom-cljs-test$` `:ns-regexp` never loaded
+;; this file at all — so they executed in NEITHER lane. Their new home
+;; ends `-dom-cljs-test`, which BOTH builds select, so the rows now run
+;; for real in the browser and stay inert on node behind `ls/available?`.
 
 (deftest load-when-slot-is-empty-returns-defaults
   (persistence/clear!)
@@ -107,30 +125,6 @@
 ;; -------------------------------------------------------------------------
 ;; (3) Storage-key override via config (per-instance isolation)
 ;; -------------------------------------------------------------------------
-
-(deftest custom-storage-key-isolates-per-instance
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (testing "story testbeds set distinct keys so two Xray instances
-              do not stomp on each other's pill state"
-      ;; Instance A
-      (config/set-filters-storage-key! "story.testbed.a.filters")
-      (persistence/save! {:in [{:pattern :a}] :out []})
-      ;; Switch to instance B and confirm an empty load
-      (config/set-filters-storage-key! "story.testbed.b.filters")
-      (is (= {:in [] :out []} (persistence/load))
-          "instance B's slot starts empty even though A wrote")
-      (persistence/save! {:in [] :out [{:pattern :b}]})
-      ;; Switch back to A and confirm A's value is intact
-      (config/set-filters-storage-key! "story.testbed.a.filters")
-      (is (= {:in [{:pattern :a}] :out []}
-             (persistence/load))
-          "instance A's slot survived the B writes")
-      ;; Cleanup
-      (config/set-filters-storage-key! "story.testbed.a.filters")
-      (persistence/clear!)
-      (config/set-filters-storage-key! "story.testbed.b.filters")
-      (persistence/clear!)
-      (config/set-filters-storage-key! nil))))
 
 ;; -------------------------------------------------------------------------
 ;; (4) configure! plumbs :rf.xray/filters and :rf.xray/filters-storage-key
@@ -162,19 +156,6 @@
 ;; (5) Hydration on install — localStorage wins, seed fills the gap
 ;; -------------------------------------------------------------------------
 
-(deftest hydration-prefers-localstorage-over-seed
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (persistence/save! {:in  [{:pattern :persisted}]
-                        :out []})
-    (config/set-filter-seed! {:in [{:pattern :seed}] :out []})
-    ;; A fresh registry install rehydrates.
-    (registry/reset-for-test!)
-    (xray-setup!)
-    (is (= [{:pattern :persisted}]
-           (:in (frame-sub [:rf.xray/active-filters])))
-        "localStorage value wins")
-    (persistence/clear!)))
-
 (deftest hydration-falls-back-to-seed-when-localstorage-empty
   (persistence/clear!)
   (config/set-filter-seed! {:in  []
@@ -198,20 +179,3 @@
 ;; (6) add-filter / remove-filter persist (round-trip via the fx)
 ;; -------------------------------------------------------------------------
 
-(deftest add-filter-persists-to-localstorage
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray/add-filter :in {:pattern :auth/*}])
-    (is (= {:in [{:pattern :auth/*}] :out []}
-           (persistence/load))
-        "add-filter writes through to localStorage")))
-
-(deftest remove-filter-persists-to-localstorage
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray/add-filter :out {:pattern :a}])
-    (frame-dispatch [:rf.xray/add-filter :out {:pattern :b}])
-    (frame-dispatch [:rf.xray/remove-filter :out 0])
-    (is (= {:in [] :out [{:pattern :b}]}
-           (persistence/load))
-        "remove-filter writes through to localStorage")))

--- a/tools/xray/test/day8/re_frame2_xray/filters/persistence_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/persistence_dom_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns day8.re-frame2-xray.filters.persistence-dom-cljs-test
+  "Browser-lane half of the filter-persistence tests (rf2-ak4ms),
+  promoted out of `day8.re-frame2-xray.filters.persistence-cljs-test`
+  under rf2-r51p.
+
+  WHY A SEPARATE NAMESPACE. The sibling keeps the pure `->edn` /
+  `<-edn` algebra and the seed/config plumbing, none of which touches
+  a host. The `save!` / `load` round-trip, the per-instance storage-key
+  isolation and the write-through assertions need a real
+  `window.localStorage`, and only a namespace ending `-dom-cljs-test`
+  is ever loaded by the `:browser-test` build, whose `:ns-regexp` is
+  `.*-dom-cljs-test$`. Sitting in the sibling file these rows executed
+  in NEITHER lane: skipped under `:node-test` for want of storage, and
+  never loaded by `:browser-test` at all. The file's LOCATION was the
+  defect. The guard was not.
+
+  THE SIBLING'S DOCSTRING USED TO CLAIM OTHERWISE, AND IT WAS WRONG.
+  It said localStorage exists under `npm run test:cljs` \"via the
+  `dom-storage` polyfill the test-support harness installs\". No such
+  polyfill is installed and no such package is depended on —
+  `implementation/package.json` lists no `dom-storage`, no `jsdom` and
+  no `happy-dom` in any dependency list, and the only occurrence of
+  the string `dom-storage` anywhere in the tree was that sentence.
+  The guard therefore never opened on node. That corrected claim is
+  why these rows are here rather than there.
+
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, so the node
+  build loads this namespace too and the overlap is deliberate (see
+  the comment above `:browser-test` in
+  `implementation/shadow-cljs.edn`). Moving a row here ADDS the browser
+  lane; it does not take the row off the node one. `ls/available?` is
+  what keeps the node run inert.
+
+  THE SKIP BRANCH ASSERTS RATHER THAN VANISHING, so the node lane never
+  holds a deftest with zero assertions — the hollow shape rf2-r51p
+  exists to remove.
+
+  These assertions had never executed in ANY lane before this
+  namespace existed. A failure here is evidence arriving for the first
+  time, not a regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.filters :as filters]
+            [day8.re-frame2-xray.filters.persistence :as persistence]
+            [day8.re-frame2-xray.local-storage :as ls]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. The slate matters more here than on
+  ;; node: the browser lane runs every namespace on ONE page, so a
+  ;; leftover slot would be in storage when the next namespace hydrates.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (persistence/clear!)
+                   (config/set-filters-storage-key! nil)
+                   (config/set-filter-seed! nil))}))
+
+(defn- xray-setup!
+  "Register Xray handlers + the :rf/xray frame, then re-run the filter
+  hydration so the seed / localStorage value lifts into the slot.
+  Mirrors the sibling's `xray-setup!`."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (filters/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; save! / load round-trip
+;; -------------------------------------------------------------------------
+
+(deftest save-and-load-round-trip
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (let [flt {:in  [{:pattern :auth/*}]
+               :out [{:pattern :mouse-move}]}]
+      (persistence/clear!)
+      (persistence/save! flt)
+      (is (= flt (persistence/load))
+          "browser-backed round-trip preserves both filter directions"))))
+
+;; -------------------------------------------------------------------------
+;; Storage-key override via config (per-instance isolation)
+;; -------------------------------------------------------------------------
+
+(deftest custom-storage-key-isolates-per-instance
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "story testbeds set distinct keys so two Xray instances
+              do not stomp on each other's pill state"
+      ;; Instance A
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (persistence/save! {:in [{:pattern :a}] :out []})
+      ;; Precondition, not decoration: without it the `{:in [] :out []}`
+      ;; read below passes on a silently no-op storage, where NOTHING
+      ;; was ever written and every slot reads empty. Proving A's write
+      ;; landed is what makes B's empty read discriminating.
+      (is (= {:in [{:pattern :a}] :out []} (persistence/load))
+          "precondition: instance A's write really did persist")
+      ;; Switch to instance B and confirm an empty load
+      (config/set-filters-storage-key! "story.testbed.b.filters")
+      (is (= {:in [] :out []} (persistence/load))
+          "instance B's slot starts empty even though A wrote")
+      (persistence/save! {:in [] :out [{:pattern :b}]})
+      ;; Switch back to A and confirm A's value is intact
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (is (= {:in [{:pattern :a}] :out []}
+             (persistence/load))
+          "instance A's slot survived the B writes")
+      ;; Cleanup
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (persistence/clear!)
+      (config/set-filters-storage-key! "story.testbed.b.filters")
+      (persistence/clear!)
+      (config/set-filters-storage-key! nil))))
+
+;; -------------------------------------------------------------------------
+;; Hydration on install — localStorage wins over the seed
+;; -------------------------------------------------------------------------
+
+(deftest hydration-prefers-localstorage-over-seed
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (persistence/save! {:in  [{:pattern :persisted}]
+                          :out []})
+      (config/set-filter-seed! {:in [{:pattern :seed}] :out []})
+      ;; A fresh registry install rehydrates.
+      (registry/reset-for-test!)
+      (xray-setup!)
+      (is (= [{:pattern :persisted}]
+             (:in (frame-sub [:rf.xray/active-filters])))
+          "localStorage value wins over the configured seed")
+      (persistence/clear!))))
+
+;; -------------------------------------------------------------------------
+;; add-filter / remove-filter write through to storage
+;; -------------------------------------------------------------------------
+
+(deftest add-filter-persists-to-localstorage
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (persistence/clear!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray/add-filter :in {:pattern :auth/*}])
+      (is (= {:in [{:pattern :auth/*}] :out []}
+             (persistence/load))
+          "add-filter writes through to localStorage"))))
+
+(deftest remove-filter-persists-to-localstorage
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (persistence/clear!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray/add-filter :out {:pattern :a}])
+      (frame-dispatch [:rf.xray/add-filter :out {:pattern :b}])
+      (frame-dispatch [:rf.xray/remove-filter :out 0])
+      (is (= {:in [] :out [{:pattern :b}]}
+             (persistence/load))
+          "remove-filter writes through to localStorage"))))

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -29,16 +29,14 @@
 
 ;; ---- fixture -----------------------------------------------------------
 
-(defn- ensure-stub-shell-root! []
-  ;; Some node test runtimes provide js/document; create the
-  ;; `#rf-xray-root` element so the apply-text-size! / apply-theme!
-  ;; calls have a target. Idempotent — second-call no-ops.
-  (when (and (exists? js/document) (.-createElement js/document))
-    (when-not (.getElementById js/document "rf-xray-root")
-      (let [el (.createElement js/document "div")]
-        (set! (.-id el) "rf-xray-root")
-        (when (.-body js/document)
-          (.appendChild (.-body js/document) el))))))
+;; `ensure-stub-shell-root!` went to the dom sibling with the rows that
+;; needed it (rf2-r51p). Its comment here used to read "Some node test
+;; runtimes provide js/document" — this one does not, and the helper
+;; opened with `(exists? js/document)` itself, so on node it created
+;; nothing and every row that depended on it asserted inside a nil
+;; binding. `remove-stub-shell-root!` stays: the fixture and the three
+;; missing-root tests below still call it, and it is a no-op on node by
+;; design rather than by accident.
 
 (defn- remove-stub-shell-root! []
   (when (exists? js/document)
@@ -62,26 +60,44 @@
   (rf/make-frame {:id :rf/xray}))
 
 ;; ---- DOM helpers --------------------------------------------------------
-
-(defn- shell-root []
-  (when (exists? js/document)
-    (.getElementById js/document "rf-xray-root")))
-
-(defn- html-root []
-  (when (exists? js/document)
-    (.-documentElement js/document)))
+;;
+;; `shell-root` and `html-root` went to the dom sibling with every row
+;; that read them (rf2-r51p). Both returned nil on node — each opened
+;; with `(exists? js/document)` — so every `(when-let [el (shell-root)]
+;; (is ...))` here asserted nothing. Nothing in this namespace reads the
+;; DOM any more.
 
 ;; ---- text-size ----------------------------------------------------------
 
-(deftest apply-text-size-writes-css-var
-  (ensure-stub-shell-root!)
-  (effects/apply-text-size! 17)
-  (when-let [el (shell-root)]
-    (is (= "17px" (.getPropertyValue (.-style el) "--rf-xray-text-size"))
-        "shell root CSS var carries the value"))
-  (when-let [html (html-root)]
-    (is (= "17px" (.getPropertyValue (.-style html) "--rf-xray-text-size"))
-        "<html> CSS var also carries the value")))
+;; THE REAL-DOM ROWS MOVED TO THE DOM SIBLING (rf2-r51p).
+;;
+;; `apply-text-size-writes-css-var`, `apply-theme-toggles-class`,
+;; `update-event-applies-text-size-effect`,
+;; `update-event-applies-theme-effect`,
+;; `apply-all-restores-text-size-and-theme`,
+;; `apply-all-restores-panel-width`,
+;; `apply-use-system-colors-stamps-and-clears-attribute`,
+;; `apply-all-restores-use-system-colors`,
+;; `apply-density-font-size-writes-css-var` and
+;; `apply-all-restores-density-font-size` now live in
+;; `day8.re-frame2-xray.settings.effects-dom-cljs-test`.
+;;
+;; Each asserted inside `(when-let [el (shell-root)] ...)`, and
+;; `shell-root` / `html-root` are themselves `(when (exists? js/document)
+;; ...)`. `ensure-stub-shell-root!` looks like it supplies the host but
+;; opens with the same `(exists? js/document)` test, so on node it
+;; creates nothing and every `when-let` binds nil. `:browser-test`'s
+;; `.*-dom-cljs-test$` `:ns-regexp` never matched this file's name, so
+;; those rows executed in NEITHER lane. Their new home ends
+;; `-dom-cljs-test`, which BOTH builds select.
+;;
+;; THREE TESTS WERE SPLIT RATHER THAN MOVED, because they mixed dead DOM
+;; claims with assertions that really do run here:
+;; `apply-use-system-colors-handles-missing-shell-root`,
+;; `update-event-applies-use-system-colors-effect` and
+;; `update-event-applies-density-font-size-effect` keep their host-free
+;; halves below; only their DOM halves crossed over. Moving them whole
+;; would have taken live assertions OFF the node lane.
 
 (deftest apply-text-size-handles-missing-shell-root
   (remove-stub-shell-root!)
@@ -90,38 +106,7 @@
 
 ;; ---- theme --------------------------------------------------------------
 
-(deftest apply-theme-toggles-class
-  (ensure-stub-shell-root!)
-  (effects/apply-theme! :light)
-  (when-let [el (shell-root)]
-    (is (true? (.contains (.-classList el) "rf-xray-theme-light"))
-        "light class applied")
-    (is (false? (.contains (.-classList el) "rf-xray-theme-dark"))
-        "dark class removed"))
-  ;; Switch to dark
-  (effects/apply-theme! :dark)
-  (when-let [el (shell-root)]
-    (is (true? (.contains (.-classList el) "rf-xray-theme-dark")))
-    (is (false? (.contains (.-classList el) "rf-xray-theme-light")))))
-
 ;; ---- update-setting! drives the side effect ----------------------------
-
-(deftest update-event-applies-text-size-effect
-  (setup!)
-  (ensure-stub-shell-root!)
-  (rf/with-frame :rf/xray
-    (rf/dispatch-sync [:rf.xray/settings-update :general :text-size 15]))
-  (when-let [el (shell-root)]
-    (is (= "15px" (.getPropertyValue (.-style el) "--rf-xray-text-size"))
-        "dispatching update writes the CSS var")))
-
-(deftest update-event-applies-theme-effect
-  (setup!)
-  (ensure-stub-shell-root!)
-  (rf/with-frame :rf/xray
-    (rf/dispatch-sync [:rf.xray/settings-update :theme nil :light]))
-  (when-let [el (shell-root)]
-    (is (true? (.contains (.-classList el) "rf-xray-theme-light")))))
 
 ;; ---- filters feature detect (removed rf2-wknb3) ------------------------
 ;;
@@ -265,16 +250,6 @@
 
 ;; ---- apply-all! ---------------------------------------------------------
 
-(deftest apply-all-restores-text-size-and-theme
-  (ensure-stub-shell-root!)
-  (config/update-setting! :general :text-size 12)
-  (config/update-setting! :theme nil :light)
-  ;; Re-apply via the boot path.
-  (effects/apply-all!)
-  (when-let [el (shell-root)]
-    (is (= "12px" (.getPropertyValue (.-style el) "--rf-xray-text-size")))
-    (is (true? (.contains (.-classList el) "rf-xray-theme-light")))))
-
 ;; ---- epoch-history (rf2-3zyyx) -----------------------------------------
 
 (deftest apply-epoch-history-writes-substrate-depth
@@ -386,18 +361,6 @@
 
 ;; ---- panel width (rf2-x8h9y) -------------------------------------------
 
-(deftest apply-all-restores-panel-width
-  (testing "rf2-x8h9y — boot path restores the persisted panel width
-            so the user's saved drag survives reload BEFORE first
-            paint. The CSS var lands on `<html>` (the cascade reaches
-            the layout host's flex-basis even pre-mount)."
-    (config/update-setting! :general :panel-width-px 700)
-    (effects/apply-all!)
-    (when-let [html (html-root)]
-      (is (= "700px"
-             (.getPropertyValue (.-style html) "--rf-xray-inline-width"))
-          "<html> --rf-xray-inline-width carries the persisted value"))))
-
 ;; ---- density → font-size knob (rf2-i40us) ------------------------------
 
 (deftest density->font-size-px-mapping
@@ -426,35 +389,16 @@
 
 ;; ---- use-system-colors? (rf2-846h2) ------------------------------------
 
-(deftest apply-use-system-colors-stamps-and-clears-attribute
-  (testing "rf2-846h2 — apply-use-system-colors! stamps
-            `data-rf-force-colors=\"active\"` on the shell root +
-            `<html>` when truthy, removes it when falsey."
-    (ensure-stub-shell-root!)
-    (effects/apply-use-system-colors! true)
-    (when-let [el (shell-root)]
-      (is (= "active" (.getAttribute el effects/force-colors-attribute))
-          "shell root carries the active attribute when toggle on"))
-    (when-let [html (html-root)]
-      (is (= "active" (.getAttribute html effects/force-colors-attribute))
-          "<html> carries the active attribute when toggle on"))
-    (effects/apply-use-system-colors! false)
-    (when-let [el (shell-root)]
-      (is (nil? (.getAttribute el effects/force-colors-attribute))
-          "shell root attribute cleared when toggle off"))
-    (when-let [html (html-root)]
-      (is (nil? (.getAttribute html effects/force-colors-attribute))
-          "<html> attribute cleared when toggle off"))))
-
 (deftest apply-use-system-colors-handles-missing-shell-root
-  (testing "rf2-846h2 — no-op when shell root absent; <html> still gets
-            the attribute write so the cascade reaches descendants
-            before the shell mounts."
+  (testing "rf2-846h2 — no-op when shell root absent; no throw."
+    ;; rf2-r51p — the `<html>`-still-written half of this test asserted
+    ;; inside `(when-let [html (html-root)] ...)`, which binds nil on
+    ;; node, so it executed in neither lane. It moved to
+    ;; `settings.effects-dom-cljs-test/apply-use-system-colors-stamps-
+    ;; html-without-a-shell-root`. The no-op return claim below is
+    ;; host-free and genuinely runs here, so it stayed.
     (remove-stub-shell-root!)
     (is (nil? (effects/apply-use-system-colors! true)))
-    (when-let [html (html-root)]
-      (is (= "active" (.getAttribute html effects/force-colors-attribute))
-          "<html> attribute still landed even without the shell root"))
     ;; Clean up so unrelated tests don't see the stamped <html>.
     (effects/apply-use-system-colors! false)))
 
@@ -462,58 +406,24 @@
   (testing "rf2-846h2 — dispatching `:rf.xray/settings-update :general
             :use-system-colors? true` stamps the chrome attribute via
             the matching effect."
+    ;; rf2-r51p — the two attribute claims asserted inside `(when-let
+    ;; [el (shell-root)] ...)`, which binds nil on node, so they
+    ;; executed in neither lane. They moved to
+    ;; `settings.effects-dom-cljs-test`. The settings-slot claim below
+    ;; is host-free and genuinely runs here, so it stayed.
     (setup!)
-    (ensure-stub-shell-root!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :use-system-colors? true]))
-    (when-let [el (shell-root)]
-      (is (= "active" (.getAttribute el effects/force-colors-attribute))
-          "dispatching update stamps the attribute"))
     (is (true? (config/get-setting :general :use-system-colors?))
         "config slot carries the new value")
-    ;; Flip off and verify clear.
+    ;; Flip off, and assert the slot follows — the DOM half of this
+    ;; flip is the dom sibling's.
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :use-system-colors? false]))
-    (when-let [el (shell-root)]
-      (is (nil? (.getAttribute el effects/force-colors-attribute))
-          "dispatching update with false clears the attribute"))))
-
-(deftest apply-all-restores-use-system-colors
-  (testing "rf2-846h2 — the boot path re-applies the persisted toggle
-            so the user's saved opt-in survives reload BEFORE first
-            paint."
-    (ensure-stub-shell-root!)
-    (config/update-setting! :general :use-system-colors? true)
-    (effects/apply-all!)
-    (when-let [el (shell-root)]
-      (is (= "active" (.getAttribute el effects/force-colors-attribute))
-          "shell root attribute restored from persistence"))
-    (when-let [html (html-root)]
-      (is (= "active" (.getAttribute html effects/force-colors-attribute))
-          "<html> attribute restored from persistence"))
-    ;; Clean up.
-    (config/update-setting! :general :use-system-colors? false)
-    (effects/apply-all!)))
-
-(deftest apply-density-font-size-writes-css-var
-  (ensure-stub-shell-root!)
-  (effects/apply-density-font-size! :compact)
-  (when-let [el (shell-root)]
-    (is (= "12px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-        "shell root --rf-xray-font-size carries the compact value"))
-  (when-let [html (html-root)]
-    (is (= "12px" (.getPropertyValue (.-style html) "--rf-xray-font-size"))
-        "<html> --rf-xray-font-size carries the compact value"))
-  (effects/apply-density-font-size! :cosy)
-  (when-let [el (shell-root)]
-    (is (= "13px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-        "shell root rewrites to 13px on cosy flip"))
-  (effects/apply-density-font-size! :comfy)
-  (when-let [el (shell-root)]
-    (is (= "14px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-        "shell root rewrites to 14px on comfy")))
+    (is (false? (config/get-setting :general :use-system-colors?))
+        "config slot follows the flip back off")))
 
 (deftest apply-density-font-size-handles-missing-shell-root
   (remove-stub-shell-root!)
@@ -524,39 +434,25 @@
   (testing "Dispatching `[:rf.xray/settings-update :general :density
             :compact]` flips `--rf-xray-font-size` to 12px so the
             whole `type-scale` rescales on the next paint."
+    ;; rf2-r51p — the two CSS-var claims asserted inside `(when-let [el
+    ;; (shell-root)] ...)`, which binds nil on node, so they executed in
+    ;; neither lane. They moved to `settings.effects-dom-cljs-test`. The
+    ;; settings-atom claims below are host-free and genuinely run here.
     (setup!)
-    (ensure-stub-shell-root!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :density :compact]))
-    (when-let [el (shell-root)]
-      (is (= "12px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-          "dispatch writes 12px on compact"))
     ;; Persistence — the dual-write goes to the in-memory atom +
     ;; localStorage shim via `config/update-setting!`.
     (is (= :compact (config/get-setting :general :density))
         "settings atom carries the new density")
-    ;; Flip to cosy — verify the inline write rewrites (not just adds).
+    ;; Flip to cosy — the atom must follow; the inline-write half of
+    ;; this flip is the dom sibling's.
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/settings-update
                          :general :density :cosy]))
-    (when-let [el (shell-root)]
-      (is (= "13px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-          "dispatch writes 13px on cosy"))))
-
-(deftest apply-all-restores-density-font-size
-  (testing "rf2-i40us — boot path restores the persisted density so
-            the user's saved knob rescales the type scale BEFORE first
-            paint. The CSS var lands on the shell root + `<html>`."
-    (ensure-stub-shell-root!)
-    (config/update-setting! :general :density :compact)
-    (effects/apply-all!)
-    (when-let [el (shell-root)]
-      (is (= "12px" (.getPropertyValue (.-style el) "--rf-xray-font-size"))
-          "shell root --rf-xray-font-size carries the persisted compact value"))
-    (when-let [html (html-root)]
-      (is (= "12px" (.getPropertyValue (.-style html) "--rf-xray-font-size"))
-          "<html> --rf-xray-font-size carries the persisted compact value"))))
+    (is (= :cosy (config/get-setting :general :density))
+        "settings atom follows the flip to cosy")))
 
 ;; ---- Keybindings tab "Handle keys?" reactive dual-write (rf2-8i1tg3) ----
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_dom_cljs_test.cljs
@@ -1,0 +1,353 @@
+(ns day8.re-frame2-xray.settings.effects-dom-cljs-test
+  "Browser-lane half of the Settings side-effect tests, promoted out of
+  `day8.re-frame2-xray.settings.effects-cljs-test` under rf2-r51p.
+
+  WHY A SEPARATE NAMESPACE. Every row here asserts a real DOM mutation
+  — a CSS custom property on the shell root or `<html>`, a theme class
+  on a `classList`, a `data-rf-force-colors` attribute. The sibling
+  keeps the host-free half: the settings-atom reads, the `with-redefs`
+  substrate wiring and the missing-shell-root no-op claims.
+
+  THESE ROWS EXECUTED IN NEITHER LANE. Each was wrapped in
+  `(when-let [el (shell-root)] ...)`, and `shell-root` /`html-root` are
+  themselves `(when (exists? js/document) ...)`. The sibling's
+  `ensure-stub-shell-root!` looks like it supplies the missing host but
+  does not: it too opens with `(and (exists? js/document)
+  (.-createElement js/document))`, so on node it creates nothing and
+  every `when-let` binds nil. Node has no jsdom, happy-dom or
+  dom-storage in any dependency list. Meanwhile `:browser-test`'s
+  `:ns-regexp` is `.*-dom-cljs-test$`, which the sibling's name never
+  matched — so it never loaded the file at all. Measured before the
+  move: the sibling ran 30 test vars containing 40 assertions against
+  68 `is` forms in the source. 28 of them had never executed.
+
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, so the node
+  build loads this namespace too and the overlap is deliberate (see the
+  comment above `:browser-test` in `implementation/shadow-cljs.edn`).
+  Moving a row here ADDS the browser lane; it does not take the row off
+  the node one. [[browser?]] is what keeps the node run inert, and the
+  skip branch ASSERTS a marker row so the node lane never holds a
+  deftest with zero assertions — the hollow shape rf2-r51p exists to
+  remove.
+
+  EACH ROW ASSERTS ITS HOST PRECONDITION BEFORE READING IT. `(when-let
+  [el (shell-root)] (is ...))` is the shape that made these rows dead,
+  and it fails OPEN: a nil root silently skips the assertion instead of
+  reporting one. The rows below bind the root, assert it is present,
+  and reach through `some->` — so a missing root is a named failure
+  rather than a vanished test. `some->` also matters because the
+  browser lane runs every namespace inside one `cljs.test/run-block`
+  with no try/catch, where a nil-deref would take down the rows after
+  it as well.
+
+  These assertions had never executed in ANY lane before this namespace
+  existed. A failure here is evidence about the Settings effects
+  arriving for the first time, not a regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.settings.effects :as effects]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; ---- host predicate (house shape — see
+;; `day8.re-frame2-xray.palette.empty-row-frame-context-dom-cljs-test`)
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- stub shell root ----------------------------------------------------
+
+(defn- ensure-stub-shell-root! []
+  (when (browser?)
+    (when-not (.getElementById js/document "rf-xray-root")
+      (let [el (.createElement js/document "div")]
+        (set! (.-id el) "rf-xray-root")
+        (when (.-body js/document)
+          (.appendChild (.-body js/document) el))))))
+
+(defn- remove-stub-shell-root! []
+  (when (browser?)
+    (when-let [el (.getElementById js/document "rf-xray-root")]
+      (when (.-parentNode el)
+        (.removeChild (.-parentNode el) el)))))
+
+(defn- shell-root []
+  (when (browser?)
+    (.getElementById js/document "rf-xray-root")))
+
+(defn- html-root []
+  (when (browser?)
+    (.-documentElement js/document)))
+
+(defn- css-var [el prop]
+  (some-> el .-style (.getPropertyValue prop)))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. The teardown matters more here than
+  ;; on node: the browser lane runs every namespace on ONE page, so a
+  ;; stamped `<html>` or a leftover stub root would leak into whatever
+  ;; namespace runs next.
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn []
+                   (effects/detach-auto-open-watcher!)
+                   (remove-stub-shell-root!))}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray}))
+
+;; ---- text-size ----------------------------------------------------------
+
+(deftest apply-text-size-writes-css-var
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (ensure-stub-shell-root!)
+      (effects/apply-text-size! 17)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "17px" (css-var el "--rf-xray-text-size"))
+            "shell root CSS var carries the value")
+        (is (= "17px" (css-var html "--rf-xray-text-size"))
+            "<html> CSS var also carries the value")))))
+
+;; ---- theme --------------------------------------------------------------
+
+(deftest apply-theme-toggles-class
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (ensure-stub-shell-root!)
+      (effects/apply-theme! :light)
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (true? (some-> el .-classList (.contains "rf-xray-theme-light")))
+            "light class applied")
+        (is (false? (some-> el .-classList (.contains "rf-xray-theme-dark")))
+            "dark class removed"))
+      ;; Switch to dark
+      (effects/apply-theme! :dark)
+      (let [el (shell-root)]
+        (is (true? (some-> el .-classList (.contains "rf-xray-theme-dark"))))
+        (is (false? (some-> el .-classList (.contains "rf-xray-theme-light"))))))))
+
+;; ---- update-setting! drives the side effect ----------------------------
+
+(deftest update-event-applies-text-size-effect
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (setup!)
+      (ensure-stub-shell-root!)
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update :general :text-size 15]))
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "15px" (css-var el "--rf-xray-text-size"))
+            "dispatching update writes the CSS var")))))
+
+(deftest update-event-applies-theme-effect
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (setup!)
+      (ensure-stub-shell-root!)
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update :theme nil :light]))
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (true? (some-> el .-classList (.contains "rf-xray-theme-light"))))))))
+
+;; ---- apply-all! ---------------------------------------------------------
+
+(deftest apply-all-restores-text-size-and-theme
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (ensure-stub-shell-root!)
+      (config/update-setting! :general :text-size 12)
+      (config/update-setting! :theme nil :light)
+      ;; Re-apply via the boot path.
+      (effects/apply-all!)
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "12px" (css-var el "--rf-xray-text-size")))
+        (is (true? (some-> el .-classList (.contains "rf-xray-theme-light"))))))))
+
+;; ---- panel width (rf2-x8h9y) -------------------------------------------
+
+(deftest apply-all-restores-panel-width
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-x8h9y — boot path restores the persisted panel width
+              so the user's saved drag survives reload BEFORE first
+              paint. The CSS var lands on `<html>` (the cascade reaches
+              the layout host's flex-basis even pre-mount)."
+      (config/update-setting! :general :panel-width-px 700)
+      (effects/apply-all!)
+      (let [html (html-root)]
+        (is (some? html) "precondition: <html> is reachable")
+        (is (= "700px" (css-var html "--rf-xray-inline-width"))
+            "<html> --rf-xray-inline-width carries the persisted value")))))
+
+;; ---- use-system-colors? (rf2-846h2) ------------------------------------
+
+(deftest apply-use-system-colors-stamps-and-clears-attribute
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-846h2 — apply-use-system-colors! stamps
+              `data-rf-force-colors=active` on the shell root +
+              `<html>` when truthy, removes it when falsey."
+      (ensure-stub-shell-root!)
+      (effects/apply-use-system-colors! true)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "active" (some-> el (.getAttribute effects/force-colors-attribute)))
+            "shell root carries the active attribute when toggle on")
+        (is (= "active" (some-> html (.getAttribute effects/force-colors-attribute)))
+            "<html> carries the active attribute when toggle on"))
+      (effects/apply-use-system-colors! false)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (nil? (some-> el (.getAttribute effects/force-colors-attribute)))
+            "shell root attribute cleared when toggle off")
+        (is (nil? (some-> html (.getAttribute effects/force-colors-attribute)))
+            "<html> attribute cleared when toggle off")))))
+
+(deftest apply-use-system-colors-stamps-html-without-a-shell-root
+  ;; The `<html>`-still-written half of the sibling's
+  ;; `apply-use-system-colors-handles-missing-shell-root`. The no-op
+  ;; return claim in that test is host-free and STAYED on node; only
+  ;; this DOM half moved, so neither lane loses an assertion.
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-846h2 — with no shell root, `<html>` still gets the
+              attribute write so the cascade reaches descendants before
+              the shell mounts."
+      (remove-stub-shell-root!)
+      (is (nil? (shell-root)) "precondition: the shell root really is absent")
+      (effects/apply-use-system-colors! true)
+      (let [html (html-root)]
+        (is (= "active" (some-> html (.getAttribute effects/force-colors-attribute)))
+            "<html> attribute still landed even without the shell root"))
+      ;; Clean up so unrelated namespaces don't see the stamped <html>.
+      (effects/apply-use-system-colors! false))))
+
+(deftest update-event-applies-use-system-colors-effect
+  ;; The settings-atom half of the sibling's test of the same name is
+  ;; host-free and STAYED on node; only the attribute claims moved.
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-846h2 — dispatching `:rf.xray/settings-update :general
+              :use-system-colors? true` stamps the chrome attribute via
+              the matching effect."
+      (setup!)
+      (ensure-stub-shell-root!)
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update
+                           :general :use-system-colors? true]))
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "active" (some-> el (.getAttribute effects/force-colors-attribute)))
+            "dispatching update stamps the attribute"))
+      ;; Flip off and verify clear.
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update
+                           :general :use-system-colors? false]))
+      (let [el (shell-root)]
+        (is (nil? (some-> el (.getAttribute effects/force-colors-attribute)))
+            "dispatching update with false clears the attribute")))))
+
+(deftest apply-all-restores-use-system-colors
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-846h2 — the boot path re-applies the persisted toggle
+              so the user's saved opt-in survives reload BEFORE first
+              paint."
+      (ensure-stub-shell-root!)
+      (config/update-setting! :general :use-system-colors? true)
+      (effects/apply-all!)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "active" (some-> el (.getAttribute effects/force-colors-attribute)))
+            "shell root attribute restored from persistence")
+        (is (= "active" (some-> html (.getAttribute effects/force-colors-attribute)))
+            "<html> attribute restored from persistence"))
+      ;; Clean up.
+      (config/update-setting! :general :use-system-colors? false)
+      (effects/apply-all!))))
+
+;; ---- density font-size --------------------------------------------------
+
+(deftest apply-density-font-size-writes-css-var
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (do
+      (ensure-stub-shell-root!)
+      (effects/apply-density-font-size! :compact)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "12px" (css-var el "--rf-xray-font-size"))
+            "shell root --rf-xray-font-size carries the compact value")
+        (is (= "12px" (css-var html "--rf-xray-font-size"))
+            "<html> --rf-xray-font-size carries the compact value"))
+      (effects/apply-density-font-size! :cosy)
+      (is (= "13px" (css-var (shell-root) "--rf-xray-font-size"))
+          "shell root rewrites to 13px on cosy flip")
+      (effects/apply-density-font-size! :comfy)
+      (is (= "14px" (css-var (shell-root) "--rf-xray-font-size"))
+          "shell root rewrites to 14px on comfy"))))
+
+(deftest update-event-applies-density-font-size-effect
+  ;; The settings-atom half of the sibling's test of the same name is
+  ;; host-free and STAYED on node; only the CSS-var claims moved.
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "Dispatching `[:rf.xray/settings-update :general :density
+              :compact]` flips `--rf-xray-font-size` to 12px so the
+              whole `type-scale` rescales on the next paint."
+      (setup!)
+      (ensure-stub-shell-root!)
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update
+                           :general :density :compact]))
+      (let [el (shell-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "12px" (css-var el "--rf-xray-font-size"))
+            "dispatch writes 12px on compact"))
+      ;; Flip to cosy — verify the inline write rewrites (not just adds).
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/settings-update
+                           :general :density :cosy]))
+      (is (= "13px" (css-var (shell-root) "--rf-xray-font-size"))
+          "dispatch writes 13px on cosy"))))
+
+(deftest apply-all-restores-density-font-size
+  (if-not (browser?)
+    (is true "skipped: no DOM (node lane — see ns docstring)")
+    (testing "rf2-i40us — boot path restores the persisted density so
+              the user's saved knob rescales the type scale BEFORE first
+              paint. The CSS var lands on the shell root + `<html>`."
+      (ensure-stub-shell-root!)
+      (config/update-setting! :general :density :compact)
+      (effects/apply-all!)
+      (let [el   (shell-root)
+            html (html-root)]
+        (is (some? el) "precondition: stub shell root is present")
+        (is (= "12px" (css-var el "--rf-xray-font-size"))
+            "shell root --rf-xray-font-size carries the persisted compact value")
+        (is (= "12px" (css-var html "--rf-xray-font-size"))
+            "<html> --rf-xray-font-size carries the persisted compact value")))))

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_cljs_test.cljs
@@ -136,11 +136,18 @@
 ;; (3) save! / load round-trip
 ;; -------------------------------------------------------------------------
 
-(deftest save-and-load-round-trip
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (let [muted #{:auth/login :user/mouse-move}]
-      (spine-filters/save! muted)
-      (is (= muted (spine-filters/load))))))
+;; The real-storage rows that lived here — `save-and-load-round-trip`,
+;; `mute-event-id-event-writes-slot-and-persists`,
+;; `unmute-event-id-event-clears-slot`,
+;; `clear-muted-event-ids-drops-every-entry` and
+;; `hydrate-lifts-localstorage-into-slot` — moved to
+;; `day8.re-frame2-xray.spine-filters-dom-cljs-test` under rf2-r51p.
+;; Each was wrapped in `(when (and (exists? js/window) (.-localStorage
+;; js/window)) ...)`, which is FALSE under `:node-test`, while
+;; `:browser-test`'s `.*-dom-cljs-test$` `:ns-regexp` never loaded this
+;; file at all — so they executed in NEITHER lane. Their new home ends
+;; `-dom-cljs-test`, which BOTH builds select, so the rows now run for
+;; real in the browser and stay inert on node behind `ls/available?`.
 
 (deftest load-when-slot-empty-returns-empty-set
   (spine-filters/clear-raw!)
@@ -150,51 +157,9 @@
 ;; (4) Event handler wiring + persist fx
 ;; -------------------------------------------------------------------------
 
-(deftest mute-event-id-event-writes-slot-and-persists
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray/mute-event-id :user/mouse-move])
-    (is (= #{:user/mouse-move}
-           (frame-sub [:rf.xray/muted-event-ids])))
-    (is (= 1 (frame-sub [:rf.xray/muted-event-ids-count])))
-    (is (= #{:user/mouse-move}
-           (spine-filters/load))
-        "mute round-trips to localStorage")))
-
-(deftest unmute-event-id-event-clears-slot
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray/mute-event-id :user/mouse-move])
-    (frame-dispatch [:rf.xray/mute-event-id :user/scroll])
-    (frame-dispatch [:rf.xray/unmute-event-id :user/scroll])
-    (is (= #{:user/mouse-move}
-           (frame-sub [:rf.xray/muted-event-ids])))
-    (is (= #{:user/mouse-move} (spine-filters/load))
-        "unmute persists the new set")))
-
-(deftest clear-muted-event-ids-drops-every-entry
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray/mute-event-id :a])
-    (frame-dispatch [:rf.xray/mute-event-id :b])
-    (frame-dispatch [:rf.xray/clear-muted-event-ids])
-    (is (= #{} (frame-sub [:rf.xray/muted-event-ids])))
-    (is (= #{} (spine-filters/load)))))
-
 ;; -------------------------------------------------------------------------
 ;; (5) Hydration
 ;; -------------------------------------------------------------------------
-
-(deftest hydrate-lifts-localstorage-into-slot
-  (when (and (exists? js/window) (.-localStorage js/window))
-    ;; Pre-seed localStorage BEFORE registry install so hydrate-on-mount
-    ;; lifts the value.
-    (spine-filters/save! #{:auth/login :user/mouse-move})
-    (registry/reset-for-test!)
-    (xray-setup!)
-    (is (= #{:auth/login :user/mouse-move}
-           (frame-sub [:rf.xray/muted-event-ids])))
-    (spine-filters/clear-raw!)))
 
 (deftest hydrate-empty-localstorage-leaves-slot-empty
   (spine-filters/clear-raw!)

--- a/tools/xray/test/day8/re_frame2_xray/spine_filters_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_filters_dom_cljs_test.cljs
@@ -1,0 +1,143 @@
+(ns day8.re-frame2-xray.spine-filters-dom-cljs-test
+  "Browser-lane half of the per-event-id mute-filter tests (rf2-ikuwt),
+  promoted out of `day8.re-frame2-xray.spine-filters-cljs-test` under
+  rf2-r51p.
+
+  WHY A SEPARATE NAMESPACE. The sibling keeps the pure reducers
+  (`mute-event-id` / `unmute-event-id` / `clear`), the EDN round-trip
+  and the cascade-composition walk — none of which touches a host. The
+  `save!` / `load` round-trip, the persist-fx write-throughs and the
+  hydrate-on-install lift need a real `window.localStorage`, and only a
+  namespace ending `-dom-cljs-test` is ever loaded by the
+  `:browser-test` build, whose `:ns-regexp` is `.*-dom-cljs-test$`.
+  Sitting in the sibling file these rows executed in NEITHER lane:
+  skipped under `:node-test` for want of storage (no jsdom in any
+  dependency list), and never loaded by `:browser-test` at all. The
+  file's LOCATION was the defect. The guard was not.
+
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, so the node
+  build loads this namespace too and the overlap is deliberate (see the
+  comment above `:browser-test` in `implementation/shadow-cljs.edn`).
+  Moving a row here ADDS the browser lane; it does not take the row off
+  the node one. `ls/available?` is what keeps the node run inert.
+
+  THE SKIP BRANCH ASSERTS RATHER THAN VANISHING, so the node lane never
+  holds a deftest with zero assertions — the hollow shape rf2-r51p
+  exists to remove.
+
+  These assertions had never executed in ANY lane before this namespace
+  existed. A failure here is evidence arriving for the first time, not a
+  regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.local-storage :as ls]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.spine-filters :as spine-filters]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. The raw-mute slate matters more here
+  ;; than on node: the browser lane runs every namespace on ONE page, so
+  ;; a leftover mute set would be in storage when the next namespace
+  ;; hydrates.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn [] (spine-filters/clear-raw!))}))
+
+(defn- xray-setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  ;; mirrors mount.cljs/ensure-xray-frame! — re-runs hydrate after the
+  ;; frame is registered (preload-time install no-op'd).
+  (spine-filters/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; save! / load round-trip
+;; -------------------------------------------------------------------------
+
+(deftest save-and-load-round-trip
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (let [muted #{:auth/login :user/mouse-move}]
+      (spine-filters/clear-raw!)
+      (spine-filters/save! muted)
+      (is (= muted (spine-filters/load))
+          "browser-backed round-trip preserves the whole mute set"))))
+
+;; -------------------------------------------------------------------------
+;; Event handler wiring + persist fx
+;; -------------------------------------------------------------------------
+
+(deftest mute-event-id-event-writes-slot-and-persists
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (spine-filters/clear-raw!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray/mute-event-id :user/mouse-move])
+      (is (= #{:user/mouse-move}
+             (frame-sub [:rf.xray/muted-event-ids])))
+      (is (= 1 (frame-sub [:rf.xray/muted-event-ids-count])))
+      (is (= #{:user/mouse-move}
+             (spine-filters/load))
+          "mute round-trips to localStorage"))))
+
+(deftest unmute-event-id-event-clears-slot
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (spine-filters/clear-raw!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray/mute-event-id :user/mouse-move])
+      (frame-dispatch [:rf.xray/mute-event-id :user/scroll])
+      (frame-dispatch [:rf.xray/unmute-event-id :user/scroll])
+      (is (= #{:user/mouse-move}
+             (frame-sub [:rf.xray/muted-event-ids])))
+      (is (= #{:user/mouse-move} (spine-filters/load))
+          "unmute persists the new set"))))
+
+(deftest clear-muted-event-ids-drops-every-entry
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (spine-filters/clear-raw!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray/mute-event-id :a])
+      (frame-dispatch [:rf.xray/mute-event-id :b])
+      ;; Precondition, not decoration: `(= #{} (load))` passes on a
+      ;; silently no-op storage, where nothing was ever written. Proving
+      ;; the two mutes persisted FIRST is what makes the empty read
+      ;; below evidence that `clear` cleared something.
+      (is (= #{:a :b} (spine-filters/load))
+          "precondition: both mutes really did persist")
+      (frame-dispatch [:rf.xray/clear-muted-event-ids])
+      (is (= #{} (frame-sub [:rf.xray/muted-event-ids])))
+      (is (= #{} (spine-filters/load))
+          "clear drops every persisted entry"))))
+
+;; -------------------------------------------------------------------------
+;; Hydration
+;; -------------------------------------------------------------------------
+
+(deftest hydrate-lifts-localstorage-into-slot
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      ;; Pre-seed localStorage BEFORE registry install so hydrate-on-mount
+      ;; lifts the value.
+      (spine-filters/save! #{:auth/login :user/mouse-move})
+      (registry/reset-for-test!)
+      (xray-setup!)
+      (is (= #{:auth/login :user/mouse-move}
+             (frame-sub [:rf.xray/muted-event-ids]))
+          "hydrate lifted the persisted set into the slot")
+      (spine-filters/clear-raw!))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -139,32 +139,17 @@
     (is (= :dynamic (static-persistence/<-raw (static-persistence/->raw :dynamic))))
     (is (= :static  (static-persistence/<-raw (static-persistence/->raw :static))))))
 
-(deftest persistence-load-default-empty-slot
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (static-persistence/clear!)
-    (testing "empty localStorage slot → :dynamic fallback"
-      (is (= :dynamic (static-persistence/load))))))
-
-(deftest persistence-save-and-load-round-trip
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (testing "save! + load round-trip"
-      (static-persistence/clear!)
-      (static-persistence/save! :static)
-      (is (= :static (static-persistence/load)))
-      (static-persistence/save! :dynamic)
-      (is (= :dynamic (static-persistence/load))))))
-
-(deftest persistence-fx-installed-by-set-mode
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (testing ":rf.xray/set-mode lands the value in localStorage via the fx"
-      (xray-setup!)
-      (static-persistence/clear!)
-      (frame-dispatch [:rf.xray/set-mode :static])
-      (is (= :static (static-persistence/load))
-          ":static was persisted")
-      (frame-dispatch [:rf.xray/toggle-mode])
-      (is (= :dynamic (static-persistence/load))
-          "toggle back to :dynamic was persisted"))))
+;; The three real-storage rows that lived here — `persistence-load-
+;; default-empty-slot`, `persistence-save-and-load-round-trip` and
+;; `persistence-fx-installed-by-set-mode` — moved to
+;; `day8.re-frame2-xray.static.shell-dom-cljs-test` under rf2-r51p.
+;; Each was wrapped in `(when (and (exists? js/window) (.-localStorage
+;; js/window)) ...)`, which is FALSE under `:node-test` (no jsdom in
+;; any dependency list), while `:browser-test`'s `.*-dom-cljs-test$`
+;; `:ns-regexp` never loaded this file at all — so they executed in
+;; NEITHER lane. Their new home ends `-dom-cljs-test`, which BOTH
+;; builds select, so the rows now run for real in the browser and stay
+;; inert on node behind `ls/available?`.
 
 ;; -------------------------------------------------------------------------
 ;; (3) Static surface — 3-layer chrome render

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_dom_cljs_test.cljs
@@ -1,0 +1,111 @@
+(ns day8.re-frame2-xray.static.shell-dom-cljs-test
+  "Browser-lane half of the Static-mode persistence tests (rf2-o5f5f.1),
+  promoted out of `day8.re-frame2-xray.static.shell-cljs-test` under
+  rf2-r51p.
+
+  WHY A SEPARATE NAMESPACE. The sibling
+  `day8.re-frame2-xray.static.shell-cljs-test` holds the pure mode
+  algebra (`normalise-mode`, `->raw` / `<-raw`) and the hiccup render
+  walk, neither of which needs host storage. The `save!` / `load`
+  round-trip and the `:rf.xray.static/persist-mode` fx need a real
+  `window.localStorage`, and only a namespace ending `-dom-cljs-test`
+  is ever loaded by the `:browser-test` build, whose `:ns-regexp` is
+  `.*-dom-cljs-test$`. Sitting in the sibling file these rows executed
+  in NEITHER lane: skipped under `:node-test` for want of storage, and
+  never loaded by `:browser-test` at all. The file's LOCATION was the
+  defect. The guard was not.
+
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does. So the node
+  build loads this namespace too, and the overlap is deliberate:
+  `implementation/shadow-cljs.edn` records above `:browser-test` that
+  the DOM-tagged files run on BOTH targets so their cross-runtime
+  asserts keep firing in Node. Moving a row here therefore ADDS the
+  browser lane; it does not take the row off the node one.
+  `ls/available?` is what keeps the node run inert.
+
+  THE SKIP BRANCH ASSERTS RATHER THAN VANISHING. A bare `(when ...)`
+  body would leave the node lane holding a deftest with ZERO
+  assertions, which is the hollow shape rf2-r51p exists to remove —
+  relocated, not fixed. The marker row keeps the skip visible in the
+  node summary. Same shape as
+  `day8.re-frame2-xray.palette.recents-dom-cljs-test`.
+
+  These assertions had never executed in ANY lane before this
+  namespace existed. A failure here is evidence about
+  `static.persistence/save!` / `load` and the `persist-mode` fx
+  arriving for the first time, not a regression introduced by the
+  move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.local-storage :as ls]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.persistence :as static-persistence]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. The storage slate matters more here
+  ;; than on node: the browser lane runs every namespace on ONE page, so
+  ;; a leftover mode value would be in storage when the next namespace
+  ;; hydrates.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (static-persistence/clear!))}))
+
+;; ---- helpers (mirror the sibling's) -------------------------------------
+
+(defn- xray-setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray}))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; localStorage persistence — round-trip
+;; -------------------------------------------------------------------------
+
+(deftest persistence-load-default-empty-slot
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "a cleared localStorage slot falls back to :dynamic"
+      ;; `save!` a NON-default first, so the fallback is read off a slot
+      ;; `clear!` demonstrably emptied. Asserting `:dynamic` straight
+      ;; after `clear!` on a never-written slot passes on a silently
+      ;; no-op storage too — the same vacuity `save-caps-at-max` was
+      ;; tightened for in the recents dom sibling.
+      (static-persistence/save! :static)
+      (is (= :static (static-persistence/load))
+          "precondition: the non-default value really did persist")
+      (static-persistence/clear!)
+      (is (= :dynamic (static-persistence/load))
+          "empty localStorage slot → :dynamic fallback"))))
+
+(deftest persistence-save-and-load-round-trip
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "save! + load round-trip through real browser storage"
+      (static-persistence/clear!)
+      (static-persistence/save! :static)
+      (is (= :static (static-persistence/load)))
+      (static-persistence/save! :dynamic)
+      (is (= :dynamic (static-persistence/load))))))
+
+(deftest persistence-fx-installed-by-set-mode
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing ":rf.xray/set-mode lands the value in localStorage via the fx"
+      (xray-setup!)
+      (static-persistence/clear!)
+      (frame-dispatch [:rf.xray/set-mode :static])
+      (is (= :static (static-persistence/load))
+          ":static was persisted")
+      (frame-dispatch [:rf.xray/toggle-mode])
+      (is (= :dynamic (static-persistence/load))
+          "toggle back to :dynamic was persisted"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_cljs_test.cljs
@@ -88,11 +88,24 @@
 
 ;; ---- (2) save! / load round-trip (depends on localStorage) --------------
 
-(deftest save-and-load-round-trip
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (let [widths {:rf.xray.epoch/subscriptions {:sub 300 :inputs 150 :value 200}}]
-      (rt/save! widths)
-      (is (= widths (rt/load))))))
+;; The real-storage rows that lived here — `save-and-load-round-trip`,
+;; `custom-storage-key-isolates-per-instance`,
+;; `resize-pair-tick-writes-slot-without-persisting`,
+;; `resize-pair-commit-persists-current-slot`,
+;; `reset-clears-table-and-persists` and `hydrate-lifts-persisted-widths`
+;; — moved to
+;; `day8.re-frame2-xray.views.resizable-table-persistence-dom-cljs-test`
+;; under rf2-r51p. Each was wrapped in `(when (and (exists? js/window)
+;; (.-localStorage js/window)) ...)`, which is FALSE under `:node-test`,
+;; while `:browser-test`'s `.*-dom-cljs-test$` `:ns-regexp` never loaded
+;; this file at all — so they executed in NEITHER lane. Their new home
+;; ends `-dom-cljs-test`, which BOTH builds select, so the rows now run
+;; for real in the browser and stay inert on node behind `ls/available?`.
+;;
+;; `resize-pair-tick-clamps-sub-floor-width` stayed BELOW rather than
+;; moving, because the choice is per PROPERTY and not per file: it
+;; asserts only over app-db and never reads storage, so its guard was
+;; incidental. The guard came off instead, which makes it run on node.
 
 (deftest load-when-slot-is-empty-returns-empty-map
   (rt/clear!)
@@ -100,106 +113,26 @@
 
 ;; ---- (3) Storage-key override (per-instance isolation) ------------------
 
-(deftest custom-storage-key-isolates-per-instance
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (testing "story testbeds set distinct keys so two Xray instances
-              do not stomp on each other's column-widths state"
-      (rt/set-storage-key! "story.testbed.a.column-widths")
-      (rt/save! {:t1 {:a 100}})
-      (rt/set-storage-key! "story.testbed.b.column-widths")
-      (is (= {} (rt/load))
-          "instance B's slot is independent of instance A")
-      (rt/save! {:t2 {:b 200}})
-      (rt/set-storage-key! "story.testbed.a.column-widths")
-      (is (= {:t1 {:a 100}} (rt/load))
-          "instance A's slot survived instance B's write"))))
-
 ;; ---- (4) resize-pair tick + commit (rf2-xm1jy split) --------------------
 
-(deftest resize-pair-tick-writes-slot-without-persisting
-  (testing "rf2-xm1jy — the pointermove-cadence event writes the slot
-            in app-db but does NOT touch localStorage (per-pixel
-            persistence flooded the main thread on lower-end devices)."
-    (when (and (exists? js/window) (.-localStorage js/window))
-      (xray-setup!)
-      (rt/clear!)
-      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                       :rf.xray.epoch/subscriptions
-                       :sub 250 :inputs 170])
-      (is (= {:sub 250 :inputs 170}
-             (frame-sub [:rf.xray.column-widths/for-table
-                         :rf.xray.epoch/subscriptions]))
-          "app-db slot reflects the tick")
-      (is (= {} (rt/load))
-          "localStorage is NOT written by the tick event"))))
-
-(deftest resize-pair-commit-persists-current-slot
-  (testing "rf2-xm1jy — pointerup dispatches the commit, which writes
-            whatever the app-db slot currently holds to localStorage
-            exactly once. Round-trip: N ticks then one commit ==
-            steady-state widths in localStorage."
-    (when (and (exists? js/window) (.-localStorage js/window))
-      (xray-setup!)
-      (rt/clear!)
-      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                       :rf.xray.epoch/subscriptions
-                       :sub 100 :inputs 100])
-      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                       :rf.xray.epoch/subscriptions
-                       :sub 200 :inputs 200])
-      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                       :rf.xray.epoch/subscriptions
-                       :sub 250 :inputs 170])
-      (is (= {} (rt/load))
-          "ticks accumulate in app-db only; localStorage untouched")
-      (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
-      (is (= {:rf.xray.epoch/subscriptions {:sub 250 :inputs 170}}
-             (rt/load))
-          "commit writes the final settled widths to localStorage
-           exactly once"))))
-
 (deftest resize-pair-tick-clamps-sub-floor-width
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                     :rf.xray.epoch/subscriptions
-                     :sub 5 :inputs 300])
-    (is (= {:sub 24 :inputs 300}
-           (frame-sub [:rf.xray.column-widths/for-table
-                       :rf.xray.epoch/subscriptions]))
-        "sub clamped to the 24px floor; inputs verbatim")))
+  ;; rf2-r51p — the `(when (and (exists? js/window) (.-localStorage
+  ;; js/window)) ...)` guard that used to wrap this body was INCIDENTAL:
+  ;; the assertion reads app-db through the `for-table` sub and never
+  ;; touches storage, so the guard bought nothing and cost the row both
+  ;; lanes. Unguarded, it runs on node — for the first time.
+  (xray-setup!)
+  (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                   :rf.xray.epoch/subscriptions
+                   :sub 5 :inputs 300])
+  (is (= {:sub 24 :inputs 300}
+         (frame-sub [:rf.xray.column-widths/for-table
+                     :rf.xray.epoch/subscriptions]))
+      "sub clamped to the 24px floor; inputs verbatim"))
 
 ;; ---- (5) reset clears one table AND persists ----------------------------
 
-(deftest reset-clears-table-and-persists
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (xray-setup!)
-    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                     :t1 :a 100 :b 200])
-    (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
-    (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
-                     :t2 :a 50 :b 70])
-    (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
-    (frame-dispatch [:rf.xray.column-widths/reset :t1])
-    (is (nil? (frame-sub [:rf.xray.column-widths/for-table :t1]))
-        "t1's overrides cleared")
-    (is (= {:a 50 :b 70}
-           (frame-sub [:rf.xray.column-widths/for-table :t2]))
-        "t2's overrides untouched")
-    (is (= {:t2 {:a 50 :b 70}} (rt/load))
-        "localStorage reflects the reset")))
-
 ;; ---- (6) hydrate! lifts persisted slot into app-db ----------------------
-
-(deftest hydrate-lifts-persisted-widths
-  (when (and (exists? js/window) (.-localStorage js/window))
-    ;; Seed localStorage BEFORE setup so hydrate sees it.
-    (rt/save! {:rf.xray.epoch/views {:view 180 :subs 220}})
-    (xray-setup!)
-    (is (= {:view 180 :subs 220}
-           (frame-sub [:rf.xray.column-widths/for-table
-                       :rf.xray.epoch/views]))
-        "hydrate! ran in xray-setup! and lifted the slot into app-db")))
 
 (deftest hydrate-is-no-op-when-storage-empty
   (rt/clear!)

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
@@ -1,0 +1,204 @@
+(ns day8.re-frame2-xray.views.resizable-table-persistence-dom-cljs-test
+  "Browser-lane half of the resizable-table column-widths persistence
+  tests (rf2-xzg1y), promoted out of
+  `day8.re-frame2-xray.views.resizable-table-persistence-cljs-test`
+  under rf2-r51p.
+
+  WHY A SEPARATE NAMESPACE. The sibling keeps the `->edn` / `<-edn`
+  algebra, the clamp arithmetic and the pre-registration hydrate
+  short-circuit, none of which touches a host. The `save!` / `load`
+  round-trip, the per-instance storage-key isolation, the tick-does-not-
+  persist / commit-does-persist split (rf2-xm1jy) and the hydrate lift
+  need a real `window.localStorage`, and only a namespace ending
+  `-dom-cljs-test` is ever loaded by the `:browser-test` build, whose
+  `:ns-regexp` is `.*-dom-cljs-test$`. Sitting in the sibling file these
+  rows executed in NEITHER lane: skipped under `:node-test` for want of
+  storage (no jsdom in any dependency list), and never loaded by
+  `:browser-test` at all. The sibling ran 15 test vars containing 11
+  assertions — FEWER assertions than vars, because whole deftests
+  contributed nothing. The file's LOCATION was the defect. The guard was
+  not.
+
+  THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES. `:node-test`'s
+  `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, so the node
+  build loads this namespace too and the overlap is deliberate (see the
+  comment above `:browser-test` in `implementation/shadow-cljs.edn`).
+  Moving a row here ADDS the browser lane; it does not take the row off
+  the node one. `ls/available?` is what keeps the node run inert.
+
+  ONE ROW DID NOT COME WITH THE OTHERS, BECAUSE THE CHOICE IS PER
+  PROPERTY. `resize-pair-tick-clamps-sub-floor-width` asserts only over
+  app-db — it never reads storage — so its guard was incidental rather
+  than load-bearing. That row stayed in the sibling with the guard
+  REMOVED, which makes it run on node for the first time. Moving it here
+  would have bought it nothing and cost it the node lane's speed.
+
+  THE SKIP BRANCH ASSERTS RATHER THAN VANISHING, so the node lane never
+  holds a deftest with zero assertions — the hollow shape rf2-r51p
+  exists to remove.
+
+  These assertions had never executed in ANY lane before this namespace
+  existed. A failure here is evidence arriving for the first time, not a
+  regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.local-storage :as ls]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.views.resizable-table :as rt]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. The slate matters more here than on
+  ;; node: the browser lane runs every namespace on ONE page, so leftover
+  ;; column widths would be in storage when the next namespace hydrates.
+  (xray-test-support/make-xray-runtime-fixture
+    {:post-reset (fn []
+                   (rt/clear!)
+                   (rt/set-storage-key! nil))}))
+
+(defn- xray-setup!
+  "Register Xray handlers + the :rf/xray frame, then re-run the
+  column-widths hydration so any localStorage value lifts into the slot.
+  Mirrors the sibling's `xray-setup!`."
+  []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray})
+  (rt/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+;; ---- save! / load round-trip -------------------------------------------
+
+(deftest save-and-load-round-trip
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (let [widths {:rf.xray.epoch/subscriptions {:sub 300 :inputs 150 :value 200}}]
+      (rt/clear!)
+      (rt/save! widths)
+      (is (= widths (rt/load))
+          "browser-backed round-trip preserves the {table-id {col-id px}} shape"))))
+
+;; ---- Storage-key override (per-instance isolation) ----------------------
+
+(deftest custom-storage-key-isolates-per-instance
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "story testbeds set distinct keys so two Xray instances
+              do not stomp on each other's column-widths state"
+      (rt/set-storage-key! "story.testbed.a.column-widths")
+      (rt/save! {:t1 {:a 100}})
+      ;; Precondition, not decoration: the `(= {} (load))` below passes
+      ;; on a silently no-op storage, where nothing was ever written and
+      ;; every slot reads empty. Proving A's write landed is what makes
+      ;; B's empty read discriminating.
+      (is (= {:t1 {:a 100}} (rt/load))
+          "precondition: instance A's write really did persist")
+      (rt/set-storage-key! "story.testbed.b.column-widths")
+      (is (= {} (rt/load))
+          "instance B's slot is independent of instance A")
+      (rt/save! {:t2 {:b 200}})
+      (rt/set-storage-key! "story.testbed.a.column-widths")
+      (is (= {:t1 {:a 100}} (rt/load))
+          "instance A's slot survived instance B's write"))))
+
+;; ---- resize-pair tick + commit (rf2-xm1jy split) ------------------------
+
+(deftest resize-pair-tick-writes-slot-without-persisting
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "rf2-xm1jy — the pointermove-cadence event writes the slot
+              in app-db but does NOT touch localStorage (per-pixel
+              persistence flooded the main thread on lower-end devices)."
+      ;; Sentinel precondition. The payload assertion of this test is a
+      ;; NEGATIVE one — `(= {} (load))` — which passes trivially against
+      ;; a storage that silently swallows every write. Writing a sentinel
+      ;; and reading it back proves the storage is live, so the empty
+      ;; read afterwards is evidence the TICK withheld the write rather
+      ;; than evidence the host has no storage.
+      (rt/save! {:sentinel {:col 1}})
+      (is (= {:sentinel {:col 1}} (rt/load))
+          "precondition: storage is live and round-trips")
+      (rt/clear!)
+      (xray-setup!)
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 250 :inputs 170])
+      (is (= {:sub 250 :inputs 170}
+             (frame-sub [:rf.xray.column-widths/for-table
+                         :rf.xray.epoch/subscriptions]))
+          "app-db slot reflects the tick")
+      (is (= {} (rt/load))
+          "localStorage is NOT written by the tick event"))))
+
+(deftest resize-pair-commit-persists-current-slot
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (testing "rf2-xm1jy — pointerup dispatches the commit, which writes
+              whatever the app-db slot currently holds to localStorage
+              exactly once. Round-trip: N ticks then one commit ==
+              steady-state widths in localStorage."
+      (xray-setup!)
+      (rt/clear!)
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 100 :inputs 100])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 200 :inputs 200])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :rf.xray.epoch/subscriptions
+                       :sub 250 :inputs 170])
+      (is (= {} (rt/load))
+          "ticks accumulate in app-db only; localStorage untouched")
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
+      (is (= {:rf.xray.epoch/subscriptions {:sub 250 :inputs 170}}
+             (rt/load))
+          "commit writes the final settled widths to localStorage
+           exactly once"))))
+
+;; ---- reset clears one table AND persists --------------------------------
+
+(deftest reset-clears-table-and-persists
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      (xray-setup!)
+      (rt/clear!)
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :t1 :a 100 :b 200])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-tick
+                       :t2 :a 50 :b 70])
+      (frame-dispatch [:rf.xray.column-widths/resize-pair-commit])
+      (frame-dispatch [:rf.xray.column-widths/reset :t1])
+      (is (nil? (frame-sub [:rf.xray.column-widths/for-table :t1]))
+          "t1's overrides cleared")
+      (is (= {:a 50 :b 70}
+             (frame-sub [:rf.xray.column-widths/for-table :t2]))
+          "t2's overrides untouched")
+      (is (= {:t2 {:a 50 :b 70}} (rt/load))
+          "localStorage reflects the reset"))))
+
+;; ---- hydrate! lifts persisted slot into app-db --------------------------
+
+(deftest hydrate-lifts-persisted-widths
+  (if-not (ls/available?)
+    (is true "skipped: no localStorage (node lane — see ns docstring)")
+    (do
+      ;; Seed localStorage BEFORE setup so hydrate sees it.
+      (rt/clear!)
+      (rt/save! {:rf.xray.epoch/views {:view 180 :subs 220}})
+      (xray-setup!)
+      (is (= {:view 180 :subs 220}
+             (frame-sub [:rf.xray.column-widths/for-table
+                         :rf.xray.epoch/views]))
+          "hydrate! ran in xray-setup! and lifted the slot into app-db"))))

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
@@ -124,8 +124,14 @@
       ;; and reading it back proves the storage is live, so the empty
       ;; read afterwards is evidence the TICK withheld the write rather
       ;; than evidence the host has no storage.
-      (rt/save! {:sentinel {:col 1}})
-      (is (= {:sentinel {:col 1}} (rt/load))
+      ;; The sentinel width must sit ABOVE the 24px floor. The first cut
+      ;; of this row used `{:col 1}` and the browser lane read back
+      ;; `{:col 24}` — the load path clamping a sub-floor width exactly
+      ;; as `resize-pair-tick-clamps-sub-floor-width` says it should.
+      ;; That was this test picking an illegal value, not the product
+      ;; misbehaving; the round-trip itself worked.
+      (rt/save! {:sentinel {:col 150}})
+      (is (= {:sentinel {:col 150}} (rt/load))
           "precondition: storage is live and round-trips")
       (rt/clear!)
       (xray-setup!)


### PR DESCRIPTION
Implements rf2-r51p — the remaining test files whose assertions have never executed in any lane.

## The defect, and why the guard was never it

A row wrapped in `(when (and (exists? js/window) (.-localStorage js/window)) ...)` or
`(when-let [el (shell-root)] ...)`, sitting in a file whose namespace ends `-cljs-test`,
executes in **neither** lane:

* `:node-test` loads the file but the guard is **false** — `implementation/package.json`
  depends on no `jsdom`, no `happy-dom` and no `dom-storage` (17 deps, zero matches).
* `:browser-test`'s `:ns-regexp` is `.*-dom-cljs-test$`, so it never loads the file at all.

`:node-test`'s `:ns-regexp` is `cljs-test$` — a bare **suffix** match, which `-dom-cljs-test`
also satisfies. So moving a row to a dom sibling **adds** the browser lane; it does not take
the row off node. The file's LOCATION was the defect. **The guard stays**, respelled through
the shared `ls/available?` seam (or the house `browser?` predicate for DOM rows), and each
skip branch **asserts a marker row** so the node lane never holds a deftest with zero
assertions — the hollow shape this item exists to remove, relocated rather than fixed.

## Census re-derived at tip

Static analysis and the runtime agree exactly. For each file, `static is-forms minus executed
assertions` equals the independently-counted guarded rows:

| file | test vars | static `is` | executed on node | dead |
|---|---:|---:|---:|---:|
| `filters/persistence_cljs_test.cljs` | 15 | 22 | 16 | **6** |
| `settings/effects_cljs_test.cljs` | 30 | 68 | 40 | **28** |
| `spine_filters_cljs_test.cljs` | 29 | 72 | 63 | **9** |
| `views/resizable_table_persistence_cljs_test.cljs` | 15 | 23 | 11 | **12** |
| `static/shell_cljs_test.cljs` | 27 | 77 | 100 | **5** (loops inflate the executed count) |
| `resize_handle_cljs_test.cljs` — **not touched, see Scope** | 33 | 48 | 37 | 11 |

`resizable_table_persistence` ran **15 test vars containing 11 assertions** — fewer assertions
than vars, so whole deftests contributed nothing.

**60 never-executed assertions across 5 files are revived here.**

## The asymmetry, measured both ways

The five new `-dom-cljs-test` namespaces carry 32 test vars. Each has exactly one skip marker
and a real branch:

* **Node (focused run, captured exit 0):** `Ran 32 tests containing 32 assertions` — exactly
  one marker per test. Every revived row **loads** under `:node-test` and reports its stated
  skip. None vanished, none failed, and no deftest holds zero assertions.
* **Browser:** the same 32 tests execute **78** real assertions.

The browser half is not inferred. The first browser run went **red inside one of the revived
rows**, on the sentinel precondition this PR added:

```
FAIL in (resize-pair-tick-writes-slot-without-persisting)
  precondition: storage is live and round-trips
  expected: (= {:sentinel {:col 1}} (rt/load))
    actual: (not (= {:sentinel {:col 1}} {:sentinel {:col 24}}))
```

`1` went to storage and came back `24` — the load path clamping a sub-floor width to the
documented 24px minimum, exactly as `resize-pair-tick-clamps-sub-floor-width` says it should.
That is a **real localStorage round-trip in a real browser**, which this row had never reached
in either lane. The test had picked an illegal sentinel; the product was correct. Sentinel
raised to 150. **No revived assertion was weakened** — and this red is the discriminating
witness that the rows genuinely execute in the browser rather than skipping there too.

## Two files were excluded, and the exclusion is measured

`resources_revalidation_cljs_test.cljc` and `keybinding_cljs_test.cljs` guard with `when-not`
— the **inverse** polarity. Those rows run on node and skip in a browser, which is a
legitimate node-baseline shape, not this defect. Their measured gaps are `1` and `-31`, against
the `25` and `2` rows a polarity-blind census would have flagged.

## A false docstring, corrected

`filters/persistence_cljs_test.cljs` claimed localStorage exists under `npm run test:cljs`
"via the `dom-storage` polyfill the test-support harness installs". No such polyfill is
installed and no such package is depended on; that sentence was the only occurrence of the
string `dom-storage` in the tree. `settings/effects_cljs_test.cljs` carried the same fiction in
a comment — "Some node test runtimes provide js/document". Both corrected.

## Choices made per property, not per file

* `resize-pair-tick-clamps-sub-floor-width` asserts only over app-db and never reads storage,
  so its guard was **incidental**. The guard came off and the row **stayed on node**, where it
  now runs for the first time. Moving it would have bought it nothing.
* Three `settings/effects` tests **mixed** dead DOM claims with assertions that genuinely run
  on node. They were **split**, not moved — moving them whole would have taken live assertions
  off the node lane. Two of them gained a real settings-slot assertion for a second dispatch
  that previously asserted nothing.
* Negative assertions got sentinel preconditions, because `(= {} (load))` passes trivially
  against a storage that silently swallows every write.
* Moved DOM rows bind the root, **assert it is present**, and reach through `some->`. The
  `when-let` shape fails open — a nil root skips the assertion instead of reporting one — and
  `some->` matters because the browser lane runs every namespace in one `cljs.test/run-block`
  with no try/catch.

Dead helpers removed from `settings/effects_cljs_test.cljs`: `ensure-stub-shell-root!`,
`shell-root`, `html-root` had no remaining callers.

## Scope — and one file deliberately left

`resize_handle_cljs_test.cljs` (11 dead assertions) is **not touched**. `worker/resizeh-a` is
live in that exact file, migrating the resize-handle satellite onto Fresco (rf2-k97c.3, 112
insertions / 32 deletions), and its diff **renames one of the very deftests** this item would
move — `handle-renders-nil-when-host-yields` becomes `handle-yields-when-host-asserts-own-handle`.
Two workers in one file is a sequencing conflict, so this is left for a follow-on once that
lands. It was not on the dispatch fence; a branch sweep found it.

`tools/story/**` is untouched — PR #9685 (lanefix-a) is open over that tree.
`implementation/shadow-cljs.edn` is untouched: the lane overlap is deliberate. No lint rule is
proposed; that is rf2-whld.

`backgrounds_test.cljc` and `viewport_test.cljc` are dead one level further out — their
namespaces end `-test`, not `cljs-test`, so node does not select them and the browser does not
match them, and their storage rows sit in `#?(:cljs ...)` which the JVM lane never reads.
Removing a guard would not help them. Reported, not improvised on, and both sit under the
fenced `tools/story/**` tree.

## Quality gates

Every number below is quoted from the run's own captured `.exit` file, not from a harness
report.

| gate | captured exit | result |
|---|---:|---|
| compile `:node-test` | **0** | clean |
| node lane `node out/node-test.js` (full) | **0** | 11748 tests / 58716 assertions, 0 failures, 0 errors |
| focused node run, 5 new dom namespaces | **0** | 32 tests / 32 assertions — markers only (asymmetry evidence) |
| compile `:browser-test` | **0** | clean |
| browser lane, port **8179** | **0** | 1029 tests / 5684 assertions, 0 failures, 0 errors |
| `scripts/check_test_lane_bijection.py` | **0** | 1645 test-defining files, 45 lanes, every file selected and every selector reached |
| `implementation/scripts/_browser-dom-lane-partition.test.cjs` | **0** | 2 passed — filename↔ns partition holds for the 5 new files |
| `scripts/check_require_alias_dialect.py` | **0** | clean |
| `scripts/check_retired_spellings.py` | **0** | clean |
| `scripts/check_fast_pr_gap.py --brief` | **0** | report only — names 101 required checks no local spine decides |

The browser lane was run **twice**: attempt 1 red with the single sentinel failure above,
attempt 2 green after the sentinel fix. Both numbers are from captured `.exit` files.

**Gates deliberately not run locally**, each with its reason:

* `scripts/test-fast-pr.sh` — not nominated by default; it tiers itself on the changed-surface
  classifier and would double-run the per-artefact work above. A green spine is in any case
  compatible with a red required check.
* JVM artefact suites, docs build, link gates — this diff is five CLJS test files plus five new
  CLJS test files under `tools/xray/test/`. No markdown, no `spec/`, no public name, no
  workflow, no production source. `mkdocs build --strict` and the two link gates have no
  surface here and would exit green having verified nothing.
* The remaining 101 required checks named by `check_fast_pr_gap.py` are CI's to grade.
