### PR TITLE
test: revive the last never-executed test rows, and re-derive the remainder (rf2-r51p)

### DIFF
--- a/tools/story/test/re_frame/story/backgrounds_storage_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/backgrounds_storage_dom_cljs_test.cljs
@@ -1,0 +1,159 @@
+(ns re-frame.story.backgrounds-storage-dom-cljs-test
+  "Browser-lane home for background-selection persistence (rf2-zll4h),
+  assembled under rf2-r51p out of rows that ran in NO lane at all.
+
+  ## Where these rows came from, and why neither source could run them
+
+  `re-frame.story.backgrounds-test` (`backgrounds_test.cljc`) held four
+  `#?(:cljs (deftest storage-* ...))` rows. Its namespace ends `-test`,
+  not `cljs-test`, so `:node-test`'s `:ns-regexp` (`cljs-test$`) does not
+  select it and `:browser-test`'s (`.*-dom-cljs-test$`) does not match it
+  either, and nothing else requires it. Those rows were therefore not
+  merely guarded-false — they were UNREACHABLE: no CLJS build compiled
+  them at all. That file's own docstring said \"Runs on both JVM and CLJS
+  — the CLJS arm exercises the localStorage round-trip\", which had never
+  been true.
+
+  `re-frame.story.ui.backgrounds-switcher-cljs-test` held the two
+  `hydrate!` rows. That namespace IS selected by `:node-test`, but its
+  rows sat inside `(when (browser?) ...)` and the node runtime has no
+  `window.localStorage` — this repo ships no jsdom, no happy-dom and no
+  DOM shim in any dependency list — while `:browser-test` never loads a
+  plain `-cljs-test` file. So those executed in neither lane.
+
+  Both defects have one repair, because both rows want the same thing: a
+  real `window.localStorage`. Every row below is a genuine round-trip —
+  `save-to-storage!` writes through `.setItem`, `load-from-storage` reads
+  back through `.getItem`, `hydrate!` seeds the shell slot from what
+  survived. That is real host-storage semantics, which is the case
+  rf2-r51p rules needs a real host rather than a stub.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `cljs-test$` is a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, and
+  `implementation/shadow-cljs.edn` records that overlap as deliberate. So
+  moving a row here ADDS the browser lane; it removes nothing. Each row
+  answers the node lane with a VISIBLE marker assertion rather than a
+  silent `when`, so no deftest here holds zero assertions — that hollow
+  shape is what rf2-r51p exists to remove, and a bare `when` would
+  merely relocate it.
+
+  The JVM half of both source files is untouched: neither carries a
+  single `#?(:clj ...)` form, and every cross-host row in them (preset
+  table, custom-colour validation, resolve precedence, `wrap-style`) is
+  a bare unconditional `deftest` that still runs under `clojure -M:test`.
+
+  These assertions had never executed in ANY lane. A failure here is
+  evidence about `save-to-storage!` / `load-from-storage` / `hydrate!`
+  arriving for the first time, not a regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story.backgrounds :as rf.story.backgrounds]
+            [re-frame.story.ui.backgrounds-switcher
+             :as rf.story.ui.backgrounds-switcher]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
+
+;; ---- host predicate ------------------------------------------------------
+
+(defn- browser?
+  "True when a working `js/window.localStorage` is present.
+
+  FALSE under `:node-test`, TRUE under `:browser-test`. Both targets load
+  this namespace (see the ns docstring), so this predicate is what routes
+  each row to the lane that can actually run it."
+  []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+(defn- clear-storage! []
+  (when (browser?)
+    (try (.removeItem (.-localStorage js/window) rf.story.backgrounds/ls-key)
+         (catch :default _ nil))))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
+
+;; ---- save / load round-trip ---------------------------------------------
+
+(deftest storage-roundtrip-preset
+  (testing "save → load returns the persisted preset id"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.backgrounds/save-to-storage! :dark)
+        (is (= :dark (rf.story.backgrounds/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-roundtrip-custom
+  (testing "save → load returns the persisted custom hex colour"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.backgrounds/save-to-storage! "#abc123")
+        (is (= "#abc123" (rf.story.backgrounds/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-save-nil-clears
+  (testing "save-to-storage! nil clears the persisted slot"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.backgrounds/save-to-storage! :dark)
+        ;; Precondition with teeth: prove something WAS persisted, so the
+        ;; nil below is evidence that the clear ran.
+        (is (some? (rf.story.backgrounds/load-from-storage)))
+        (rf.story.backgrounds/save-to-storage! nil)
+        (is (nil? (rf.story.backgrounds/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-rejects-invalid-on-save
+  (testing "an invalid selection is DROPPED rather than persisted — and
+            because `save-to-storage!` only writes when `coerce` yields a
+            value, the previously persisted selection SURVIVES"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        ;; This row used to assert `(nil? (load-from-storage))` straight
+        ;; after a `clear-storage!`, which passes against a storage that
+        ;; silently swallows every write — the exact vacuity rf2-r51p
+        ;; tightens for. Seed a VALID value first, so the assertions below
+        ;; distinguish "the invalid save was refused" from "nothing works".
+        (rf.story.backgrounds/save-to-storage! :dark)
+        (is (= :dark (rf.story.backgrounds/load-from-storage))
+            "precondition: a valid selection really does persist")
+        (rf.story.backgrounds/save-to-storage! :neon)          ;; unknown preset
+        (is (= :dark (rf.story.backgrounds/load-from-storage))
+            "an unknown preset id neither persists nor clobbers the slot")
+        (rf.story.backgrounds/save-to-storage! "rgb(1,2,3)")   ;; bad shape
+        (is (= :dark (rf.story.backgrounds/load-from-storage))
+            "a non-hex colour string neither persists nor clobbers the slot")
+        (clear-storage!)))))
+
+;; ---- hydrate! from the persisted slot -----------------------------------
+
+(deftest hydrate-from-storage-seeds-empty-slot
+  (testing "hydrate! seeds an empty shell slot from persisted localStorage"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.backgrounds/save-to-storage! :dark)
+        (rf.story.ui.state/reset-shell-state!)
+        (is (nil? (:background (rf.story.ui.state/get-state))))
+        (rf.story.ui.backgrounds-switcher/hydrate!)
+        (is (= :dark (:background (rf.story.ui.state/get-state))))
+        (clear-storage!)))))
+
+(deftest hydrate-skips-populated-slot
+  (testing "hydrate is idempotent — an already-populated slot is left alone"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.backgrounds/save-to-storage! :dark)
+        (rf.story.ui.state/swap-state! assoc :background :midnight)
+        (rf.story.ui.backgrounds-switcher/hydrate!)
+        (is (= :midnight (:background (rf.story.ui.state/get-state)))
+            "populated slot was preserved")
+        (clear-storage!)))))

--- a/tools/story/test/re_frame/story/backgrounds_test.cljc
+++ b/tools/story/test/re_frame/story/backgrounds_test.cljc
@@ -1,9 +1,16 @@
 (ns re-frame.story.backgrounds-test
   "Tests for the backgrounds switcher's pure state model (rf2-zll4h).
 
-  Runs on both JVM and CLJS — the CLJS arm exercises the localStorage
-  round-trip; both arms exercise the preset table + resolve precedence
-  + wrap-style shape.
+  Runs on the JVM under `clojure -M:test`. This namespace ends `-test`
+  rather than `cljs-test`, so NO CLJS build selects it: `:node-test`'s
+  `:ns-regexp` is `cljs-test$` and `:browser-test`'s is
+  `.*-dom-cljs-test$`, and nothing else requires it.
+
+  This docstring used to say \"Runs on both JVM and CLJS — the CLJS arm
+  exercises the localStorage round-trip\". That was never true, and the
+  four `#?(:cljs ...)` rows it described were unreachable rather than
+  merely skipped. They now live in
+  `re-frame.story.backgrounds-storage-dom-cljs-test` (rf2-r51p).
 
   Coverage layers:
 
@@ -11,7 +18,7 @@
   - Custom hex-colour validation.
   - Selection precedence (story-override > toolbar selection > default).
   - `wrap-style` shape for flat colour + transparent / checkerboard.
-  - localStorage round-trip — CLJS-only."
+  - localStorage round-trip — moved out; see the dom sibling named above."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.backgrounds :as rf.story.backgrounds]))
 
@@ -132,51 +139,17 @@
   (testing "unknown colour shape → nil (caller falls back)"
     (is (nil? (rf.story.backgrounds/wrap-style {:color 42})))))
 
-;; ---- localStorage round-trip --------------------------------------------
-
-#?(:cljs
-   (defn- browser?
-     []
-     (and (exists? js/window) (.-localStorage js/window))))
-
-#?(:cljs
-   (defn- clear-storage!
-     []
-     (when (browser?)
-       (try (.removeItem (.-localStorage js/window) rf.story.backgrounds/ls-key)
-            (catch :default _ nil)))))
-
-#?(:cljs
-   (deftest storage-roundtrip-preset
-     (when (browser?)
-       (clear-storage!)
-       (rf.story.backgrounds/save-to-storage! :dark)
-       (is (= :dark (rf.story.backgrounds/load-from-storage)))
-       (clear-storage!))))
-
-#?(:cljs
-   (deftest storage-roundtrip-custom
-     (when (browser?)
-       (clear-storage!)
-       (rf.story.backgrounds/save-to-storage! "#abc123")
-       (is (= "#abc123" (rf.story.backgrounds/load-from-storage)))
-       (clear-storage!))))
-
-#?(:cljs
-   (deftest storage-save-nil-clears
-     (when (browser?)
-       (clear-storage!)
-       (rf.story.backgrounds/save-to-storage! :dark)
-       (is (some? (rf.story.backgrounds/load-from-storage)))
-       (rf.story.backgrounds/save-to-storage! nil)
-       (is (nil? (rf.story.backgrounds/load-from-storage)))
-       (clear-storage!))))
-
-#?(:cljs
-   (deftest storage-rejects-invalid-on-save
-     (when (browser?)
-       (clear-storage!)
-       (rf.story.backgrounds/save-to-storage! :neon)
-       (is (nil? (rf.story.backgrounds/load-from-storage)))
-       (rf.story.backgrounds/save-to-storage! "rgb(1,2,3)")
-       (is (nil? (rf.story.backgrounds/load-from-storage))))))
+;; ---- localStorage round-trip: see the dom sibling ----------------------
+;;
+;; rf2-r51p MOVED the four `storage-*` rows to
+;; `re-frame.story.backgrounds-storage-dom-cljs-test`. They were written as
+;; `#?(:cljs (deftest ...))` here, and THIS namespace ends `-test` rather
+;; than `cljs-test`, so `:node-test`'s `:ns-regexp` (`cljs-test$`) never
+;; selected it, `:browser-test`'s (`.*-dom-cljs-test$`) never matched it,
+;; and nothing else requires it. Those rows were therefore UNREACHABLE --
+;; not guarded-false, but never compiled by any CLJS build at all. The
+;; docstring above used to claim "the CLJS arm exercises the localStorage
+;; round-trip"; it never did.
+;;
+;; The JVM half of this file is unaffected: every row above is a bare
+;; unconditional `deftest` and this file carries no `#?(:clj ...)` form.

--- a/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
@@ -130,26 +130,12 @@
          (is (= "light" (:data-background (first attrs)))
              "default render reports :light")))))
 
-;; ---- localStorage hydration ---------------------------------------------
-
-#?(:cljs
-   (defn- browser? []
-     (and (exists? js/window) (.-localStorage js/window))))
-
-#?(:cljs
-   (deftest cljs-hydrate-from-storage-seeds-empty-slot
-     (when (browser?)
-       (rf.story.backgrounds/save-to-storage! :dark)
-       (rf.story.ui.state/reset-shell-state!)
-       (is (nil? (:background (rf.story.ui.state/get-state))))
-       (rf.story.ui.backgrounds-switcher/hydrate!)
-       (is (= :dark (:background (rf.story.ui.state/get-state)))))))
-
-#?(:cljs
-   (deftest cljs-hydrate-skips-populated-slot
-     (when (browser?)
-       (rf.story.backgrounds/save-to-storage! :dark)
-       (rf.story.ui.state/swap-state! assoc :background :midnight)
-       (rf.story.ui.backgrounds-switcher/hydrate!)
-       (is (= :midnight (:background (rf.story.ui.state/get-state)))
-           "populated slot was preserved"))))
+;; ---- localStorage hydration: see the dom sibling -----------------------
+;;
+;; rf2-r51p MOVED the two `hydrate!` rows to
+;; `re-frame.story.backgrounds-storage-dom-cljs-test`, where they sit
+;; beside the `save-to-storage!` / `load-from-storage` round-trip they
+;; depend on. They were guarded by `(when (browser?) ...)` here, and this
+;; namespace ends `-cljs-test`, so `:browser-test` never loaded it while
+;; `:node-test` -- which has no `window.localStorage` -- skipped the body:
+;; they executed in neither lane.

