### PR TITLE
fix(xray): qualify the three Epoch diagnostic inspector mounts (rf2-1ar7)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2721,8 +2721,15 @@
   and the interceptor row conflated the two). `coord-link` drops cleanly
   to plain text + no glyph when the interceptor was registered via the
   `reg-interceptor*` fn, is a framework interceptor, or the bundle elided
-  the coord in production."
-  [idx {:keys [interceptor-id phase errors coord]}]
+  the coord in production.
+
+  `instance` (rf2-1ar7) is the mount qualifier, threaded down from
+  [[render-step]]'s `ctx` exactly as every other cascade-level value is. It
+  reaches the row's 'Exception Thrown' card, whose `ex-data` disclosure
+  mounts an `ei/edn-inspector-view` — which is why this chain needed the
+  parameter at all. See §per-mount inspector identity above
+  [[dispatch-body]]."
+  [idx {:keys [interceptor-id phase errors coord]} instance]
   (let [label (fmt/ns-keyword interceptor-id)]
     [:div {:key (str "interceptor-row-" idx)
            :data-testid (str "rf-xray-epoch-interceptor-row-" idx)
@@ -2745,7 +2752,7 @@
      ;; rf2-yz57h — the interceptor EXCEPTION attaches here as the shared
      ;; inline 'Exception Thrown' card (button-17 :before / button-18
      ;; :after), under the INTERCEPTOR step where it occurred.
-     (error-blocks (keyword (str "interceptor-row-" idx)) errors)]))
+     (error-blocks (keyword (str "interceptor-row-" idx)) errors instance)]))
 
 (defn render-interceptor-step
   "Render the INTERCEPTOR step (rf2-yz57h — present ONLY when a user
@@ -2754,8 +2761,26 @@
   <go-to-source glyph>` (rf2-rvxem) with the shared 'Exception Thrown'
   card attaching below it. The step's `:errors` slot (attached by
   `attach-exceptions`) is rendered per-row by matching the exception's
-  `:failing-id` to the row's `:interceptor-id`."
-  [{:keys [rows step-number errors]}]
+  `:failing-id` to the row's `:interceptor-id`.
+
+  ## `instance` — WHICH MOUNT OF THIS PANEL (rf2-1ar7)
+
+  rf2-3ymg threaded the mount qualifier to every step that mounts an
+  `ei/edn-inspector-view` and recorded this step as mounting none. That was
+  wrong in one direction that only shows up on a THROW: a row's exception
+  card discloses its `ex-data` through [[error-block-details]], which mounts
+  an inspector under `epoch/error-ex-data/<testid-base>`. Since the
+  testid-base is composed from the step-key and the row ordinal alone, two
+  named Epoch mounts showing the same interceptor exception composed ONE
+  mount-id — so the second installed no ResizeObserver, and detaching either
+  released the survivor's entry and its measured width.
+
+  The single-argument arity is the unnamed single-mount default and composes
+  ids byte-for-byte as before rf2-3ymg; it is what the renderer-shape rows in
+  `panels/epoch/view_cljs_test` call. A caller that HAS an instance in scope
+  passes it — the dispatcher [[render-step]] does."
+  ([step] (render-interceptor-step step nil))
+  ([{:keys [rows step-number errors]} instance]
   ;; The step-level `:errors` (from `attach-exceptions`) carry the exception
   ;; records; thread each onto its matching row by `:failing-id`.
   (let [rows* (mapv (fn [row]
@@ -2776,7 +2801,7 @@
     [:div {:data-testid "rf-xray-epoch-step-interceptor"
            :data-step-kw "interceptor"}
      (numbered-circle step-number :INTERCEPTOR)
-     (map-indexed (fn [i row] (interceptor-row-view i row)) rows*)]))
+     (map-indexed (fn [i row] (interceptor-row-view i row instance)) rows*)])))
 
 ;; ---- INTERCEPTORS step — the authored / resolved chain (rf2-se9a9t) ------
 
@@ -5060,12 +5085,18 @@
       ;; owning row (mirrors the FX step's `fx-row-with-violations`
       ;; shape). The step-level violations (non-row attributed) still
       ;; ride at the foot via the call-site below.
+      ;; rf2-1ar7 — `instance` reaches here too. The per-row explainer mounts
+      ;; an `ei/edn-inspector-view` for the humanized explain map, so two
+      ;; named mounts showing the same sub's violation composed one mount-id
+      ;; until this argument was passed. It was already in scope — the value
+      ;; cell above uses it — which is the whole of what was wrong here.
       :row-extras
       (fn [row _i]
         (when (seq (:violations row))
           (violation-blocks
             (keyword (str "sub-row-" (some-> row :sub-id name)))
-            (:violations row))))}]))
+            (:violations row)
+            instance)))}]))
 
 (defn- dispose-reason-label
   "Render a `:rf.sub/dispose` `:reason` keyword as a UI label
@@ -5219,7 +5250,11 @@
      ;; pooled at the foot of the step). Step-level violations
      ;; (indirect recomputes that don't surface a row) continue to
      ;; ride at the foot.
-     (violation-blocks :subscriptions violations)])))
+     ;; rf2-1ar7 — qualified by the mount, like the per-row explainers
+     ;; above and every other inspector-bearing site in this file. Two named
+     ;; mounts of one epoch both composed
+     ;; `epoch/violation-explain/:subscriptions/0` before this argument.
+     (violation-blocks :subscriptions violations (:instance ctx))])))
 
 ;; ---- VIEWS step ----------------------------------------------------------
 
@@ -5726,7 +5761,17 @@
 (defn violation-blocks
   "Render every violation in `violations` as a sub-block inside the
   current step's body. `step-key` is the owning step keyword (used
-  for stable test ids). nil-safe."
+  for stable test ids). nil-safe.
+
+  `instance` (rf2-3ymg) qualifies the explainer's inspector `:mount-id`.
+  THE TWO-ARGUMENT ARITY MEANS `UNNAMED SINGLE MOUNT` — it is not a
+  shorthand for `whatever the caller has`. It composes ids byte-for-byte as
+  they were before rf2-3ymg, which is right for a direct test call and wrong
+  for any renderer that has an instance in scope: two named mounts showing
+  the same violation then share one lifecycle entry, one ResizeObserver and
+  one width slot. rf2-1ar7 is the bead filed because two call sites in this
+  file took the short arity while holding the value — say `nil` deliberately
+  or pass what you have. Every call site in this file passes it."
   ([step-key violations] (violation-blocks step-key violations nil))
   ([step-key violations instance]
    (when (seq violations)
@@ -5911,7 +5956,15 @@
   "Render every exception in `errors` as an inline card inside the
   current step's body (rf2-ahhgn). `step-key` is the owning step keyword
   (stable test ids). nil-safe — a clean step passes nil/empty and renders
-  nothing."
+  nothing.
+
+  `instance` (rf2-3ymg) qualifies the `ex-data` disclosure's inspector
+  `:mount-id`. THE TWO-ARGUMENT ARITY MEANS `UNNAMED SINGLE MOUNT`, with the
+  same caveat [[violation-blocks]] carries: it is the pre-rf2-3ymg identity,
+  correct for a direct test call and wrong for a renderer holding an
+  instance. The INTERCEPTOR row took it while its whole chain lacked the
+  parameter, which is half of rf2-1ar7. Every call site in this file passes
+  it."
   ([step-key errors] (error-blocks step-key errors nil))
   ([step-key errors instance]
    (when (seq errors)
@@ -5956,16 +6009,25 @@
   [step ctx]
   ;; rf2-3ymg — `:instance` rides `ctx` like every other cascade-level
   ;; value, and reaches the steps that mount an `ei/edn-inspector-view`.
-  ;; The three that mount none (`:recordable-cofx`, `:interceptors`,
-  ;; `:interceptor`) are not passed it, which is the honest signal that
-  ;; they have no per-mount identity to qualify.
+  ;; The TWO that mount none (`:recordable-cofx`, `:interceptors`) are not
+  ;; passed it, which is the honest signal that they have no per-mount
+  ;; identity to qualify.
+  ;;
+  ;; rf2-1ar7 — that list read THREE and named `:interceptor` among them.
+  ;; It mounts none on a CLEAN cascade, which is every cascade in which the
+  ;; step is absent altogether (it is conditional on a throw). When it IS
+  ;; present it mounts one per throwing row carrying `ex-data`, through
+  ;; `interceptor-row-view` → [[error-blocks]] → [[error-block-details]].
+  ;; The reachability question is "does any path from here reach an
+  ;; inspector", not "does this renderer name one", and the two remaining
+  ;; names were re-checked against that question rather than inherited.
   (let [instance (:instance ctx)]
     (case (:step step)
       :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx) instance)
       :recordable-cofx   (render-recordable-cofx-step step)
       :coeffect          (render-coeffect-step step instance)
       :interceptors      (render-interceptors-step step)
-      :interceptor       (render-interceptor-step step)
+      :interceptor       (render-interceptor-step step instance)
       :handler           (render-handler-step step ctx)
       :flow              (render-flow-step step instance)
       :side-effects      (render-side-effects-step step instance)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch_machine_mount_instance_id_dom_cljs_test.cljs
@@ -173,6 +173,132 @@
              :event      [:auth/submit]
              :rf.trace/dispatch-id "d-1"}}]}])
 
+;; ---- the seeded DIAGNOSTICS epoch (rf2-1ar7) ------------------------------
+;;
+;; A SECOND fixture rather than seeds bolted onto `fixture-history`, and that
+;; is deliberate. W1-W5 grade the ORDINARY payload mounts, and three of them
+;; count ids or compare whole id sets; folding diagnostics into their epoch
+;; would move those counts for reasons that have nothing to do with what they
+;; assert. The rows below seed their own epoch and leave the five above
+;; reading exactly what they read before.
+;;
+;; rf2-3ymg threaded the qualifier to every step that mounts an inspector and
+;; recorded `:interceptor` as a step that mounts none. It mounts none on a
+;; CLEAN cascade — the step is conditional on a throw — and one per throwing
+;; row carrying `ex-data`. The three sites this epoch reaches are the three
+;; that still dropped the argument at the merge commit of #9680:
+;;
+;;   * the INTERCEPTOR row's exception card, whose `ex-data` disclosure mounts
+;;     under `epoch/error-ex-data/<testid-base>`. Its whole chain
+;;     (`render-interceptor-step` → `interceptor-row-view` → `error-blocks`)
+;;     had no instance parameter at all.
+;;   * the PER-ROW subscription violation explainer, reached through
+;;     `subscriptions-table`'s `:row-extras` — which held the instance and
+;;     used it one line above, in the value cell.
+;;   * the STEP-LEVEL subscription violation explainer at the foot of
+;;     `render-subscriptions-step`.
+
+(def ^:private throwing-interceptor-id :audit/log)
+(def ^:private violating-sub-id :cart/preview)
+
+(def ^:private diagnostics-history
+  "ONE epoch that RENDERS all three diagnostics, so two mounts of it compose
+  three qualified ids each.
+
+  Three shape requirements, each measured rather than assumed:
+
+    * the interceptor exception must carry a real `ex-info`. `error-block-
+      details` mounts the inspector only `(when (seq ex-data*))`, so a bare
+      message throws the card without the mount this row is about.
+    * the subscription row must carry `:rf.sub/value-changed? true`. The
+      SUBSCRIPTIONS step's filter mode defaults to `:changed`, so an
+      unchanged row is filtered out of `visible-rows` BEFORE
+      `subscriptions-table` sees it and its inline violation never renders.
+    * the two violations split per-row vs step-level ON `:failing-id` alone.
+      `attach-to-sub-row` attaches to the row whose `:sub-id` matches, and
+      falls back to the step-level bucket when none does — so the second
+      violation names a sub that recomputed nowhere in this cascade, which
+      is the real shape it models (an indirect recompute outside the
+      cascade's surfaced rows).
+
+  The throw is `:after` rather than `:before`: a `:before` throw aborts the
+  chain, and `mark-skipped-handler` then stamps the HANDLER and SIDE EFFECTS
+  steps `:skipped`. Nothing here grades those, but an `:after` throw is the
+  cascade in which the subscriptions actually ran, which is the one that
+  carries all three diagnostics at once."
+  [{:epoch-id      1
+    :dispatch-id   "d-1"
+    :event         [:cart/set "bad"]
+    :trigger-event [:cart/set "bad"]
+    :trace-events
+    [{:id 1 :time 10 :operation :rf.event/dispatch
+      :tags {:event [:cart/set "bad"] :rf.trace/dispatch-id "d-1"}}
+     ;; INTERCEPTOR step — one throwing row, carrying ex-data so the
+     ;; disclosure mounts an inspector.
+     {:id 2 :time 20 :operation :rf.error/interceptor-exception
+      :tags {:failing-id        throwing-interceptor-id
+             :phase             :after
+             :exception-message "audit interceptor threw"
+             :exception         (ex-info "audit interceptor threw"
+                                         {:rf.xray.test/interceptor
+                                          throwing-interceptor-id})}}
+     ;; SUBSCRIPTIONS step — one CHANGED row, so it survives the default
+     ;; `:changed` filter and the table renders its `:row-extras`.
+     {:id 3 :time 30 :operation :rf.sub/run
+      :tags {:rf.sub/id             violating-sub-id
+             :rf.sub/query-v        [violating-sub-id]
+             :rf.sub/value-changed? true
+             :rf.sub/prev-value     1
+             :rf.sub/value          "bad"}}
+     ;; PER-ROW violation — `:failing-id` MATCHES the row's `:sub-id`.
+     {:id 4 :time 40 :operation :rf.error/schema-validation-failure
+      :tags {:where             :sub-return
+             :failing-id        violating-sub-id
+             :path              [:cart :preview]
+             :value             "bad"
+             :explain-humanized {:preview ["should be an int"]}}}
+     ;; STEP-LEVEL violation — `:failing-id` matches NO row, so
+     ;; `attach-to-sub-row` falls back to the step-level bucket.
+     {:id 5 :time 50 :operation :rf.error/schema-validation-failure
+      :tags {:where             :sub-return
+             :failing-id        :cart/indirect
+             :path              [:cart :indirect]
+             :value             "bad"
+             :explain-humanized {:indirect ["should be an int"]}}}]}])
+
+;; ---- the ids those three diagnostics compose, WRITTEN OUT -----------------
+;;
+;; LITERALS, not values re-derived from the same render the rows read. A door
+;; that compares what it read against something composed the same way agrees
+;; with itself under the revert — both sides go unqualified together, the
+;; comparison still holds, and the row passes ON the defect. These strings
+;; are what the panel must produce, stated independently of it.
+;;
+;; Each tail is composed by the source as `(str "epoch/violation-explain/"
+;; step-key "/" idx)` — `step-key` is a KEYWORD and `str` keeps its leading
+;; colon, which is why `:subscriptions` appears here with one. The
+;; step-level id below is verbatim the one rf2-1ar7 names as its worked
+;; example of the collision.
+
+(def ^:private interceptor-ex-data-site
+  "epoch/error-ex-data/rf-xray-epoch-error-interceptor-row-0-0")
+
+(def ^:private sub-row-violation-site
+  "epoch/violation-explain/:sub-row-preview/0")
+
+(def ^:private sub-step-violation-site
+  "epoch/violation-explain/:subscriptions/0")
+
+(def ^:private diagnostic-sites
+  [interceptor-ex-data-site sub-row-violation-site sub-step-violation-site])
+
+(defn- qualified
+  "The id a mount named `instance` composes for `site` — `inspector-mount-id`
+  puts the instance OUTERMOST. Spelled out here rather than called out of the
+  source: this is the test's own statement of the contract."
+  [instance site]
+  (str instance "/" site))
+
 (defn- setup!
   "Register Xray's handlers plus the test-override seam the fixtures write
   through, then seed the machine registry, the epoch ring and the focus.
@@ -194,22 +320,31 @@
   rather than the claims. `ensure-xray-frame!` is idempotent, so running it
   here leaves the facade's own call a no-op and the seed is what the panels
   read. The sibling suites do not meet this because they mount the registry
-  head under a `frame-provider` directly and never reach the facade."
-  []
-  (registry/register-xray-handlers!)
-  (xray-test-support/install-test-overrides!)
-  (mount/ensure-xray-frame! :rf/xray)
-  (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
-                     [machine-id]]
-                    {:frame :rf/xray})
-  (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test
-                     {machine-id fixture-definition}]
-                    {:frame :rf/xray})
-  (rf/dispatch-sync [:rf.xray/set-epoch-history-for-test fixture-history]
-                    {:frame :rf/xray})
-  (rf/dispatch-sync [:rf.xray/set-focus-epoch-id-for-test 1]
-                    {:frame :rf/xray})
-  nil)
+  head under a `frame-provider` directly and never reach the facade.
+
+  rf2-1ar7 — the one-argument arity takes the history to seed, so the
+  diagnostics rows below run the SAME facade path W1-W5 do rather than a
+  second one of their own. The focus is taken FROM that history rather than
+  written as a constant beside it: a fixture whose `:epoch-id` drifted from a
+  hard-coded focus paints an empty panel, and an empty panel reads as
+  disjoint ids rather than as a broken seed."
+  ([] (setup! fixture-history))
+  ([history]
+   (registry/register-xray-handlers!)
+   (xray-test-support/install-test-overrides!)
+   (mount/ensure-xray-frame! :rf/xray)
+   (rf/dispatch-sync [:rf.xray/set-registered-machines-override-for-test
+                      [machine-id]]
+                     {:frame :rf/xray})
+   (rf/dispatch-sync [:rf.xray/set-machine-definitions-override-for-test
+                      {machine-id fixture-definition}]
+                     {:frame :rf/xray})
+   (rf/dispatch-sync [:rf.xray/set-epoch-history-for-test history]
+                     {:frame :rf/xray})
+   (rf/dispatch-sync [:rf.xray/set-focus-epoch-id-for-test
+                      (:epoch-id (first history))]
+                     {:frame :rf/xray})
+   nil))
 
 ;; ---- mounting, and reading the DOM back ----------------------------------
 
@@ -558,5 +693,254 @@
                  identities, not per-render nonces"))
           (finally
             (unmount! named)
+            (unmount! b)
+            (unmount! a)))))))
+
+;; ===========================================================================
+;; W6 — the INTERCEPTOR row's ex-data disclosure (rf2-1ar7)
+;; ===========================================================================
+
+(deftest two-named-epoch-mounts-qualify-the-interceptor-ex-data-mount
+  (testing "rf2-1ar7 — two named Epoch mounts showing the SAME interceptor
+            exception compose two disjoint `epoch/error-ex-data/…` mount-ids.
+
+            This is the path rf2-3ymg missed entirely rather than passed
+            wrongly: `render-interceptor-step` → `interceptor-row-view` →
+            `error-blocks` carried NO instance parameter, so there was
+            nothing for the dispatcher to hand down. The card's `ex-data`
+            disclosure mounts an `ei/edn-inspector-view` whose `:mount-id` is
+            composed from the step-key and the row ordinal ALONE — both of
+            which are identical across two mounts of one epoch."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup! diagnostics-history)
+            left  (mount-epoch! {:instance-id "left"})
+            right (mount-epoch! {:instance-id "right"})]
+        (try
+          (let [ids-l (mount-ids (:container left))
+                ids-r (mount-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (some? (some-> (:container left)
+                               (.querySelector
+                                 "[data-testid=\"rf-xray-epoch-step-interceptor\"]")))
+                "control: the INTERCEPTOR step rendered at all. It is
+                 CONDITIONAL on a throw, so a fixture that failed to project
+                 one would leave the assertions below comparing two empty
+                 sets and passing")
+            (is (some? (some-> (:container left)
+                               (.querySelector
+                                 "[data-testid=\"rf-xray-epoch-error-interceptor-row-0-0-ex-data\"]")))
+                "control: and the row's ex-data disclosure is present — the
+                 inspector mounts only `(when (seq ex-data*))`, so a throw
+                 carrying no ex-data would render the card and no mount")
+
+            ;; ---- the claim, against LITERALS ----------------------------
+            (is (some #(= (qualified "left" interceptor-ex-data-site) %) ids-l)
+                (str "the left mount composed the id written out in this "
+                     "file, not merely something different from the right's. "
+                     "expected=" (qualified "left" interceptor-ex-data-site)
+                     " left=" (pr-str ids-l)))
+            (is (some #(= (qualified "right" interceptor-ex-data-site) %) ids-r)
+                (str "and the right mount composed its own. expected="
+                     (qualified "right" interceptor-ex-data-site)
+                     " right=" (pr-str ids-r)))
+            (is (nil? (some #(= interceptor-ex-data-site %)
+                            (concat ids-l ids-r)))
+                (str "and NEITHER still presents the unqualified id — an "
+                     "EQUALITY test, because the qualified ids contain the "
+                     "unqualified one as a substring. unqualified="
+                     interceptor-ex-data-site " left=" (pr-str ids-l)
+                     " right=" (pr-str ids-r))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W7 — both SUBSCRIPTION violation explainers, per-row and step-level
+;; ===========================================================================
+
+(deftest two-named-epoch-mounts-qualify-both-subscription-violation-mounts
+  (testing "rf2-1ar7 — two named Epoch mounts rendering the SAME subscription
+            schema violations compose disjoint explainer mount-ids, on BOTH
+            the per-row and the step-level path.
+
+            The two failed differently and are therefore both rows here.
+            `subscriptions-table` HELD the instance — the value cell one line
+            above uses it — and its `:row-extras` callback took
+            `violation-blocks`' two-argument arity anyway. The step-level call
+            at the foot of `render-subscriptions-step` had `(:instance ctx)`
+            available and omitted it. That second one is the bead's own worked
+            example: both named panels produced
+            `epoch/violation-explain/:subscriptions/0`."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_     (setup! diagnostics-history)
+            left  (mount-epoch! {:instance-id "left"})
+            right (mount-epoch! {:instance-id "right"})]
+        (try
+          (let [ids-l (mount-ids (:container left))
+                ids-r (mount-ids (:container right))]
+            ;; ---- controls, taken from the target ------------------------
+            (is (some? (some-> (:container left)
+                               (.querySelector
+                                 "[data-testid=\"rf-xray-epoch-violations-sub-row-preview\"]")))
+                "control: the PER-ROW violation block rendered. It rides the
+                 table's `:row-extras`, which only runs for a VISIBLE row —
+                 the default `:changed` filter drops an unchanged one before
+                 the table sees it")
+            (is (some? (some-> (:container left)
+                               (.querySelector
+                                 "[data-testid=\"rf-xray-epoch-violations-subscriptions\"]")))
+                "control: and the STEP-LEVEL block rendered — its violation
+                 names a sub that recomputed nowhere in this cascade, which
+                 is what makes `attach-to-sub-row` fall back to the
+                 step-level bucket rather than attaching to a row")
+
+            ;; ---- the claim, against LITERALS ----------------------------
+            (doseq [[who ids] [["left" ids-l] ["right" ids-r]]]
+              (is (some #(= (qualified who sub-row-violation-site) %) ids)
+                  (str "the " who " mount qualified the PER-ROW explainer. "
+                       "expected=" (qualified who sub-row-violation-site)
+                       " ids=" (pr-str ids)))
+              (is (some #(= (qualified who sub-step-violation-site) %) ids)
+                  (str "the " who " mount qualified the STEP-LEVEL explainer. "
+                       "expected=" (qualified who sub-step-violation-site)
+                       " ids=" (pr-str ids))))
+
+            (is (nil? (some #{sub-row-violation-site sub-step-violation-site}
+                            (concat ids-l ids-r)))
+                (str "and neither mount still presents either unqualified "
+                     "explainer id — the step-level one is verbatim what "
+                     "rf2-1ar7 reported both named panels producing. left="
+                     (pr-str ids-l) " right=" (pr-str ids-r)))
+            (is (nil? (some (set ids-l) ids-r))
+                (str "taken whole, the two mounts share no id at all. left="
+                     (pr-str ids-l) " right=" (pr-str ids-r))))
+          (finally
+            (unmount! right)
+            (unmount! left)))))))
+
+;; ===========================================================================
+;; W8 — the lifecycle half for a DIAGNOSTIC mount: the survivor keeps both
+;; ===========================================================================
+
+(deftest diagnostic-mounts-each-keep-their-own-observer-and-width
+  (testing "rf2-1ar7 — the half a distinctness row passes over, asserted on a
+            DIAGNOSTIC mount rather than an ordinary payload one.
+
+            Distinctness alone is satisfied by any two different strings. What
+            the shared id actually costs is physical: the second mount's ref
+            callback finds an observer already on the entry and installs
+            NONE, and `release-mount!` then tears the shared entry down — and
+            clears the shared width — when EITHER holder detaches, leaving the
+            panel still on screen unobserved and unmeasured. W2 pins this for
+            the dispatch-event mount; this row pins it for the step-level
+            violation explainer, which is the mount rf2-1ar7 is about."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (async done
+        (setup! diagnostics-history)
+        (let [left  (mount-epoch! {:instance-id "left"})
+              right (mount-epoch! {:instance-id "right"})
+              id-l  (qualified "left" sub-step-violation-site)
+              id-r  (qualified "right" sub-step-violation-site)]
+          ;; Controls: the two ids are LITERALS, so a fixture that stopped
+          ;; rendering the step-level explainer would leave every assertion
+          ;; below reading an absent key — which is why presence is asserted
+          ;; before anything is concluded from it.
+          (is (some #(= id-l %) (mount-ids (:container left)))
+              (str "control: the left mount really committed the step-level "
+                   "explainer under the id this row keys on. expected=" id-l
+                   " ids=" (pr-str (mount-ids (:container left)))))
+          (is (some #(= id-r %) (mount-ids (:container right)))
+              (str "control: and so did the right. expected=" id-r))
+
+          ;; ---- the observer half -------------------------------------
+          ;; Liveness rather than discrimination, exactly as in W2: under the
+          ;; shared identity both lookups resolve to the SAME entry and both
+          ;; pass with the defect fully present. The survivor row below is
+          ;; what bites.
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "the left mount's explainer installed its own ResizeObserver")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r))
+                         :observer)
+              "and so did the right's — two live mounts, two observers")
+
+          ;; ---- the width half ----------------------------------------
+          ;; Driven through the slot's own public event, for the reason W2
+          ;; records: the headless container measures `clientWidth` 0, so the
+          ;; real measurement path need never fire and a row asserting a
+          ;; measured VALUE would be red for a reason that is not this defect.
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-l 640]
+                            {:frame :rf/xray})
+          (rf/dispatch-sync [:rf.xray.edn-inspector/set-width id-r 480]
+                            {:frame :rf/xray})
+          (is (= 2 (count (select-keys (widths) [id-l id-r])))
+              (str "two live explainer mounts hold TWO width slots — under "
+                   "the shared identity both writes land on one key. slot="
+                   (pr-str (widths))))
+
+          (unmount! right)
+
+          ;; ---- the survivor keeps both -------------------------------
+          (is (nil? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-r)))
+              "the detached mount's entry is gone")
+          (is (contains? (ei/mount-state-held (ei/lifecycle-key :rf/xray id-l))
+                         :observer)
+              "and the mount STILL ON SCREEN is still observed — releasing the
+               survivor's entry is exactly what the shared key did")
+          (-> (rf.test-support/poll-until
+                (fn [] (nil? (get (widths) id-r)))
+                {:label "release-mount! cleared the detaching explainer's width"})
+              (.then
+                (fn [_]
+                  (is (some? (get (widths) id-l))
+                      (str "and the survivor's width is STILL in the frame's "
+                           "slot — `release-mount!` clears under the DETACHING "
+                           "mount's id, which under the shared identity is the "
+                           "survivor's own. slot=" (pr-str (widths))))))
+              (.catch
+                (fn [e]
+                  (is false (str "the width clear never landed: "
+                                 (.-message e) " slot=" (pr-str (widths))))
+                  nil))
+              (.then (fn [_] (unmount! left) (done)))))))))
+
+;; ===========================================================================
+;; W9 — the negative control: unnamed diagnostic mounts collide, unchanged
+;; ===========================================================================
+
+(deftest two-unnamed-epoch-mounts-still-collide-on-the-diagnostic-ids
+  (testing "rf2-1ar7 — the defect verbatim, kept as a row, and the thing that
+            makes W6-W8 measurements rather than silence.
+
+            Two UNNAMED Epoch mounts rendering the same three diagnostics
+            present the SAME ids, and those ids are byte-for-byte the
+            unqualified sites this file writes out — so the instrument can see
+            a collision, and the single-mount default that every call site in
+            this tree uses composes exactly what it always did. W5 states both
+            halves for the ordinary payload mounts; this is the diagnostics'."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (let [_ (setup! diagnostics-history)
+            a (mount-epoch! nil)
+            b (mount-epoch! {})]
+        (try
+          (let [ids-a (mount-ids (:container a))
+                ids-b (mount-ids (:container b))]
+            (is (seq ids-a)
+                "control: both unnamed mounts committed widgets")
+            (is (= ids-a ids-b)
+                (str "two unnamed mounts present the SAME ids — so the "
+                     "instrument W6 and W7 use CAN see a collision. a="
+                     (pr-str ids-a)))
+            (doseq [site diagnostic-sites]
+              (is (some #(= site %) ids-a)
+                  (str "the unnamed mount composes the unqualified " site
+                       " — this is the collision rf2-1ar7 reported, and it is "
+                       "also the identity that must not move for a single "
+                       "mount. a=" (pr-str ids-a)))))
+          (finally
             (unmount! b)
             (unmount! a)))))))


### PR DESCRIPTION
Closes rf2-1ar7.

The residue of #9680, filed by that change's own merged-PR audit — the system
working, not a complaint about the work. #9680 threaded a per-mount instance
qualifier through the Epoch panel's `ei/edn-inspector-view` heads; the qualifier
correctly reaches ordinary Epoch payloads and the shared Machine Inspector
cascade, and three diagnostic call paths kept composing the unqualified id.

## The premise, re-checked at tip before any repair

It holds. A census of every `error-blocks` / `violation-blocks` /
`inspector-mount-id` call in `panels/epoch/view.cljs`, each mapped to its
enclosing top-level form, found **exactly three** sites dropping the qualifier
against eleven passing it — precisely the three rf2-1ar7 names, and no others.

## The three paths

| path | what was wrong |
| --- | --- |
| interceptor step/row/error | `render-interceptor-step` → `interceptor-row-view` → `error-blocks` had **no instance parameter at all** — there was nothing for the dispatcher to hand down |
| subscription row-extras | `subscriptions-table` already *received* the instance and uses it in the value cell one line above; its `:row-extras` callback took the two-argument arity |
| subscription step-level | `render-subscriptions-step` omitted `(:instance ctx)` from its foot-of-step call |

## The bead's argument was static. It now executes.

rf2-1ar7 says so itself: *"a static, complete argument-flow counterexample, not
a newly executed browser reproduction."* The witness was committed first and run
against the **unrepaired** source, reverted to its pre-fix blob and verified by
content hash so the revert could not be a silent no-op.

**Captured exit 1, 15 failures** — all fifteen in the three new claim rows, none
in a control. The left mount's committed `data-rf-mount-id` set read:

```
["left/epoch/dispatch-event"                                     <- payload: qualified
 "epoch/error-ex-data/rf-xray-epoch-error-interceptor-row-0-0"   <- UNQUALIFIED
 "epoch/violation-explain/:sub-row-preview/0"                    <- UNQUALIFIED
 "epoch/violation-explain/:subscriptions/0"                      <- UNQUALIFIED
 ...]
```

and the right mount composed those same three. That last id is **verbatim the
one rf2-1ar7 gives as its worked example** of the collision. Restored, the same
suite reads 0 failures with the test and assertion counts unmoved (1016 / 5692
both runs), so nothing aborted a namespace.

## Why the existing witness could not see it

`epoch_machine_mount_instance_id_dom_cljs_test` seeds a dispatch plus one
machine transition, so it never renders a diagnostic. Four rows were added to
that existing witness — not a new suite — against a **second** fixture rather
than seeds bolted onto `fixture-history`: three of W1–W5 count ids or compare
whole id sets, and folding diagnostics into their epoch would move those counts
for reasons unrelated to what they assert.

- **W6** the INTERCEPTOR row's `ex-data` disclosure
- **W7** both subscription violation explainers, per-row and step-level
- **W8** the lifecycle half on a **diagnostic** mount — the survivor keeps its
  observer and its width when its sibling detaches. Distinctness alone is
  satisfied by any two different strings; what the shared id actually costs is
  that the second mount installs no ResizeObserver and `release-mount!` tears
  the shared entry down when *either* holder goes. This is the assertion a
  distinctness-only witness passes over, and #9680's own witness caught it the
  same way.
- **W9** the negative control — unnamed mounts still collide on all three and
  compose the unqualified ids byte-for-byte, so W6–W8's disjointness is a
  measurement rather than silence.

Every expected id is a **literal** written out in the file, never re-derived
from the render the row reads: a door comparing what it read against a value
composed the same way agrees with itself under the revert — both sides go
unqualified together and the row passes *on* the defect.

## The dispatcher comment #9680 left behind

It recorded `:interceptor` as one of three steps that mount no inspector. It
mounts none on a **clean** cascade — the step is conditional on a throw — and
one per throwing row carrying ex-data, via `error-block-details`. Corrected to
name the two that genuinely mount none, both re-checked for reachability
(transitively, including `authored-interceptor-row-view`) rather than inherited.

## The two retained two-argument arities: KEPT, deliberately

rf2-1ar7 asks for a deliberate decision. They stay:

- they are the documented nil-safe public shape, `tools/xray/spec/021-Dynamic-Panel-Designs.md` cites the two-argument form, and a nil-safety unit row exercises one;
- removing them turns a bounded correction into an API change across a spec page and a test file, for no defect-related reason;
- after this change **no call site in the file takes them**.

What made them dangerous was never the arity — it was that neither docstring
mentioned `instance` at all, so a caller had nothing to read. Both now say the
short arity means **unnamed single mount** rather than "whatever the caller
has". `render-interceptor-step` gains one on the same terms, following #9680's
own convention: private helpers get the parameter appended, public step
renderers keep a short arity for their direct test callers.

## Scope held

Unnamed ids, logical site ids, row keys and disclosure sharing are unchanged —
W4 and W9 pin that bound and both pass. No new identity mechanism, no broad test
matrix. Two files touched.

## Quality gates

Each compound gate was split into compile and run, with the **run gated on the
compile's own captured exit code** rather than chained — a failed compile
otherwise leaves the runner grading a stale artefact and returning a truthful
zero of its own. Every number below is read from the run's own `.exit` file.

| gate | phase | captured exit | result |
| --- | --- | --- | --- |
| `npm run test:browser` (sabotaged: source reverted to pre-fix blob) | compile | 0 | — |
| `npm run test:browser` (sabotaged) | run | **1** | 1016 tests, 5692 assertions, **15 failures**, 0 errors — all 15 in the new rows |
| `npm run test:browser` (repaired) | compile | 0 | — |
| `npm run test:browser` (repaired) | run | **0** | 1016 tests, 5692 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | compile | 0 | 1970 files |
| `npm run test:cljs` | run | **0** | 11753 tests, 58688 assertions, 0 failures, 0 errors |
| `scripts/check_retired_spellings.py` | — | **0** | and **1** on a planted violation, restored to 0 |
| `scripts/check_retired_composition_vocab.py` | — | 0 | |
| `scripts/check_test_lane_bijection.py` | — | 0 | new deftests rostered correctly |
| `scripts/check_require_alias_dialect.py` | — | 0 | |
| `scripts/check_thrown_error_messages.py` | — | 0 | |
| `scripts/check_flattened_lists.py` | — | 0 | |
| `scripts/check_escaped_continuations.py` | — | 0 | |
| `scripts/check-no-hardcoded-paths.sh` | — | 0 | |
| `scripts/check-commit-attribution.sh origin/main` | — | 0 | grades the 2 commits this branch introduces |
| `scripts/check-beads-pr-boundary.sh origin/main` | — | 0 | no tracker-database paths in the diff |
| `scripts/check_fast_pr_gap.py --brief` | — | 0 | a report, run to learn what CI owns; its 101 listed checks were deliberately **not** run locally |

Run bare, `check-commit-attribution.sh` exits 1 with *"no base ref … failing
closed: a gate that cannot see the commit range certifies nothing"*. That is the
gate refusing to certify, not a finding; it is given `origin/main` above. Its
PR-**body** arm runs in CI, which reads the body from the frozen event payload.

The browser runner logged `http://127.0.0.1:8183` and printed the root it
served — a path under this branch's own worktree, which is how each browser run
was confirmed to be grading this tree and not a sibling's. The node compile
printed this worktree's `shadow-cljs.edn` for the same reason.

`check_retired_spellings.py` covers `.cljs` under `tools/`, so it grades both
files here. Its green was not taken on trust: a violation planted in
`epoch/view.cljs` turned it red **naming that planted line**, which discriminates
this worktree from any other, since the fault existed only here. Restored and
re-run green, with the file's blob hash checked back to its committed value.

**Not run locally, left to CI:** everything in the gap report above, including
`cljs-browser`, `jvm-tools-xray` and the prod-gate lanes. The five merge clauses
are read against CI, never a local run.
