### PR TITLE
test(xray): let the column-width isolation row own both storage keys (rf2-nnh0)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs
@@ -89,26 +89,66 @@
 
 ;; ---- Storage-key override (per-instance isolation) ----------------------
 
+;; THIS ROW OWNS BOTH TEST KEYS, BECAUSE THE FIXTURE CANNOT (rf2-nnh0).
+;; `rt/clear!` removes exactly ONE slot — the one `rt/get-storage-key`
+;; currently names — so the fixture's `(rt/clear!) (rt/set-storage-key!
+;; nil)` pair can only ever reach whichever key the previous row left
+;; selected. This row ends on A, so B's write survived it, and the
+;; fixture runs as INITIALISATION (`:post-reset` fires before the body,
+;; never after), so nothing clears B at all. A repeat against the same
+;; localStorage origin then reaches the `(= {} (rt/load))` assertion
+;; below holding the PRIOR run's `{:t2 {:b 200}}` and reds on an
+;; isolation property that production honours perfectly.
+;;
+;; MEASURED, not traced: with one Playwright context and two loads of
+;; `out/browser-test` (the canonical runner calls `browser.newContext()`
+;; per invocation, so its origin is ephemeral and CI never sees this),
+;; load 1 was green here and load 2 failed at the `(= {} (rt/load))`
+;; assertion, one extra failure and no other difference. `browser-watch`
+;; and any repeated hand-run against a persistent profile are the live
+;; exposure.
+;;
+;; So: establish the empty initial state for BOTH keys, and clear BOTH
+;; in a `finally` that also restores the default key — guaranteed even
+;; if the setup or the body throws. The sibling
+;; `filters.persistence-dom-cljs-test/custom-storage-key-isolates-per-instance`
+;; clears both keys the same way; the `finally` is what makes it hold
+;; when a row above the cleanup throws.
 (deftest custom-storage-key-isolates-per-instance
   (if-not (ls/available?)
     (is true "skipped: no localStorage (node lane — see ns docstring)")
     (testing "story testbeds set distinct keys so two Xray instances
               do not stomp on each other's column-widths state"
-      (rt/set-storage-key! "story.testbed.a.column-widths")
-      (rt/save! {:t1 {:a 100}})
-      ;; Precondition, not decoration: the `(= {} (load))` below passes
-      ;; on a silently no-op storage, where nothing was ever written and
-      ;; every slot reads empty. Proving A's write landed is what makes
-      ;; B's empty read discriminating.
-      (is (= {:t1 {:a 100}} (rt/load))
-          "precondition: instance A's write really did persist")
-      (rt/set-storage-key! "story.testbed.b.column-widths")
-      (is (= {} (rt/load))
-          "instance B's slot is independent of instance A")
-      (rt/save! {:t2 {:b 200}})
-      (rt/set-storage-key! "story.testbed.a.column-widths")
-      (is (= {:t1 {:a 100}} (rt/load))
-          "instance A's slot survived instance B's write"))))
+      (let [key-a "story.testbed.a.column-widths"
+            key-b "story.testbed.b.column-widths"
+            clear-both! (fn []
+                          (rt/set-storage-key! key-a)
+                          (rt/clear!)
+                          (rt/set-storage-key! key-b)
+                          (rt/clear!)
+                          (rt/set-storage-key! nil))]
+        (try
+          ;; Own the initial state rather than assuming it. Without this
+          ;; the `(= {} (rt/load))` below is an assertion about whatever
+          ;; a previous run happened to leave behind.
+          (clear-both!)
+          (rt/set-storage-key! key-a)
+          (rt/save! {:t1 {:a 100}})
+          ;; Precondition, not decoration: the `(= {} (load))` below passes
+          ;; on a silently no-op storage, where nothing was ever written and
+          ;; every slot reads empty. Proving A's write landed is what makes
+          ;; B's empty read discriminating.
+          (is (= {:t1 {:a 100}} (rt/load))
+              "precondition: instance A's write really did persist")
+          (rt/set-storage-key! key-b)
+          (is (= {} (rt/load))
+              "instance B's slot is independent of instance A")
+          (rt/save! {:t2 {:b 200}})
+          (rt/set-storage-key! key-a)
+          (is (= {:t1 {:a 100}} (rt/load))
+              "instance A's slot survived instance B's write")
+          (finally
+            (clear-both!)))))))
 
 ;; ---- resize-pair tick + commit (rf2-xm1jy split) ------------------------
 


### PR DESCRIPTION
## What

`custom-storage-key-isolates-per-instance` in
`tools/xray/test/day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs`
now owns **both** of the test storage keys it touches: it establishes their empty
initial state, and clears both — plus restores the default key — in a `finally`,
so the cleanup holds even if setup or the body throws.

The A round-trip, the two cross-instance assertions and every other revived case
in the namespace are unchanged. One file, test-only, no production change.

## Why

`rt/clear!` removes exactly one slot — whichever key `rt/get-storage-key` names at
the moment it is called. The namespace fixture's `:post-reset` does
`(rt/clear!) (rt/set-storage-key! nil)`, so it can only ever reach the key the
*previous* row left selected, and it runs as **initialisation** (before the body,
never after). This row ended on A, so `story.testbed.b.column-widths` survived it
holding `{:t2 {:b 200}}`, and nothing anywhere cleared it.

A repeat against the same localStorage origin therefore reached
`(is (= {} (rt/load)))` with the prior run's B value and went red on an isolation
property production honours perfectly.

## Evidence — measured, not traced

rf2-nnh0 recorded a source-level state trace and said so. It was executed.

The canonical runner (`implementation/scripts/run-browser-tests.cjs`) calls
`chromium.launch()` then `browser.newContext()` — an **ephemeral** context — so
every `npm run test:browser` invocation starts from an empty origin and CI never
meets this. A throwaway driver kept **one** context and loaded `out/browser-test`
**twice**, which is the "same browser localStorage origin, twice, no clearing in
between" the acceptance criterion asks for.

**Before the fix**, on one bundle:

| load | summary | `story.testbed.b.column-widths` after the load |
|---|---|---|
| 1 | Ran 1079 tests containing 5704 assertions. 11 failures, 0 errors. | `{:t2 {:b 200}}` |
| 2 | Ran 1079 tests containing 5704 assertions. **12** failures, 0 errors. | `{:t2 {:b 200}}` |

The single extra failure on load 2 was exactly the predicted one:

```
FAIL in (custom-storage-key-isolates-per-instance) (day8/re_frame2_xray/views/resizable_table_persistence_dom_cljs_test.cljs:106:11)
```

that being the `(is (= {} (rt/load)) "instance B's slot is independent of instance A")` line.

**After the fix**, same driver, same two loads:

| load | summary | `story.testbed.*` keys after the load |
|---|---|---|
| 1 | Ran 1079 tests containing 5704 assertions. 11 failures, 0 errors. | none |
| 2 | Ran 1079 tests containing 5704 assertions. 11 failures, 0 errors. | none |

Test and assertion counts are identical across all four loads, so no namespace was
truncated and the comparison is of like with like.

**The 11 failures common to every load are an artefact of the throwaway driver,
not of the tree.** They are the trusted-input keyboard rows (`a-real-tab-*`,
`a-real-escape-*`), which need the `TRUSTED_INPUT_BRIDGE` init script that only the
canonical runner installs. They are identical in every load, which is what makes
the 11-vs-12 delta the measurement.

**Injected body exception.** With `(throw (ex-info ...))` planted immediately after
the B write and the bundle recompiled, the run reported
`Ran 1079 tests containing 5704 assertions. 11 failures, 1 errors.` — the error
named `ERROR in (custom-storage-key-isolates-per-instance)`, so the plant was
observed by the runtime and `cljs.test` caught it rather than unwinding the lane —
and localStorage afterwards carried **neither** test key. The `finally` holds.
The plant was reverted and the restore verified against the committed blob by
content hash and by `git diff --quiet HEAD` (exit 0).

## Quality gates

Every exit code below is quoted from that run's own captured `.exit` file.

| gate | captured exit | note |
|---|---|---|
| `shadow-cljs compile browser-test` (pre-fix baseline) | 0 | 5 pre-existing `:infer-warning`s, unchanged |
| double-load reproduction, **pre-fix** | 1 | driver verdict; 11 then **12** failures — the defect |
| `shadow-cljs compile browser-test` (with fix) | 0 | same 5 pre-existing warnings |
| double-load, **post-fix** | 1 | driver verdict; 11 then 11 — the defect is gone |
| planted-exception witness (1 load) | 1 | driver verdict; 11 failures / **1 error**, both keys cleared |
| `python scripts/check_retired_spellings.py` | 0 | |
| `python scripts/check_test_lane_bijection.py` | 0 | 1654 test-defining files, 45 lanes |
| `python scripts/check_require_alias_dialect.py` | 0 | |
| `python scripts/check_thrown_error_messages.py` | 0 | |
| `python scripts/check_retired_composition_vocab.py` | 0 | |
| `node --test implementation/scripts/_browser-dom-lane-partition.test.cjs` | 0 | filename ↔ ns partition |

The three driver exit 1s are the throwaway driver's own "zero failures" verdict
refusing the 11 trusted-input rows it cannot serve. They are **not** a red tree —
the numbers inside them are the deliverable.

**Left to CI**, deliberately, per the project's gate-nomination policy: the
canonical browser lane (`cljs-browser`, `npm run test:browser`), the node lane
(`cljs`, `npm run test:cljs` — this namespace loads there and short-circuits on
`ls/available?`, unchanged by this diff), and the rest of the required matrix.
