### PR TITLE
feat(xray): ship a Fresco head for the machine canvas chart (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -15,10 +15,14 @@
        `[:rf.xray/machine-canvas :chart-collapsed-by-id machine-id]`.
        Persisted to localStorage so the operator's choice to hide the
        chart real-estate survives reloads.
-    2. **`Chart` hiccup adapter** — thin wrapper around
+    2. **The chart adapter** — a thin wrapper around
        `mv-chart/MachineChart` that wires the focused-event lens
        from-state / to-state highlights, the on-state-click
-       dispatch, and the after-rings overlay.
+       dispatch, and the after-rings overlay. rf2-k97c.3 split it into
+       one body, `chart-tree`, behind TWO heads: `Chart` for a Reagent
+       parent and `Chart-view` for a Fresco boundary. `chart-tree`'s
+       docstring carries why both are needed and what differs between
+       them; nothing else about this surface moved.
 
   ## What this no longer owns
 
@@ -55,8 +59,13 @@
   (:require [clojure.string :as str]
             [cljs.reader :as reader]
             [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.local-storage :as ls]
+            ;; rf2-k97c.3 — the `as-child` door [[Chart-view]] hands
+            ;; [[chart-tree]] for the machines-viz mount. See that fn's
+            ;; docstring for why the chart itself stays Reagent.
+            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-machines-viz.chart :as mv-chart]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
             ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the canvas-side
@@ -213,19 +222,53 @@
       (rf/dispatch [:rf.xray.machine-canvas/hydrate-chart-collapsed by-id]
                    {:frame defaults/default-frame-id}))))
 
-;; ---- public Chart view --------------------------------------------------
+;; ---- the shared chart body ----------------------------------------------
 
-(rf/reg-view Chart
-  "Render the interactive MachineChart inside the Dynamic Machines
-  panel (or the Static Machines Topology body).
+(defn chart-tree
+  "The chart's whole markup, as a pure function of its props and the two
+  spellings that differ between the substrates. [[Chart]] and
+  [[Chart-view]] are both one call to this and nothing else, so the two
+  heads cannot drift apart on anything an operator sees (rf2-k97c.3).
 
-  rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
-  React-context frame tier carries the enclosing `:rf/xray` frame
-  through to xray-internal subscribes (e.g. the chart-collapsed slot).
-  As a plain fn the subscribe routed to `:rf/default` (the host app),
-  which is a real frame-leak — xray-internal slots must be read via
-  xray's own frame. Same surgery PR #2110 (rf2-uu3lp) applied to the
-  rest of xray chrome.
+  ## Why there are two heads rather than one
+
+  `Chart` answers hiccup, but that hiccup is NOT head-free: it mounts
+  `mv-chart/MachineChart`, a Reagent component, and the after-rings
+  overlay. So the standard HD-016 repair — inline it into the calling
+  boundary — cannot terminate here, and the door is Fresco's component
+  ABI: a React ELEMENT is a legal child anywhere.
+
+  `Chart` could not simply BECOME [[Chart-view]], because two of its four
+  consumers reach it from REAGENT: `static/machines/topology.cljs` and
+  `static/machines/sim.cljs` render inside the `as-child` island
+  `static/machines/definition_detail.cljs` hands down, and that island is
+  that slice's to retire. A Reagent parent's only inward door to a
+  boundary is `rf.fresco/as-component`, whose contract is explicit that
+  `[:>]` converts first, so \"names round-trip across the crossing and
+  values do not\" — and this props map is nothing BUT values a conversion
+  would destroy: a nested `:definition`, keyword ids, two edge-id SETS and
+  three callbacks. So the `reg-view` head survives for them, and the
+  boundary serves the consumer that is already a boundary.
+
+  That is `views/edn_widget.cljs`'s dual-head facade (`inspect` beside
+  `inspect-view`) applied to this widget: same value, same opts, same
+  renderer, only the head differs.
+
+  ## The two spellings
+
+  `as-child` wraps the machines-viz mount. `identity` leaves it the
+  Reagent head it has always been; `substrate/as-element` answers a React
+  element through the INSTALLED adapter's own walk. The chart itself stays
+  Reagent either way — xyflow is a React library reached through a Reagent
+  component, and making it substrate-neutral is machines-viz's concern,
+  not Xray's. So this is a REAL island with a defined end, and the end is
+  not in this tree.
+
+  `overlay` is the after-rings mount, which differs by HEAD rather than by
+  wrapping and so cannot ride `as-child`: the Reagent lane heads
+  `after-rings/AfterRingsOverlay-bridge`, the boundary heads the
+  `rf.fresco/defview` directly. It is used only when
+  `:show-after-rings?` is on, so a caller may build it unconditionally.
 
   Args (map):
 
@@ -330,7 +373,9 @@
            ;; `:theme` prop still wins. No toggle UI is built in.
            theme                   @default-chart-theme
            testid                  "rf-xray-machine-canvas-host"
-           inner-testid            "rf-mv-chart"}}]
+           inner-testid            "rf-mv-chart"}}
+   as-child
+   overlay]
   [:div
    {:data-testid testid
     :data-machine-id (str machine-id)
@@ -349,47 +394,96 @@
    [:div {:data-testid inner-testid
           :data-machine-id (str machine-id)
           :style {:width "100%" :height "100%"}}
-    [mv-chart/MachineChart
-     {:definition      definition
-      :machine-id      machine-id
-      :context-band    context-band
-      ;; rf2-3q4k5b (EP-0005) — declared-over-inferred provenance for the
-      ;; Context band badge. Forwarded so the Static topology path can mark a
-      ;; `[:schemas :data]`-declared shape AUTHORITATIVE (false → no inferred
-      ;; badge). Defaults true (rf2-5tz9p's inferred-by-default posture).
-      :context-band-inferred? context-band-inferred?
-      :from-highlight  from-highlight
-      :to-highlight    to-highlight
-      :current-state   current-state
-      :fired-edge-ids  fired-edge-ids
-      :guard-blocked-edge-ids guard-blocked-edge-ids
-      :sim?            sim?
-      :theme           theme
-      :on-state-click  on-state-click
-      :on-edge-click   on-edge-click
-      ;; rf2-6tw7t — fit-on-entry nonce. The host (Machine panel /
-      ;; Static topology) bumps this on panel-entry / tab-activation so
-      ;; the chart re-fits the topology even when the layout-key is
-      ;; unchanged (re-entering the same machine). Forwarded verbatim.
-      :fit-signal      fit-signal
-      :show-minimap?   false
-      :show-controls?  show-controls?
-      :show-background? true
-      :testid          "rf-mv-chart"}]]
-   (when show-after-rings?
-     ;; The overlay walks the chart's node DOM by data-testid to find
-     ;; bbox positions; no positioned-graph prop is needed
-     ;; post-migration (xyflow owns positions internally).
-     ;;
-     ;; rf2-k97c.3 — `AfterRingsOverlay` is now an `rf.fresco/defview`,
-     ;; i.e. a real React component, and `Chart` here is still a
-     ;; `reg-view`, i.e. a Reagent tree. `AfterRingsOverlay-bridge` is
-     ;; the one line between them (`rf.fresco/as-component`, crossing an
-     ;; empty props map — the overlay's opts were never read, which is
-     ;; why the old `nil` argument is no loss). Both the bridge and this
-     ;; call go at step 3, when `Chart` is itself a Fresco body and can
-     ;; mount the boundary directly.
-     [after-rings/AfterRingsOverlay-bridge])])
+    ;; rf2-k97c.3 — `as-child` is the island spelling. `identity` under
+    ;; [[Chart]] leaves this the Reagent head it has always been;
+    ;; `substrate/as-element` under [[Chart-view]] answers a React element,
+    ;; which Fresco's codec passes through as a legal child. The props map
+    ;; crosses BY IDENTITY either way, because the vector itself is what is
+    ;; handed to the walk — the very property `rf.fresco/as-component`
+    ;; cannot offer in the opposite direction.
+    (as-child
+      [mv-chart/MachineChart
+       {:definition      definition
+        :machine-id      machine-id
+        :context-band    context-band
+        ;; rf2-3q4k5b (EP-0005) — declared-over-inferred provenance for the
+        ;; Context band badge. Forwarded so the Static topology path can mark
+        ;; a `[:schemas :data]`-declared shape AUTHORITATIVE (false → no
+        ;; inferred badge). Defaults true (rf2-5tz9p's inferred-by-default
+        ;; posture).
+        :context-band-inferred? context-band-inferred?
+        :from-highlight  from-highlight
+        :to-highlight    to-highlight
+        :current-state   current-state
+        :fired-edge-ids  fired-edge-ids
+        :guard-blocked-edge-ids guard-blocked-edge-ids
+        :sim?            sim?
+        :theme           theme
+        :on-state-click  on-state-click
+        :on-edge-click   on-edge-click
+        ;; rf2-6tw7t — fit-on-entry nonce. The host (Machine panel /
+        ;; Static topology) bumps this on panel-entry / tab-activation so
+        ;; the chart re-fits the topology even when the layout-key is
+        ;; unchanged (re-entering the same machine). Forwarded verbatim.
+        :fit-signal      fit-signal
+        :show-minimap?   false
+        :show-controls?  show-controls?
+        :show-background? true
+        :testid          "rf-mv-chart"}])]
+   ;; The overlay walks the chart's node DOM by data-testid to find bbox
+   ;; positions; no positioned-graph prop is needed post-migration (xyflow
+   ;; owns positions internally).
+   ;;
+   ;; rf2-k97c.3 — the overlay is an `rf.fresco/defview`, so WHICH head
+   ;; mounts it is the caller's to decide and arrives as `overlay`: a
+   ;; Reagent tree cannot head a boundary and takes the `as-component`
+   ;; bridge, while [[Chart-view]] heads the boundary itself. Building the
+   ;; value is free, so callers build it unconditionally and this is the
+   ;; only place `:show-after-rings?` is read.
+   (when show-after-rings? overlay)])
+
+;; ---- the two public heads (rf2-k97c.3) ----------------------------------
+
+(rf/reg-view Chart
+  "Render the interactive MachineChart from a REAGENT tree — the Static
+  Machines Topology and Sim bodies, which render inside the `as-child`
+  island `static/machines/definition_detail.cljs` hands down.
+
+  One call to [[chart-tree]] and nothing else; that fn's docstring carries
+  the args, the two spellings, and why this head survives beside
+  [[Chart-view]] rather than being replaced by it.
+
+  rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
+  React-context frame tier carries the enclosing `:rf/xray` frame through
+  to xray-internal subscribes. That reasoning is HISTORICAL as of
+  rf2-k97c.3: this body performs no read at all, so nothing here depends
+  on the frame it renders under. What `reg-view` still buys is that a
+  Reagent parent can HEAD it, which a boundary cannot offer.
+
+  Returns hiccup."
+  [props]
+  (chart-tree props identity [after-rings/AfterRingsOverlay-bridge]))
+
+(rf.fresco/defview Chart-view
+  "[[Chart]], for a caller that is already a Fresco boundary — today
+  `panels/machine_inspector.cljs`'s ELEMENT 3, which headed the `reg-view`
+  through an `as-child` island until this landed.
+
+  Same value, same props, same renderer; the ONLY differences are the head
+  and the two spellings [[chart-tree]] takes — `substrate/as-element` for
+  the machines-viz mount, and the after-rings boundary headed directly
+  rather than through its `as-component` bridge.
+
+  NO `:mount-id`, and that is a property of this widget rather than an
+  omission: a boundary cannot mint its own per-mount identity, but this
+  body reads nothing and holds no per-instance state, so it has none to
+  key. Its one stateful descendant, the machines-viz chart, keeps its
+  identity from React's own reconciliation exactly as it did under
+  `reg-view`.
+
+  Takes the ordinary one-props-map argument every `defview` takes."
+  [props]
+  (chart-tree props substrate/as-element [after-rings/AfterRingsOverlay {}]))
 
 ;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -68,12 +68,6 @@
             ;; marker before any panel surface reads it — never raw.
             [re-frame.classification :as rf.classification]
             [re-frame.fresco :as rf.fresco]
