### PR TITLE
test(story): give toolbar_persistence_dom's 11 node rows a stated skip (rf2-vdlk)

### DIFF
--- a/tools/story/test/re_frame/story/ui/toolbar_persistence_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/toolbar_persistence_dom_cljs_test.cljs
@@ -54,13 +54,21 @@
   reload-persistence regression net — was running zero assertions
   anywhere.
 
-  The `(when (browser?) ...)` guards STAY, and are not vestigial:
-  `:node-test`'s `cljs-test$` regexp matches the `-dom-cljs-test`
-  suffix too, so this namespace is loaded on BOTH targets. Under node
-  the guards short-circuit and the rows report a skip; under
-  `:browser-test` they are true and the assertions run for real. That
-  is the same shape every other `*_dom_cljs_test.cljs` in this tree
-  uses.
+  The host guard STAYS, and is not vestigial: `:node-test`'s
+  `cljs-test$` regexp matches the `-dom-cljs-test` suffix too, so this
+  namespace is loaded on BOTH targets. Every row spells that guard as
+  `(if-not (browser?) (is true skip-msg) (do ...))`: under node the
+  marker assertion fires and the row reports a STATED skip; under
+  `:browser-test` the guard is true and the assertions run for real. So
+  no deftest here holds zero assertions in EITHER lane. That is the same
+  shape every other `*_dom_cljs_test.cljs` in this tree uses.
+
+  rf2-vdlk: the rows first landed carrying a bare `(when (browser?) ...)`
+  while this paragraph already claimed they reported a skip. They did
+  not — the node lane ran eleven deftests holding zero assertions each,
+  a silent pass rather than a legible one. The marker is what closed the
+  gap; the coverage itself never moved, since these assertions run in the
+  browser lane and always did after the rename above.
 
   These assertions had never executed before this rename. A failure
   here is evidence about `hydrate-modes-from-storage!` /
@@ -86,6 +94,9 @@
   suppressing it in the only lane that ever looked."
   []
   (and (exists? js/window) (.-localStorage js/window)))