--- a/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
@@ -20,15 +20,12 @@
                        [re-frame.registrar :as rf.registrar]
                        [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]])))
 
-#?(:cljs
-   (defn- browser?
-     "True iff `js/window.localStorage` is available — mirrors the gate
-     in `story_help_cljs_test`. The node-runtime test target returns
-     false; browser-runner returns true. localStorage round-trip tests
-     skip silently when this is false."
-     []
-     (boolean
-       (and (exists? js/window) (.-localStorage js/window)))))
+;; The `browser?` predicate that stood here is gone with the rows it
+;; gated (rf2-r51p). "Skip silently when this is false" was the whole
+;; defect: nothing else ever ran them, so the silence was permanent
+;; rather than a routing decision. The dom sibling keeps an equivalent
+;; predicate, but there it routes between two lanes that BOTH load the
+;; file, and its false branch asserts a visible skip.
 
 ;; ---- fixtures (CLJS) -----------------------------------------------------
 
@@ -298,32 +295,13 @@
          (is (= "" (get-in @rf.story.ui.dispatch-console/input-state [vid :event-id-input])))
          (is (= "" (get-in @rf.story.ui.dispatch-console/input-state [vid :payload-input])))))))
 
-#?(:cljs
-   (deftest cljs-history-localstorage-roundtrip
-     (testing "save-history! → load-history! survives across reset"
-       (when (browser?)
-         (let [vid    :story.persist/v
-               entry  (rf.story.ui.dispatch-console/build-history-entry :counter/inc nil :dispatch
-                                              1700000000000)
-               one    [entry]]
-           (rf.story.ui.dispatch-console/save-history! vid one)
-           ;; Drop in-memory state to simulate a reload.
-           (reset! rf.story.ui.dispatch-console/history-state {})
-           (let [loaded (rf.story.ui.dispatch-console/load-history! vid)]
-             (is (= 1 (count loaded)))
-             (is (= :counter/inc (:event-id (first loaded))))))))))
-
-#?(:cljs
-   (deftest cljs-current-history-hydrates-once
-     (testing "current-history hydrates from localStorage on first access"
-       (when (browser?)
-         (let [vid   :story.hyd/v
-               entry (rf.story.ui.dispatch-console/build-history-entry :ev/x nil :dispatch 17)]
-           (rf.story.ui.dispatch-console/save-history! vid [entry])
-           (reset! rf.story.ui.dispatch-console/history-state {})
-           (let [h (rf.story.ui.dispatch-console/current-history vid)]
-             (is (= 1 (count h)))
-             (is (= :ev/x (:event-id (first h))))))))))
+;; The localStorage round-trip rows (`save-history!` → `load-history!`
+;; across a dropped ratom, and `current-history`'s first-access hydrate)
+;; MOVED to `re-frame.story.ui.dispatch-console-dom-cljs-test` under
+;; rf2-r51p. They were guarded by `(when (browser?) ...)` here, and this
+;; namespace ends `-cljs-test`, so `:browser-test` never loaded them while
+;; `:node-test` — which has no `window.localStorage` — skipped the body:
+;; they executed in neither lane.
 
 #?(:cljs
    (deftest cljs-clear-history-drops-storage
@@ -333,11 +311,13 @@
          (rf.story.ui.dispatch-console/append-history! vid entry)
          (is (= 1 (count (rf.story.ui.dispatch-console/current-history vid))))
          (rf.story.ui.dispatch-console/clear-history! vid)
-         (is (= 0 (count (rf.story.ui.dispatch-console/current-history vid))))
-         (when (browser?)
-           ;; Drop in-memory state and confirm storage was actually wiped.
-           (reset! rf.story.ui.dispatch-console/history-state {})
-           (is (= [] (rf.story.ui.dispatch-console/load-history! vid))))))))
+         ;; The RATOM half of this claim runs here. The storage half was
+         ;; dead (guarded, in a namespace the browser lane never loads),
+         ;; so rf2-r51p SPLIT the row rather than moving it whole — moving
+         ;; it would have taken the live assertions below off the node
+         ;; lane. See `clear-history-drops-storage` in
+         ;; `re-frame.story.ui.dispatch-console-dom-cljs-test`.
+         (is (= 0 (count (rf.story.ui.dispatch-console/current-history vid))))))))
 
 #?(:cljs
    (deftest cljs-dispatch-event-changes-app-db

--- a/tools/story/test/re_frame/story/ui/dispatch_console_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_dom_cljs_test.cljs
@@ -1,0 +1,115 @@
+(ns re-frame.story.ui.dispatch-console-dom-cljs-test
+  "Browser-lane half of the Dispatch Console's history persistence
+  (rf2-q9kv5), promoted out of `re-frame.story.ui.dispatch-console-cljs-test`
+  under rf2-r51p.
+
+  ## What was wrong, and it was the file's LOCATION rather than its guard
+
+  These rows sat inside `(when (browser?) ...)` in a namespace ending
+  `-cljs-test`. `:node-test` selected that namespace and the guard was
+  false there — this repo ships no jsdom, no happy-dom and no DOM shim in
+  any dependency list, so `window.localStorage` is simply absent under
+  Node — while `:browser-test`, whose `:ns-regexp` is
+  `.*-dom-cljs-test$`, never loaded the file at all. They executed in
+  NEITHER lane.
+
+  Every row here is a real `.setItem` / `.getItem` round-trip through
+  `save-history!` / `load-history!`, read back after the in-memory ratom
+  is dropped to simulate a reload. That is real host-storage semantics,
+  which rf2-r51p rules needs a real host rather than a stub.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `cljs-test$` is a bare SUFFIX match that
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, and
+  `implementation/shadow-cljs.edn` records that overlap as deliberate. So
+  moving a row here ADDS the browser lane; it removes nothing. Each row
+  answers the node lane with a VISIBLE marker assertion rather than a
+  silent `when`, so no deftest here holds zero assertions.
+
+  ## The fixture clears ONLY this suite's keys
+
+  The sibling's `reset-all!` calls `.clear` on the whole of
+  `localStorage`. That is harmless on a node lane that has none, but the
+  BROWSER lane runs every namespace on one page, so a blanket wipe would
+  destroy another suite's slot mid-run. This fixture removes only the
+  variants below, through the panel's own `clear-history!`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.ui.dispatch-console :as rf.story.ui.dispatch-console]))
+
+;; ---- host predicate ------------------------------------------------------
+
+(defn- browser?
+  "True when a working `js/window.localStorage` is present. FALSE under
+  `:node-test`, TRUE under `:browser-test`; both targets load this ns."
+  []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
+
+(def ^:private variants
+  [:story.persist/v :story.hyd/v :story.clear/v])
+
+(defn- reset-all! []
+  (reset! rf.story.ui.dispatch-console/history-state {})
+  (when (browser?)
+    (doseq [vid variants]
+      (try (rf.story.ui.dispatch-console/clear-history! vid)
+           (catch :default _ nil))))
+  (reset! rf.story.ui.dispatch-console/history-state {}))
+
+(use-fixtures :each (fn [t] (reset-all!) (t)))
+
+;; ---- save → load across a simulated reload ------------------------------
+
+(deftest history-localstorage-roundtrip
+  (testing "save-history! → load-history! survives a dropped ratom"
+    (if-not (browser?)
+      (is true skip-msg)
+      (let [vid   :story.persist/v
+            entry (rf.story.ui.dispatch-console/build-history-entry
+                    :counter/inc nil :dispatch 1700000000000)]
+        (rf.story.ui.dispatch-console/save-history! vid [entry])
+        ;; Drop in-memory state to simulate a reload.
+        (reset! rf.story.ui.dispatch-console/history-state {})
+        (let [loaded (rf.story.ui.dispatch-console/load-history! vid)]
+          (is (= 1 (count loaded)))
+          (is (= :counter/inc (:event-id (first loaded)))))))))
+
+(deftest current-history-hydrates-once
+  (testing "current-history hydrates from localStorage on first access"
+    (if-not (browser?)
+      (is true skip-msg)
+      (let [vid   :story.hyd/v
+            entry (rf.story.ui.dispatch-console/build-history-entry
+                    :ev/x nil :dispatch 17)]
+        (rf.story.ui.dispatch-console/save-history! vid [entry])
+        (reset! rf.story.ui.dispatch-console/history-state {})
+        (let [h (rf.story.ui.dispatch-console/current-history vid)]
+          (is (= 1 (count h)))
+          (is (= :ev/x (:event-id (first h)))))))))
+
+(deftest clear-history-drops-storage
+  (testing "clear-history! wipes the PERSISTED slot, not just the ratom.
+
+            The node half of this row (ratom emptied) stays in the
+            sibling; only the storage claim lives here."
+    (if-not (browser?)
+      (is true skip-msg)
+      (let [vid   :story.clear/v
+            entry (rf.story.ui.dispatch-console/build-history-entry
+                    :ev/x nil :dispatch 1)]
+        (rf.story.ui.dispatch-console/append-history! vid entry)
+        ;; Teeth: the old row asserted `(= [] (load-history! vid))` after
+        ;; the clear, which passes just as happily against a storage that
+        ;; never held anything. Prove the entry WAS persisted first, so
+        ;; the empty read below is evidence that `clear-history!` removed
+        ;; it rather than evidence that nothing ever landed.
+        (reset! rf.story.ui.dispatch-console/history-state {})
+        (is (= 1 (count (rf.story.ui.dispatch-console/load-history! vid)))
+            "precondition: append-history! really did persist the entry")
+        (rf.story.ui.dispatch-console/clear-history! vid)
+        (reset! rf.story.ui.dispatch-console/history-state {})
+        (is (= [] (rf.story.ui.dispatch-console/load-history! vid))
+            "clear-history! removed the persisted slot too")))))

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -26,13 +26,10 @@
             #?@(:cljs [[re-frame.story.ui.cofx :as rf.story.ui.cofx]
                        [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]])))
 
-#?(:cljs
-   (defn- browser?
-     "True when running in a context with a working `js/window.localStorage`.
-     Node-test (the shadow `:node-test` target) returns false; browser-
-     test returns true. Mirrors the gate in `story_help_cljs_test`."
-     []
-     (and (exists? js/window) (.-localStorage js/window))))
+;; The `browser?` predicate that stood here is gone with the rows it
+;; gated (rf2-r51p). It routed between a lane that could not run them and
+;; no other lane at all; the dom sibling now routes between two lanes
+;; that BOTH load the file, with a visible skip on the node side.
 
 ;; rf2-96y71s: the `:active-modes` URL contract lives in ONE place.
 ;; The pure `modes=` parser and the registrar-pruning helper are now
@@ -200,15 +197,12 @@
 ;;
 ;; The localStorage / `js/window` surfaces only exist under CLJS.
 
-#?(:cljs
-   (deftest cljs-storage-roundtrip
-     (testing "save-modes-to-storage! + load-modes-from-storage round-trip"
-       (when (browser?)
-         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/dark :Mode.app/light])
-         (is (= [:Mode.app/dark :Mode.app/light]
-                (rf.story.ui.toolbar/load-modes-from-storage)))
-         (rf.story.ui.toolbar/save-modes-to-storage! [])
-         (is (= [] (rf.story.ui.toolbar/load-modes-from-storage)))))))
+;; `cljs-storage-roundtrip` MOVED to
+;; `re-frame.story.ui.toolbar-storage-dom-cljs-test` under rf2-r51p, with
+;; the two hydrate rows below it. Each was guarded by
+;; `(when (browser?) ...)` here, and this namespace ends `-cljs-test`, so
+;; `:browser-test` never loaded them while `:node-test` — which has no
+;; `window.localStorage` — skipped every body: they ran in neither lane.
 
 #?(:cljs
    (deftest cljs-toggle-writes-shell-state
@@ -239,30 +233,16 @@
        (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
        (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state))))
        (rf.story.ui.toolbar/reset-modes!)
