### PR TITLE
docs(xray): say what the stock-Reagent dep actually costs (rf2-99qn)

### DIFF
--- a/tools/xray/deps.edn
+++ b/tools/xray/deps.edn
@@ -83,21 +83,33 @@
          ;; (re-frame.views late-binds via `:adapter/current-component`), so
          ;; every artefact that requires reagent.* must declare it.
          ;;
-         ;; SINCE rf2-7ds8 THERE IS EXACTLY ONE PRODUCTION REQUIRE, in
+         ;; SINCE rf2-7ds8 `src` HAS EXACTLY ONE PRODUCTION REQUIRE, in
          ;; `day8.re-frame2-xray.substrate`, and it is the FALLBACK arm of
          ;; the hiccup->React-element crossing — taken only when no
-         ;; ratom-family adapter is installed to answer
-         ;; `:adapter/as-element` (Xray owning its own root under an
-         ;; element-shaped adapter). Before that bead, six view sources
-         ;; named `reagent.core/as-element` directly, which is why Xray
-         ;; under the reagent-slim adapter shipped BOTH ratom runtimes and
-         ;; rendered nothing.
+         ;; ratom-family adapter answers `:adapter/as-element`, which is a
+         ;; REAL case rather than a defensive flourish: Xray can own its own
+         ;; React root, and the acceptance harness mounts the Static surface
+         ;; through Fresco's root with UIx installed. Before that bead, nine
+         ;; sites across six view sources named `reagent.core/as-element`
+         ;; statically, so under the reagent-slim adapter the islands were
+         ;; rendered by the wrong ratom build and Xray came up BLANK.
+         ;;
+         ;; RETIRING THAT ONE REQUIRE WOULD BUY NO BUNDLE BYTES — measured
+         ;; under rf2-99qn, and said here because the previous wording
+         ;; invited exactly that wasted errand. `day8/re-frame2-machines-viz`
+         ;; above requires `reagent.core` in its chart tree and calls
+         ;; `reagent.core/as-element` at ten sites of its own, and the edge
+         ;; `preload -> registry -> panels.machine-inspector ->
+         ;; panels.machine-canvas -> machines-viz.chart` is live, so stock
+         ;; Reagent lands in every Xray-carrying build whether this door
+         ;; requires it or not. THAT — not the nine retired crossings — is
+         ;; why a reagent-slim page carrying Xray ships both ratom runtimes,
+         ;; and the work to change it is in the machines-viz chart tree, not
+         ;; here.
          ;;
          ;; This is dev-only (Xray is a devtools panel excluded from
          ;; production bundles) and independent of the reagent-slim adapter
-         ;; above, which carries no stock Reagent. Retiring the last require
-         ;; needs a non-Reagent answer for that fallback; it is a bundle
-         ;; concern now, not a correctness one.
+         ;; above, which carries no stock Reagent.
          ;; Test code still requires reagent.* freely.
          reagent/reagent {:mvn/version "2.0.1"}
 


### PR DESCRIPTION
## What this is

`rf2-99qn` asked two questions about `tools/xray/deps.edn` after PR #9686 landed:
is the stock-Reagent dependency still earning its place, and is the comment
explaining it telling the truth. This PR answers the second. The first needed no
change.

**Comment-only.** No dependency, coordinate, alias or require moved — proved
below rather than asserted.

## The measurement

Re-derived at this tip, not taken from the bead.

| claim | measured |
|---|---|
| production `reagent.*` requires under `tools/xray/src` | **1** — `substrate.cljs`, the fallback arm |
| pre-#9686 static `reagent.core/as-element` call sites | **9 sites across 6 sources** (the comment said "six view sources") |
| bundle bytes freed by retiring that one require | **0** |

Zero, because `day8/re-frame2-machines-viz` — declared three coordinates above
in this same file — requires `reagent.core` in its chart tree and calls
`reagent.core/as-element` at **ten** call sites of its own. The require edge

```
day8.re-frame2-xray.preload
  -> day8.re-frame2-xray.registry
  -> day8.re-frame2-xray.panels.machine-inspector
  -> day8.re-frame2-xray.panels.machine-canvas
  -> day8.re-frame2-machines-viz.chart
  -> reagent.core
```

is live in every Xray build, so stock Reagent is in the module graph whether or
not `substrate.cljs` names it. Taken by walking the `ns` forms from the preload
with `substrate` excluded from the graph, and confirmed at source on every hop.

## Why the comment needed correcting

Two things in it were wrong in the direction that costs someone a cycle:

1. It called retiring the last require **"a bundle concern"**, which reads as an
   errand worth running. It buys nothing.
2. It blamed the nine retired crossings for a reagent-slim page shipping both
   ratom runtimes. They were never the cause, and removing them did not fix it —
   the Machines panel's chart engine is the carrier.

The new text says both plainly and names where that work would actually have to
go, so the next reader does not re-derive this.

Also recorded: the fallback arm is reachable for a real reason — the acceptance
harness mounts the Static surface through Fresco's root with UIx installed,
where no ratom walk answers `:adapter/as-element` — and the one-require claim is
scoped to `src`, since test code requires `reagent.*` freely.

## Quality gates

| gate | exit | note |
|---|---|---|
| EDN parses (`clojure.edn/read-string`) | `0` | proved discriminating: a planted `:aliases` fault returned `1` with *"Map literal must contain an even number of forms"*, then restored and re-verified by blob hash |
| parsed EDN identical to parent commit | `0` | `parsed-equal? true`, `clojure.data/diff` first two slots `(nil nil)`. Positive control against a different `deps.edn` returned `1` |
| `scripts/check_retired_spellings.py` | `0` | proved discriminating: a planted retired product name returned `1` naming the planted line, then restored and re-verified by blob hash |
| `scripts/check_retired_composition_vocab.py` | `0` | |
| `scripts/check_retired_image_keys.py` | `0` | |
| `scripts/check_thrown_error_messages.py` | `0` | |
| `scripts/check_keyword_catalogue_drift.py` | `0` | |
| `scripts/check-no-hardcoded-paths.sh` | `0` | |

Every number quoted from that gate's own `.exit` file. The cheap gates were
re-run on the final post-rebase base.

**Left to CI:** `tools/xray/deps.edn` arms the classifier's `examples_compile`
surface, so `test.yml`'s `cljs-examples-compile` grades this PR. It is not run
locally: the sweep is a 58-build compile needing an npm install this worktree
does not carry, and the semantic-identity gate above already proves the file
produces a byte-identical classpath, so there is nothing for a compile to find
that the parse did not.

Closes rf2-99qn's comment half. The dependency stays, and the bead's "verified
that the fallback genuinely needs it" outcome holds with a stronger reason than
expected: it is not the fallback keeping stock Reagent in the tree.