+
+(def ^:private skip-msg
+  "skipped: no localStorage (node lane — see ns docstring)")
 
 (defn- clear-storage!
   "Remove the chrome-wide active-modes slot from localStorage between
@@ -183,59 +194,65 @@
 (deftest theme-and-viewport-persist-and-rehydrate-on-reload
   (testing "rf2-jpi7n marquee scenario: set theme + viewport, reload,
             both active modes rehydrate from localStorage"
-    (when (browser?)
-      ;; Seed: register the modes the user will toggle.
-      (rf.story/reg-mode :Mode.persist.theme/dark
-        {:axis :theme :args {:theme :dark}})
-      (rf.story/reg-mode :Mode.persist.vp/mobile
-        {:axis :viewport :args {:viewport :mobile}})
-      ;; User actions: toggle each on. toggle-mode! persists per call.
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
-      ;; Pre-reload sanity.
-      (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (rf.story.ui.state/get-state)))))
-      ;; SIMULATED RELOAD — in-memory state cleared, localStorage
-      ;; survives. The registry survives by design (it's a side-table,
-      ;; not per-instance state).
-      (simulate-reload!)
-      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
-          "post-reload in-memory state is empty — no surprise carry-over")
-      ;; Shell's :component-did-mount fires this.
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (rf.story.ui.state/get-state))))
-          "both modes rehydrated from localStorage — reload preserved"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        ;; Seed: register the modes the user will toggle.
+        (rf.story/reg-mode :Mode.persist.theme/dark
+          {:axis :theme :args {:theme :dark}})
+        (rf.story/reg-mode :Mode.persist.vp/mobile
+          {:axis :viewport :args {:viewport :mobile}})
+        ;; User actions: toggle each on. toggle-mode! persists per call.
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
+        ;; Pre-reload sanity.
+        (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
+               (set (:active-modes (rf.story.ui.state/get-state)))))
+        ;; SIMULATED RELOAD — in-memory state cleared, localStorage
+        ;; survives. The registry survives by design (it's a side-table,
+        ;; not per-instance state).
+        (simulate-reload!)
+        (is (= [] (:active-modes (rf.story.ui.state/get-state)))
+            "post-reload in-memory state is empty — no surprise carry-over")
+        ;; Shell's :component-did-mount fires this.
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
+               (set (:active-modes (rf.story.ui.state/get-state))))
+            "both modes rehydrated from localStorage — reload preserved")))))
 
 (deftest single-mode-persists-and-rehydrates
   (testing "the simpler one-mode case: a single mode survives reload.
             Pins the baseline contract before the multi-mode case"
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/light
-        {:axis :theme :args {:theme :light}})
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
-      (is (= [:Mode.persist.theme/light]
-             (:active-modes (rf.story.ui.state/get-state))))
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= [:Mode.persist.theme/light]
-             (:active-modes (rf.story.ui.state/get-state)))
-          "single mode survives the reload round-trip"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/light
+          {:axis :theme :args {:theme :light}})
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
+        (is (= [:Mode.persist.theme/light]
+               (:active-modes (rf.story.ui.state/get-state))))
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [:Mode.persist.theme/light]
+               (:active-modes (rf.story.ui.state/get-state)))
+            "single mode survives the reload round-trip")))))
 
 (deftest empty-active-modes-rehydrates-as-empty
   (testing "the boundary case: no active modes before reload → no active
             modes after reload. Pins the empty-cycle path"
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark
-        {:axis :theme :args {:theme :dark}})
-      ;; Toggle on then off — leaves an empty vector in localStorage.
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (is (= [] (:active-modes (rf.story.ui.state/get-state))))
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
-          "empty active set survives reload"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark
+          {:axis :theme :args {:theme :dark}})
+        ;; Toggle on then off — leaves an empty vector in localStorage.
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+        (is (= [] (:active-modes (rf.story.ui.state/get-state))))
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [] (:active-modes (rf.story.ui.state/get-state)))
+            "empty active set survives reload")))))
 
 ;; ===========================================================================
 ;; rf2-96y71s — modes=, omitted modes=, and localStorage fallback all