-       (is (= [] (:active-modes (rf.story.ui.state/get-state))))
-       (when (browser?)
-         (is (= [] (rf.story.ui.toolbar/load-modes-from-storage)))))))
+       ;; The SHELL-STATE half of this claim runs here. The storage half
+       ;; was dead, so rf2-r51p SPLIT the row rather than moving it whole
+       ;; — moving it would have taken this live assertion off the node
+       ;; lane. See `reset-modes-persists-empty` in
+       ;; `re-frame.story.ui.toolbar-storage-dom-cljs-test`.
+       (is (= [] (:active-modes (rf.story.ui.state/get-state)))))))
 
-#?(:cljs
-   (deftest cljs-hydrate-from-storage-only-when-empty
-     (testing "hydrate skips when the slot is already populated"
-       (when (browser?)
-         (rf.story/reg-mode :Mode.app/x {:args {}})
-         (rf.story/reg-mode :Mode.app/y {:args {}})
-         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/x])
-         (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes [:Mode.app/y])
-         (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-         (is (= [:Mode.app/y] (:active-modes (rf.story.ui.state/get-state)))
-             "non-empty slot is preserved")))))
-
-#?(:cljs
-   (deftest cljs-hydrate-from-storage-prunes-stale
-     (testing "hydrate drops mode ids not in the registrar"
-       (when (browser?)
-         (rf.story/reg-mode :Mode.app/x {:args {}})
-         (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/x :Mode.app/zzz])
-         (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-         (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state))))))))
+;; The two `hydrate-modes-from-storage!` rows (precedence and stale-id
+;; pruning) MOVED to `re-frame.story.ui.toolbar-storage-dom-cljs-test`
+;; alongside the round-trip above — same reason, same rf2-r51p.
 
 #?(:cljs
    (deftest cljs-toolbar-strip-renders-chip-per-mode

--- a/tools/story/test/re_frame/story/ui/toolbar_storage_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/toolbar_storage_dom_cljs_test.cljs
@@ -1,0 +1,133 @@
+(ns re-frame.story.ui.toolbar-storage-dom-cljs-test
+  "Browser-lane half of the toolbar's mode-persistence round-trip and
+  hydrate precedence, promoted out of `re-frame.story.ui.toolbar-cljs-test`
+  under rf2-r51p.
+
+  ## What was wrong, and it was the file's LOCATION rather than its guard
+
+  These rows sat inside `(when (browser?) ...)` in a namespace ending
+  `-cljs-test`. `:node-test` selected it and the guard was false — this
+  repo ships no jsdom, no happy-dom and no DOM shim in any dependency
+  list, so `window.localStorage` is absent under Node — while
+  `:browser-test` (`:ns-regexp \".*-dom-cljs-test$\"`) never loaded the
+  file at all. They executed in NEITHER lane.
+
+  Every row is a real `.setItem` / `.getItem` round-trip through
+  `save-modes-to-storage!` / `load-modes-from-storage`, which is real
+  host-storage semantics — the case rf2-r51p rules needs a real host
+  rather than a stub.
+
+  ## Why this is a SECOND dom namespace for the toolbar
+
+  `re-frame.story.ui.toolbar-persistence-dom-cljs-test` already exists and
+  owns the reload-survival scenarios (rf2-jpi7n): set modes, simulate a
+  reload, assert rehydration, plus URL-beats-storage ordering. What lives
+  HERE is the narrower contract its docstring names as its pair and does
+  not itself cover — the bare save/load round-trip, and hydrate's
+  precedence and pruning rules. Keeping them apart keeps each file's
+  narrative intact.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `cljs-test$` is a bare SUFFIX match that
+  `-dom-cljs-test` satisfies, so moving a row here ADDS the browser lane
+  and removes nothing. Each row answers the node lane with a VISIBLE
+  marker assertion rather than a silent `when`, so no deftest here holds
+  zero assertions — a bare `when` would relocate the hollow shape
+  rf2-r51p exists to remove rather than fix it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story :as rf.story]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.toolbar :as rf.story.ui.toolbar]))
+
+;; ---- host predicate ------------------------------------------------------
+
+(defn- browser?
+  "True when a working `js/window.localStorage` is present. FALSE under
+  `:node-test`, TRUE under `:browser-test`; both targets load this ns."
+  []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
+
+(defn- reset-all! []
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  ;; The active-modes slot is chrome-wide, and the browser lane runs every
+  ;; namespace on ONE page — so a leftover value here would be in storage
+  ;; when the next namespace hydrates.
+  (when (browser?)
+    (try (.removeItem (.-localStorage js/window) rf.story.ui.toolbar/ls-key)
+         (catch :default _ nil)))
+  (rf.story/install-canonical-vocabulary!))
+
+(use-fixtures :each (fn [t] (reset-all!) (t)))
+
+;; ---- save → load round-trip ---------------------------------------------
+
+(deftest storage-roundtrip
+  (testing "save-modes-to-storage! + load-modes-from-storage round-trip"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.app/dark :Mode.app/light])
+        (is (= [:Mode.app/dark :Mode.app/light]
+               (rf.story.ui.toolbar/load-modes-from-storage)))
+        (rf.story.ui.toolbar/save-modes-to-storage! [])
+        (is (= [] (rf.story.ui.toolbar/load-modes-from-storage)))))))
+
+(deftest reset-modes-persists-empty
+  (testing "reset-modes! persists the empty vector, not just the ratom.
+
+            The node half of this row (shell state emptied) stays in the
+            sibling; only the storage claim lives here."
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.app/x {:args {:k 1}})
+        (rf.story.ui.toolbar/toggle-mode! :Mode.app/x)
+        ;; Teeth: the old row asserted `(= [] (load-modes-from-storage))`
+        ;; after the reset, which passes just as happily against a storage
+        ;; that never held anything. Prove the toggle PERSISTED first, so
+        ;; the empty read below is evidence that reset-modes! cleared it.
+        (is (= [:Mode.app/x] (rf.story.ui.toolbar/load-modes-from-storage))
+            "precondition: toggle-mode! really did persist the mode")
+        (rf.story.ui.toolbar/reset-modes!)
+        (is (= [] (rf.story.ui.toolbar/load-modes-from-storage))
+            "reset-modes! persisted the empty vector")))))
+
+;; ---- hydrate precedence + pruning ---------------------------------------
+
+(deftest hydrate-from-storage-only-when-empty
+  (testing "hydrate skips when the shell slot is already populated"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.app/x {:args {}})
+        (rf.story/reg-mode :Mode.app/y {:args {}})
+        (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.app/x])
+        ;; Teeth: without this, an unwritten slot would leave hydrate with
+        ;; nothing to find, and the populated value below would survive for
+        ;; the wrong reason — passing while proving nothing about
+        ;; precedence.
+        (is (= [:Mode.app/x] (rf.story.ui.toolbar/load-modes-from-storage))
+            "precondition: storage really holds a COMPETING value")
+        (rf.story.ui.state/swap-state!
+          rf.story.ui.state/set-active-modes [:Mode.app/y])
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [:Mode.app/y] (:active-modes (rf.story.ui.state/get-state)))
+            "non-empty slot is preserved")))))
+
+(deftest hydrate-from-storage-prunes-stale
+  (testing "hydrate drops mode ids that are not in the registrar"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.app/x {:args {}})
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.app/x :Mode.app/zzz])
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [:Mode.app/x] (:active-modes (rf.story.ui.state/get-state)))
+            "the unregistered id was pruned at hydrate")))))

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -18,13 +18,66 @@
 
 ;; ---- fixtures ------------------------------------------------------------
 
-(defn- browser? []
-  (and (exists? js/window) (exists? js/URLSearchParams)))
-
 (defn reset-all! []
   (rf.story.ui.state/reset-shell-state!))
 
 (use-fixtures :each {:before reset-all!})
+
+;; ---- the window stub, and why it sits up here (rf2-r51p) ----------------
+;;
+;; This namespace ends `-cljs-test`, so `:node-test` selects it and
+;; `:browser-test` — whose `:ns-regexp` is `.*-dom-cljs-test$` — never
+;; loads it at all. A row here wrapped in `(when (browser?) ...)`
+;; therefore executed in NEITHER lane: node loaded it with the guard
+;; false, and no browser ever saw the file. That is the defect rf2-r51p
+;; exists to remove, and this file carried three such rows while being
+;; cited across that bead as the PRECEDENT for fixing them.
+;;
+;; The fix is the one this file already invented for the popstate suite
+;; below: the host touch in these rows is INCIDENTAL — they assert
+;; `push!`'s idempotence algebra and `parse-current-url-or-empty`'s
+;; blank-search branch, neither of which needs a real browser — so a
+;; stub host makes them run on node rather than nowhere. The helpers
+;; were defined beside the popstate tests; they are hoisted here because
+;; three separate suites now depend on them.
+;;
+;; `url-state/safe-window` is `(when (exists? js/window) js/window)`, so
+;; setting `globalThis.window` is all it takes to satisfy the whole
+;; module. The stub's `:search ""` is not incidental either — it IS the
+;; blank-search condition the rf2-fkmnh row below asserts against.
+
+(defn- install-window-stub!
+  "Install a minimal `window` on `js/globalThis` with a countable
+  event-listener registry and a location whose `search` is `search-str`
+  (default `\"\"`, the blank-search case). Returns the registry atom
+  `{event-type → [listener ...]}`."
+  ([] (install-window-stub! ""))
+  ([search-str]
+    (let [registry (atom {})
+          location #js {:pathname "/" :search search-str :hash ""}
+          window   #js {:location location
+                        :history  #js {:pushState    (fn [& _] nil)
+                                       :replaceState (fn [& _] nil)}
+                        :addEventListener
+                        (fn [type listener]
+                          (swap! registry update type (fnil conj []) listener))
+                        :removeEventListener
+                        (fn [type listener]
+                          (swap! registry update type
+                                 (fnil (fn [xs] (vec (remove #(= % listener) xs)))
+                                       [])))
+                        :dispatchEvent
+                        (fn [event]
+                          (doseq [l (get @registry (.-type event) [])]
+                            (l event)))}]
+      (set! (.-window js/globalThis) window)
+      registry)))
+
+(defn- uninstall-window-stub! []
+  (js-delete js/globalThis "window"))
+
+(defn- popstate-listener-count [registry]
+  (count (get @registry "popstate" [])))
 
 ;; ---- url-from-state composition -----------------------------------------
 
@@ -272,46 +325,76 @@
 
 ;; ---- pushState idempotence ----------------------------------------------
 ;;
-;; Under the node runner `js/window.history` is mocked by jsdom. The
-;; tests below capture pushState invocations via a wrapper atom so we
-;; can assert n calls without actually mutating the test runner's URL.
+;; THIS SECTION USED TO SAY "under the node runner `js/window.history` is
+;; mocked by jsdom". It is not, and never was: there is no jsdom, no
+;; happy-dom and no DOM shim in any dependency list here, so on node
+;; `js/window` is simply undefined. The two rows below were wrapped in
+;; `(when (browser?) ...)` — and because that `when` wrapped the `deftest`
+;; FORMS THEMSELVES rather than their bodies, the test vars were never
+;; even DEFINED under `:node-test`, while `:browser-test` never loads this
+;; `-cljs-test` namespace at all. They executed in neither lane (rf2-r51p).
+;;
+;; The property here is `push!`'s idempotence ALGEBRA — does it compare the
+;; candidate URL against the current location and decline when they match —
+;; which needs a `location` and a `history.pushState` to call, not a real
+;; browser. So the guard is gone and the rows run on node against
+;; `install-window-stub!`, the same stub the popstate suite below uses.
 
-(when (browser?)
-  (defn- with-history-spy
-    "Install a spy around `window.history.pushState`; returns the
-    captured-calls atom + a restore fn."
-    []
-    (let [captured (atom [])
-          orig     (.-pushState (.-history js/window))
-          spy      (fn [_state _title url]
-                     (swap! captured conj url))]
-      (set! (.-pushState (.-history js/window)) spy)
-      [captured (fn [] (set! (.-pushState (.-history js/window)) orig))]))
+(defn- with-history-spy
+  "Install a spy around `window.history.pushState`; returns the
+  captured-calls atom + a restore fn. Requires a window — real or the
+  stub installed by `install-window-stub!`."
+  []
+  (let [captured (atom [])
+        orig     (.-pushState (.-history js/window))
+        spy      (fn [_state _title url]
+                   (swap! captured conj url))]
+    (set! (.-pushState (.-history js/window)) spy)
+    [captured (fn [] (set! (.-pushState (.-history js/window)) orig))]))
 
-  (deftest push!-skips-when-url-matches-current-location
-    (testing "rf2-o4u18 — push! is idempotent: no-op when the URL matches
-              the current location (avoids gratuitous back-stack entries)"
+(defn- current-url-str []
+  (str (.-pathname (.-location js/window))
+       (.-search   (.-location js/window))
+       (.-hash     (.-location js/window))))
+
+(deftest push!-skips-when-url-matches-current-location
+  (testing "rf2-o4u18 — push! is idempotent: no-op when the URL matches
+            the current location (avoids gratuitous back-stack entries)"
+    (install-window-stub!)
+    (try
       (let [[captured restore] (with-history-spy)
-            ;; Use the actual current pathname so the diff says 'same'.
-            cur (str (.-pathname (.-location js/window))
-                     (.-search   (.-location js/window))
-                     (.-hash     (.-location js/window)))]
-        (rf.story.ui.url-state/push! cur)
+            cur                (current-url-str)]
         (try
+          ;; Control FIRST, so the zero below is evidence that `push!`
+          ;; DECLINED rather than evidence that nothing could have been
+          ;; captured either way. A bare `(= 0 (count @captured))` passes
+          ;; just as happily against an unwired spy or an absent window —
+          ;; which is precisely how this row read green while never
+          ;; running at all.
+          (rf.story.ui.url-state/push! (str cur "?control=1"))
+          (is (= 1 (count @captured))
+              "precondition: the spy captures a genuine differing push")
+          (reset! captured [])
+          (rf.story.ui.url-state/push! cur)
           (is (= 0 (count @captured))
               "no pushState calls when URL matches")
-          (finally (restore))))))
+          (finally (restore))))
+      (finally (uninstall-window-stub!)))))
 