-            ;; rf2-k97c.3 — `substrate/as-element` is the `as-child`
-            ;; spelling [[Panel]] hands down for the ONE island this panel
-            ;; still needs (the topology chart; see [[panel-tree]]). The
-            ;; markup stays pure hiccup — Reagent appears here as a
-            ;; migration seam, not as an authoring dependency.
-            [day8.re-frame2-xray.substrate :as substrate]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             ;; rf2-g2axio — the SHARED EVENT HANDLER machine-cascade
@@ -362,17 +356,27 @@
   mini-pipeline above the chart, or relocated to the chart's own
   toolbar.
 
-  rf2-k97c.3 — `as-child` is the island spelling [[panel-tree]] threads
-  down: `identity` for a hiccup caller (the node lane), and
-  `substrate/as-element` under the boundary. It wraps ELEMENT 3 only.
-  `machine-canvas/Chart` is still an `rf/reg-view`, and a `reg-view` head
-  grades `:invalid` under Fresco's codec down the IDENTICAL arm a plain
-  `defn` does — the codec reads one own property, `frescoBoundary`, which
-  only `rf.fresco/defview` sets. Islanding rather than migrating `Chart`
-  is a SCHEDULING call and a deliberate one: `Chart` has a second consumer
-  outside this panel (`panels/machines/topology_view.cljs`, on the Static
-  surface), so migrating it is that slice's to make, not this one's.
-  ELEMENT 2 needs no island — every head reachable through
+  rf2-k97c.3 — THE ISLAND IS GONE FROM THIS PANEL. ELEMENT 3 used to wrap
+  its chart mount in an `as-child` crossing, because `machine-canvas/Chart`
+  is an `rf/reg-view` and a `reg-view` head grades `:invalid` under
+  Fresco's codec down the IDENTICAL arm a plain `defn` does — the codec
+  reads one own property, `frescoBoundary`, which only `rf.fresco/defview`
+  sets. `machine-canvas/Chart-view` now ships that boundary beside the
+  `reg-view`, both one call to the same `machine-canvas/chart-tree`, so
+  this panel heads it directly and the `as-child` parameter is gone from
+  this fn and from the three above it.
+
+  The `reg-view` survives for the two Static consumers, which reach the
+  chart from inside `static/machines/definition_detail.cljs`'s own island
+  and whose only inward door would convert the props map's values. That is
+  their slice's to retire; nothing about it reaches this panel any more.
+
+  The ISLAND HAS NOT VANISHED, it has MOVED DOWN one level, out of this
+  panel and into `machine-canvas/chart-tree`, which crosses the
+  machines-viz chart itself. Its end condition is machines-viz shipping a
+  substrate-neutral head, which is not this tree's to schedule.
+
+  ELEMENT 2 needs no island either — every head reachable through
   `epoch-view/machine-cascade-mini-pipeline` was repaired in the same
   commit, so that whole subtree is head-free.
 
@@ -386,7 +390,6 @@
    {:keys [machine-id from-state to-state definition fired-edge-ids
            guard-blocked-edge-ids start? no-op?]
     :as _record}
-   as-child
    fit-signal
    instance]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
@@ -498,55 +501,62 @@
          ;; rf2-y3l8z — the chart wraps an interactive viewport adapter
          ;; (zoom/pan/fit + controls toolbar) and owns the after-rings
          ;; overlay so they stay co-located with the canvas.