@@ -255,17 +272,19 @@
             localStorage seed: the localStorage hydrator seeds :dark
             first, then apply-parsed-to-state writes the URL's :light.
             Last-shared wins over last-used — through ONE path."
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme :args {:theme :dark}})
-      (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme :args {:theme :light}})
-      ;; localStorage seeded with :dark (last-used).
-      (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
-      (simulate-reload!)
-      ;; Mount with a URL that carries modes=...light (last-shared).
-      (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/light]))
-      (is (= [:Mode.persist.theme/light]
-             (:active-modes (rf.story.ui.state/get-state)))
-          "URL modes (light) replaced the localStorage seed (dark)"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme :args {:theme :dark}})
+        (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme :args {:theme :light}})
+        ;; localStorage seeded with :dark (last-used).
+        (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+        (simulate-reload!)
+        ;; Mount with a URL that carries modes=...light (last-shared).
+        (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/light]))
+        (is (= [:Mode.persist.theme/light]
+               (:active-modes (rf.story.ui.state/get-state)))
+            "URL modes (light) replaced the localStorage seed (dark)")))))
 
 (deftest mount-omitted-modes-clears-localstorage-seed
   (testing "rf2-96y71s / rf2-fkmnh — a URL that carries OTHER params but
@@ -273,31 +292,35 @@
             seed to [] (the URL is the source of truth for the full
             share surface). A share link like ?variant=foo restores the
             DEFAULT (no modes) chrome for the recipient."
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
-      (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
-      (simulate-reload!)
-      ;; Mount with a populated URL that has NO modes= param.
-      (mount-hydrate-modes! "?variant=story.counter/loaded")
-      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
-          "omitted modes= cleared the localStorage seed — URL authoritative"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+        (rf.story.ui.toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+        (simulate-reload!)
+        ;; Mount with a populated URL that has NO modes= param.
+        (mount-hydrate-modes! "?variant=story.counter/loaded")
+        (is (= [] (:active-modes (rf.story.ui.state/get-state)))
+            "omitted modes= cleared the localStorage seed — URL authoritative")))))
 
 (deftest mount-no-url-falls-back-to-localstorage
   (testing "rf2-96y71s — a fresh mount with NO URL state at all preserves
             the localStorage seed (apply-parsed-to-state is not run when
             the search is empty). This is the intentional last-used
             fallback that survives ONLY when the URL carries nothing."
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
-      (rf.story/reg-mode :Mode.persist.vp/mobile  {:axis :viewport :args {:viewport :mobile}})
-      (rf.story.ui.toolbar/save-modes-to-storage!
-        [:Mode.persist.theme/dark :Mode.persist.vp/mobile])
-      (simulate-reload!)
-      ;; Mount with NO URL params — localStorage is the only source.
-      (mount-hydrate-modes! "")
-      (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (rf.story.ui.state/get-state))))
-          "no URL state ⇒ localStorage seed survives (last-used fallback)"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+        (rf.story/reg-mode :Mode.persist.vp/mobile  {:axis :viewport :args {:viewport :mobile}})
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.persist.theme/dark :Mode.persist.vp/mobile])
+        (simulate-reload!)
+        ;; Mount with NO URL params — localStorage is the only source.
+        (mount-hydrate-modes! "")
+        (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
+               (set (:active-modes (rf.story.ui.state/get-state))))
+            "no URL state ⇒ localStorage seed survives (last-used fallback)")))))
 
 (deftest mount-url-modes-prune-is-url-authoritative
   (testing "rf2-96y71s — URL-derived modes ride apply-parsed-to-state
@@ -305,16 +328,18 @@
             registrar — same discipline as every other URL-owned slot).
             A stale localStorage seed, by contrast, IS pruned by the
             localStorage hydrator before the URL apply overrides it."
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
-      ;; localStorage seed carries a stale id; the storage hydrator prunes it.
-      (rf.story.ui.toolbar/save-modes-to-storage!
-        [:Mode.persist.theme/dark :Mode.persist.removed/zzz])
-      (simulate-reload!)
-      ;; URL carries the live :dark only.
-      (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/dark]))
-      (is (= [:Mode.persist.theme/dark] (:active-modes (rf.story.ui.state/get-state)))
-          "URL modes win; the stale localStorage id never surfaces"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+        ;; localStorage seed carries a stale id; the storage hydrator prunes it.
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.persist.theme/dark :Mode.persist.removed/zzz])
+        (simulate-reload!)
+        ;; URL carries the live :dark only.
+        (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/dark]))
+        (is (= [:Mode.persist.theme/dark] (:active-modes (rf.story.ui.state/get-state)))
+            "URL modes win; the stale localStorage id never surfaces")))))
 
 ;; ===========================================================================
 ;; rf2-jpi7n — unknown mode id in localStorage is dropped at hydrate