-  (deftest push!-fires-when-url-differs
-    (testing "rf2-o4u18 — push! pushes a different URL"
+(deftest push!-fires-when-url-differs
+  (testing "rf2-o4u18 — push! pushes a different URL"
+    (install-window-stub!)
+    (try
       (let [[captured restore] (with-history-spy)]
-        (rf.story.ui.url-state/push! (str (.-pathname (.-location js/window))
-                       "?variant=foo%2Fbar"
-                       (.-hash (.-location js/window))))
+        (rf.story.ui.url-state/push!
+          (str (.-pathname (.-location js/window))
+               "?variant=foo%2Fbar"
+               (.-hash (.-location js/window))))
         (try
           (is (= 1 (count @captured)))
           (is (re-find #"variant=foo" (first @captured)))
-          (finally (restore)))))))
+          (finally (restore))))
+      (finally (uninstall-window-stub!)))))
 
 ;; ---- state-watcher install/teardown -------------------------------------
 ;;
@@ -350,46 +433,16 @@
 ;;
 ;; The node runner has no `window`, so the old test wrapped its whole body
 ;; in `(when (browser?) ...)` and executed ZERO assertions under
-;; `npm run test:cljs` — a vacuous pass. Here we install a minimal `window`
-;; stub on `js/globalThis` (the same pattern the routing suites use) whose
-;; add/removeEventListener maintain a countable per-type listener registry.
-;; That makes the "re-install replaces rather than stacks" invariant
-;; node-runnable AND gives it teeth: after a double-install exactly ONE
-;; popstate listener is registered and a single popstate event fires the
-;; handler exactly once. A stacking regression leaves 2 listeners and
-;; double-fires — so this fails under the default node gate rather than
+;; `npm run test:cljs` — a vacuous pass. The `install-window-stub!` helper
+;; at the top of this file (hoisted there under rf2-r51p, when two further
+;; suites came to need it) installs a minimal `window` on `js/globalThis`
+;; whose add/removeEventListener maintain a countable per-type listener
+;; registry. That makes the "re-install replaces rather than stacks"
+;; invariant node-runnable AND gives it teeth: after a double-install
+;; exactly ONE popstate listener is registered and a single popstate event
+;; fires the handler exactly once. A stacking regression leaves 2 listeners
+;; and double-fires — so this fails under the default node gate rather than
 ;; passing vacuously.
-
-(defn- install-window-stub!
-  "Install a minimal `window` on `js/globalThis` with a countable
-  event-listener registry and an empty-search location. Returns the
-  registry atom `{event-type → [listener ...]}`."
-  []
-  (let [registry (atom {})
-        location #js {:pathname "/" :search "" :hash ""}
-        window   #js {:location location
-                      :history  #js {:pushState    (fn [& _] nil)
-                                     :replaceState (fn [& _] nil)}
-                      :addEventListener
-                      (fn [type listener]
-                        (swap! registry update type (fnil conj []) listener))
-                      :removeEventListener
-                      (fn [type listener]
-                        (swap! registry update type
-                               (fnil (fn [xs] (vec (remove #(= % listener) xs)))
-                                     [])))
-                      :dispatchEvent
-                      (fn [event]
-                        (doseq [l (get @registry (.-type event) [])]
-                          (l event)))}]
-    (set! (.-window js/globalThis) window)
-    registry))
-
-(defn- uninstall-window-stub! []
-  (js-delete js/globalThis "window"))
-
-(defn- popstate-listener-count [registry]
-  (count (get @registry "popstate" [])))
 
 (deftest popstate-listener-reinstall-replaces-rather-than-stacks
   (testing "rf2-o4u18 / rf2-x76af2.21 — re-installing the popstate listener
@@ -446,16 +499,41 @@
   (testing "rf2-fkmnh — when the window is present but the search is empty
             `parse-current-url-or-empty` returns the all-nil parsed shape
             (not nil), so a no-query popstate drives the URL-owned slots to
-            their defaults instead of no-op'ing. (The harness URL has no
-            Story params, so this exercises the blank-search branch.)"
-    (when (browser?)
+            their defaults instead of no-op'ing.
+
+            Under rf2-r51p this row stopped being guarded by `(when
+            (browser?) ...)` — which held its whole body, so the deftest
+            existed on node carrying ZERO assertions while the browser
+            lane never loaded this namespace — and now runs against a
+            stub window whose `search` is literally blank, which IS the
+            condition under test."
+    (install-window-stub! "")
+    (try
       (let [parsed (rf.story.ui.url-state/parse-current-url-or-empty)]
         (is (map? parsed) "returns a parsed map, never nil, when window present")
         (is (nil? (:variant-id parsed)))
         (is (nil? (:active-modes parsed)))
         (is (nil? (:viewport parsed)))
         (is (nil? (:background parsed)))
-        (is (nil? (:tag-filter parsed)))))))
+        (is (nil? (:tag-filter parsed))))
+      (finally (uninstall-window-stub!)))))
+
+(deftest parse-current-url-or-empty-reads-a-populated-search
+  (testing "rf2-r51p — the discriminating contrast for the blank-search row
+            above. Every assertion there is a `nil?`, so all of them pass
+            against a `parse-current-url-or-empty` that ignored the URL
+            entirely and always answered the empty shape. This row proves
+            the function really does read `window.location.search`, so the
+            nils above are evidence about a BLANK search rather than about
+            a function that never looks."
+    (install-window-stub! "?variant=foo%2Fbar&viewport=tablet")
+    (try
+      (let [parsed (rf.story.ui.url-state/parse-current-url-or-empty)]
+        (is (map? parsed))
+        (is (= :foo/bar (:variant-id parsed))
+            "a populated search really is parsed (not the empty shape)")
+        (is (= :tablet (:viewport parsed))))
+      (finally (uninstall-window-stub!)))))
 
 (deftest popstate-to-empty-url-clears-prior-state-via-swap
   (testing "rf2-fkmnh — the back/forward-to-bare-URL scenario through the

--- a/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
@@ -141,28 +141,12 @@
          (is (= "full" (:data-viewport (first attrs)))
              "default render reports :full")))))
 
-;; ---- localStorage hydration ---------------------------------------------
-
-#?(:cljs
-   (defn- browser? []
-     (and (exists? js/window) (.-localStorage js/window))))
-
-#?(:cljs
-   (deftest cljs-hydrate-from-storage-seeds-empty-slot
-     (testing "hydrate! seeds the shell slot from persisted localStorage"
-       (when (browser?)
-         (rf.story.viewport/save-to-storage! :tablet)
-         (rf.story.ui.state/reset-shell-state!)
-         (is (nil? (:viewport (rf.story.ui.state/get-state))))
-         (rf.story.ui.viewport-switcher/hydrate!)
-         (is (= :tablet (:viewport (rf.story.ui.state/get-state))))))))
-
-#?(:cljs
-   (deftest cljs-hydrate-skips-populated-slot
-     (testing "hydrate is idempotent — leaves an already-populated slot alone"
-       (when (browser?)
-         (rf.story.viewport/save-to-storage! :tablet)
-         (rf.story.ui.state/swap-state! assoc :viewport :mobile-portrait)
-         (rf.story.ui.viewport-switcher/hydrate!)
-         (is (= :mobile-portrait (:viewport (rf.story.ui.state/get-state)))
-             "populated slot was preserved")))))
+;; ---- localStorage hydration: see the dom sibling -----------------------
+;;
+;; rf2-r51p MOVED the two `hydrate!` rows to
+;; `re-frame.story.viewport-storage-dom-cljs-test`, where they sit beside
+;; the `save-to-storage!` / `load-from-storage` round-trip they depend on.
+;; They were guarded by `(when (browser?) ...)` here, and this namespace
+;; ends `-cljs-test`, so `:browser-test` never loaded it while
+;; `:node-test` -- which has no `window.localStorage` -- skipped the body:
+;; they executed in neither lane.