-         (as-child
-           [machine-canvas/Chart
-            {:definition         definition
-             :machine-id         machine-id
-             ;; rf2-kq8nac (EP-0005) — surface the AUTHORITATIVE declared
-             ;; Context shape (keys + type captions) in the focused-event
-             ;; chart's root Context band, with the declared-vs-inferred
-             ;; indicator. When the machine declares a `[:schemas :data]` schema the
-             ;; shape is read off the schema and `:context-band-inferred?`
-             ;; is FALSE (the chart drops the `inferred from :data` badge and
-             ;; shows `declared` — consistent with the Static Topology view
-             ;; from rf2-3q4k5b); absent a schema it falls back to the
-             ;; one-sample inference (rf2-5tz9p's badge stays). This is the
-             ;; SHAPE, not live `:data` VALUES — the live runtime `:data`
-             ;; surfaces (egress-redacted) through the SHARED mini-pipeline's
-             ;; cascade rows above, never raw here.
-             :context-band       (topology-view/static-context-shape definition)
-             :context-band-inferred? (topology-view/static-context-inferred? definition)
-             ;; rf2-skmc7 — a NO-OP has no from→to edge; suppress the
-             ;; from/to highlight grammar and surface the CURRENT state via
-             ;; `:current-state` instead.
-             :from-highlight     (when-not no-op? from-state)
-             :to-highlight       (when-not no-op? to-state)
-             ;; rf2-eldze / rf2-skmc7 — a BIRTH's initial state and a
-             ;; NO-OP's unchanged current state both ride `:current-state`
-             ;; so the chart highlights the one resting node.
-             :current-state      (cond
-                                   start? to-state
-                                   no-op? to-state
-                                   :else  nil)
-             ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
-             ;; treatment on the live chart.
-             :fired-edge-ids     fired-edge-ids
-             ;; rf2-fzrzlw — the attempted-and-rejected edges (guard-blocked
-             ;; no-op, e.g. door :door/close blocked by :may-close?) paint
-             ;; the PINK guard-blocked treatment on the live chart so the
-             ;; operator sees which edge the event hit + that a guard
-             ;; rejected it (no transition fired, so the fired set is empty).
-             :guard-blocked-edge-ids guard-blocked-edge-ids
-             ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
-             ;; tab re-frames the topology.
-             :fit-signal         fit-signal
-             :on-state-click     (fn [path]
-                                   (rf/dispatch
-                                     [:rf.xray/machine-state-clicked
-                                      {:machine-id machine-id
-                                       :path       path}]
-                                     {:frame frame}))
-             :show-after-rings?  true}])]])]))
+         ;;
+         ;; rf2-k97c.3 — `Chart-view` is the FRESCO head of the same
+         ;; `machine-canvas/chart-tree` the `reg-view` `Chart` renders, so
+         ;; this mount is an ordinary boundary head and no longer crosses an
+         ;; `as-child` island. The props map reaches it BY IDENTITY, which
+         ;; is why the two-heads-one-body shape was needed rather than an
+         ;; `as-component` bridge: a Reagent parent's `[:>]` converts first
+         ;; and this map is nothing but values a conversion would destroy.
+         [machine-canvas/Chart-view
+          {:definition         definition
+           :machine-id         machine-id
+           ;; rf2-kq8nac (EP-0005) — surface the AUTHORITATIVE declared
+           ;; Context shape (keys + type captions) in the focused-event
+           ;; chart's root Context band, with the declared-vs-inferred
+           ;; indicator. When the machine declares a `[:schemas :data]` schema the
+           ;; shape is read off the schema and `:context-band-inferred?`
+           ;; is FALSE (the chart drops the `inferred from :data` badge and
+           ;; shows `declared` — consistent with the Static Topology view
+           ;; from rf2-3q4k5b); absent a schema it falls back to the
+           ;; one-sample inference (rf2-5tz9p's badge stays). This is the
+           ;; SHAPE, not live `:data` VALUES — the live runtime `:data`
+           ;; surfaces (egress-redacted) through the SHARED mini-pipeline's
+           ;; cascade rows above, never raw here.
+           :context-band       (topology-view/static-context-shape definition)
+           :context-band-inferred? (topology-view/static-context-inferred? definition)
+           ;; rf2-skmc7 — a NO-OP has no from→to edge; suppress the
+           ;; from/to highlight grammar and surface the CURRENT state via
+           ;; `:current-state` instead.
+           :from-highlight     (when-not no-op? from-state)
+           :to-highlight       (when-not no-op? to-state)
+           ;; rf2-eldze / rf2-skmc7 — a BIRTH's initial state and a
+           ;; NO-OP's unchanged current state both ride `:current-state`
+           ;; so the chart highlights the one resting node.
+           :current-state      (cond
+                                 start? to-state
+                                 no-op? to-state
+                                 :else  nil)
+           ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
+           ;; treatment on the live chart.
+           :fired-edge-ids     fired-edge-ids
+           ;; rf2-fzrzlw — the attempted-and-rejected edges (guard-blocked
+           ;; no-op, e.g. door :door/close blocked by :may-close?) paint
+           ;; the PINK guard-blocked treatment on the live chart so the
+           ;; operator sees which edge the event hit + that a guard
+           ;; rejected it (no transition fired, so the fired set is empty).
+           :guard-blocked-edge-ids guard-blocked-edge-ids
+           ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
+           ;; tab re-frames the topology.
+           :fit-signal         fit-signal
+           :on-state-click     (fn [path]
+                                 (rf/dispatch
+                                   [:rf.xray/machine-state-clicked
+                                    {:machine-id machine-id
+                                     :path       path}]
+                                   {:frame frame}))
+           :show-after-rings?  true}]]])]))
 
 ;; ---- prev/next nav (per-machine epoch walking) -------------------------
 
@@ -614,13 +624,14 @@
   rf2-alsnz — `records` flows in as an arg so the panel reads the
   composite once per render instead of twice.
 
-  rf2-k97c.3 — `as-child` and `fit-signal` are threaded straight through
-  to [[focused-event-section]], the only place either is used; see that
-  fn's docstring for what the island covers and why the nonce is an
-  argument now. `target-frame` likewise ARRIVES AS AN ARGUMENT rather
-  than being read here, for the same reason: a `rf.fresco/sub` raises
-  outside a collector window, and this fn is node-lane-driven."
-  [records cascade as-child fit-signal target-frame instance]
+  rf2-k97c.3 — `fit-signal` is threaded straight through to
+  [[focused-event-section]], the only place it is used; see that fn's
+  docstring for why the nonce is an argument now. `target-frame` likewise
+  ARRIVES AS AN ARGUMENT rather than being read here, for the same reason:
+  a `rf.fresco/sub` raises outside a collector window, and this fn is
+  node-lane-driven. The `as-child` argument that sat between them is gone
+  with the island it spelled."
+  [records cascade fit-signal target-frame instance]
   (let [;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
@@ -661,7 +672,7 @@
        ;; `focused-event-section` answers hiccup whose own attribute map
        ;; is not ours to write into, so the key rides the fragment.
        [:<> {:key (h/focused-event-section-key target-frame record)}
-        (focused-event-section cascade record as-child fit-signal instance)]])))
+        (focused-event-section cascade record fit-signal instance)]])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
@@ -741,10 +752,6 @@
   paint, liveness, frame targeting and teardown — is
   `machine_inspector_fresco_boundary_dom_cljs_test`'s subject.
 
-  `as-child` is the island spelling, threaded down to
-  [[focused-event-section]] and used nowhere else: `identity` for a
-  hiccup caller, `substrate/as-element` under the boundary.
-
   PURE: every helper it calls is a plain fn of its arguments. Two values
   that used to be read deep in the tree — [[focused-event-view]]'s
   target-frame and [[focused-event-section]]'s fit-signal — are arguments
@@ -757,10 +764,10 @@
   ;; to name working, and answers this panel's OWN token for them rather
   ;; than nil: the cascade ids below are composed in the Epoch panel's id
   ;; namespace, so `no instance` still has to say which panel is rendering.