@@ -328,35 +353,39 @@
   (testing "localStorage contains a mode id that no longer resolves at
             the registrar — hydrate prunes it and only the valid ids
             survive. Pin the stale-survive contract"
-    (when (browser?)
-      ;; Register only one of the two ids the localStorage will name.
-      (rf.story/reg-mode :Mode.persist.live/x {:args {:k 1}})
-      ;; Manually seed localStorage with one live id + one stale id.
-      (rf.story.ui.toolbar/save-modes-to-storage!
-        [:Mode.persist.live/x :Mode.persist.removed/y])
-      ;; Reload + hydrate.
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= [:Mode.persist.live/x]
-             (:active-modes (rf.story.ui.state/get-state)))
-          "only the live mode id survives — stale id silently dropped")
-      (is (not (some #{:Mode.persist.removed/y}
-                     (:active-modes (rf.story.ui.state/get-state))))
-          "the stale id is NOT in active-modes — drop, not error"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        ;; Register only one of the two ids the localStorage will name.
+        (rf.story/reg-mode :Mode.persist.live/x {:args {:k 1}})
+        ;; Manually seed localStorage with one live id + one stale id.
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.persist.live/x :Mode.persist.removed/y])
+        ;; Reload + hydrate.
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [:Mode.persist.live/x]
+               (:active-modes (rf.story.ui.state/get-state)))
+            "only the live mode id survives — stale id silently dropped")
+        (is (not (some #{:Mode.persist.removed/y}
+                       (:active-modes (rf.story.ui.state/get-state))))
+            "the stale id is NOT in active-modes — drop, not error")))))
 
 (deftest all-stale-ids-pruned-to-empty
   (testing "if every persisted id is stale, hydrate leaves the active-
             modes vector empty rather than seeding garbage. The shell
             renders no chips selected — the user re-discovers the
             available modes from scratch"
-    (when (browser?)
-      ;; No registered modes here — every id in storage is stale.
-      (rf.story.ui.toolbar/save-modes-to-storage!
-        [:Mode.persist.removed/a :Mode.persist.removed/b])
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= [] (:active-modes (rf.story.ui.state/get-state)))
-          "every stale id dropped — active vector is empty after hydrate"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        ;; No registered modes here — every id in storage is stale.
+        (rf.story.ui.toolbar/save-modes-to-storage!
+          [:Mode.persist.removed/a :Mode.persist.removed/b])
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= [] (:active-modes (rf.story.ui.state/get-state)))
+            "every stale id dropped — active vector is empty after hydrate")))))
 
 ;; ===========================================================================
 ;; rf2-jpi7n — axis semantics survive reload
@@ -374,45 +403,49 @@
             leave :light. The viewport mode (different axis) is
             untouched. Pin the axis-aware behaviour survives the
             reload boundary"
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
-      (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme    :args {:theme :light}})
-      (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
-      ;; Seed: dark + mobile (multi-select across axes).
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
-      ;; Reload + hydrate.
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
-             (set (:active-modes (rf.story.ui.state/get-state)))))
-      ;; Post-reload action: toggle light theme — must evict dark.
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
-      (let [active (set (:active-modes (rf.story.ui.state/get-state)))]
-        (is (contains? active :Mode.persist.theme/light)
-            ":light is now active")
-        (is (not (contains? active :Mode.persist.theme/dark))
-            ":dark was evicted by axis sibling rule — survived reload")
-        (is (contains? active :Mode.persist.vp/mobile)
-            ":mobile (different axis) untouched")))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
+        (rf.story/reg-mode :Mode.persist.theme/light {:axis :theme    :args {:theme :light}})
+        (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
+        ;; Seed: dark + mobile (multi-select across axes).
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
+        ;; Reload + hydrate.
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
+               (set (:active-modes (rf.story.ui.state/get-state)))))
+        ;; Post-reload action: toggle light theme — must evict dark.
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/light)
+        (let [active (set (:active-modes (rf.story.ui.state/get-state)))]
+          (is (contains? active :Mode.persist.theme/light)
+              ":light is now active")
+          (is (not (contains? active :Mode.persist.theme/dark))
+              ":dark was evicted by axis sibling rule — survived reload")
+          (is (contains? active :Mode.persist.vp/mobile)
+              ":mobile (different axis) untouched"))))))
 
 (deftest reload-preserves-multi-axis-set
   (testing "spec/010 §Optional grouping :axis: modes in distinct axes
             survive reload as a set. Toggling between them does not
             disturb the membership of sibling axes"
-    (when (browser?)
-      (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
-      (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
-      (rf.story/reg-mode :Mode.persist.locale/en   {:axis :locale   :args {:locale :en}})
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
-      (rf.story.ui.toolbar/toggle-mode! :Mode.persist.locale/en)
-      ;; Three axes co-active.
-      (is (= 3 (count (:active-modes (rf.story.ui.state/get-state)))))
-      (simulate-reload!)
-      (rf.story.ui.toolbar/hydrate-modes-from-storage!)
-      (is (= #{:Mode.persist.theme/dark
-               :Mode.persist.vp/mobile
-               :Mode.persist.locale/en}
-             (set (:active-modes (rf.story.ui.state/get-state))))
-          "three-axis active set survives the reload round-trip"))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        (rf.story/reg-mode :Mode.persist.theme/dark  {:axis :theme    :args {:theme :dark}})
+        (rf.story/reg-mode :Mode.persist.vp/mobile   {:axis :viewport :args {:viewport :mobile}})
+        (rf.story/reg-mode :Mode.persist.locale/en   {:axis :locale   :args {:locale :en}})
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.theme/dark)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.vp/mobile)
+        (rf.story.ui.toolbar/toggle-mode! :Mode.persist.locale/en)
+        ;; Three axes co-active.
+        (is (= 3 (count (:active-modes (rf.story.ui.state/get-state)))))
+        (simulate-reload!)
+        (rf.story.ui.toolbar/hydrate-modes-from-storage!)
+        (is (= #{:Mode.persist.theme/dark
+                 :Mode.persist.vp/mobile
+                 :Mode.persist.locale/en}
+               (set (:active-modes (rf.story.ui.state/get-state))))
+            "three-axis active set survives the reload round-trip")))))