--- a/tools/story/test/re_frame/story/viewport_storage_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/viewport_storage_dom_cljs_test.cljs
@@ -1,0 +1,158 @@
+(ns re-frame.story.viewport-storage-dom-cljs-test
+  "Browser-lane home for viewport-selection persistence (rf2-zll4h),
+  assembled under rf2-r51p out of rows that ran in NO lane at all.
+
+  ## Where these rows came from, and why neither source could run them
+
+  `re-frame.story.viewport-test` (`viewport_test.cljc`) held four
+  `#?(:cljs (deftest storage-* ...))` rows. Its namespace ends `-test`,
+  not `cljs-test`, so `:node-test`'s `:ns-regexp` (`cljs-test$`) does not
+  select it, `:browser-test`'s (`.*-dom-cljs-test$`) does not match it,
+  and nothing else requires it. Those rows were not merely guarded-false
+  — they were UNREACHABLE: no CLJS build compiled them at all.
+
+  That file's docstring was candid about half of this and wrong about the
+  rest. It said CLJS coverage \"comes from the parallel
+  `viewport_switcher_cljs_test`\" — but the corresponding rows THERE were
+  themselves dead, sitting inside `(when (browser?) ...)` in a namespace
+  the browser lane never loads and a node runtime that has no
+  `window.localStorage` (this repo ships no jsdom, no happy-dom and no
+  DOM shim in any dependency list). Both layers of the intended coverage
+  were inert, and each pointed at the other.
+
+  Both defects have one repair, because both want the same thing: a real
+  `window.localStorage`. Every row below is a genuine round-trip —
+  `save-to-storage!` writes through `.setItem`, `load-from-storage` reads
+  back through `.getItem`, `hydrate!` seeds the shell slot from what
+  survived. That is real host-storage semantics, which rf2-r51p rules
+  needs a real host rather than a stub.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `cljs-test$` is a bare SUFFIX match that
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does, and
+  `implementation/shadow-cljs.edn` records that overlap as deliberate. So
+  moving a row here ADDS the browser lane; it removes nothing. Each row
+  answers the node lane with a VISIBLE marker assertion rather than a
+  silent `when`, so no deftest here holds zero assertions — a bare `when`
+  would merely relocate the hollow shape rf2-r51p exists to remove.
+
+  The JVM half of both source files is untouched: neither carries a
+  single `#?(:clj ...)` form, and every cross-host row in them (preset
+  table, custom `{:width :height}` validation, resolve precedence,
+  `wrap-style`) is a bare unconditional `deftest` that still runs under
+  `clojure -M:test`.
+
+  These assertions had never executed in ANY lane. A failure here is
+  evidence about `save-to-storage!` / `load-from-storage` / `hydrate!`
+  arriving for the first time, not a regression introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story.viewport :as rf.story.viewport]
+            [re-frame.story.ui.viewport-switcher
+             :as rf.story.ui.viewport-switcher]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
+
+;; ---- host predicate ------------------------------------------------------
+
+(defn- browser?
+  "True when a working `js/window.localStorage` is present.
+
+  FALSE under `:node-test`, TRUE under `:browser-test`. Both targets load
+  this namespace (see the ns docstring), so this predicate is what routes
+  each row to the lane that can actually run it."
+  []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+(defn- clear-storage! []
+  (when (browser?)
+    (try (.removeItem (.-localStorage js/window) rf.story.viewport/ls-key)
+         (catch :default _ nil))))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
+
+;; ---- save / load round-trip ---------------------------------------------
+
+(deftest storage-roundtrip-preset
+  (testing "save → load returns the persisted preset id"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.viewport/save-to-storage! :tablet)
+        (is (= :tablet (rf.story.viewport/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-roundtrip-custom
+  (testing "save → load returns the persisted custom {:width :height} map"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.viewport/save-to-storage! {:width 800 :height 600})
+        (is (= {:width 800 :height 600} (rf.story.viewport/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-save-nil-clears
+  (testing "save-to-storage! nil clears the persisted slot"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        (rf.story.viewport/save-to-storage! :tablet)
+        ;; Precondition with teeth: prove something WAS persisted, so the
+        ;; nil below is evidence that the clear ran.
+        (is (some? (rf.story.viewport/load-from-storage)))
+        (rf.story.viewport/save-to-storage! nil)
+        (is (nil? (rf.story.viewport/load-from-storage)))
+        (clear-storage!)))))
+
+(deftest storage-rejects-invalid-on-save
+  (testing "an invalid selection is DROPPED rather than persisted — and
+            because `save-to-storage!` only writes when `coerce` yields a
+            value, the previously persisted selection SURVIVES"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (clear-storage!)
+        ;; This row used to assert `(nil? (load-from-storage))` straight
+        ;; after a `clear-storage!`, which passes against a storage that
+        ;; silently swallows every write — the exact vacuity rf2-r51p
+        ;; tightens for. Seed a VALID value first, so the assertions below
+        ;; distinguish "the invalid save was refused" from "nothing works".
+        (rf.story.viewport/save-to-storage! :tablet)
+        (is (= :tablet (rf.story.viewport/load-from-storage))
+            "precondition: a valid selection really does persist")
+        (rf.story.viewport/save-to-storage! :phablet)        ;; unknown preset
+        (is (= :tablet (rf.story.viewport/load-from-storage))
+            "an unknown preset id neither persists nor clobbers the slot")
+        (rf.story.viewport/save-to-storage! {:width "no"})   ;; bad shape
+        (is (= :tablet (rf.story.viewport/load-from-storage))
+            "a malformed custom map neither persists nor clobbers the slot")
+        (clear-storage!)))))
+
+;; ---- hydrate! from the persisted slot -----------------------------------
+
+(deftest hydrate-from-storage-seeds-empty-slot
+  (testing "hydrate! seeds an empty shell slot from persisted localStorage"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.viewport/save-to-storage! :tablet)
+        (rf.story.ui.state/reset-shell-state!)
+        (is (nil? (:viewport (rf.story.ui.state/get-state))))
+        (rf.story.ui.viewport-switcher/hydrate!)
+        (is (= :tablet (:viewport (rf.story.ui.state/get-state))))
+        (clear-storage!)))))
+
+(deftest hydrate-skips-populated-slot
+  (testing "hydrate is idempotent — an already-populated slot is left alone"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.viewport/save-to-storage! :tablet)
+        (rf.story.ui.state/swap-state! assoc :viewport :mobile-portrait)
+        (rf.story.ui.viewport-switcher/hydrate!)
+        (is (= :mobile-portrait (:viewport (rf.story.ui.state/get-state)))
+            "populated slot was preserved")
+        (clear-storage!)))))

--- a/tools/story/test/re_frame/story/viewport_test.cljc
+++ b/tools/story/test/re_frame/story/viewport_test.cljc
@@ -1,11 +1,18 @@
 (ns re-frame.story.viewport-test
   "Tests for the viewport switcher's pure state model (rf2-zll4h).
 
-  Runs on both the JVM (cognitect.test-runner under `clojure -M:test`)
-  and the CLJS node-test build (shadow's `:node-test` target — the
-  ns name doesn't end in `cljs-test` so the JVM gate is the primary
-  surface; CLJS coverage comes from the parallel
-  `viewport_switcher_cljs_test`).
+  Runs on the JVM (cognitect.test-runner under `clojure -M:test`) and
+  NOWHERE ELSE. This namespace ends `-test` rather than `cljs-test`, so
+  no CLJS build selects it: `:node-test`'s `:ns-regexp` is `cljs-test$`
+  and `:browser-test`'s is `.*-dom-cljs-test$`, and nothing else
+  requires it.
+
+  This docstring used to add \"and the CLJS node-test build\" and send a
+  reader to `viewport_switcher_cljs_test` for the CLJS coverage. Both
+  halves were wrong: the `#?(:cljs ...)` rows here were unreachable, and
+  that sibling's matching rows were themselves guarded into neither
+  lane. They are now together in
+  `re-frame.story.viewport-storage-dom-cljs-test` (rf2-r51p).
 
   Coverage layers:
 
@@ -13,7 +20,7 @@
   - Custom `{:width :height}` validation.
   - Selection precedence (story-override > toolbar selection > default).
   - `wrap-style` shape (nil for `:full`, populated for sized presets).
-  - localStorage round-trip — CLJS-only, gated by `browser?`."
+  - localStorage round-trip — moved out; see the dom sibling named above."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.viewport :as rf.story.viewport]))
 
@@ -137,57 +144,22 @@
       (is (= "0 auto" (:margin s))
           "centred horizontally"))))
 
-;; ---- localStorage round-trip --------------------------------------------
+;; ---- localStorage round-trip: see the dom sibling ----------------------
 ;;
-;; CLJS only — JVM `load-from-storage` always returns nil.
-
-#?(:cljs
-   (defn- browser?
-     []
-     (and (exists? js/window) (.-localStorage js/window))))
-
-#?(:cljs
-   (defn- clear-storage!
-     []
-     (when (browser?)
-       (try (.removeItem (.-localStorage js/window) rf.story.viewport/ls-key)
-            (catch :default _ nil)))))
-
-#?(:cljs
-   (deftest storage-roundtrip-preset
-     (testing "save → load returns the persisted preset id"
-       (when (browser?)
-         (clear-storage!)
-         (rf.story.viewport/save-to-storage! :tablet)
-         (is (= :tablet (rf.story.viewport/load-from-storage)))
-         (clear-storage!)))))
-
-#?(:cljs
-   (deftest storage-roundtrip-custom
-     (testing "save → load returns the persisted custom map"
-       (when (browser?)
-         (clear-storage!)
-         (rf.story.viewport/save-to-storage! {:width 800 :height 600})
-         (is (= {:width 800 :height 600} (rf.story.viewport/load-from-storage)))
-         (clear-storage!)))))
-
-#?(:cljs
-   (deftest storage-save-nil-clears
-     (testing "save-to-storage! nil clears the persisted slot"
-       (when (browser?)
-         (clear-storage!)
-         (rf.story.viewport/save-to-storage! :tablet)
-         (is (some? (rf.story.viewport/load-from-storage)))
-         (rf.story.viewport/save-to-storage! nil)
-         (is (nil? (rf.story.viewport/load-from-storage)))
-         (clear-storage!)))))
-
-#?(:cljs
-   (deftest storage-rejects-invalid-on-save
-     (testing "save-to-storage! drops invalid values to nil (no leak)"
-       (when (browser?)
-         (clear-storage!)
-         (rf.story.viewport/save-to-storage! :phablet)         ;; unknown preset
-         (is (nil? (rf.story.viewport/load-from-storage)))
-         (rf.story.viewport/save-to-storage! {:width "no"})    ;; bad shape
-         (is (nil? (rf.story.viewport/load-from-storage)))))))
+;; rf2-r51p MOVED the four `storage-*` rows to
+;; `re-frame.story.viewport-storage-dom-cljs-test`. They were written as
+;; `#?(:cljs (deftest ...))` here, and THIS namespace ends `-test` rather
+;; than `cljs-test`, so `:node-test`'s `:ns-regexp` (`cljs-test$`) never
+;; selected it, `:browser-test`'s (`.*-dom-cljs-test$`) never matched it,
+;; and nothing else requires it. Those rows were UNREACHABLE -- never
+;; compiled by any CLJS build at all.
+;;
+;; The docstring above used to send a reader to
+;; `viewport_switcher_cljs_test` for the CLJS coverage. That file's
+;; corresponding rows were themselves dead (guarded by `(when (browser?)
+;; ...)` in a namespace the browser lane never loads), so both layers of
+;; the intended coverage were inert and each pointed at the other. They
+;; are now together in the dom sibling named above.
+;;
+;; The JVM half of this file is unaffected: every row above is a bare
+;; unconditional `deftest` and this file carries no `#?(:clj ...)` form.

--- a/tools/story/test/re_frame/story_help_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_help_cljs_test.cljs
@@ -3,20 +3,18 @@
 
   Covers:
 
-  - `seen?` / `mark-seen!` round-trip against localStorage (browser only).
-  - `reset-seen!` clears the flag.
+  - `seen?` degrades to false when localStorage is absent.
   - `help-content` renders as hiccup.
   - `open!` / `close!` toggle the local open atom.
 
-  The localStorage round-trip is browser-only — on node-test there's no
-  `js/window`, so we guard those assertions on the runtime detection."
+  The localStorage round-trip is NOT here. It used to be, guarded by a
+  `browser?` predicate — but this namespace ends `-cljs-test`, which
+  `:browser-test` never loads, and the node lane has no
+  `window.localStorage`, so those rows ran in neither lane. They now live
+  in `re-frame.story-help-dom-cljs-test`, which BOTH lanes load
+  (rf2-r51p)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.story.ui.help :as rf.story.ui.help]))
-
-;; ---- runtime detection ---------------------------------------------------
-
-(defn- browser? []
-  (and (exists? js/window) (.-localStorage js/window)))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -32,13 +30,13 @@
   (testing "seen? is false when localStorage has never been touched"
     (is (false? (rf.story.ui.help/seen?)))))
 
-(deftest mark-seen-persists
-  (testing "mark-seen! flips seen? to true (browser only)"
-    (when (browser?)
-      (rf.story.ui.help/mark-seen!)
-      (is (true? (rf.story.ui.help/seen?)))
-      (rf.story.ui.help/reset-seen!)
-      (is (false? (rf.story.ui.help/seen?))))))
+;; `mark-seen-persists` MOVED to `re-frame.story-help-dom-cljs-test`
+;; (rf2-r51p). It was guarded by `(when (browser?) ...)` here, and this
+;; namespace ends `-cljs-test`, so `:browser-test` never loaded it while
+;; `:node-test` — which has no `window.localStorage` — skipped the body:
+;; it executed in neither lane. `seen-defaults-to-false` above STAYS,
+;; because it asserts the no-storage degradation path and the node lane
+;; is exactly where that belongs.
 
 ;; ---- hiccup shape --------------------------------------------------------
 