-  ([data records cascade as-child fit-signal target-frame]
-   (panel-tree data records cascade as-child fit-signal target-frame
+  ([data records cascade fit-signal target-frame]
+   (panel-tree data records cascade fit-signal target-frame
                (instance-token nil)))
-  ([{:keys [empty-kind]} records cascade as-child fit-signal target-frame
+  ([{:keys [empty-kind]} records cascade fit-signal target-frame
     instance]
   (let [;; The first record's machine-id drives the prev/next nav (a
         ;; cascade may touch multiple machines; the nav's "this machine"
@@ -794,7 +801,7 @@
        ;; does not duplicate-subscribe the same composite handle.
        [:div {:data-testid "rf-xray-machine-inspector-focused-event-host"
               :style focused-event-host-style}
-        (focused-event-view records cascade as-child fit-signal target-frame
+        (focused-event-view records cascade fit-signal target-frame
                             instance)]
 
        :else
@@ -829,11 +836,12 @@
   resolves `:rf/xray` identically under today's Reagent-rendered shell
   and under the Fresco root Xray will own.
 
-  ONE ISLAND SURVIVES, and it is scheduling rather than residue:
-  `substrate/as-element` is handed down for the topology chart, because
-  `machine-canvas/Chart` is still an `rf/reg-view` and has a second
-  consumer on the Static surface. [[focused-event-section]] records the
-  condition that retires it.
+  NO ISLAND SURVIVES IN THIS PANEL. The topology chart was the last one,
+  and `machine-canvas/Chart-view` — the Fresco head of the same body the
+  `reg-view` `Chart` renders — retired it; [[focused-event-section]]
+  records what moved and what is left. The island the chart still needs
+  for the machines-viz component now lives inside `machine-canvas`, one
+  level below anything this panel hands down.
 
   The argument is the ordinary one-props-map vector every `defview` takes.
 
@@ -874,7 +882,6 @@
               ;; same focused epoch Prev/Next drives, so the mini-pipeline
               ;; and the chart move together.
               (:cascade (rf.fresco/sub [:rf.xray/machine-focused-epoch-cascade]))
-              substrate/as-element
               (rf.fresco/sub [:rf.xray/machine-tab-fit-signal])
               (rf.fresco/sub [:rf.xray/target-frame])
               ;; rf2-3ymg — this mount's qualifier for the SHARED
@@ -910,9 +917,12 @@
 ;; The Tier 4 sub-components (after-rings overlay, arc/cluster overlays,
 ;; scrubber strip, sim side-rail) render UNDER `Panel` and are not
 ;; independently mountable, so they need no bridge of their own. The
-;; after-rings overlay is the ONE exception and already carries its own
-;; (`machine_after_rings/AfterRingsOverlay-bridge`), because it is mounted
-;; from `machine-canvas/Chart`, which is still Reagent.
+;; after-rings overlay carries its own
+;; (`machine_after_rings/AfterRingsOverlay-bridge`), but NOT for this
+;; panel's sake any more: rf2-k97c.3 made `machine-canvas/Chart-view` a
+;; boundary, and it heads the overlay directly. The bridge survives for the
+;; `reg-view` `machine-canvas/Chart`, which the two Static Reagent-island
+;; consumers still head.
 ;;
 ;; STILL SCAFFOLDING WITH A DEFINED END: when the shell is itself a Fresco
 ;; tree, `reg-l4-tab!` takes `Panel` directly, `[:>]` goes, and both defs

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -17,7 +17,12 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            ;; rf2-k97c.3 — `boundary-head?` is the production predicate the
+            ;; codec grades a hiccup head with. The dual-head rows read it
+            ;; rather than restating how each head was spelled.
+            [re-frame.fresco.impl.codec :as rf.fresco.impl.codec]
             [re-frame.registrar :as rf.registrar]
+            [day8.re-frame2-machines-viz.chart :as mv-chart]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.panels.machine-after-rings :as after-rings]
@@ -219,6 +224,84 @@
                         (hiccup-seq tree))]
         (is (not (contains? heads after-rings/AfterRingsOverlay-bridge))
             ":show-after-rings? false drops the overlay mount entirely")))))
+
+;; ---- 3b. the two heads, and the one body behind them (rf2-k97c.3) ------
+
+(deftest the-two-chart-heads-differ-only-in-boundary-grade
+  (testing "rf2-k97c.3 — this ns ships a DUAL-HEAD FACADE, the shape
+            `views/edn_widget.cljs` already uses for `inspect` /
+            `inspect-view`: `Chart` for a Reagent parent, `Chart-view` for a
+            Fresco one, both one call to [[mc/chart-tree]].
+
+            Graded by the production predicate `codec/boundary-head?`, which
+            reads the single own property (`frescoBoundary`) that only
+            `rf.fresco/defview` sets — so this row states what the codec will
+            actually do with each head rather than restating how each was
+            spelled.
+
+            BOTH DIRECTIONS, because a predicate that answered true for
+            everything would satisfy the first half alone. The `reg-view`
+            must grade FALSE: it is what the two Static consumers head from
+            inside `definition_detail`'s own Reagent island, and heading it
+            under a boundary is the loud `:invalid` this facade exists to
+            avoid."
+    (is (rf.fresco.impl.codec/boundary-head? mc/Chart-view)
+        "Chart-view is a Fresco boundary head")
+    (is (not (rf.fresco.impl.codec/boundary-head? mc/Chart))
+        "CONTROL: the surviving reg-view is NOT, so the assertion above
+         discriminates rather than reading true for any fn")))
+
+(deftest chart-tree-wraps-only-the-machines-viz-mount-in-as-child
+  (testing "rf2-k97c.3 — `as-child` covers the machines-viz chart and NOTHING
+            else. Driven with a marking wrapper rather than a real substrate
+            walk, so the row reads the seam's EXTENT without depending on a
+            React element being constructible in the node lane.
+
+            The extent is the claim worth pinning: widen it and the Fresco
+            lane would cross its own wrapper divs into Reagent, which paints
+            the same and silently puts the panel's chrome back under the
+            installed adapter's renderer."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [crossed  (atom [])
+            marking  (fn [v] (swap! crossed conj v) [:marked v])
+            tree     (mc/chart-tree {:definition fixture-definition
+                                     :machine-id :m}
+                                    marking
+                                    [::overlay-sentinel])
+            heads    (into #{}
+                           (comp (filter vector?) (map first))
+                           (hiccup-seq tree))]
+        (is (some? (find-by-testid tree "rf-xray-machine-canvas-host"))
+            "the canvas host is emitted by chart-tree itself and does NOT
+             cross the seam — the boundary's own chrome stays its own")
+        (is (= 1 (count @crossed))
+            (str "exactly one thing crosses. Crossed: " (pr-str @crossed)))
+        (is (= mv-chart/MachineChart (ffirst @crossed))
+            "and it is the machines-viz chart, the one head in this body that
+             Fresco's codec would refuse")
+        (is (contains? heads ::overlay-sentinel)
+            "the overlay value the caller handed in is mounted verbatim —
+             which is how the two heads mount DIFFERENT overlay heads (the
+             bridge, or the boundary) through one body")))))
+
+(deftest chart-tree-reads-show-after-rings-and-nothing-else-gates-the-overlay
+  (testing "rf2-k97c.3 — the NON-VACUITY control for the row above: with
+            `:show-after-rings? false` the caller's overlay value is dropped
+            altogether, so the assertion that it is mounted verbatim is a
+            claim about the gate and not about a value that is always there."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (let [tree  (mc/chart-tree {:definition fixture-definition
+                                  :machine-id :m
+                                  :show-after-rings? false}
+                                 identity
+                                 [::overlay-sentinel])
+            heads (into #{}
+                        (comp (filter vector?) (map first))
+                        (hiccup-seq tree))]
+        (is (not (contains? heads ::overlay-sentinel))
+            ":show-after-rings? false drops the caller's overlay entirely")))))
 
 ;; ---- 4. SnapshotDrillIn view (rf2-lxvn6 · spec/021 §10) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_fresco_boundary_dom_cljs_test.cljs
@@ -19,18 +19,17 @@
                                     OWN sub-cache rather than off the DOM
     6 CLEAN TEARDOWN              — W3
 
-  W4 answers no epic criterion. It is the CONTROL under W1's island row: it
-  mounts the panel's own tree with the island child removed and shows the
-  island assertion failing while the wrapper assertions still pass.
+    5 NO APPLICATION VIEW TRACE   — W5, with the positive `reg-view` control
+                                    that makes the zero mean silence
 
-  Criteria 3 and 5 have no row here for the reasons the Epoch panel's sibling
-  suite sets out: criterion 5 is structural and identical for every boundary
-  in this migration, and `static/flows/panel_fresco_boundary_dom_cljs_test`
-  carries it with a positive `reg-view` control; criterion 3's affordances
-  here (Prev/Next, the chart's state-click) dispatch through a frame captured
-  at render time by `rf/current-frame-id`, which this migration did not touch.
+  W4 answers no epic criterion. It is the standing demonstration under W1's
+  chart row that the wrapper selector cannot witness the chart.
 
-  ## FIVE READS, AND THE ISLAND
+  Criterion 3 has no row here: its affordances (Prev/Next, the chart's
+  state-click) dispatch through a frame captured at render time by
+  `rf/current-frame-id`, which this migration did not touch.
+
+  ## FIVE READS, AND NO ISLAND
 
   The boundary reads `:rf.xray/machine-inspector-data`,
   `:rf.xray/machine-transitions-for-focused-event`,
@@ -39,21 +38,22 @@
   deep in the tree; rf2-k97c.3 hoisted them into the body so the helpers stay
   pure functions the node lane can drive. W1 and W3 assert on all five.
 
-  ONE ISLAND SURVIVES and W1 has a row for it. `machine-canvas/Chart` is
-  still an `rf/reg-view` — it has a second consumer on the Static surface, so
-  migrating it belongs to that slice — and a `reg-view` head grades
-  `:invalid` under Fresco's codec down the IDENTICAL arm a plain `defn` does.
-  The boundary therefore hands `r/as-element` down as the `as-child`
-  spelling. That is not a detail a node-lane row can witness: under
-  `identity` the island is a no-op and the tree looks the same either way.
-  Here, a missing or wrong island does not paint at all.
+  NO ISLAND SURVIVES IN THIS PANEL, and that is what changed at the commit
+  these rows were last revised for. ELEMENT 3 used to hand `r/as-element`
+  down as an `as-child` spelling, because `machine-canvas/Chart` is an
+  `rf/reg-view` and a `reg-view` head grades `:invalid` under Fresco's codec
+  down the IDENTICAL arm a plain `defn` does. `machine-canvas/Chart-view`
+  now ships that boundary beside the `reg-view` — both one call to the same
+  `machine-canvas/chart-tree` — so the panel heads it directly, the
+  parameter is gone from four signatures, and W5's zero becomes reachable
+  for the first time.
 
-  SELECT THE ISLAND BY A NODE THE ISLAND EMITS (rf2-q6n3). That is
-  `rf-xray-machine-canvas-host`, `Chart`'s own root. It is NOT
+  SELECT THE CHART BY A NODE THE CHART EMITS (rf2-q6n3). That is
+  `rf-xray-machine-canvas-host`, the chart's own root. It is NOT
   `rf-xray-machine-focused-event-chart`, which `machine_inspector` emits two
-  levels ABOVE its `as-child` call and which therefore survives the whole
-  Chart subtree being absent — W1 claimed the island on that marker until
-  rf2-q6n3, and W4 is the standing demonstration of why it could not.
+  levels ABOVE the mount and which therefore survives the whole chart
+  subtree being absent — W1 claimed the chart on that marker until rf2-q6n3,
+  and W4 is the standing demonstration of why it could not.
 
   ## The mount is the SHELL's mount, taken from the registry
 
@@ -94,14 +94,6 @@
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.machines]
             [re-frame.test-support :as rf.test-support]
-            ;; W4 only. `r/as-element` is the island spelling [[Panel]] hands
-            ;; down, and W4's control is that same call with the ONE argument
-            ;; swapped — so the test needs the production spelling verbatim.
-            [reagent.core :as r]
-            ;; W4 only, and it is the one place this file names a panel var
-            ;; rather than reaching through the registry: `panel-tree` IS the
-            ;; seam the island rides on, so the control has to call it.
-            [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
@@ -264,23 +256,26 @@
 
 (defn- chart-wrapper-node
   "The chart WRAPPER — a `:div` `machine_inspector` itself emits above the
-  island (`panels/machine_inspector.cljs`, ELEMENT 3). Its presence says the
-  focused-event section reached element 3 and took the has-definition arm,
-  and it says NOTHING WHATEVER about the island: `machine_inspector` emits
-  this node and a second styling wrapper BEFORE the `as-child` call, so it is
-  committed even when `as-child` answers nil and the entire Chart subtree is
-  absent. [[w4-the-island-selector-discriminates-and-the-wrapper-does-not]]
+  chart mount (`panels/machine_inspector.cljs`, ELEMENT 3). Its presence says
+  the focused-event section reached element 3 and took the has-definition
+  arm, and it says NOTHING WHATEVER about the chart: `machine_inspector`
+  emits this node and a second styling wrapper ABOVE the mount, so it is
+  committed even when the entire chart subtree is absent.
+  [[w4-the-chart-selector-discriminates-and-the-wrapper-does-not]]
   demonstrates exactly that, which is why this is not a claim about the
-  island and must never be written as one again (rf2-q6n3)."
+  chart and must never be written as one again (rf2-q6n3)."
   [container]
   (q container "[data-testid=\"rf-xray-machine-focused-event-chart\"]"))
 
 (defn- island-node
-  "The ISLAND — `machine-canvas/Chart`'s OWN root div. `Chart` emits
+  "THE CHART's OWN root div. `machine-canvas/chart-tree` emits
   `:data-testid` from its `testid` prop, whose `:or` default is this literal
-  (`panels/machine_canvas.cljs`), and `machine_inspector`'s `as-child` call
-  site passes no `:testid`, so this marker IS Chart's root here. Nothing but
-  `Chart` running can put this node in the DOM."
+  (`panels/machine_canvas.cljs`), and `machine_inspector`'s mount passes no
+  `:testid`, so this marker IS the chart's root here. Nothing but the chart
+  boundary running can put this node in the DOM.
+
+  The NAME is kept from when this really was an island, so the W-row
+  cross-references stay resolvable; rf2-k97c.3 made it a Fresco boundary."
   [container]
   (q container "[data-testid=\"rf-xray-machine-canvas-host\"]"))
 
@@ -334,31 +329,31 @@
                focused-event surface, so the body really ran through
                `panel-tree` rather than painting an empty shell")
 
-          ;; ---- the island, which only a real commit can witness -----------
+          ;; ---- the chart, which only a real commit can witness ------------
           ;;
-          ;; TWO ROWS, AND THE ORDER IS THE POINT (rf2-q6n3). Until this
-          ;; commit there was ONE row here, selecting the WRAPPER and
-          ;; claiming the island. `machine_inspector` emits that wrapper
-          ;; itself, two levels above its `as-child` call, so the row was
-          ;; true of a tree with no island in it at all — it restated what
-          ;; the `focused-section?` row above already establishes. The
-          ;; wrapper row is kept because it IS a real witness of its own
-          ;; claim; what changed is the sentence attached to it.
+          ;; TWO ROWS, AND THE ORDER IS THE POINT (rf2-q6n3). There was once
+          ;; ONE row here, selecting the WRAPPER and claiming the chart.
+          ;; `machine_inspector` emits that wrapper itself, two levels above
+          ;; the mount, so the row was true of a tree with no chart in it at
+          ;; all — it restated what the `focused-section?` row above already
+          ;; establishes. The wrapper row is kept because it IS a real
+          ;; witness of its own claim; what changed is the sentence attached
+          ;; to it.
           (is (some? (chart-wrapper-node container))
               "the focused-event section reached ELEMENT 3 and took the
                has-definition arm, so it emitted the chart WRAPPER. This is a
                claim about `machine_inspector`'s own markup and no more: the
-               wrapper sits above the `as-child` call and survives the island
-               being absent, which is W4's subject.")
+               wrapper sits above the mount and survives the chart being
+               absent, which is W4's subject.")
           (is (some? (island-node container))
-              "THE ISLAND MOUNTED — `machine-canvas/Chart`'s OWN root div,
-               below the migration seam. `Chart` is still an `rf/reg-view`,
-               which Fresco's codec grades `:invalid` in head position down
-               the identical arm a plain `defn` takes, so this node reaches
-               the DOM only because the boundary hands `r/as-element` down as
-               the `as-child` spelling and Reagent expanded the head. Under
-               the node lane's `identity` the island is a no-op and this
-               claim cannot be made at all.")
+              "THE CHART MOUNTED — `machine-canvas/Chart-view`'s OWN root
+               div. rf2-k97c.3 made that head an `rf.fresco/defview`, so this
+               node reaches the DOM because Fresco's codec graded the head a
+               BOUNDARY and rendered it — where until then it reached the DOM
+               only because the panel handed `r/as-element` down as an
+               `as-child` spelling and Reagent expanded a head the codec
+               refuses. The node lane cannot make this claim either way: out
+               of a render window the mount is hiccup data and nothing runs.")
 
           ;; ---- criterion 4: the reads are where the tree said they'd be ----
           (doseq [query-v boundary-reads]
@@ -504,80 +499,42 @@
             (.then (fn [_] (done))))))))
 
 ;; ===========================================================================
-;; W4 — the island selector discriminates, and the wrapper selector does not
+;; W4 — the island is GONE, and the wrapper selector still cannot witness it
 ;; ===========================================================================
 
-;; THE CONTROL IS `Panel`'s OWN BODY WITH ONE ARGUMENT SWAPPED.
+;; WHAT THIS ROW USED TO BE, AND WHY IT COULD NOT SURVIVE UNCHANGED.
 ;;
-;; `machine-inspector/panel-tree` takes the island spelling as a PARAMETER —
-;; `r/as-element` under the boundary, `identity` for the node lane — and
-;; threads it to exactly one call site, `focused-event-section`'s
-;; `(as-child [machine-canvas/Chart …])`. An island-less tree is therefore
-;; that same fn with `(constantly nil)` in that one argument: not a hand-built
-;; fixture resembling the panel, but the production tree builder emitting the
-;; production wrapper through the production seam. Both halves below come from
-;; the same fn over the same seeded state, so `as-child` is the ONLY variable
-;; between them.
+;; `panel-tree` used to take the island spelling as a PARAMETER and thread it
+;; to one call site, `focused-event-section`'s `(as-child [machine-canvas/
+;; Chart …])`. W4's control was that same fn with `(constantly nil)` in that
+;; one argument, which produced a tree with the wrapper and no island.
 ;;
-;; IT IS HOSTED IN A REAL BOUNDARY rather than in a bare Reagent tree, and
-;; that is load-bearing rather than ceremony: `panel-tree`'s ELEMENT 2 reaches
-;; the shared mini-pipeline, whose EDN-widget heads are Fresco boundaries.
-;; Reagent mints its own component for a fn head and CALLS it during Reagent's
-;; render, which is not a React function-component render, so the boundary's
-;; first hook throws, React swallows the render throw, and that subtree
-;; silently commits nothing. `machine_epochs_always_round_dom_cljs_test`
-;; records the same fact from the other side and hosts its subject this way.
+;; rf2-k97c.3 retired that seam: `machine-canvas/Chart-view` is a Fresco
+;; boundary — the same `machine-canvas/chart-tree` body the surviving
+;; `reg-view` renders — so the panel heads it directly and the parameter is
+;; gone from four signatures. There is no longer an argument that can remove
+;; the chart, which is the point of the change and not a loss of coverage.
 ;;
-;; The spelling arrives through an atom rather than through props because only
-;; an EMPTY props map survives the `[:>]` crossing intact.
+;; THE CLAIM rf2-q6n3 MADE IS UNCHANGED AND STILL WORTH PINNING, because it
+;; is a claim about the two SELECTORS rather than about the island: a row
+;; that selects `rf-xray-machine-focused-event-chart` reads GREEN over a tree
+;; with no chart in it at all, so W1's chart assertion has to select
+;; `rf-xray-machine-canvas-host`. Both halves below make that claim against
+;; the real committed DOM:
+;;
+;;   1. STRUCTURALLY — the wrapper is a strict ANCESTOR of the chart's own
+;;      root, emitted by `machine_inspector` two levels above the mount. So
+;;      its presence is implied by the chart's and never implies it.
+;;   2. OPERATIONALLY — with the chart's root removed from the committed DOM,
+;;      the wrapper query still answers while the chart query does not. That
+;;      is the rf2-q6n3 defect stated as a passing assertion.
 
-(defonce ^:private !island-spelling
-  (atom nil))
-
-(rf.fresco/defview IslandProbe
-  "[[Panel]]'s body — the same five queries through the same collector, the
-  same `panel-tree` call — with the island spelling read from
-  [[!island-spelling]] rather than hard-coded to `r/as-element`. Takes the
-  ordinary one-props-map argument every `defview` takes and reads nothing
-  from it."
-  [_props]
-  (machine-inspector/panel-tree
-    (rf.fresco/sub data-q)
-    (rf.fresco/sub records-q)
-    (:cascade (rf.fresco/sub cascade-q))
-    @!island-spelling
-    (rf.fresco/sub fit-q)
-    (rf.fresco/sub frame-q)))
-
-(def ^:private IslandProbe-component
-  "The React component [[IslandProbe]] presents as, for the Reagent root
-  below. Declared ONCE at top level, as `rf.fresco/as-component` requires."
-  (rf.fresco/as-component IslandProbe))
-
-(defn- mount-probe!
-  "Mount [[IslandProbe]] with `as-child` as its island spelling, inside the
-  `frame-provider` the real shell wraps every panel in. Committed
-  synchronously, as [[mount-panel!]] is and for the same reason."
-  [as-child]
-  (reset! !island-spelling as-child)
-  (let [container (.createElement js/document "div")
-        root      (rdc/create-root container)]
-    (.appendChild (.-body js/document) container)
-    (react-dom/flushSync
-      (fn []
-        (rdc/render root [rf/frame-provider {:frame :rf/xray}
-                          [:> IslandProbe-component {}]])))
-    {:container container :root root}))
-
-(deftest w4-the-island-selector-discriminates-and-the-wrapper-does-not
-  (testing "rf2-q6n3 — with the island child removed, the
-            `rf-xray-machine-focused-event-chart` wrapper is STILL COMMITTED
-            while the `rf-xray-machine-canvas-host` island is GONE. That
-            asymmetry is the whole row. It is what makes W1's island
-            assertion a claim about the island, and it is the standing
-            demonstration that the assertion W1 used to carry — which
-            selected the wrapper — could not have failed on an absent island
-            and therefore never made the claim its docstring stated."
+(deftest w4-the-chart-selector-discriminates-and-the-wrapper-does-not
+  (testing "rf2-q6n3 / rf2-k97c.3 — `rf-xray-machine-focused-event-chart` is
+            a strict ANCESTOR of `rf-xray-machine-canvas-host`, so a row
+            selecting the wrapper cannot fail on an absent chart. Asserted on
+            the panel's own committed DOM, and then demonstrated directly by
+            taking the chart's root away and re-querying."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
@@ -585,59 +542,125 @@
         (seed-machines!)
         (set-history! fixture-history)
         (focus-epoch! 1)
-        (let [!live (atom (mount-probe! r/as-element))
-              !dark (atom nil)
-              drop! (fn [a]
-                      (when-let [{:keys [root container]} @a]
-                        (reset! a nil)
-                        (teardown! root container)))]
+        (let [{:keys [container root]} (mount-panel! :rf/xray)]
           (-> (rf.test-support/poll-until
-                #(some? (island-node (:container @!live)))
-                {:label "the probe committed Chart's own canvas host"})
+                #(some? (island-node container))
+                {:label "the panel committed the chart's own canvas host"})
               (.then
                 (fn [_]
-                  ;; ---- the island is really there when it is there --------
-                  (is (= "rf-xray-machine-canvas-host"
-                         (some-> (island-node (:container @!live))
-                                 (.getAttribute "data-testid")))
-                      "NON-VACUITY: handed the production spelling
-                       `r/as-element`, the probe commits `machine-canvas/
-                       Chart`'s own root. So this harness CAN produce an
-                       island, and the absence asserted below is a real
-                       absence rather than a harness that never renders one.
-                       Compared against the marker written out in full, so a
-                       nil node cannot agree with a nil expectation.")
-                  (is (some? (chart-wrapper-node (:container @!live)))
-                      "and the wrapper is committed here too, exactly as in
-                       W1 — which is what makes the pair below a controlled
-                       comparison rather than two unrelated trees")
-                  (drop! !live)
-                  ;; ---- now take the island away, and only the island -----
-                  (reset! !dark (mount-probe! (constantly nil)))
-                  (settle)))
-              (.then
-                (fn [_]
-                  (let [container (:container @!dark)]
+                  (let [wrapper (chart-wrapper-node container)
+                        chart   (island-node container)]
+                    ;; ---- 1. the structural half ---------------------------
+                    (is (= "rf-xray-machine-canvas-host"
+                           (some-> chart (.getAttribute "data-testid")))
+                        "NON-VACUITY: the chart's own root really is committed
+                         here, compared against the marker written out in
+                         full so a nil node cannot agree with a nil
+                         expectation")
+                    (is (some? wrapper)
+                        "and so is the wrapper, which is what makes the
+                         comparison below a controlled one rather than two
+                         unrelated trees")
+                    (is (and (some? wrapper) (some? chart)
+                             (not (identical? wrapper chart))
+                             (.contains wrapper chart))
+                        "THE WRAPPER IS A STRICT ANCESTOR of the chart's root.
+                         `machine_inspector` emits it two levels ABOVE the
+                         chart mount, so its presence is implied by the
+                         chart's and never implies it — which is the whole of
+                         why W1's chart assertion must not select it.")
+                    ;; ---- 2. the operational half --------------------------
+                    (.remove chart)
                     (is (nil? (island-node container))
-                        "THE ISLAND IS GONE. `as-child` answered nil, so
-                         `machine-canvas/Chart` never ran and nothing in the
-                         committed DOM carries its root marker. Asserted
-                         after a full settling window, so the absence is a
-                         decision and not a race.")
+                        "with the chart's root taken out of the committed DOM,
+                         the chart selector answers nothing")
                     (is (some? (chart-wrapper-node container))
                         "AND THE WRAPPER IS STILL STANDING. This is the
-                         rf2-q6n3 defect stated as a passing assertion:
-                         `machine_inspector` emits
-                         `rf-xray-machine-focused-event-chart` two levels
-                         ABOVE its `as-child` call, so a row selecting that
-                         marker reads GREEN over a tree with no island in it
-                         at all. The island claim cannot be made with this
-                         node, and W1 no longer makes it."))))
+                         rf2-q6n3 defect stated as a passing assertion: a row
+                         selecting that marker reads GREEN over a tree with no
+                         chart in it at all. W1 no longer makes the claim with
+                         this node."))))
               (.catch (fn [e]
                         (is false (str "W4 never settled: " (.-message e)))
                         nil))
               (.then (fn [_]
-                       (drop! !live)
-                       (drop! !dark)
-                       (reset! !island-spelling nil)
+                       (teardown! root container)
                        (done)))))))))
+
+;; ===========================================================================
+;; W5 — the panel's render is not application view evidence (criterion 5)
+;; ===========================================================================
+
+(rf/reg-view ProbeRegView
+  "The POSITIVE CONTROL for W5, and nothing else. An ordinary `reg-view`
+  rendered by the installed adapter in the same root, in the same frame and
+  in the same commit shape as the panel — so the only variable between it
+  and the panel is which view layer authored the body."
+  []
+  [:div {:data-testid "rf-xray-probe-reg-view"}])
+
+(deftest w5-the-panels-render-emits-no-view-trace
+  (testing "rf2-k97c.3 — epic criterion 5, and THIS PANEL'S ZERO IS NEW AT
+            THIS COMMIT. `Panel` has been a boundary since the earlier slice,
+            but its focused-event subtree still bottomed out in
+            `machine-canvas/Chart`, an `rf/reg-view`, islanded behind
+            `as-child` — and a `reg-view` emits view trace wherever it
+            renders, so the panel's rendered subtree was NOT trace-silent.
+            `machine-canvas/Chart-view` is what makes it so.
+
+            THE SCOPE IS ASSERTED RATHER THAN ASSUMED: the row pins that the
+            focused-event section and the chart's own root are BOTH on screen
+            in the commit being measured, so the zero covers the whole chart
+            subtree and not a tree that happened not to render one."
+    (if-not (browser?)
+      (is true ":node — the :browser-test runner drives the real React mount")
+      (do
+        (setup!)
+        (seed-machines!)
+        (set-history! fixture-history)
+        (focus-epoch! 1)
+        (let [traces   (atom [])
+              view-op? #(and (keyword? (:operation %))
+                             (= "rf.view" (namespace (:operation %))))]
+          (rf/register-listener! :trace ::collect (fn [ev] (swap! traces conj ev)))
+          (try
+            ;; ---- the subject: the panel, chart and all ---------------------
+            (let [{:keys [container root]} (mount-panel! :rf/xray)
+                  subject-views (filterv view-op? @traces)]
+              (try
+                (is (focused-section? container)
+                    "precondition: the focused-event section really did render
+                     in this commit — an empty container would make the zero
+                     below vacuous")
+                (is (some? (island-node container))
+                    "SCOPE: and so did the CHART, whose root marker is on
+                     screen. This is the half that moved: before `Chart-view`
+                     this same assertion stood over a `reg-view` render, and
+                     the zero below could not have held beside it.")
+                (is (zero? (count subject-views))
+                    (str "the panel's whole rendered subtree, chart included, "
+                         "put NO :rf.view/* op in the trace stream. Ops seen: "
+                         (pr-str (mapv :operation subject-views))))
+                (finally (teardown! root container))))
+            ;; ---- the control: a reg-view, same root shape, same frame ------
+            (reset! traces [])
+            (let [container (.createElement js/document "div")
+                  root      (rdc/create-root container)]
+              (.appendChild (.-body js/document) container)
+              (try
+                (react-dom/flushSync
+                  (fn []
+                    (rdc/render root [rf/frame-provider {:frame :rf/xray}
+                                      [ProbeRegView]])))
+                (let [control-views (filterv view-op? @traces)]
+                  (is (some? (q container "[data-testid=\"rf-xray-probe-reg-view\"]"))
+                      "precondition: the control really did render")
+                  (is (pos? (count control-views))
+                      (str "CONTROL FIRES: an ordinary reg-view rendered the "
+                           "same way DOES emit a :rf.view/* op, so the "
+                           "subject's zero is a property of the boundary and "
+                           "not of a dead instrument. Ops seen: "
+                           (pr-str (mapv :operation control-views)))))
+                (finally (teardown! root container))))
+            (finally
+              (rf/unregister-listener! :trace ::collect))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -111,10 +111,13 @@
   `machine_inspector_fresco_boundary_dom_cljs_test`'s subject, read off a
   real React commit.
 
-  `identity` is the `as-child` spelling for a hiccup caller: the island
-  the boundary needs for the still-Reagent topology chart is a no-op
-  here, so the rows below walk the chart's own vector exactly as they did
-  before the migration. `r/as-element` is what the boundary passes.
+  THERE IS NO `as-child` ARGUMENT ANY MORE. `panel-tree` used to take the
+  island spelling and thread it to the topology chart; the chart is a
+  Fresco boundary head now (`machine-canvas/Chart-view`), so the parameter
+  went with the island. The rows below still walk the chart's own vector,
+  because a boundary head is ordinary hiccup data outside a render window
+  — which is exactly what made the argument droppable without a second
+  spelling for this lane.
 
   The reads are spelled `@(rf/subscribe …)` rather than `rf.fresco/sub`
   deliberately: outside a render window there is no collector edge to
@@ -126,7 +129,6 @@
     @(rf/subscribe [:rf.xray/machine-inspector-data])
     @(rf/subscribe [:rf.xray/machine-transitions-for-focused-event])
     (:cascade @(rf/subscribe [:rf.xray/machine-focused-epoch-cascade]))
-    identity
     @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
     @(rf/subscribe [:rf.xray/target-frame])))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -39,6 +39,10 @@
             [re-frame.registrar :as rf.registrar]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
+            ;; rf2-k97c.3 — the chart-head row below needs BOTH of this
+            ;; ns's public heads: the Fresco boundary ELEMENT 3 mounts, and
+            ;; the surviving `reg-view` that is its two-directions control.
+            [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -767,6 +771,65 @@
     (vector? hiccup) (some find-machine-chart-props hiccup)
     (seq? hiccup)    (some find-machine-chart-props hiccup)
     :else            nil))
+
+(defn- find-chart-mount
+  "The whole `[<head> {props}]` vector ELEMENT 3 emits for the topology
+  chart, HEAD INCLUDED — where [[find-machine-chart-props]] answers only the
+  props map. Same props-shape match, because the head is exactly what this
+  is trying to learn and so cannot be part of the selector."
+  [hiccup]
+  (cond
+    (and (vector? hiccup) (machine-chart-props? (second hiccup)))
+    hiccup
+
+    (vector? hiccup) (some find-chart-mount hiccup)
+    (seq? hiccup)    (some find-chart-mount hiccup)
+    :else            nil))
+
+(deftest element-3-heads-a-fresco-boundary-rf2-k97c-3
+  (testing "rf2-k97c.3 — ELEMENT 3 mounts `machine-canvas/Chart-view`, a
+            Fresco BOUNDARY, and no longer islands `machine-canvas/Chart`
+            behind an `as-child` crossing.
+
+            The head is graded by `codec/boundary-head?` — the production
+            predicate, reading the one own property (`frescoBoundary`) that
+            only `rf.fresco/defview` sets — rather than by identity against a
+            var, so the row states the PROPERTY the codec will act on rather
+            than a name that could be satisfied by the wrong kind of thing.
+
+            CONTROLLED BOTH WAYS on this same tree. `machine-canvas/Chart`,
+            the surviving `reg-view` the two Static Reagent-island callers
+            still head, must grade FALSE: without that half a predicate that
+            answered true for everything would satisfy the claim above. The
+            two heads share one body (`machine-canvas/chart-tree`), so they
+            differ in exactly the property being read."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [mount (find-chart-mount (panel-tree))
+            head  (first mount)]
+        (is (some? mount)
+            "precondition: ELEMENT 3 emitted a chart mount at all — an
+             absent mount would make the head assertion vacuous")
+        (is (rf.fresco.impl.codec/boundary-head? head)
+            (str "the chart head is a Fresco boundary, so the panel's own "
+                 "boundary mounts it directly instead of crossing an "
+                 "`as-child` island into Reagent. Head was "
+                 (pr-str head)))
+        (is (not (rf.fresco.impl.codec/boundary-head? machine-canvas/Chart))
+            "CONTROL: the surviving `reg-view` head grades FALSE under the
+             same predicate, so the assertion above discriminates rather
+             than reading true for any fn it is handed")))))
 
 (def ^:private schema-fixture-definition
   "A machine carrying a `[:schemas :data]` schema so the declared Context shape


### PR DESCRIPTION
## What

`machine-canvas/Chart` was the last plain `rf/reg-view` interactive chart head under `tools/xray/src`. This slice gives it a Fresco head beside the `reg-view`, and retires the Machine Inspector panel's last Reagent island.

**This is ONE SLICE of rf2-k97c.3, a large long-running bead. The bead is NOT closed by this PR.**

## Why a dual head rather than a migration

`Chart` could not simply become an `rf.fresco/defview`. Two of its four consumers reach it from REAGENT:

- `static/machines/topology.cljs`
- `static/machines/sim.cljs`

Both render inside the `as-child` island `static/machines/definition_detail.cljs` hands down, and retiring that island is that slice's to make. A Reagent parent's only inward door to a boundary is `rf.fresco/as-component`, whose own contract states that a Reagent parent's `[:>]` converts first, so *"names round-trip across the crossing and values do not"*. `Chart`'s props map is nothing but values a conversion would destroy: a nested `:definition`, keyword ids, two edge-id SETS and three callbacks.

So this is the taxonomy's **T4 dual-head facade at the callee**, the shape `views/edn_widget.cljs` already ships as `inspect` / `inspect-view`:

| var | head kind | consumer |
|---|---|---|
| `chart-tree` | plain fn — the one body | both heads |
| `Chart` | `rf/reg-view` | the two Static Reagent-island consumers |
| `Chart-view` | `rf.fresco/defview` | `panels/machine_inspector.cljs` ELEMENT 3 |

`chart-tree` takes `as-child` for the machines-viz mount (`identity`, or `substrate/as-element`) and takes the after-rings mount as a VALUE, because the two lanes differ there by HEAD rather than by wrapping — the Reagent lane heads `AfterRingsOverlay-bridge`, the boundary heads the `defview` directly.

## The island moved down; it did not vanish

`machine_inspector`'s ELEMENT 3 heads the boundary directly, which retires the panel's island and the `as-child` parameter threaded through four signatures. The remaining island is inside `chart-tree`, crossing the machines-viz chart itself. Its end condition is machines-viz shipping a substrate-neutral head, which is not this tree's to schedule.

`Chart-view` takes no `:mount-id`: the body reads nothing and holds no per-instance state, so it has no identity to key. Its one stateful descendant keeps its identity from React's own reconciliation, exactly as under `reg-view`.

## Registration census, re-measured at this branch's merge base

Two spellings over `tools/xray/src`, excluding the tracker export:

| spelling | hits | real registrations |
|---|---|---|
| `(rf/reg-view` | 8 | 7 (one is prose in a `mode_pill` docstring) |
| `(reg-view` (bare) | 1 | 0 (a comment in `mount.cljs`) |

Control from the target: `defview` reads non-zero across 20+ files, so the instrument bites. The seven agree with the dispatch brief exactly. After this PR `Chart` remains among them, deliberately — see above.

## Two findings reported rather than acted on

1. **`panels/machines/topology_view.cljs`'s `Topology` has no production caller.** Only `static-context-shape` / `static-context-inferred?` are used from that namespace by `machine_inspector`, `static/machines/sim` and `static/machines/topology`; `Topology` itself is called only from its own test file. Its `[machine-canvas/Chart …]` head is therefore pure data that nothing renders, and needed no treatment. Deleting it is sprawl into another item.
2. **`panels/machine_canvas.cljs`'s `SnapshotDrillIn` likewise has no production caller** — only its own test file. Its `[ei/edn-inspector …]` Reagent head is not in `Chart`'s subtree and is enclosed by no boundary, so no `edn_widget` facade swap was needed. The dispatch brief's premise that it sits under a migrating boundary does not hold at this tip.

## Fenced files not touched

`views/edn_widget.cljs`, `views/edn_inspector_popup.cljs`, `views/edn_inspector.cljs`, `views/resizable_table.cljs` and its tests, `tools/xray/deps.edn`, `panels.cljs`, `shell.cljs`, `implementation/**`, `spec/006`. `panels/machine_after_rings.cljs` was not edited either: its `AfterRingsOverlay-bridge` survives for the `reg-view` lane, so its "deleted at step 3" note is now one step further out than it reads.

## Quality gates

See the `## Quality gates` comment below.