### PR DESCRIPTION
## What

`tools/story/test/re_frame/story/ui/toolbar_persistence_dom_cljs_test.cljs` — one file.

All eleven `deftest`s wrapped their bodies in a bare `(when (browser?) ...)`. The namespace is
loaded by BOTH shadow targets (`:node-test`'s `cljs-test$` is a bare suffix match that
`-dom-cljs-test` satisfies), so on the node lane every one of those rows ran holding **zero
assertions** — a silent pass. The file's own docstring already claimed "the rows report a skip";
they did not.

Each row now answers the node lane with a visible marker assertion, and the docstring says what
the rows actually do.

## What is NOT at stake

**This is a legibility repair, not a coverage repair.** These rows execute for real in the browser
lane, and have done since the rf2-r51p rename that gave the namespace its `-dom-cljs-test` suffix,
so the assertions are real coverage and none of them moved. What was missing is the node-lane
marker that makes a zero-assertion node run legible rather than silent — the *stated green skip*
`TESTING.md` names in its `cljs_browser` row.

This is **not** the never-executed class rf2-r51p closed. That census still reads 0 tree-wide; this
change does not touch it.

## Premises checked at source

The bead relayed three claims from another worker. Two held, one did not:

| Claim | Verdict |
| --- | --- |
| All **13** `deftest`s wrap their bodies in `(when (browser?) ...)` | **11**, not 13. All eleven did carry the bare guard. |
| None carries a skip marker | Held — zero `(is true …)` markers in the file. |
| The docstring says "the rows report a skip", which is false | Held — the sentence was there and was false. |

The count is the only correction; the defect and its shape are exactly as reported.

## The spelling, and where it came from

    (if-not (browser?)
      (is true skip-msg)
      (do
        ...))

with

    (def ^:private skip-msg
      "skipped: no localStorage (node lane — see ns docstring)")