@@ -55,6 +53,11 @@
     (rf.story.ui.help/open!)
     (is (true? @@#'rf.story.ui.help/open?))
     (rf.story.ui.help/close!)
-    (is (false? @@#'rf.story.ui.help/open?))
-    (when (browser?)
-      (is (true? (rf.story.ui.help/seen?))))))
+    (is (false? @@#'rf.story.ui.help/open?))))
+
+;; This row was SPLIT rather than moved (rf2-r51p). Its two `open?` ratom
+;; assertions above genuinely run on node; only a trailing
+;; `(when (browser?) (is (true? (seen?))))` was dead. Moving the row whole
+;; would have taken LIVE assertions off the node lane — this bug in
+;; reverse — so the persistence half now lives in
+;; `re-frame.story-help-dom-cljs-test` as `close!-marks-the-overlay-seen`.

--- a/tools/story/test/re_frame/story_help_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_help_dom_cljs_test.cljs
@@ -1,0 +1,85 @@
+(ns re-frame.story-help-dom-cljs-test
+  "Browser-lane half of the first-time-user help overlay's persistence
+  (rf2-381i), promoted out of `re-frame.story-help-cljs-test` under
+  rf2-r51p.
+
+  ## What was wrong, and it was the file's LOCATION rather than its guard
+
+  The `seen?` / `mark-seen!` round-trip sat inside `(when (browser?) ...)`
+  in a namespace ending `-cljs-test`. `:node-test` selected it and the
+  guard was false — this repo ships no jsdom, no happy-dom and no DOM
+  shim in any dependency list, so `window.localStorage` is absent under
+  Node — while `:browser-test` (`:ns-regexp \".*-dom-cljs-test$\"`) never
+  loaded the file at all. Those assertions executed in NEITHER lane.
+
+  The sibling's docstring said the guard was there because \"on node-test
+  there's no `js/window`, so we guard those assertions on the runtime
+  detection\". That much was true; what it did not say is that no other
+  lane ever picked them up, so the guard was a permanent silence rather
+  than a routing decision.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `cljs-test$` is a bare SUFFIX match that
+  `-dom-cljs-test` satisfies, so moving a row here ADDS the browser lane
+  and removes nothing. Each row answers the node lane with a VISIBLE
+  marker assertion rather than a silent `when`.
+
+  ## What deliberately did NOT move
+
+  `open-then-close-toggles-atom` MIXED a live claim with a dead one: its
+  two `open?` ratom assertions genuinely run on node, and only the
+  trailing `seen?` assertion was guarded. Moving the row whole would have
+  taken LIVE assertions OFF the node lane — this bug in reverse — so it
+  was SPLIT: the ratom half stays in the sibling, and the persistence
+  half is `close!-marks-the-overlay-seen` below.
+
+  `seen-defaults-to-false` also stays: it asserts the NO-storage
+  degradation path, so the node lane is exactly where it belongs."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.ui.help :as rf.story.ui.help]))
+
+;; ---- host predicate ------------------------------------------------------
+
+(defn- browser?
+  "True when a working `js/window.localStorage` is present. FALSE under
+  `:node-test`, TRUE under `:browser-test`; both targets load this ns."
+  []
+  (and (exists? js/window) (.-localStorage js/window)))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
+
+(defn- clear-flag! []
+  (rf.story.ui.help/reset-seen!)
+  (reset! @#'rf.story.ui.help/open? false))
+
+(use-fixtures :each {:before clear-flag! :after clear-flag!})
+
+;; ---- the seen? flag round-trip ------------------------------------------
+
+(deftest mark-seen-persists
+  (testing "mark-seen! flips seen? to true, and reset-seen! flips it back"
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story.ui.help/mark-seen!)
+        (is (true? (rf.story.ui.help/seen?)))
+        (rf.story.ui.help/reset-seen!)
+        (is (false? (rf.story.ui.help/seen?)))))))
+
+(deftest close!-marks-the-overlay-seen
+  (testing "closing the overlay persists the seen flag, so a returning
+            user is not shown it again. The ratom half of this claim
+            stays on the node lane in the sibling namespace."
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        ;; Precondition, so the true below is evidence that `close!`
+        ;; wrote rather than evidence that the flag was already set.
+        (is (false? (rf.story.ui.help/seen?))
+            "precondition: the fixture cleared the flag")
+        (rf.story.ui.help/open!)
+        (rf.story.ui.help/close!)
+        (is (true? (rf.story.ui.help/seen?))
+            "close! marked the overlay seen")))))

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -380,177 +380,31 @@
       (is (= config/min-panel-width-px (:aria-valuemin props))
           "handle exposes minimum width to assistive tech"))))
 
-;; ---- yield-to-consumer (rf2-70u8q) -------------------------------------
-
-(defn- ensure-stub-host! [resize-value]
-  (when (and (exists? js/document) (.-createElement js/document))
-    ;; Remove any prior host so the test is hermetic.
-    (when-let [old (.querySelector js/document "[data-rf-xray-host]")]
-      (when (.-parentNode old)
-        (.removeChild (.-parentNode old) old)))
-    (let [host (.createElement js/document "aside")]
-      (.setAttribute host "data-rf-xray-host" "")
-      ;; Set resize via inline style — getComputedStyle resolves it.
-      (when resize-value
-        (set! (-> host .-style .-resize) resize-value))
-      (when (.-body js/document)
-        (.appendChild (.-body js/document) host))
-      host)))
-
-(defn- remove-stub-host! [host]
-  (when (and host (.-parentNode host))
-    (.removeChild (.-parentNode host) host)))
-
-(deftest host-without-resize-does-not-yield
-  ;; Default: consumer drops `<aside data-rf-xray-host></aside>` with
-  ;; no explicit `resize:` declaration. Xray should render its own
-  ;; handle (the auto-inject zero-config path).
-  (when (exists? js/document)
-    (let [host (ensure-stub-host! nil)]
-      (try
-        (is (false? (resize-handle/host-asserts-own-handle?))
-            "no explicit resize → no yield → Xray handle renders")
-        (finally
-          (remove-stub-host! host))))))
-
-(deftest host-with-resize-horizontal-yields
-  ;; Consumer asserts their own browser-native handle by setting
-  ;; `resize: horizontal`. Xray MUST yield to avoid a double-handle.
-  (when (exists? js/document)
-    (let [host (ensure-stub-host! "horizontal")]
-      (try
-        (is (true? (resize-handle/host-asserts-own-handle?))
-            "explicit resize:horizontal → yield → Xray renders nil")
-        (finally
-          (remove-stub-host! host))))))
-
-(deftest host-with-resize-both-yields
-  ;; `resize: both` also gives the consumer a browser-native handle
-  ;; (covers a future vertical-resize use case too). Yield.
-  (when (exists? js/document)
-    (let [host (ensure-stub-host! "both")]
-      (try
-        (is (true? (resize-handle/host-asserts-own-handle?))
-            "explicit resize:both → yield → Xray renders nil")
-        (finally
-          (remove-stub-host! host))))))
-
-;; rf2-k97c.3 — THE YIELD GATE LIVES IN `handle-view`, THE BOUNDARY, and
-;; deliberately not in the `Handle` bridge beside the mode gate. The
-;; bridge is scaffolding with a defined end: when `shell-view` becomes a
-;; boundary, `Handle` is DELETED. A spec'd product behaviour (rf2-70u8q)
-;; parked there would be deleted with it, silently. The mode gate is in
-;; the bridge only because a keyword cannot cross the props ABI, and it
-;; moves INTO the boundary as a prop when the bridge goes.
+;; ---- yield-to-consumer + the real-DOM writes: see the dom sibling -------
 ;;
