### PR TITLE
docs(xray): the resizable-table Fresco boundary IS adopted — correct the head docs (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/resizable_table.cljs
@@ -18,7 +18,7 @@
 
   ## Consumer API
 
-      [resizable-table
+      [resizable-table-view
        {:table-id   :rf.xray.epoch/subscriptions  ;; unique kw
         :columns    [{:id :sub    :label \"sub\"     :default-flex \"1fr\"}
                      {:id :inputs :label \"inputs\"  :default-flex \"1fr\"}
@@ -44,8 +44,15 @@
   read and the frame-bound dispatcher. **Mount the one your parent is**: a
   Fresco boundary in a Reagent head position fails as loudly as the
   reverse, so a panel adopts `resizable-table-view` when its own mount
-  becomes a boundary and not before. Every call site in the tree is still
-  on `resizable-table`.
+  becomes a boundary and not before.
+
+  THAT MIGRATION IS DONE, AND `resizable-table-view` IS NOW THE ONLY MOUNT
+  SPELLING IN THE TREE (rf2-k97c.3). Both consumer panels became Fresco
+  boundaries — Trace in `04350d02e5`, Epoch in `5c6b56f7ab` — so all five
+  production call sites head the boundary: `panels/epoch/view.cljs` ×3 and
+  `panels/trace.cljs` ×2. **A new consumer mounts `resizable-table-view`.**
+  The Reagent head keeps NO production call site and survives for the
+  reasons its own docstring gives; do not mount it.
 
   ## localStorage persistence (rf2-xzg1y)
 
@@ -758,12 +765,26 @@
 ;;
 ;; BOTH SHIP, and that is the sequencing rather than an indecision
 ;; (rf2-fcy5). A Fresco boundary in a Reagent head position fails exactly
-;; as loudly as the reverse, so the boundary cannot be ADOPTED until each
-;; consumer's own mount is one: `panels/trace.cljs` and
-;; `panels/epoch/view.cljs` migrate on their own beads, and until they do
-;; every call site keeps mounting `resizable-table`. Same pair, same
-;; reason, as `views/edn_inspector.cljs`'s `edn-inspector` /
-;; `edn-inspector-view`.
+;; as loudly as the reverse, so the boundary could not be ADOPTED until
+;; each consumer's own mount was one. Same pair, same reason, as
+;; `views/edn_inspector.cljs`'s `edn-inspector` / `edn-inspector-view`.
+;;
+;; THAT CONDITION IS NOW MET AND THE SEQUENCING IS SPENT (rf2-k97c.3).
+;; `panels/trace.cljs` became a boundary in `04350d02e5` and
+;; `panels/epoch/view.cljs` in `5c6b56f7ab`, and both adopted
+;; `resizable-table-view` in the same commit. Censused at the tip that
+;; carries this comment: ZERO code references to the Reagent head remain
+;; under `tools/xray/src` — head-position, alias-qualified or by-name via
+;; `(rf/view …)` — against a control of 5 live `resizable-table-view`
+;; mounts on the same instrument.
+;;
+;; THE REAGENT HEAD IS NOT RETIRED, AND THAT IS A DECISION RATHER THAN AN
+;; OVERSIGHT. `render-table` is `defn-`, so the Reagent head is the ONLY
+;; public pure-render door into it, and four test namespaces depend on
+;; that door — see its docstring for the inventory. Retiring it would
+;; delete real coverage to remove a var that costs a bundle-isolated dev
+;; tool almost nothing. Nothing here blocks a later retirement; it would
+;; just have to re-point those namespaces first.
 ;;
 ;; Neither head has any state to hold, so neither needs an instance key:
 ;; the widget's one piece of component-local state was the gutter's hover
@@ -772,6 +793,37 @@
 (rf/reg-view resizable-table
   "THE REAGENT HEAD. See the ns docstring for the consumer API and
   `render-table` for the option inventory.
+
+  ## NO PRODUCTION CONSUMER — do not mount this (rf2-k97c.3)
+
+  Every production call site heads `resizable-table-view` since Trace and
+  Epoch became Fresco boundaries; a censused ZERO code references survive
+  under `tools/xray/src`. Mounting this head inside either panel now
+  raises `:rf.error/fresco-bad-head`, which is the refusal
+  `reagent-head-is-invalid-to-the-codec` pins.
+
+  ## WHY IT STILL SHIPS — it is the tree's only pure-render door
+
+  `render-table` is `defn-`. This head is the one PUBLIC way to drive it
+  and get hiccup back without entering a React render window, and nine
+  live call sites across four test namespaces depend on exactly that:
+
+    - `views/resizable_table_key_cljs_test`     renders through it to
+      grade React keys at both substrate doors.
+    - `views/resizable_table_fresco_head_cljs_test`  grades it `:invalid`
+      to the codec, and drives it for `both-heads-resolve-the-same-widths`.
+    - `panels/epoch/view_cljs_test`             substitutes it for the
+      boundary in `expand-widgets` / `call-widget-head`, which is what
+      lets ~40 rows assert on the markup EPOCH supplies; and counts it as
+      the negative control in `panel-emits-the-fresco-widget-heads-test`.
+    - `panels/trace_view_cljs_test`             the same substitution in
+      `lower-head`, plus the `:invalid` control in
+      `panel-heads-are-the-ones-the-codec-accepts`.
+
+  The last two roles are the ones a reader is most likely to mistake for
+  dead weight: those suites assert this head does NOT appear in a panel
+  tree, so the var is the REFERENT that makes a revert detectable. Delete
+  it and those rows cannot be written, let alone go red.
 
   ## Frame-aware via `reg-view` (rf2-r0o63)
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -992,13 +992,15 @@
           (hiccup-seq tree))))
 
 (deftest trace-row-react-keys-are-stable-trace-ids
-  (testing "rf2-jnxfj — rows now ride `rt/resizable-table` so the row
+  (testing "rf2-jnxfj — rows ride the shared resizable-table widget
+            (`rt/resizable-table-view` since rf2-k97c.3) so the row
             container is a `:div` (formerly `:li`). `op-row-attrs`
             stamps the `(h/row-key row)` value into the attrs map's
             `:key` slot so the contract surface stays observable in
-            the rendered hiccup; resizable-table also threads the
-            same value via the meta-key it emits for React's
-            reconciler."
+            the rendered hiccup; the widget threads the same value
+            into the attrs map of every node it weaves — the ATTRS
+            map and not vector metadata, which rf2-fcy5 slice 1
+            retired and `resizable_table_key_cljs_test` gates."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -1226,8 +1228,11 @@
             `reg-view` head grades `:invalid` down the IDENTICAL arm a plain
             `defn` does, and with no error boundary above this render path
             an HD-016 throw presents as a tab that never appears rather than
-            as an error. The three heads are the two `rt/resizable-table`
-            sites and `ei/edn-inspector` in `render-payload`.
+            as an error. The three heads are the two
+            `rt/resizable-table-view` sites and `ei/edn-inspector-view` in
+            `render-payload` — the boundaries this panel adopted; the
+            `:invalid` rows below name their Reagent siblings as the
+            controls that prove the classifier discriminates.
 
             THE INSTRUMENT IS THE CODEC'S OWN CLASSIFIER, and neither
             obvious shape works: a boundary IS a fn, so an `fn?` filter is

--- a/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/resizable_table_fresco_head_cljs_test.cljs
@@ -58,14 +58,25 @@
   scopes the SAME frame the boundary renders under, which is a match
   rather than a conflict.
 
-  ## What is deliberately NOT here
+  ## WHO ADOPTS `resizable-table-view` (rf2-k97c.3)
 
-  Nothing adopts `resizable-table-view`. The two consumer panels
-  (`panels/trace.cljs`, `panels/epoch/view.cljs`) migrate on their own
-  beads, and until their own mounts are boundaries they must keep
-  mounting the Reagent head — a Fresco boundary in a Reagent head
-  position is the mirror of the failure `reagent-head-is-invalid-to-the-
-  codec` pins below."
+  This section used to read \"Nothing adopts `resizable-table-view`\" —
+  the two consumer panels migrated on their own beads, and until their
+  own mounts were boundaries they had to keep mounting the Reagent head.
+  BOTH HAVE SINCE MIGRATED, so all five production call sites now head
+  the boundary: `panels/epoch/view.cljs` ×3 and `panels/trace.cljs` ×2.
+  The Reagent head has no production call site left.
+
+  That does NOT make the rows below vestigial, and they are the reason
+  this namespace is still the right home for them. A Fresco boundary in
+  a Reagent head position is the mirror of the failure
+  `reagent-head-is-invalid-to-the-codec` pins, and that refusal is what
+  makes a revert of either panel LOUD rather than silent — so the row
+  grades a live contract, not a historical one. `both-heads-resolve-the-
+  same-widths` likewise still has two heads to compare: the Reagent one
+  survives as the tree's only public pure-render door into the private
+  `render-table` (see its own docstring for the four namespaces that
+  depend on it)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]


### PR DESCRIPTION
## What this is

One slice of **rf2-k97c.3**. **The bead is not mine to finish and is NOT closed by this PR**, as
every previous slice has said.

The slice asked a disposition question: does `views/resizable_table.cljs`'s **Reagent** head
`resizable-table` still have a live consumer, and what follows from the answer?

## The answer

**No live PRODUCTION consumer — and the head is nonetheless NOT retired.** Both halves are
deliverables; the second is the one that needed the reading.

### The census — zero, with controls that bite

Measured at this branch's merge base over `tools/xray/src`, using a lexer that separates Clojure
**code** from comments and docstrings, so "live consumer" is answered against code alone. Three
passes per file: line-oriented, whitespace-flattened, and comment-markers-stripped-then-flattened.

| probe | pass 1 | pass 2 | pass 3 |
|---|---|---|---|
| `[rt/resizable-table` (head position) | **0** | **0** | **0** |
| `[resizable-table/resizable-table` | **0** | **0** | **0** |
| any `rt/resizable-table` reference in code | **0** | **0** | 7 (all comment/docstring) |
| CONTROL `[rt/resizable-table-view` | **5** | **5** | 5 |
| CONTROL `[ei/edn-inspector` | **3** | **3** | 16 |

`reg-view` also registers under an id, so a by-name mount through `(rf/view …)` was censused
separately: **0**, against a control of 2 for the `edn-inspector` analogue.

The five live boundary mounts are `panels/epoch/view.cljs` ×3 and `panels/trace.cljs` ×2.

**A broken instrument was caught by these controls and is worth recording**: a head-position
pattern ending in a character class reads **0** on `[rt/resizable-table-view` too — the heads sit
at end-of-line, so a trailing class matches nothing. The control's known-5 is what exposed it.

### Why the head is not retired

Its stated reason to exist *has* expired — the sequencing comment said the boundary "cannot be
ADOPTED until each consumer's own mount is one", and both consumers migrated
(`04350d02e5` Trace, `5c6b56f7ab` Epoch). But it has acquired a second, load-bearing role:

`render-table` is `defn-`. **The Reagent head is the tree's only PUBLIC pure-render door into
it**, and nine live call sites across four test namespaces depend on exactly that — including two
that assert the head does **not** appear in a panel tree, which makes the var the referent that
keeps a revert detectable. Delete it and those rows cannot be written, let alone go red.

Retiring it would delete real coverage across four namespaces to remove one var from a
bundle-isolated dev tool. Nothing here blocks a later retirement; it would just have to re-point
those namespaces first. The docstring now says all of this, so the head no longer reads as dead
weight to the next person who censuses it.

## What changed

Comments and docstrings only. **No executable form changes, and no assertion is added, removed or
altered** — verified by a diff probe for `(is` / `(deftest` / `(are` forms reading **0** against a
control commit reading **50**.

The stale text misdirected in the dangerous direction: it instructed the next consumer to mount
the Reagent head, which now raises `:rf.error/fresco-bad-head` inside either migrated panel.

- `views/resizable_table.cljs` — Consumer API sample now shows the boundary; the "every call site
  is still on `resizable-table`" claim and the "cannot be ADOPTED until…" comment corrected; the
  `reg-view` docstring records that it has no production consumer and why it still ships.
- `views/resizable_table_fresco_head_cljs_test.cljs` — "Nothing adopts `resizable-table-view`" was
  false; corrected, with why its rows still grade a live contract rather than a historical one.
- `panels/trace_view_cljs_test.cljs` — two stale present-tense claims, including one describing the
  **retired** meta-key spelling as current.

## Quality gates

| gate | exit (quoted from its own `.exit` file) |
|---|---|
| `compile-node-test.cjs node-test` (phase 1, split) | **0** — 1982 compiled, 0 warnings |
| `node out/node-test.js` (phase 2, gated on phase 1) | **0** — 11772 tests, 58774 assertions, 0 failures, 0 errors |
| `check_retired_spellings.py` | **0** |
| 12 further ratchets reaching `tools/` + `check-ai-tracking-ratchet.sh` | **0** each |
| SABOTAGE run of `check_retired_spellings.py` | **1** — named this PR's file and line and quoted the plant |

The compound `test:cljs` was **split** rather than chained, so the compile's exit is captured
separately. (Worth noting for future slices: `compile-node-test.cjs` already deletes `:output-to`
before compiling, so the stale-bundle hazard is closed by construction here.)

**Both worktree-verification routes were available and both were taken**: the compile log names
this branch's own `shadow-cljs.edn`, and the planted fault went red naming the planted line —
a fault that existed only in this checkout. Restore verified by blob hash against the committed
object, plus `git diff --quiet HEAD` as an independent instrument.

Left to CI: the 101 required checks `check_fast_pr_gap.py --brief` reports the local spine does not
decide, plus the Xray compile sweep and the feature-matrix gate.

## One thing left alone, deliberately

`panels/trace.cljs:1032` carries the same stale spelling (`ei/edn-inspector` described as a current
head in `render-payload`, where the code heads `ei/edn-inspector-view`). That file is a production
source fenced to another worker this tick, so it is reported rather than edited.