Taken from **`tools/story/test/re_frame/story/ui/toolbar_storage_dom_cljs_test.cljs`** — the
sibling in the same directory, covering the same localStorage surface, landed hours ago under the
same parent bead (PR #9690). Its own docstring states the rule this change applies: *"Each row
answers the node lane with a VISIBLE marker assertion rather than a silent `when`, so no deftest
here holds zero assertions — a bare `when` would relocate the hollow shape rf2-r51p exists to
remove rather than fix it."*

Census of the convention at tip (`.cljs`, tracked, `.beads/` excluded):

| Spelling | Files |
| --- | --- |
| `(if-not (browser?) ...)` guard shape | **117** |
| `skip-msg` binding + `(is true skip-msg)` | **5**, all under `tools/story/` — `toolbar_storage`, `backgrounds_storage`, `viewport_storage`, `ui/dispatch_console`, `story_help` |
| the exact message string `skipped: no localStorage (node lane — see ns docstring)` | **10** files (5 via the `skip-msg` binding, 5 inline under `tools/xray/`) |

The inline-string variant (`(is true "skipped: no DOM (node lane …)")`) is the other common form —
same shape, message inlined. The `skip-msg` binding is what every `tools/story/` file with more
than two guarded rows uses, and this file has eleven.

## What did NOT change

- **No row body changed.** Every assertion, every registration, every helper call is byte-identical
  modulo two columns of indentation. The browser lane runs exactly what it ran before.
- **`clear-storage!` keeps its `(when (browser?) ...)`.** It is a fixture helper, not a row; it
  holds no assertions in either lane and a marker there would assert nothing about anything.
- **No row moves between lanes**, so the lane bijection and the browser/DOM lane partition are
  untouched — the namespace name, the file name and the `:ns-regexp` match are all unchanged.

## Quality gates

Run from this branch. Each exit code is quoted from the run's own `.exit` file.

| Gate | Exit | Result |
| --- | --- | --- |
| `npm run test:cljs` (node lane) — BEFORE, this file reverted to the merge base | 0 | `Ran 11772 tests containing 58774 assertions. 0 failures, 0 errors.` |
| `npm run test:cljs` (node lane) — AFTER | 0 | `Ran 11772 tests containing 58785 assertions. 0 failures, 0 errors.` |
| `python scripts/check_test_lane_bijection.py` | 0 | `PASS test-lane bijection: 1654 test-defining files, 45 lanes, every file selected and every selector reached` |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | report only, per policy — not a suite |
| 14 static ratchets covering this path | 0 | `check_require_alias_dialect`, `check_retired_spellings`, `check_retired_composition_vocab`, `check_retired_image_keys`, `check_thrown_error_messages`, `check_view_lifetime_residue`, `check_egress_walker_residue`, `check_inject_cofx_residue`, `check_failure_corpus_residue`, `check_flattened_lists`, `check_ambient_durable_reads`, `check_escaped_continuations`, `check_architecture_census`, `check_keyword_catalogue_drift` — all 0 |
| `npm run test:browser` | — | **not run, deliberately.** See below. |

**The BEFORE/AFTER pair is the whole evidence for this change.** Test count is
**identical at 11772** — nothing new runs, nothing moved lane. Assertion count rises by
**exactly 11**, one per marker, from 58774 to 58785. That is precisely the claim: the change
alters what is REPORTED and not what is RUN.

It is also the proof the runner read this worktree rather than a sibling's — the AFTER
content exists nowhere else, and the +11 could not appear from any other tree.

`npm run test:browser` was not run because no expression inside any row body changed. The
eleven bodies are byte-identical modulo two columns of indentation, wrapped in a `do`; the
browser lane takes the `(browser?)`-true arm and compiles and runs an identical program. Left
to CI, which runs it on the `cljs_browser` surface.

The lane-bijection gate is a negative control here and its green is expected: the namespace
name, the file name and the `:ns-regexp` match are all unchanged, so no row could have moved
lanes.

Anchors and table column counts in this body checked by hand.

## Found nearby, NOT fixed here

A census of all 205 tracked `*_dom_cljs_test.cljs` files finds the same defect — deftests
guarded by a bare `(when (browser?) ...)` with no marker assertion anywhere in the file — in
exactly two more files:

| File | Bare rows |
| --- | --- |
| `implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs` | 13 of 17 deftests |
| `tools/story/test/re_frame/story/xray_preset_dom_cljs_test.cljs` | 1 of 1 deftest |

Both are out of scope for this PR and are left for their own items. The census instrument was
controlled against this file's pre-fix content, where it correctly reads 11.