-;; The node lane cannot call a boundary — `rf.fresco/sub` is legal only
-;; inside a render — so these two rows assert the PREDICATE the boundary
-;; gates on, plus the markup it gates. The composition of the two is the
-;; browser lane's subject.
-
-(deftest handle-yields-when-host-asserts-own-handle
-  (when (exists? js/document)
-    (let [host (ensure-stub-host! "horizontal")]
-      (try
-        (setup!)
-        (is (true? (resize-handle/host-asserts-own-handle?))
-            "yield path: the gate `handle-view` short-circuits on is true,
-             so the boundary renders nil and the page carries one handle")
-        (finally
-          (remove-stub-host! host))))))
-
-(deftest handle-renders-when-host-does-not-yield
-  ;; The no-yield path: the zero-config consumer, who declares no
-  ;; `resize` at all and gets Xray's handle.
-  (when (exists? js/document)
-    (let [host (ensure-stub-host! nil)]
-      (try
-        (setup!)
-        (rf/with-frame :rf/xray
-          (is (false? (resize-handle/host-asserts-own-handle?))
-              "no-yield path: the boundary's gate is false, so it renders")
-          (let [tree (handle-markup)]
-            (is (some? tree)
-                "and the markup it then composes is present")
-            (is (= "rf-xray-resize-handle" (:data-testid (second tree)))
-                "the rendered tree is the documented handle node")))
-        (finally
-          (remove-stub-host! host))))))
+;; rf2-r51p MOVED the yield-predicate rows and `apply-panel-width!`'s
+;; `<html>` writes out to `day8.re-frame2-xray.resize-handle-dom-cljs-test`.
+;; They were guarded by `(when (exists? js/document) ...)` in THIS file,
+;; whose name does not end `-dom-cljs-test`, so `:browser-test` never loaded
+;; them while `:node-test` -- which ships no jsdom -- skipped every one:
+;; ELEVEN assertions executing in neither lane. `getComputedStyle` resolving
+;; an inline `resize:` declaration is the behaviour under test and cannot be
+;; stubbed, so the repair was the file LOCATION rather than the guard. The
+;; dom sibling loads on BOTH lanes (`:node-test`'s `cljs-test$` is a bare
+;; suffix match) and answers node with a stated skip per row.
+;;
+;; What stays here is everything that needs no host: the pure `handle-tree`
+;; markup, the drag lifecycle, write-time clamping, the keyboard rows and the
+;; subscription -- plus `apply-panel-width-handles-missing-root` below, which
+;; asserts the NO-host path and so belongs on the node lane precisely because
+;; there is no host here.
 
 ;; ---- apply-panel-width! (CSS var write) --------------------------------
-
-(defn- ensure-stub-shell-root! []
-  (when (and (exists? js/document) (.-createElement js/document))
-    (when-not (.getElementById js/document "rf-xray-root")
-      (let [el (.createElement js/document "div")]
-        (set! (.-id el) "rf-xray-root")
-        (when (.-body js/document)
-          (.appendChild (.-body js/document) el))))))
-
-(deftest apply-panel-width-writes-css-var-on-html
-  (ensure-stub-shell-root!)
-  (settings-effects/apply-panel-width! 700)
-  (when-let [html (and (exists? js/document)
-                       (.-documentElement js/document))]
-    (is (= "700px"
-           (.getPropertyValue (.-style html) "--rf-xray-inline-width"))
-        "<html> CSS var carries the value so the cascade resolves")))
 
 (deftest apply-panel-width-handles-missing-root
   ;; Even without a layout host present, the call should not throw.
   (is (nil? (settings-effects/apply-panel-width! 480))
       "no-op safe pre-mount"))
-
-(deftest apply-panel-width-does-not-pin-host-inline-style
-  ;; Regression for rf2-6fqr5: an earlier draft wrote the CSS custom
-  ;; property as an INLINE style on the layout host as well as on
-  ;; `<html>`. Inline declarations beat any selector-based rule in
-  ;; the cascade, so a consumer's `:root { --rf-xray-inline-width:
-  ;; 720px; }` was silently shadowed by Xray's host write. The
-  ;; documented inline-host contract (spec/011-Launch-Modes.md
-  ;; §Resizing the inline host) requires that an override anywhere
-  ;; up the cascade takes effect — which means Xray MUST NOT write
-  ;; the property to the host element itself; the host inherits the
-  ;; value from `<html>` via the `var(...)` lookup on the next paint.
-  (when (and (exists? js/document) (.-createElement js/document))
-    (let [host (.createElement js/document "aside")]
-      (.setAttribute host "data-rf-xray-host" "")
-      (when (.-body js/document)
-        (.appendChild (.-body js/document) host))
-      (try
-        (settings-effects/apply-panel-width! 480)
-        (is (= "" (.getPropertyValue (.-style host)
-                                     "--rf-xray-inline-width"))
-            "host element MUST NOT carry the CSS var as an inline style")
-        (finally
-          (when (.-parentNode host)
-            (.removeChild (.-parentNode host) host)))))))
-
-(deftest apply-panel-width-clears-html-inline-when-default
-  ;; Regression for rf2-6fqr5: an earlier draft asserted the default
-  ;; value as an inline style on `<html>` at boot. Inline `<html>`
-  ;; declarations beat author-normal `:root { ... }` rules (the cascade
-  ;; treats inline as the highest origin), so a consumer's documented
-  ;; `:root { --rf-xray-inline-width: 720px; }` was silently shadowed
-  ;; by Xray's default-assertion. When the user has NOT explicitly
-  ;; resized — i.e. the value still equals `default-panel-width-px` —
-  ;; `apply-panel-width!` MUST clear any prior inline declaration so
-  ;; the consumer's `:root` override (or the host CSS's `var(...)`
-  ;; fallback) wins.
-  (when-let [html (and (exists? js/document)
-                       (.-documentElement js/document))]
-    ;; Prime an inline declaration first to prove the clear path runs.
-    (.setProperty (.-style html) "--rf-xray-inline-width" "999px")
-    (settings-effects/apply-panel-width! config/default-panel-width-px)
-    (is (= "" (.getPropertyValue (.-style html)
-                                 "--rf-xray-inline-width"))
-        "default value MUST clear the inline `<html>` declaration")
-    ;; nil arg also routes to the default and must clear.
-    (.setProperty (.-style html) "--rf-xray-inline-width" "888px")
-    (settings-effects/apply-panel-width! nil)
-    (is (= "" (.getPropertyValue (.-style html)
-                                 "--rf-xray-inline-width"))
-        "nil arg defaults to the published width and clears the inline")))
 
 ;; ---- panel-width-px sub --------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_dom_cljs_test.cljs
@@ -1,0 +1,276 @@
+(ns day8.re-frame2-xray.resize-handle-dom-cljs-test
+  "Browser-lane half of the resize-handle suite, promoted out of
+  `day8.re-frame2-xray.resize-handle-cljs-test` under rf2-r51p.
+
+  ## What was wrong, and it was the file's LOCATION rather than its guard
+
+  The eleven assertions below were wrapped in `(when (exists? js/document)
+  ...)` inside a namespace ending `-cljs-test`. `:node-test` selected that
+  namespace and the guard was false there — this repo ships no jsdom, no
+  happy-dom and no DOM shim in any dependency list, so `js/document` is
+  simply undefined under Node — while `:browser-test`, whose `:ns-regexp`
+  is `.*-dom-cljs-test$`, never loaded the file at all. The rows therefore
+  executed in NEITHER lane. Their first run is here.
+
+  The sibling `resize_handle_boundary_dom_cljs_test` recorded the same
+  finding from the other side and measured it rather than inferring it: a
+  deliberate failure planted inside those `when` bodies leaves
+  `npm run test:cljs` green.
+
+  ## THE GUARD STAYS, BECAUSE THIS FILE RUNS ON BOTH LANES
+
+  `:node-test`'s `:ns-regexp` is `cljs-test$` — a bare SUFFIX match, which
+  `-dom-cljs-test` satisfies exactly as `-cljs-test` does. So the node
+  build loads this namespace too, and `implementation/shadow-cljs.edn`
+  records above `:browser-test` that this overlap is deliberate: the
+  DOM-tagged files run on BOTH targets so their cross-runtime asserts keep
+  firing in Node. Moving a row here ADDS the browser lane; it removes
+  nothing.
+
+  ## THE SKIP BRANCH ASSERTS RATHER THAN VANISHING
+
+  A bare `(when ...)` body would leave the node lane holding a deftest with
+  ZERO assertions — the hollow shape rf2-r51p exists to remove, relocated
+  rather than fixed. Each row below answers the node lane with a visible
+  marker row instead, so the skip is legible in the node summary and no
+  deftest here holds nothing.
+
+  ## Scope, against the two neighbouring files
+
+  `resize_handle_cljs_test` keeps everything that needs no host: the pure
+  `handle-tree` markup, the drag lifecycle, write-time clamping, the
+  keyboard rows and the subscription. `resize_handle_boundary_dom_cljs_test`
+  owns the Fresco BOUNDARY — real React mounts through the `Handle` bridge.
+  This file sits between them: the yield PREDICATE read off a real computed
+  style, and `apply-panel-width!`'s writes to a real `<html>`. Neither can
+  be stubbed, because `getComputedStyle` resolving an inline `resize:`
+  declaration IS the behaviour under test.
+
+  A failure here is evidence about `host-asserts-own-handle?` and
+  `apply-panel-width!` arriving for the first time, not a regression
+  introduced by the move."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.resize-handle :as resize-handle]
+            [day8.re-frame2-xray.settings.effects :as settings-effects]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  ;; Mirrors the sibling's fixture. `:post-reset` force-clears the
+  ;; module-level drag-state defonce (it survives the runtime reset) so no
+  ;; stale drag leaks between tests.
+  (xray-test-support/make-xray-runtime-fixture
+    {:tier       :runtime
+     :post-reset (fn [] (resize-handle/simulate-up!))}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (rf/make-frame {:id :rf/xray}))
+
+(defn- browser?
+  "True only under the real-DOM `:browser-test` build. The `:node-test`
+  build loads this ns and has no `js/document` — and no jsdom either,
+  which is why these rows never executed before this file existed."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+;; ---- the handle's own markup (rf2-k97c.3) -------------------------------
+;;
+;; `handle-tree` is the boundary's PURE inner fn. Driving it directly is
+;; what a test can assert without a React render window: `handle-view` is a
+;; Fresco boundary and its `rf.fresco/sub` is legal only inside one.
+
+(defn- handle-markup
+  "The handle's node as `handle-view` composes it.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))`, the same door the
+  boundary uses — not `rf/dispatch`."
+  []
+  (resize-handle/handle-tree
+    @(rf/subscribe [:rf.xray/panel-width-px])
+    (resize-handle/aria-max-panel-width-px)
+    (:dispatch (rf/capture-frame))))
+
+;; ---- yield-to-consumer (rf2-70u8q) -------------------------------------
+
+(defn- ensure-stub-host!
+  "Attach `<aside data-rf-xray-host>` to the page, optionally declaring
+  `resize: <resize-value>` as an inline style. `getComputedStyle` — which
+  is what `host-asserts-own-handle?` probes — resolves that declaration,
+  and nothing short of a real browser does."
+  [resize-value]
+  (when (browser?)
+    ;; Remove any prior host so the test is hermetic.
+    (when-let [old (.querySelector js/document "[data-rf-xray-host]")]
+      (when (.-parentNode old)
+        (.removeChild (.-parentNode old) old)))
+    (let [host (.createElement js/document "aside")]
+      (.setAttribute host "data-rf-xray-host" "")
+      (when resize-value
+        (set! (-> host .-style .-resize) resize-value))
+      (when (.-body js/document)
+        (.appendChild (.-body js/document) host))
+      host)))
+
+(defn- remove-stub-host! [host]
+  (when (and host (.-parentNode host))
+    (.removeChild (.-parentNode host) host)))
+
+(deftest host-without-resize-does-not-yield
+  (testing "rf2-70u8q — the zero-config consumer drops
+            `<aside data-rf-xray-host></aside>` with no explicit `resize:`
+            declaration, so Xray renders its own handle (auto-inject)"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! nil)]
+        (try
+          (is (false? (resize-handle/host-asserts-own-handle?))
+              "no explicit resize → no yield → Xray handle renders")
+          (finally
+            (remove-stub-host! host)))))))
+
+(deftest host-with-resize-horizontal-yields
+  (testing "rf2-70u8q — the consumer asserts their own browser-native
+            handle with `resize: horizontal`; Xray MUST yield to avoid a
+            double handle"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! "horizontal")]
+        (try
+          (is (true? (resize-handle/host-asserts-own-handle?))
+              "explicit resize:horizontal → yield → Xray renders nil")
+          (finally
+            (remove-stub-host! host)))))))
+
+(deftest host-with-resize-both-yields
+  (testing "rf2-70u8q — `resize: both` also gives the consumer a
+            browser-native handle (covers a future vertical-resize use
+            case too), so Xray yields"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! "both")]
+        (try
+          (is (true? (resize-handle/host-asserts-own-handle?))
+              "explicit resize:both → yield → Xray renders nil")
+          (finally
+            (remove-stub-host! host)))))))
+
+;; rf2-k97c.3 — THE YIELD GATE LIVES IN `handle-view`, THE BOUNDARY, and
+;; deliberately not in the `Handle` bridge beside the mode gate. The
+;; bridge is scaffolding with a defined end: when `shell-view` becomes a
+;; boundary, `Handle` is DELETED. A spec'd product behaviour (rf2-70u8q)
+;; parked there would be deleted with it, silently.
+;;
+;; The two rows below assert the PREDICATE the boundary gates on, plus the
+;; markup it gates. The COMPOSITION of the two — the gate driving a real
+;; mount — is `resize_handle_boundary_dom_cljs_test`'s W3.
+
+(deftest handle-yields-when-host-asserts-own-handle
+  (testing "rf2-k97c.3 / rf2-70u8q — the yield path: `handle-view`'s gate
+            short-circuits, so the boundary renders nil and the page
+            carries exactly one handle (the consumer's)"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! "horizontal")]
+        (try
+          (setup!)
+          (is (true? (resize-handle/host-asserts-own-handle?))
+              "yield path: the gate `handle-view` short-circuits on is true,
+               so the boundary renders nil and the page carries one handle")
+          (finally
+            (remove-stub-host! host)))))))
+
+(deftest handle-renders-when-host-does-not-yield
+  (testing "rf2-k97c.3 / rf2-70u8q — the no-yield path: the zero-config
+            consumer declares no `resize` at all, the gate is false, and
+            the markup the boundary then composes is the documented node"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! nil)]
+        (try
+          (setup!)
+          (rf/with-frame :rf/xray
+            (is (false? (resize-handle/host-asserts-own-handle?))
+                "no-yield path: the boundary's gate is false, so it renders")
+            (let [tree (handle-markup)]
+              (is (some? tree)
+                  "and the markup it then composes is present")
+              (is (= "rf-xray-resize-handle" (:data-testid (second tree)))
+                  "the rendered tree is the documented handle node")))
+          (finally
+            (remove-stub-host! host)))))))
+
+;; ---- apply-panel-width! (CSS var write) --------------------------------
+
+(defn- html-root []
+  (when (browser?) (.-documentElement js/document)))
+
+(deftest apply-panel-width-writes-css-var-on-html
+  (testing "rf2-6fqr5 — the width lands as an inline custom property on
+            `<html>`, so the cascade resolves it at the host through
+            `var(--rf-xray-inline-width, ...)` inheritance"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [html (html-root)]
+        ;; BIND, ASSERT PRESENT, then reach through. The original row was
+        ;; `(when-let [html ...] (is ...))`, which fails OPEN: a nil root
+        ;; silently skips the assertion rather than reporting one, which
+        ;; is the same shape that let this row die unnoticed.
+        (is (some? html) "precondition: a real <html> root to write to")
+        (settings-effects/apply-panel-width! 700)
+        (is (= "700px"
+               (some-> html .-style (.getPropertyValue "--rf-xray-inline-width")))
+            "<html> CSS var carries the value so the cascade resolves")))))
+
+(deftest apply-panel-width-does-not-pin-host-inline-style
+  (testing "rf2-6fqr5 — an earlier draft wrote the custom property as an
+            INLINE style on the layout host as well as on `<html>`. Inline
+            declarations beat any selector-based rule, so a consumer's
+            `:root { --rf-xray-inline-width: 720px; }` was silently
+            shadowed. Xray MUST NOT write the property to the host; the
+            host inherits it from `<html>`."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [host (ensure-stub-host! nil)
+            html (html-root)]
+        (try
+          (settings-effects/apply-panel-width! 480)
+          ;; The `""` below passes just as happily against a call that
+          ;; wrote NOTHING ANYWHERE, so prove the write landed first. That
+          ;; makes this row a claim about WHERE the value went rather than
+          ;; about whether anything happened. 480 is not
+          ;; `default-panel-width-px` (560), so it writes rather than clears.
+          (is (= "480px"
+                 (some-> html .-style (.getPropertyValue "--rf-xray-inline-width")))
+              "precondition: the call really did write the property on <html>")
+          (is (= "" (some-> host .-style (.getPropertyValue "--rf-xray-inline-width")))
+              "host element MUST NOT carry the CSS var as an inline style")
+          (finally
+            (remove-stub-host! host)))))))
+
+(deftest apply-panel-width-clears-html-inline-when-default
+  (testing "rf2-6fqr5 — when the user has NOT explicitly resized (the value
+            still equals `default-panel-width-px`), `apply-panel-width!`
+            MUST clear any prior inline declaration so the consumer's
+            `:root` override, or the host CSS's `var(...)` fallback, wins"
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane — see ns docstring)")
+      (let [html (html-root)]
+        (is (some? html) "precondition: a real <html> root to clear")
+        ;; Prime an inline declaration first, so the empty read below is
+        ;; evidence that the CLEAR path ran rather than evidence that
+        ;; nothing was ever set.
+        (.setProperty (.-style html) "--rf-xray-inline-width" "999px")
+        (settings-effects/apply-panel-width! config/default-panel-width-px)
+        (is (= "" (some-> html .-style (.getPropertyValue "--rf-xray-inline-width")))
+            "default value MUST clear the inline `<html>` declaration")
+        ;; nil arg also routes to the default and must clear.
+        (.setProperty (.-style html) "--rf-xray-inline-width" "888px")
+        (settings-effects/apply-panel-width! nil)
+        (is (= "" (some-> html .-style (.getPropertyValue "--rf-xray-inline-width")))
+            "nil arg defaults to the published width and clears the inline")))))


### PR DESCRIPTION
Final slice of rf2-r51p — the class of test rows that execute in NEITHER lane.
**Tree-wide, the class is now ZERO.**

## The mechanism, re-verified at source

`implementation/shadow-cljs.edn` (~line 990) states it in terms: `:node-test`'s
`:ns-regexp` is `cljs-test$` — a BARE SUFFIX match that `-dom-cljs-test` also
satisfies — while `:browser-test`'s is `.*-dom-cljs-test$`. So a `-dom-cljs-test`
file loads on BOTH targets: moving a row there ADDS the browser lane rather than
taking it off node. The guard stays; the file LOCATION was the defect.

A guarded row in a plain `-cljs-test` file therefore runs nowhere — node loads it
with the guard false, the browser lane never loads the file at all.

## THE COUNT WAS NOT FOUR. THE REMAINDER WAS NINE FILES, 51 ASSERTIONS

This bead's count has drifted four times (16 → 15 → 13 → 14), each correction
coming from a worker rather than from the brief. Re-derived here with a
paren-balanced scanner that masks comments, strings and char literals, and that
reads the POLARITY of every guard:

| file | dead sites | repair |
|---|---|---|
| `tools/xray/.../resize_handle_cljs_test.cljs` | 11 | (B) move — real `getComputedStyle` |
| `tools/story/.../ui/url_state_cljs_test.cljs` | 9 | (A) host stub — stays on node |
| `tools/story/.../backgrounds_test.cljc` | 6 | (B) extract — **unreachable**, see below |
| `tools/story/.../viewport_test.cljc` | 6 | (B) extract — **unreachable** |
| `tools/story/.../ui/dispatch_console_cljs_test.cljc` | 5 | (B) move + split |
| `tools/story/.../ui/toolbar_cljs_test.cljc` | 5 | (B) move + split |
| `tools/story/.../ui/backgrounds_switcher_cljs_test.cljc` | 3 | (B) move |
| `tools/story/.../ui/viewport_switcher_cljs_test.cljc` | 3 | (B) move |
| `tools/story/.../story_help_cljs_test.cljs` | 3 | (B) move + split |

The dispatch brief named only the first four. **The bead's own CORRECTION 1 is
what reconciles it**: it puts the composition of the 14 at *6 xray + 6 story + 2
dead-one-level-out*, and this census finds exactly those six story files. The
bead's closing REMAINDER line listed only `url_state` among them because at the
time it was written the six story files were FENCED as lanefix-a's tree (PR
#9685, then open). #9685 has since merged, so the fence was resolved and the
other five were free.

**After this PR the census reads 0 across the whole tree** (it read 83 at my
branch point; 32 of those were PR #9688's four files, which merged while I
worked).

### Two controls on the scanner

* `xray_preset_cljs_test.cljs` correctly drops out — repaired by #9685. Before
  comments were masked it reported 24 dead assertions there, all of them prose
  quoting the row that bead had already fixed.
* The polarity control reads **25** and **2** for `resources_revalidation_cljs_test.cljc`
  and `keybinding_cljs_test.cljs` — the exact gaps lanefix-b measured for those
  two `when-not` false positives, which guard on the host being ABSENT and so RUN
  on node. Two instruments, one answer.

## `backgrounds_test.cljc` / `viewport_test.cljc` were worse than "dead one level out"

The bead asked for a different answer here and left the shape open. Measured:
their CLJS rows are not guarded-false, they are **UNREACHABLE**. Both namespaces
end `-test`, not `cljs-test`, so neither build's `:ns-regexp` selects them and
nothing else requires them — no CLJS build ever compiled those
`#?(:cljs (deftest ...))` forms at all. Removing the inner guard would have
changed nothing.

**The `.cljc` worry the bead raised does not bite.** Neither file carries a
single `#?(:clj ...)` form, and every cross-host row in them (preset table,
custom-value validation, resolve precedence, `wrap-style`) is a bare
unconditional `deftest` that still runs under `clojure -M:test`. Only the
`#?(:cljs ...)` blocks moved.

The repair consolidates **by subject**, because the dead sets in the `_test.cljc`
files and their `_switcher_cljs_test.cljc` siblings are two halves of one
contract — `save-to-storage!` / `load-from-storage`, and the `hydrate!` that
seeds the shell slot from what survived.

## FIVE FALSE DOCSTRINGS, three of them found here

lanefix-b corrected two (a `dom-storage` polyfill that does not exist, and
`ensure-stub-shell-root!`). Three more:

* `url_state_cljs_test.cljs` — "under the node runner `js/window.history` is
  mocked by jsdom". There is no jsdom.
* `backgrounds_test.cljc` — "Runs on both JVM and CLJS — the CLJS arm exercises
  the localStorage round-trip". It never did.
* `viewport_test.cljc` — claimed the node-test build ran it, and sent readers to
  `viewport_switcher_cljs_test` for CLJS coverage. **That file's matching rows
  were themselves dead.** Both layers of the intended coverage were inert and
  each pointed at the other.

## ROWS SPLIT RATHER THAN MOVED

Three rows MIXED a live claim with a dead one. Moving them whole would have taken
LIVE assertions OFF the node lane — this bug in reverse — so each was split:

* `cljs-clear-history-drops-storage` — ratom half stays, storage half moves
* `cljs-reset-clears` — shell-state half stays, storage half moves
* `open-then-close-toggles-atom` — `open?` ratom half stays, `seen?` half moves

`seen-defaults-to-false` and `apply-panel-width-handles-missing-root` also stay on
node deliberately: both assert a NO-host path, so the hostless lane is exactly
where they belong.

## NINE ASSERTIONS GIVEN TEETH (no assertion was weakened)

Per the bead's vacuity rule. The recurring shape is an EMPTY read after a clear —
`(= [] (load-history! vid))`, `(= [] (load-modes-from-storage))`,
`(nil? (load-from-storage))` — which passes just as happily against a storage that
silently swallows every write, i.e. against the very absence that kept these rows
dead. Each now proves the value was persisted FIRST, so the empty read is evidence
the clear ran. Also:

* `push!-skips-when-url-matches-current-location` asserted `(= 0 (count @captured))`,
  which passes against an unwired spy or an absent window. It now pushes a
  DIFFERING url first and asserts that one was captured.
* `parse-current-url-or-empty-…-on-blank-search` is all `nil?` assertions, which
  pass against a function that ignored the URL entirely — added
  `parse-current-url-or-empty-reads-a-populated-search` as the discriminating
  contrast.
* `hydrate-from-storage-only-when-empty` asserted a populated slot survives
  hydrate, which also passes if storage held nothing to compete with it. It now
  asserts storage really holds a COMPETING value first.
* `storage-rejects-invalid-on-save` (x2): `save-to-storage!` only writes
  `when-let` `coerce` yields a value, so the real contract is that an invalid
  selection neither persists NOR clobbers. Both rows now seed a valid value, prove
  it persisted, and assert it SURVIVES the invalid save.
* `apply-panel-width-writes-css-var-on-html` was `(when-let [html ...] (is ...))`,
  which fails OPEN — a nil root skips the assertion rather than reporting one, the
  very shape that let these rows die. It now binds, ASSERTS the root is present,
  and reaches through `some->`.
* `apply-panel-width-does-not-pin-host-inline-style` asserted only that the host
  carries `""`, which passes against a call that wrote nothing anywhere. It now
  proves the write landed on `<html>` first.

## THE ASYMMETRY, MEASURED BOTH WAYS

A green node lane is also consistent with these rows having been deleted, so both
directions are shown:

* **NODE, focused run over the six new dom namespaces — exit 0: `Ran 29 tests
  containing 29 assertions`.** Exactly one skip marker per test. Nothing vanished,
  nothing failed, and no deftest holds zero assertions. Every row uses the
  `if-not` + visible-marker shape, never a bare `(when ...)` — a bare `when` would
  relocate the hollow shape this bead exists to remove rather than fix it.
* **BROWSER — the same tests execute the real assertions**, proven by a witness
  run rather than asserted (below).

## WITNESS: the browser lane goes RED on planted faults

A green browser lane alone would not prove these rows execute. Two faults were
planted, one per new suite, on a committed tree:

```
browser lane, faults planted            captured exit 1   2 failures, 0 errors
  FAIL in (apply-panel-width-writes-css-var-on-html)
       resize_handle_dom_cljs_test.cljs:226
       expected: (= "SABOTAGE-701px" ...)   actual: (not (= "SABOTAGE-701px" "700px"))
  FAIL in (storage-roundtrip-preset)
       backgrounds_storage_dom_cljs_test.cljs:84
       expected: (= :SABOTAGE-dark ...)     actual: (not (= :SABOTAGE-dark :dark))
```

The `actual` values are the discriminating evidence: `"700px"` was read back off a
REAL `<html>` inline style and `:dark` out of REAL `localStorage` — neither
reachable on node, and neither row had ever reached them in any lane. Plants
reverted; restore verified by blob hash against the committed objects (MATCH on
both) and independently by `git diff --quiet HEAD` (exit 0).

## Quality gates

Every number below is quoted from that run's own captured `.exit` file, not from
a harness report.

| gate | captured exit | result |
|---|---|---|
| compile `:node-test` | **0** | 1981 files, 1980 compiled, 0 warnings |
| `node out/node-test.js` (full) | **0** | **11766 tests / 58761 assertions, 0 failures 0 errors** |
| focused node, 6 new dom namespaces | **0** | 29 tests / 29 assertions (markers only) |
| compile `:browser-test` | **0** | 1082 files, 5 pre-existing warnings |
| browser lane (port **8187**) | **0** | **1073 tests / 5794 assertions, 0 failures 0 errors** |
| browser lane, faults planted (witness) | **1** | 2 failures, naming both plants |
| `check_test_lane_bijection.py` | **0** | 1653 test-defining files, 45 lanes, every file selected |
| `_browser-dom-lane-partition.test.cjs` | **0** | 2 passed (filename ↔ ns partition) |
| `check_retired_spellings.py` | **0** | 4675 files repo-wide for the retired product name, plus arrow + bench-coordinate scans |
| `check_fast_pr_gap.py --brief` | **0** | report only — 101 required checks no local spine decides |

The run step of each compile+run pair was gated on the compile's captured exit,
not chained to it. The browser runner logged
`Serving …/re-frame2-worktrees/lanefix-c/implementation/out/browser-test on
http://127.0.0.1:8187`, which is how the run is known to have read this worktree;
the node compile likewise named this worktree's `shadow-cljs.edn`. The witness
red is the independent confirmation, since the plants existed only in this tree.

**Not run locally, deliberately:** the JVM artefact suites (`clojure -M:test` for
`tools/story`), and the rest of the 101-check matrix. `backgrounds_test.cljc` and
`viewport_test.cljc` are JVM-graded and this PR removes CLJS-only forms from them,
leaving every bare `deftest` untouched — CI's `jvm` lanes are the authority and
grade it in parallel for free. No gate was re-run red-to-green locally.

## One finding this PR does NOT fix

`toolbar_persistence_dom_cljs_test.cljs`, landed by PR #9685 under this same bead,
uses a bare `(when (browser?) ...)` in all 13 of its deftests and carries **zero**
skip markers — so under `:node-test` those 13 deftests hold zero assertions. Its
own docstring says "the rows report a skip"; they do not, they short-circuit
silently. This is a violation of the convention the bead settled (rule 2: the skip
branch ASSERTS, it does not vanish), not a member of the never-executes class —
those assertions DO run, in the browser lane. Left alone as sprawl into another
change; worth a follow-up.
