### PR TITLE
docs(method): trim the mayor method to rules, discriminators and gotchas

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -280,7 +280,7 @@ Three siblings carry the operational detail:
 
 - [`bootstrap.md`](bootstrap.md) — the opening prompt, and the hard-won list of things that
   bite.
-- [`loops.md`](loops.md) — the 5 standing loops, and the merge criterion in full.
+- [`loops.md`](loops.md) — the standing loops, and the merge criterion in full.
 - [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — the worker-prompt shapes, the
   common preamble, the worktree-boundary block, and the gate-mechanics block. The last 3
   travel verbatim: the preamble into every dispatch, the other 2 into every editing one.

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -75,7 +75,7 @@ and paste that block verbatim into every dispatch preamble. Skip the interview i
 the operator's opening message already names the stance; restate it as a one-line
 confirmation instead.
 
-SET UP THE LOOPS. The five loops are in `loops.md`. If you codify each as a command
+SET UP THE LOOPS. The loops are in `loops.md`. If you codify each as a command
 file so it is one invocation, keep that file a THIN pointer into `loops.md` — a command
 file is re-injected into your context on every tick, so one that absorbs the method
 costs you that much context per tick AND becomes a second copy of every rule it

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -36,103 +36,74 @@ The order is what makes it accurate. Each step is a check the next depends on.
 **Keep the brief to what is specific to THIS item.** The blocks below travel verbatim into every
 dispatch and already carry the standing rules, so restating them is the commonest way a brief doubles
 in length while adding nothing — and the worker pays for every word twice, once reading and once
-obeying. Measured on one fleet: briefs of roughly two thousand words, sitting on top of a five-thousand
-word block file, against workers that finished comparable items in a third of the time on briefs of
-four hundred.
+obeying. Measured on one fleet: two-thousand-word briefs sitting on top of a five-thousand-word block
+file, against workers that finished comparable items in a third of the time on briefs of four hundred.
 
-1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by
-    position, and not by dates written in the prose. The full mechanics are spelled out
-    for the worker under *Common preamble* below: the description is usually the oldest
-    text but the bottom is not reliably the newest either, a date in the prose is content
-    rather than a mutation time, the plain history listing names no changed field, you
-    walk adjacent snapshot pairs newest-first to the first text-bearing change, and you
-    re-enumerate a bead's children before concluding a decision is absent. Every one of
-    those binds the mayor writing the brief exactly as it binds the worker reading it.
+1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by position, and not
+    by dates written in the prose. The mechanics are spelled out for the worker under *Common
+    preamble* below, and every one of them binds the mayor writing the brief exactly as it binds the
+    worker reading it.
 
-    **And one cheap query tells you which items are most likely to punish skipping the walk:
-    has this item ever been CLOSED and reopened?** The rule above is unconditional, which is
-    why it gets skipped — an unconditional instruction competes with every other unconditional
-    instruction. A closed-to-open transition is the strongest cheap signal there is that the
-    description is no longer the live instruction: it was written about the defect as originally
-    found, and something later disagreed enough to reopen the item. Nothing about the rendered
-    item says so — the description still reads as a current bug report, because it once was one.
-    Measured across one session: three briefs written from descriptions whose work had already
-    merged, and **all three items showed a closed-to-open transition in their status history
-    while the control, never closed, showed none**. Ask the tracker for the item's status over
-    time rather than its status now.
+    **One cheap query tells you which items will punish skipping that walk: has this item ever been
+    CLOSED and reopened?** The rule above is unconditional, which is why it gets skipped — an
+    unconditional instruction competes with every other unconditional instruction. A closed-to-open
+    transition is the strongest cheap signal that the description is no longer the live instruction:
+    it was written about the defect as originally found, and something later disagreed enough to
+    reopen. Nothing in the rendered item says so — the description still reads as a current bug
+    report, because it once was one. Measured: three briefs in one session written from descriptions
+    whose work had already merged, **all three showing a closed-to-open transition while the control,
+    never closed, showed none**.
 
-    **It is a signal to do the walk, though, not a substitute for it, and the two ways of
-    over-reading it are worth naming because both are natural.** *Closed* does not mean
-    *shipped* — a project whose items close when a change is opened for review will have closed
-    items whose work is still unmerged, so "the closing work has landed" is an inference about
-    this project's conventions rather than a fact about the transition. And a reopening does not
-    always supersede: an item reopened because the same defect REGRESSED has a description that is
-    accurate, and treating it as stale sends the worker looking for a newer instruction that does
-    not exist. **What decides currency is the history and the tree**, which is what the rule above
-    already says; the query tells you where that reading is most likely to change your brief.
+    **It is a signal to do the walk, not a substitute for it, and both over-readings are natural.**
+    *Closed* does not mean *shipped* where items close on change-open rather than merge; and a
+    reopening does not always supersede — an item reopened because the defect REGRESSED has an
+    accurate description, and treating it as stale sends the worker hunting a newer instruction that
+    does not exist. **What decides currency is the history and the tree.**
 
-    **The three consequences differ, and only the first is obvious.** The dispatch may re-do
-    finished work; it may point a worker at a defect that no longer exists, whose deliverable is
-    then a refutation; or — the expensive one — it may describe a *smaller* problem than the one
-    the reopening found, so the worker fixes what you asked and the real defect survives with an
-    item now closed over it. The worker's own history walk catches all three, which is why this
-    costs a dispatch rather than a defect. **Do not let that safety net become the plan**: it
-    spends a worker's context re-deriving what one query answers, and the mayor learns nothing,
-    because a brief refuted politely reads much like a brief fulfilled.
+    **The three consequences differ, and only the first is obvious.** The dispatch may re-do finished
+    work; it may point a worker at a defect that no longer exists, whose deliverable is then a
+    refutation; or — the expensive one — it may describe a *smaller* problem than the one the
+    reopening found, so the worker fixes what you asked and the real defect survives with an item now
+    closed over it. The worker's own history walk catches all three, **but do not let that safety net
+    become the plan**: it spends a worker's context re-deriving what one query answers, and the mayor
+    learns nothing, because a brief refuted politely reads much like a brief fulfilled.
 
-    **Do that read before the brief exists, and read it for two things: a HOLD, and SEQUENCING.** It is
-    a step rather than another note because the knowledge is already written down and already travelling —
-    the common preamble below orders the worker to read by tracker timestamps, at length and with the
-    reasoning, and the mayor pastes that into every dispatch and then does not do it. A hold is the newest
-    field often enough that the description cannot be trusted to mention it, so an item reads as an
-    ordinary defect report while the live instruction is *wait*. Sequencing is the mirror case and the
-    easier one to miss, because the brief's instinct is right by default: a triage note naming the
-    predecessors that had to land first is an **authorisation with a precondition**, so restating a
-    generic fence over it converts a satisfied precondition back into a blocker — which either strands
-    the work or, as measured here, costs the worker a justification round it should not have had to
-    write. Both shapes went out in real briefs, and the worker caught both.
+    **Read it for two things: a HOLD, and SEQUENCING.** A hold is the newest field often enough that
+    the description cannot be trusted to mention it, so an item reads as an ordinary defect report
+    while the live instruction is *wait*. Sequencing is the mirror case and easier to miss, because
+    the brief's instinct is right by default: a triage note naming the predecessors that had to land
+    first is an **authorisation with a precondition**, so restating a generic fence over it converts a
+    satisfied precondition back into a blocker.
 
     **Read the INVERSE with more care than either, because it is the one that fails open.** A note
-    lifting a fence names *the fence it lifts*, not the item — so an item can carry a second sequencing
-    the lift says nothing about, and its newest layer then reads *released* while a live precondition
-    sits underneath. The two above merely re-block work that was already clear; this one dispatches into
-    a surface somebody else holds, or into one gated by a decision nobody has made. Measured: an item
-    whose fence had been lifted on the holder's own explicit words still sat behind an older note
-    sequencing it behind an unruled operator call — and the *other* half of that same older note had
-    genuinely cleared, which is exactly what made the whole of it look discharged. **Where the tracker
-    can express a precondition, encode it there rather than leaving it in prose**: a fence that exists
+    lifting a fence names *the fence it lifts*, not the item — so an item can carry a second
+    sequencing the lift says nothing about, and its newest layer then reads *released* while a live
+    precondition sits underneath. The other two merely re-block work that was already clear; this one
+    dispatches into a surface somebody holds, or into one gated by a decision nobody has made.
+    Measured: an item whose fence had been lifted on the holder's own words still sat behind an older
+    note sequencing it behind an unruled operator call — and the *other* half of that older note had
+    genuinely cleared, which is what made the whole of it look discharged. **Where the tracker can
+    express a precondition, encode it there rather than leaving it in prose**: a fence that exists
     only in a note is re-derived every pass, and a fence re-derived every pass is eventually missed.
 
-    **And where you sweep a whole board for hold markers, that sweep is a candidate filter and never a
-    verdict.** It narrows the open items to a handful; the hold is then established by READING each
-    candidate, which is affordable at that size and is the only thing that separates a live banner from
-    one quoted, discussed, or already struck. Write the question the sweep answers beside the question you
-    are asking — *does this text contain these characters* against *is this item currently held* — because
-    the gap is invisible in the answer. Measured: a sweep reported eleven of twenty-seven open items held
-    and the number reached the operator before anyone read a candidate; the first two falsified were an
-    item quoting another item's banner and an item whose own text said its banner was struck. Why the
-    sweep fails in both directions, why a second sweep built to tell live from struck fails the same way,
-    and the structured field that is the durable answer where a project wants this machine-checkable, are
-    under *Tracker mechanics* in [`loops.md`](loops.md#tracker-mechanics) — this step is the concrete
-    instance and does not restate them.
+    **And a board-wide sweep for hold markers is a candidate filter, never a verdict** — it narrows to
+    a handful, and the hold is then established by READING each one. Why it fails in both directions,
+    and the structured field that is the durable answer, are under *Tracker mechanics* in
+    [`loops.md`](loops.md#tracker-mechanics).
 
-2. **Check every factual claim you are about to write.** Does the symbol resolve?
-    Does the file say what you think? Is the count still true? Is the ruling you cite
-    *ruled*, or only recommended? A recommendation and a decision read identically in
-    a summary and are opposite in force.
-    **Then one question of a different kind: is this work still OUTSTANDING?** The four
-    above ask whether a claim is TRUE. A note saying "X is all that remains" was true when
-    it was written and says nothing about now, so checking it at source confirms the wrong
-    thing. Check the TREE. The sentence that says so is addressed to you and sits in the
-    common preamble below — inside the block you extract and paste without reading, because
-    its audience looks like the worker. A dispatch went out for work that had merged the
-    previous day, and the worker's deliverable was refuting the premise.
+2. **Check every factual claim you are about to write.** Does the symbol resolve? Does the file say
+    what you think? Is the count still true? Is the ruling you cite *ruled*, or only recommended? A
+    recommendation and a decision read identically in a summary and are opposite in force.
+    **Then one question of a different kind: is this work still OUTSTANDING?** The four above ask
+    whether a claim is TRUE. A note saying "X is all that remains" was true when written and says
+    nothing about now, so checking it at source confirms the wrong thing. Check the TREE. The sentence
+    that says so sits in the common preamble below — inside the block you extract and paste without
+    reading, because its audience looks like the worker.
 
-3. **Establish the fence by asking who is live, not what is open.** A listing of open
-    changes misses a worker that has not pushed yet. **And ask what each nominated gate
-    COMPARES, here, not at dispatch** — a fence derived from files alone misses a gate that
-    couples two surfaces (see *Fences*), and one mayor struck an item's fence and dispatched
-    before asking, then re-fenced it five minutes later on exactly that ground.
+3. **Establish the fence by asking who is live, not what is open.** A listing of open changes misses a
+    worker that has not pushed yet. **And ask what each nominated gate COMPARES, here, not at
+    dispatch** — a fence derived from files alone misses a gate that couples two surfaces (see
+    *Fences*).
 
 4. **Name the discriminator**, if the task is "find every X".
 
@@ -142,11 +113,9 @@ four hundred.
 
 ## The three sentences that do the most work
 
-The first two go in **every** editing brief. The third goes in every brief whose
-nominated gate affords a safe, bounded, discriminating plant — which is a question
-about the **gate**, not about the deliverable. A brief that builds a control is the
-obvious case; a documentation correction covered by a link or anchor validator is the
-same case, and gets the sentence too.
+The first two go in **every** editing brief. The third goes in every brief whose nominated gate
+affords a safe, bounded, discriminating plant — which is a question about the **gate**, not about the
+deliverable.
 
 > **This brief's premises are CLAIMS, not findings.** Check each at source before
 > acting on it. A verified "already fixed" or "the premise does not hold" is a
@@ -160,39 +129,28 @@ same case, and gets the sentence too.
 > **The control is the deliverable.** Show it red when the property is removed,
 > restore, and verify the restore by hashing the bytes.
 
-The first is the highest-yield sentence in the preamble. Read-the-item-first caught
-five stale briefs in a single day: one whose fix had landed two days earlier under a
-sibling item; one that named the wrong audit finding; one told to execute a resolution
-that had already merged; one a scope correction had redefined; and one carrying three
-wrong path, flag and script details. **Every one of those briefs was accurate when it
-was written**, and the yield is in *the item governs the brief* rather than in the
-direction of reading.
+The first is the highest-yield sentence in the preamble. Read-the-item-first caught five stale briefs
+in a single day: one whose fix had landed two days earlier under a sibling item; one that named the
+wrong audit finding; one told to execute a resolution that had already merged; one a scope correction
+had redefined; and one carrying three wrong path, flag and script details. **Every one of those
+briefs was accurate when it was written**, and the yield is in *the item governs the brief* rather
+than in the direction of reading.
 
-**The third is scoped by the nominated gate's capabilities — not by prose versus
-code.** Ask whether the gate covering the edited surface affords a safe, bounded,
-discriminating fault at a line the brief is already touching. Where it does, the
-sentence goes in — and a documentation correction is emphatically included, because the
-cheap validators that run over a docs tree red on one broken link target or one bad
-heading anchor and go green again on restore. That is measured rather than supposed:
-doc-only briefs have planted exactly those faults *in this file*, taken a red naming the
-plant, and hash-verified the restore against the committed object. Where the covering
-gate affords no such plant, the sentence is the unsatisfiable quantifier the
-method-reread loop is told to hunt for, and an unsatisfiable rule does not stop the
-reader — it makes one up.
+**The third is scoped by the nominated gate's capabilities — not by prose versus code.** A
+documentation correction is emphatically included: the cheap validators over a docs tree red on one
+broken link target or one bad heading anchor and go green again on restore. Where the covering gate
+affords no such plant, the sentence is the unsatisfiable quantifier the method-reread loop is told to
+hunt for — and an unsatisfiable rule does not stop the reader, it makes one up. **That failure was
+measured on the *enforcing* side rather than a worker's**: four editing briefs went out on one tick
+carrying the first two sentences verbatim and none carrying the third, each improvising the same
+omission separately — the tell that the rule was doing no work because it was **unscoped**. Scoping
+it on the shape of the deliverable instead licenses the same omissions with a reason attached.
 
-**That failure was measured on the *enforcing* side rather than a worker's.** On one
-dispatch tick four editing briefs went out, two of them prose-only, and all four carried
-the first two sentences verbatim while none carried the third. Nobody decided to drop it;
-each brief improvised the same omission separately, which is the tell that the rule was
-doing no work — because it was **unscoped**, not because prose has no controls. Scoping
-it on the shape of the deliverable licenses the same omissions with a reason attached.
-
-**Say what a brief whose gate affords no plant does instead, or that gets improvised
-too.** Both wordings are settled below and cover different cases: where no automated gate
-covers the surface at all, *Quality gates — which gate*; where a gate does cover it but
-affords no safe discriminating plant, *Quality gates — how a gate is run*. Point at both
-rather than restating either — naming the alternative is what keeps the scoping from
-reading as permission to prove nothing.
+**Say what a brief whose gate affords no plant does instead, or that gets improvised too.** Both
+wordings are settled below and cover different cases: where no automated gate covers the surface at
+all, *Quality gates — which gate*; where a gate covers it but affords no safe discriminating plant,
+*Quality gates — how a gate is run*. Point at both rather than restating either — naming the
+alternative is what keeps the scoping from reading as permission to prove nothing.
 
 ---
 
@@ -252,192 +210,165 @@ the item being corrected by the work, which is the system functioning.
 
 ## A lean is a claim too — demand the number that decides it
 
-When a brief poses a choice between two designs and names which one the author favours,
-that lean is as unreliable as any count, and it fails in a worse way: the worker reads it
-as guidance rather than as a premise, so the premises-are-claims sentence does not catch it.
+When a brief poses a choice between two designs and names which one the author favours, that lean is
+as unreliable as any count, and it fails in a worse way: the worker reads it as guidance rather than
+as a premise, so the premises-are-claims sentence does not catch it.
 
-So attach the measurement to the lean in the same breath. *"I think A beats B, and I want
-the cost that decides it, not a preference."*
+So attach the measurement to the lean in the same breath. *"I think A beats B, and I want the cost
+that decides it, not a preference."*
 
-The evidence is one dispatch where every part of the author's lean was wrong and the number
-found it. The brief said compiling a doc corpus would beat growing a static checker and guessed
-that speed was the risk; the worker measured the compile at **24.73s for 441 files**, killing
-that argument, then rejected compiling anyway on three grounds the brief had not imagined — half
-the required namespaces are imaginary, so the compile runs against stubs whose fidelity nobody
-owns; three-quarters of the blocks open no namespace form, so they need the very per-block
-harness the brief had called disqualifying; and the job would move to a slower CI class already
-rejected elsewhere. Final margin: **0.12s against 46s, about 380x, for the same catch**. That
-brief's fallback was wrong in a checkable way too — it prescribed scoping a rule **per page**,
-which flags 21 sites on a corpus that is correct, where the item's own shape, **per section**,
-measures 0. The worker followed the item over the brief and was right to.
+The evidence is one dispatch where every part of the author's lean was wrong and the number found it.
+The brief guessed that speed was the risk in compiling a doc corpus; the worker measured the compile
+fast enough to kill that argument, then rejected compiling anyway on three grounds the brief had not
+imagined, and the final margin came out around **380x the other way, for the same catch**. That
+brief's fallback was wrong in a checkable way too — it prescribed scoping a rule **per page**, which
+flags 21 sites on a corpus that is correct, where the item's own shape, **per section**, measures 0.
+The worker followed the item over the brief and was right to.
 
-Two rules come out of that. **Ask for the cost whenever you state a lean** — it converts a
-confident wrong brief into a correct outcome, and costs the worker one measurement. And
-**say plainly that the item outranks the brief on scope**, because here the item's shape was
-right and the author's prescription was not.
+Two rules come out of that. **Ask for the cost whenever you state a lean** — it converts a confident
+wrong brief into a correct outcome, and costs the worker one measurement. And **say plainly that the
+item outranks the brief on scope**.
 
-**A number the brief asserts is a lean too**, and it slips through by the same mechanism: a
-figure stated as guidance is read as instruction, so the premises-are-claims sentence never
-reaches it. Before writing a predecessor's figure into a brief, ask what produced it. One
-such figure — a bound a measurement window had derived from its own most-negative reading —
-went into the next brief as guidance and was reported to the operator before two independent
-refutations caught it, and one question would have caught it first: *what null arm produced
-that bound?*
+**A number the brief asserts is a lean too**, and it slips through by the same mechanism: a figure
+stated as guidance is read as instruction, so the premises-are-claims sentence never reaches it.
+Before writing a predecessor's figure into a brief, ask what produced it. One such figure — a bound a
+measurement window had derived from its own most-negative reading — went into the next brief as
+guidance and was reported to the operator before two independent refutations caught it, and one
+question would have caught it first: *what null arm produced that bound?*
 
 ---
 
 ## Fences
 
-State what the worker owns, then what it may not touch **and who holds it**. Naming the
-holder tells the worker whether a conflict means "rebase" or "stop and report".
+State what the worker owns, then what it may not touch **and who holds it**. Naming the holder tells
+the worker whether a conflict means "rebase" or "stop and report".
 
-**A fence is a claim about FILES, so derive it from what each open change actually
-touches rather than from its name.** A name — of a branch, a worker, a task — cannot
-distinguish a change holding four named files from one holding a whole tree, so a fence
-written from names is still a guess about files, which is the guess deriving it was meant
-to replace. Ask your change-listing tool for the paths, not just the names.
+**A fence is a claim about FILES, so derive it from what each open change actually touches rather
+than from its name.** A name — of a branch, a worker, a task — cannot distinguish a change holding
+four named files from one holding a whole tree, so a fence written from names is still the guess
+deriving it was meant to replace.
 
-**But check whether that tool PAGINATES, because a truncated list under-reports silently
-and in the expensive direction.** A hosted API asked for a change's files commonly answers
-with one page and no marker that it stopped. Measured here: a change of 722 files returned
-exactly 100, and not one of the files a pending fence turned on was among them — a fence
-derived from that answer would have declared the surface free and cleared a second worker
-onto it. **A round number is the tell**; treat 100, 250 or 1000 as a page size until you
-have proved otherwise. Where the change is large, derive the paths from version control
-instead, diffing the trunk against the branch, which reports all of them.
+**But check whether your change-listing tool PAGINATES, because a truncated list under-reports
+silently and in the expensive direction.** A hosted API asked for a change's files commonly answers
+with one page and no marker that it stopped: measured, a change of 722 files returned exactly 100,
+and not one of the files a pending fence turned on was among them — a fence derived from that answer
+would have cleared a second worker onto the surface. **A round number is the tell**; treat 100, 250
+or 1000 as a page size until proved otherwise, and for a large change derive the paths from version
+control instead, diffing the trunk against the branch.
 
-**And a listing built from committed history is blind to work already done but not yet
-committed** — which is the state a freshly dispatched worker stays in until its first
-commit, so an empty answer from it is not evidence of an empty fence. Ask the worker's own
-working copy too, and read a change that is clean by both as *not started yet* rather than
-as owning nothing: what it will touch is recorded on the item it was dispatched under, not
-in version control.
+**And a listing built from committed history is blind to work already done but not yet committed** —
+the state a freshly dispatched worker stays in until its first commit, so an empty answer is not
+evidence of an empty fence. Ask the worker's own working copy too, and read a change clean by both as
+*not started yet* rather than as owning nothing: what it will touch is recorded on the item it was
+dispatched under, not in version control.
 
-**And an item's own scope claim is a name too, wearing a reviewer's authority.** A review
-that files a dozen items will call them *src-only* or *parallel-safe* at the altitude it
-worked at, and every collision such a wave produces is invisible from there: four items
-editing one file in four regions; a *test-only* cut that keeps a file a sibling was told
-would be deleted; a *src-only* lane that must cross into a held tree by one line. Measured
-on one wave: ten items dispatched under that claim, three same-file collisions, every one
-caught by routing after the fact and none by the fence. So before you paste a fence, read
-each item's cited files against its siblings' — the citations are usually there, and the
-claim was made without doing that — and when two items share a file, sequence them or
-brief both with the overlap named. **A fence built from the claim is the guess the
+**And an item's own scope claim is a name too, wearing a reviewer's authority.** A review that files
+a dozen items will call them *src-only* or *parallel-safe* at the altitude it worked at, and every
+collision such a wave produces is invisible from there: four items editing one file in four regions;
+a *test-only* cut that keeps a file a sibling was told would be deleted; a *src-only* lane that must
+cross into a held tree by one line. Measured on one wave: ten items dispatched under that claim,
+three same-file collisions, every one caught by routing after the fact and none by the fence. Read
+each item's cited files against its siblings' before you paste a fence — the citations are usually
+there, and the claim was made without doing that. **A fence built from the claim is the guess the
 claim's author skipped, not a fence.**
 
-**A fence is derived, never remembered — and the worker derives it again at start-up.**
-Step 3 above settles how you establish it; a list assembled from memory of who you dispatched
-is stale inside the dispatch's own lifetime and on a busy fleet can be wrong before the brief
-is finished, so the fence travels as a claim the worker re-checks, like every other premise,
-and its own result wins.
-**That re-check is the load-bearing half, because the two staleness directions cost
-differently.** Too BROAD costs one re-derivation — the worker is warned off something
-nobody holds. Too NARROW omits a worker dispatched after you last looked, and two workers
-on one surface merge-conflict and can silently revert each other. Accuracy alone cannot
-reach the second: it expires between writing the brief and reading it.
+**A fence is derived, never remembered — and the worker derives it again at start-up.** A list
+assembled from memory of who you dispatched is stale inside the dispatch's own lifetime, so the fence
+travels as a claim the worker re-checks, like every other premise, and its own result wins. **That
+re-check is the load-bearing half, because the two staleness directions cost differently.** Too BROAD
+costs one re-derivation. Too NARROW omits a worker dispatched after you last looked, and two workers
+on one surface merge-conflict and can silently revert each other — accuracy alone cannot reach that,
+because it expires between writing the brief and reading it.
 
-Hot-zone files — anything sequential, where two concurrent editors conflict by construction
-— take one toucher at a time. If a remedy needs one, the instruction is **stop and report**,
-not edit. **A citation is not permission**: briefs routinely cite a specification section as
-context, and a worker can read that as licence to edit it.
+Hot-zone files — anything sequential, where two concurrent editors conflict by construction — take
+one toucher at a time. If a remedy needs one, the instruction is **stop and report**, not edit. **A
+citation is not permission**: briefs routinely cite a specification section as context, and a worker
+can read that as licence to edit it.
 
-**A GENERATED file is the one same-file overlap that sequencing does not fix.** A manifest or
-export regenerated from the tree is touched by every change that moves what it derives from, and
-serialising those changes serialises the fleet for nothing: two regenerations of the same file
-conflict textually and agree semantically. Brief every toucher instead — regenerate after
-rebasing, never hand-merge, and where a job diffs the committed file against a fresh generation,
-run exactly that job locally. Three concurrent changes regenerated one manifest here with no
-sequence between them.
+**A GENERATED file is the one same-file overlap that sequencing does not fix.** A manifest or export
+regenerated from the tree is touched by every change that moves what it derives from, and serialising
+those changes serialises the fleet for nothing: two regenerations conflict textually and agree
+semantically. Brief every toucher instead — regenerate after rebasing, never hand-merge, and where a
+job diffs the committed file against a fresh generation, run exactly that job locally.
 
-**And N changes that each touch ONE LINE of one shared index are the second exception.** A
-catalogue, a roster, a table of rows: eight items each editing a different row of it are not a
-collision worth a sequence, and one-toucher would serialise the fleet for one-line hunks. Brief
-every worker to isolate that edit as its own final commit, merge in landing order, and let each
-later change rebase — the conflict, when it comes, is one line in one commit. Write the lane rule
-on every item that shares the file, in the same words, so no worker discovers it at rebase time.
+**And N changes that each touch ONE LINE of one shared index are the second exception.** A catalogue,
+a roster, a table of rows: eight items each editing a different row are not a collision worth a
+sequence. Brief every worker to isolate that edit as its own final commit, merge in landing order,
+and let each later change rebase — the conflict, when it comes, is one line in one commit. Write the
+lane rule on every item that shares the file, in the same words, so no worker discovers it at rebase
+time.
 
 **But a gate that reconciles two surfaces couples them into ONE change, and sequencing those
-deadlocks.** The one-toucher rule reasons about files, and it is right about files. Some checkers,
-though, hold one surface against another in both directions — a catalogue against the emitters it
-lists, a schema against the fixtures that exercise it, a manifest against the modules it names — and
-under such a gate neither half is green alone: the change that deletes the emitters reds until the
-rows go, and the change that strikes the rows reds until the emitters go. Fence the two halves to
-two items and each waits on the other's merge. Measured here: one lane sat on exactly that hold for
-an hour, the first change red at three successive heads and the second never dispatched, with every
-fence correctly derived from files. Nothing in a file list shows it. **Ask what each nominated gate
-COMPARES**, and when two items hold the two sides of one comparison, brief both halves to one
-worker — or route the second half into the live change and re-scope the item that held it. Where a
-one-toucher file is held only for a region an item does not need yet, the fence can sit INSIDE the
-brief instead of in front of it: the worker does the unheld part first, takes the held file only on
-a trunk that already carries the holder's merge, and stops and reports if it reaches that point
-first.
+deadlocks.** The one-toucher rule reasons about files, and it is right about files. Some checkers
+hold one surface against another in both directions — a catalogue against the emitters it lists, a
+schema against its fixtures, a manifest against the modules it names — and under such a gate neither
+half is green alone: the change deleting the emitters reds until the rows go, and the change striking
+the rows reds until the emitters go. Fence the two halves to two items and each waits on the other's
+merge. Nothing in a file list shows it. **Ask what each nominated gate COMPARES**, and when two items
+hold the two sides of one comparison, brief both halves to one worker — or route the second half into
+the live change and re-scope the item that held it. Where a one-toucher file is held only for a
+region an item does not need yet, the fence can sit INSIDE the brief instead of in front of it: the
+worker does the unheld part first, takes the held file only on a trunk that already carries the
+holder's merge, and stops and reports if it reaches that point first.
 
-**The unit is the block, not the file.** Two items were dispatched into the same paragraph
-of one document because they were nominally different concerns. They conflicted, the second
-change could not merge, and by the time its worker was resumed the hygiene loop had already
-reaped its worktree. Two costs from one scheduling error. If two items touch the same
-section, sequence them.
+**The unit is the block, not the file.** Two items dispatched into the same paragraph of one document
+because they were nominally different concerns conflicted; the second change could not merge, and by
+the time its worker was resumed the hygiene loop had reaped its worktree — two costs from one
+scheduling error. If two items touch the same section, sequence them.
 
-**Complementary work is not duplicate work.** When two items attack one defect from
-different sides — one making a silent failure loud, one stopping a document teaching the
-failing shape — say so in both, or one gets closed as a duplicate of the other.
+**Complementary work is not duplicate work.** When two items attack one defect from different sides —
+one making a silent failure loud, one stopping a document teaching the failing shape — say so in
+both, or one gets closed as a duplicate of the other.
 
 ---
 
 ## Choosing solo or cluster
 
-Pick by **kind first, then priority, then size**. Do not reflexively dispatch
-one-worker-per-item, and do not reflexively bundle everything.
+Pick by **kind first, then priority, then size**. Do not reflexively dispatch one-worker-per-item,
+and do not reflexively bundle everything.
 
-* **Highest priority → always SOLO.** A dedicated worker and its own change, so it merges
-  on its own green and is never blocked by a cluster sibling.
+* **Highest priority → always SOLO.** A dedicated worker and its own change, so it merges on its own
+  green and is never blocked by a cluster sibling.
 * **Second tier → SOLO by default.** Cluster several only when they are genuinely small,
   same-surface and low-risk.
-* **Many small low-priority same-surface items → CLUSTER.** This is the primary clustering
-  case. It stops you handling dozens of trivia serially.
-* **Any LARGE item → SOLO**, whatever its priority. Never pad a meaty item into a cluster,
-  and never bundle two large ones — the agent times out. Bundles of four or more items time
-  out routinely where single-item workers succeed.
-* **A measurement window → SOLO, Shape 6**, picked by kind rather than size and never folded
-  into a cluster.
-* **One item too large for one worker → SPLIT by disjoint file, one worker each, and NOBODY
-  CLAIMS IT.** The reverse of a cluster, for an item whose slices are each a full session.
-  A claim marks the item one worker's, and the ready list, the stranded sweep and every
-  other slice's worker then read it that way; so each worker appends a claim note and a
-  result note instead, and the mayor closes the item when the last slice has landed, citing
-  every change. Measured: four slices of one item in one session, each its own change,
-  none colliding, closed once with four cross-references.
+* **Many small low-priority same-surface items → CLUSTER.** This is the primary clustering case. It
+  stops you handling dozens of trivia serially.
+* **Any LARGE item → SOLO**, whatever its priority. Never pad a meaty item into a cluster, and never
+  bundle two large ones — bundles of four or more items time out routinely where single-item workers
+  succeed.
+* **A measurement window → SOLO, Shape 6**, picked by kind rather than size and never folded into a
+  cluster.
+* **One item too large for one worker → SPLIT by disjoint file, one worker each, and NOBODY CLAIMS
+  IT.** The reverse of a cluster, for an item whose slices are each a full session. A claim marks the
+  item one worker's, and the ready list, the stranded sweep and every other slice's worker then read
+  it that way; so each worker appends a claim note and a result note instead, and the mayor closes
+  the item when the last slice has landed, citing every change.
 
 **Three of those rules consume a SIZE, and the size you are holding is usually a TITLE.** Sizing
-happens at the listing — the ready queue, the backlog view — and a listing prints names. This page
-already argues that a name is not evidence about *files* (see *Fences*), and that an item's own
-scope claim is a name wearing a reviewer's authority. Magnitude is the third thing a name gets
-wrong, and it is the one no fence catches, because it corrupts the decision before any fence is
-derived. Measured: an item whose title named one test that could pass vacuously — the archetypal
-small same-surface cluster candidate — carried a body that deleted four public tools, removed an
-entire subsystem, and ran to seven acceptance criteria with explicit non-goals. Clustered on its
-title it would have produced both failures the list warns about at once, a bundle that times out
-and a large item padded into a cluster, and it would have carried an unreviewed public-interface
-deletion inside a change whose stated subject was trivia.
+happens at the listing, and a listing prints names. This page already argues that a name is not
+evidence about *files*, and that an item's own scope claim is a name wearing a reviewer's authority;
+magnitude is the third thing a name gets wrong, and the one no fence catches, because it corrupts the
+decision before any fence is derived. Measured: an item whose title named one test that could pass
+vacuously — the archetypal small same-surface cluster candidate — carried a body that deleted four
+public tools, removed a subsystem, and ran to seven acceptance criteria with explicit non-goals.
 
 **So open every candidate before you cluster it, and read for SHAPE rather than for content** —
 acceptance criteria, non-goals, the length of the evidence, whether the body names a few files or
-names a subsystem. None of that requires understanding the work, which is why it is cheap: it is a
-few reads against a listing you were going to act on anyway. The asymmetry is what settles it,
-because a misread item does not merely arrive oversized — it poisons the change its siblings ride
-in. **And where a title and its body disagree, correct it on the item** rather than only in your
-own decision. The listing is what the next reader sees, so an item that misled you will mislead
-them identically, and a retitle is the only repair that does not have to be made twice.
+names a subsystem. None of that requires understanding the work, which is why it is cheap. The
+asymmetry is what settles it: a misread item does not merely arrive oversized, it poisons the change
+its siblings ride in. **And where a title and its body disagree, correct it on the item** rather than
+only in your own decision — the listing is what the next reader sees, and a retitle is the only
+repair that does not have to be made twice.
 
 **One agent owns a surface; surfaces run in parallel.** That is how you avoid serial handling:
 same-surface items ride one agent, which never collides with itself, while genuinely separable
 surfaces dispatch as concurrent agents.
 
-**The serial exceptions**, where same-surface work is *meant* to be sequential: a deliberately
-serial epic, and a single tightly-coupled module whose core files many items touch. That surface
-is its own serial lane — sequence its changes, later ones rebasing on the earlier merges, never
-resolving a conflict by taking one side wholesale. On a coupled surface even solo high-priority
-work cannot run in parallel.
+**The serial exceptions**, where same-surface work is *meant* to be sequential: a deliberately serial
+epic, and a single tightly-coupled module whose core files many items touch. That surface is its own
+serial lane — sequence its changes, later ones rebasing on the earlier merges, never resolving a
+conflict by taking one side wholesale. On a coupled surface even solo high-priority work cannot run
+in parallel.
 
 ---
 
@@ -446,9 +377,8 @@ work cannot run in parallel.
 **Shape 1 — Solo.** One item, one change. Item id and verbatim title; two to four paragraphs of
 context with `file:line` citations; numbered concrete steps; a dedicated worktree and branch; the
 boundary block; claim the item — unless it is a slice of a split item, which nobody claims (see
-*Choosing solo or cluster*): a slice's worker appends a claim note and a result note, and the
-mayor closes the item when the last slice lands; gates with exact commands; push and open the change **as a draft**
-with a `## Quality gates` section; report the change URL, a per-step summary and test deltas.
+*Choosing solo or cluster*); gates with exact commands; push and open the change **as a draft** with
+a `## Quality gates` section; report the change URL, a per-step summary and test deltas.
 
 *A coverage or rigour pass must add at least one adversarial or negative case per surface.*
 Assertion-count growth alone only exercises the happy path.
@@ -462,36 +392,32 @@ opening with what it finished and listing the remainder, never a half-item uncom
 Disjoint-surface "small-misc" clusters are valid at the tail of a drain — the binding rule is
 hot-zone parallelism, not strict same-surface.
 
-**Shape 3 — Audit (read-only).** A finding, not a fix. Goal, surface paths, and prior findings
-to avoid re-discovering; the boundary block; write the findings document to the version-ignored
-working tree FIRST, never commit it, never link it from committed files; file follow-on items one
-at a time, appending each id to the audit item's notes so progress survives a timeout; close with
-a verdict, severity counts and cross-references; no change by default.
+**Shape 3 — Audit (read-only).** A finding, not a fix. Goal, surface paths, and prior findings to
+avoid re-discovering; the boundary block; write the findings document to the version-ignored working
+tree FIRST, never commit it, never link it from committed files; file follow-on items one at a time,
+appending each id to the audit item's notes so progress survives a timeout; close with a verdict,
+severity counts and cross-references; no change by default.
 
-**An audit brief needs the stance more than an implementation brief does.** The audit is
-*producing* findings, and a project that rejects findings as often as it actions them will reject
-the weak ones at the cost of a dispatch each. Tell it plainly: eight sourced findings beat thirty
-plausible ones, and a finding whose remedy the project's stance excludes is worse than none.
-Giving it two or three worked examples of a good finding beats asking for "a careful review".
+**An audit brief needs the stance more than an implementation brief does.** The audit is *producing*
+findings, and a project that rejects findings as often as it actions them will reject the weak ones
+at the cost of a dispatch each. Tell it plainly: eight sourced findings beat thirty plausible ones,
+and a finding whose remedy the project's stance excludes is worse than none. Two or three worked
+examples of a good finding beat asking for "a careful review". The mayor may reorganise or reject
+findings; not every finding is actioned.
 
-The mayor may reorganise or reject findings. Not every finding is actioned.
-
-**Shape 4 — Cluster reviewer (read-only, no dispatch).** Shapes the next wave. List in-flight
-workers and their surfaces first, and do not recommend touching those. Enumerate recently filed
-items and the ready queue. Per item decide: add to an in-flight cluster; form a new cluster (three
-or more items on a shared non-hot-zone surface); solo (correctness, large, decision-resolved or
-cross-cutting); or defer. Output the net next-dispatch shape in two or three sentences. **Do not
-change tracker state.**
+**Shape 4 — Cluster reviewer (read-only, no dispatch).** Shapes the next wave. List in-flight workers
+and their surfaces first, and do not recommend touching those. Enumerate recently filed items and the
+ready queue. Per item decide: add to an in-flight cluster; form a new cluster (three or more items on
+a shared non-hot-zone surface); solo (correctness, large, decision-resolved or cross-cutting); or
+defer. Output the net next-dispatch shape in two or three sentences. **Do not change tracker state.**
 
 **When items arrive faster than the mayor can read them, ask this shape for the brief inputs as
-well**, per item: the premise check at the current tip (each cited line holds, drifted to what,
-or does not hold; every asserted count re-run), the surfaces it would edit and which are hot-zone,
+well**, per item: the premise check at the current tip (each cited line holds, drifted to what, or
+does not hold; every asserted count re-run), the surfaces it would edit and which are hot-zone,
 same-file collisions against the live and queued sets, the gates by exact command with the
 heavyweight ones marked, and each ambiguity a worker would otherwise improvise, with a
-recommendation. That is the part of a brief the mayor cannot write without reading the tree, and
-the part that goes stale first. Measured: three such passes over twenty-six items in one evening,
-each returning premise drifts — a cited file that did not exist, an alias at another line, a flag
-the toolchain already supplied — before any worker was dispatched.
+recommendation. That is the part of a brief the mayor cannot write without reading the tree, and the
+part that goes stale first.
 
 **Shape 5 — Fix a failing check.** The failing check name and log lines; two or three root-cause
 hypotheses; a worktree off the **existing** branch, not a new one; the boundary block; **run the
@@ -509,66 +435,58 @@ at all.
 
 - **The controls are the arbiter, not the worker's judgement about the machine.** A worker asked
   whether its own machine was quiet enough will always find a reason it was. If a control fails, or
-  an ordering guard refuses, the run refuses and the worker reports the refusal without weighing it
-  against how the machine felt.
-- **A refusal is a deliverable, not a failure.** Two of three windows in one day came back as
-  refusals and both were correct. If everything refuses, the window succeeded: you now know the rig
-  cannot see what you hoped it would, which is what you dispatched it to find out. Say this in the
-  brief, or the worker reads its refusal as its own failure and goes hunting for a way to turn it
-  green.
+  an ordering guard refuses, the run refuses and the worker reports the refusal.
+- **A refusal is a deliverable, not a failure.** If everything refuses, the window succeeded: you now
+  know the rig cannot see what you hoped it would, which is what you dispatched it to find out. Say
+  this in the brief, or the worker reads its refusal as its own failure and goes hunting for a way to
+  turn it green.
 - **Never "fix" a refusal by loosening a gate.** Every gate in a rig is there because something once
   passed that should not have. Widening a threshold to admit today's run retro-admits that failure
   too, and the series loses the one property that made it worth running.
-- **Do not improve the rig mid-window.** No new instrument, no extra rungs, no third estimator,
-  however obvious it looks from inside the run: a rung added between runs makes the series two
-  instruments. File the improvement and run it as its own window.
-- **Do not restate a published figure on thin evidence.** A worker holding four reportable runs, every
-  one reading *below* both published figures, recorded them without publishing. That was right: four
-  runs disagreeing with a number are a reason to look again, not a mandate to move it.
+- **Do not improve the rig mid-window.** No new instrument, no extra rungs, no third estimator: a
+  rung added between runs makes the series two instruments. File the improvement as its own window.
+- **Do not restate a published figure on thin evidence.** Four runs disagreeing with a number are a
+  reason to look again, not a mandate to move it.
 - **Verify the machine with real counters, not the convenient one.** One system's headline CPU
-  counter read 93% while the true value was 11%. Cross-check, and prefer the counter saying whether
-  anything is actually *waiting for a core*. **Read it on its own, never inside a measured run**:
-  sampled beside anything heavy it measures the sampler — one reading of 59–77 was the dispatcher's
-  own directory copy — and sampled inside a run it measures the benchmark. Bracket the run, and say
-  plainly that nothing is claimed about within-run quietness beyond the bracketing.
+  counter read 93% while the true value was 11%. Prefer the counter saying whether anything is
+  actually *waiting for a core*, and **read it on its own, never inside a measured run** — sampled
+  beside anything heavy it measures the sampler, and inside a run it measures the benchmark. Bracket
+  the run, and say plainly that nothing is claimed about within-run quietness beyond the bracketing.
 - **Only a CLOCK estimand needs the quiet machine.** A census of monotone counters — allocations,
   recomputations, calls — reads the same on a loaded box, so it may run beside anything and must not
-  consume a drain. Classify the estimand before you schedule it. Getting this wrong is expensive in
-  both directions: drain the fleet for a counter census and the idle machine is wasted, run a clock
-  window beside a peer and the number is worthless while looking measured.
+  consume a drain. Classify the estimand before you schedule it; getting it wrong wastes an idle
+  machine in one direction and produces a worthless-but-measured-looking number in the other.
 - **While a clock window runs, every OTHER dispatch carries a clause reserving the machine** — naming
   the heavyweight gates that worker may not run, **and** saying that *if the only gate covering your
   surface is a heavy one, stop and report* is a correct outcome. Without that second half a worker
-  held off the machine runs the gate anyway, to satisfy the surface-gate menu the same brief hands it.
-  The failure is silent in both directions: the window does not fail, it returns a plausible number
-  that is worthless and then gets published and cited.
-- **One run at a time, never concurrent.** Concurrency is precisely the contention the window exists to
-  exclude, so two runs the worker believes are independent still are not.
-- **Your published sentences are claims too.** **What slips is the prose ONE LAYER ABOVE the number**:
-  a worker that has just spent an hour being rigorous writes its summary in ordinary confident English,
-  and ordinary confident English overclaims. Three measurement changes merged in one day, all exemplary
-  on the run itself, and all three overstated their published claim — one called three values
-  *run-medians* where the code stored the arithmetic MEAN of five per-round ratios, which was its whole
-  stated basis; one said a spread "loosely brackets" a figure sitting *above* the maximum of its own
-  ratios. No audit overturned a measurement or a refusal. What they corrected is the sentence a future
-  reader will quote, which is how a measured result becomes a false premise in someone else's brief.
-  So: name the evidence licensing each summarising statement, check the arithmetic of any comparison,
-  name the estimator you actually computed rather than the one the surrounding prose habitually says,
-  and do not attribute a spread to one cause unless your data excludes the others.
+  held off the machine runs the gate anyway, to satisfy the surface-gate menu the same brief hands
+  it. The failure is silent in both directions: the window returns a plausible worthless number, and
+  that number gets published and cited.
+- **One run at a time, never concurrent.** Concurrency is precisely the contention the window exists
+  to exclude, so two runs the worker believes are independent still are not.
+- **Your published sentences are claims too, and what slips is the prose ONE LAYER ABOVE the
+  number**: a worker that has just spent an hour being rigorous writes its summary in ordinary
+  confident English, and ordinary confident English overclaims. Three measurement changes merged in
+  one day, all exemplary on the run itself, all three overstating their published claim — one calling
+  three values *run-medians* where the code stored the arithmetic MEAN of five per-round ratios, its
+  whole stated basis; one saying a spread "loosely brackets" a figure sitting *above* the maximum of
+  its own ratios. No audit overturned a measurement or a refusal; what they corrected is the sentence
+  a future reader will quote, which is how a measured result becomes a false premise in someone
+  else's brief. So: name the evidence licensing each summarising statement, check the arithmetic of
+  any comparison, name the estimator you actually computed rather than the one the surrounding prose
+  habitually says, and do not attribute a spread to one cause unless your data excludes the others.
 - **An impossible reading cannot bound the quantity.** Let an observed delta *y* be an unknown
   positive true cost *t* plus estimator error *e*. A reading of *y* = −0.0062 proves only that the
   negative error excursion exceeded 0.0062 + *t*: it neither makes ±0.0062 a calibrated symmetric
   floor nor upper-bounds *t*. **A most-negative observation is a statement about the ERROR TERM, not
   about the quantity** — and comparing most-negative readings from *different* positive-cost arms at
   two window widths cannot establish a floor-scaling factor either. **Where a bound is inferred from
-  estimator error or noise-floor behaviour, name the NULL OR CONTROL ARM that produced it**; otherwise
-  report the term as UNRESOLVED. A bound resting on a direct analytic argument or an independently
-  calibrated error figure needs no arm at all — say which warrant you have. One window quoted
-  "bounded: < 0.006 ms/commit" from its own most-negative reading, was refuted by audit, and was
-  refuted again by the next window reading −0.0141.
+  estimator error or noise-floor behaviour, name the NULL OR CONTROL ARM that produced it**;
+  otherwise report the term as UNRESOLVED. A bound resting on a direct analytic argument or an
+  independently calibrated error figure needs no arm at all — say which warrant you have.
 
-Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what was
-**not** concluded. A window that publishes nothing still reports everything.
+Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what
+was **not** concluded. A window that publishes nothing still reports everything.
 
 ---
 
@@ -582,173 +500,126 @@ section as reliance on CI rather than waited out in silence.
 **Mark it ready for review as the last act before reporting done.** That one line is what stops
 push-as-you-go colliding with a merge loop that merges the moment CI goes green, because the merge
 criterion tests the CHANGE and nothing in it can see whether the author has finished. Twice in one
-session here a change was merged out from under a live worker: once the host's delete-on-merge removed
-the branch and the worker's next push recreated it, producing a duplicate change carrying a
-byte-identical diff; once a merge landed mid-gate, and the remainder took a whole extra change and
-review cycle to carry. Neither merge was wrong on the criterion — both were green on every clause.
+session a change was merged out from under a live worker: once the host's delete-on-merge removed the
+branch and the worker's next push recreated it as a duplicate change with a byte-identical diff; once
+a merge landed mid-gate, and the remainder took a whole extra change and review cycle. Neither merge
+was wrong on the criterion — both were green on every clause.
 
-**Use the host's own draft flag rather than a rule to remember.** Merge commands refuse a draft, so the
-interlock is enforced where it cannot be forgotten — the property the no-stash rule and a mayor-side
-commit guard both have, and the reason they hold. The rejected alternative, having the mayor check
-worker liveness before every merge, works but must be remembered on every merge forever, and it
-re-introduces exactly the worktree-activity sweep the merge loop deliberately does not do.
+**Use the host's own draft flag rather than a rule to remember.** Merge commands refuse a draft, so
+the interlock is enforced where it cannot be forgotten. The rejected alternative — having the mayor
+check worker liveness before every merge — works, but must be remembered on every merge forever, and
+it re-introduces exactly the worktree-activity sweep the merge loop deliberately does not do.
 
-**But the flag is only as good as the author eventually setting it, and it fails in BOTH
-directions.** Both were measured in one session, and neither is visible from the change.
+**But the flag is only as good as the author eventually setting it, and it fails in BOTH directions.**
+Neither direction is visible from the change.
 
 **Stale-OPEN — a fix dispatch inherits a flag somebody else already set.** A fix worker goes onto an
 EXISTING change whose original author finished and marked it ready, so the flag is set before the
 second worker arrives and nothing in the change records that anyone is inside it now. The merge loop
 reads a ready change, the criterion passes, and the merge lands under a live worker — the exact
 failure the flag exists to prevent, arriving by the one path where the flag was never the current
-worker's to set. Measured here; nothing was lost, because the commits that went green were the ones
-that landed, but that was timing rather than protection.
-
-**The remedy belongs to the DISPATCHER, because the worker cannot supply it.** Telling the fix worker
-to mark the change ready last does nothing when the flag is already ready before it starts, and a rule
-the protected party is unable to execute is not a rule. So converting the change back to draft is part
-of dispatching a fix, done before the worker begins — and **confirm the state took rather than trusting
+worker's to set. **The remedy belongs to the DISPATCHER, because the worker cannot supply it**: a rule
+the protected party is unable to execute is not a rule. Converting the change back to draft is part of
+dispatching a fix, done before the worker begins — and **confirm the state took rather than trusting
 the call**, since a host that ignores the request fails silently and leaves exactly the gap you were
-closing. The dispatch ledger is then the record of who is inside it, not the only one.
+closing.
 
 **Stuck-CLOSED — an author appears to go silent holding a green draft. Read this one carefully,
-because the reading is usually wrong.** The remedies above assume the author answers: wait for the
-ready mark, or message them. What gets read instead is a worker that has stopped — no writes, tip
-unmoved, worktree clean, everything pushed, a direct message unanswered for half an hour, and a draft
-sitting exactly at band with nothing non-terminal and nothing failing.
+because the reading is usually wrong.** What gets read as a stopped worker is: no writes, tip unmoved,
+worktree clean, everything pushed, a direct message unanswered for half an hour, and a draft sitting
+exactly at band with nothing failing.
 
 **Every signal in that list is also what a worker in its FINAL MINUTES looks like.** A worker
-finishing up — running one last foreground gate, deleting gate logs, unlinking a shared-dependency
-link, tidying a scratch directory — writes outside the worktree and outside version control, and is
-too busy to answer. So the tip does not move, the fetch clock does not move, the write clock does not
-move, and the message goes unanswered. **The four indirect signals do not fail independently here;
-they fail together, for one cause.**
+finishing up — one last foreground gate, deleting gate logs, unlinking a shared-dependency link,
+tidying a scratch directory — writes outside the worktree and outside version control, and is too busy
+to answer. **The four indirect signals do not fail independently; they fail together, for one cause.**
 
 **Which makes the frozen reading AMBIGUOUS, and that is the whole finding — not that it means the
 opposite.** Frozen-across-three-readings feels like the most damning pattern available, and it is
 compatible with a stopped worker and with healthy foreground work alike, so it identifies neither.
-Re-reading the same four clocks cannot break the tie, however long the freeze runs: an hour of it is
-the same non-signal as a minute of it.
-
-Measured, twice: on the first occasion five workers were reported dormant; **three completed alive
-with full reports**, one answering the ping directly to say it had been on final hygiene, and **two
-were never explained either way**. The diagnosis was retracted in full, including a second claim —
-that messaging was inoperative — which was *slow* converted into *broken*. It recurred the same day
-on a sixth worker whose clocks were frozen for over an hour and which completed normally.
-
-**Name those outcomes rather than reducing them to a ratio, because the ratio has already been got
-wrong twice.** A ratio invites you to round the unexplained cases into whichever side you are
-arguing for, and the first attempt also counted a **live control** — a worker that was moving
-throughout, and was the comparison the measurement rested on — among the completions. Four alive,
-two unexplained, one control that was never in question: **treat that as a warning against the
-dormancy reading, not as a licence for its inverse**, and note that the two unexplained workers are
-precisely why the reading is ambiguous rather than merely mistaken.
+Re-reading the same four clocks cannot break the tie: an hour of freeze is the same non-signal as a
+minute of it. Measured twice — on the first occasion five workers were reported dormant, **three
+completed alive with full reports**, one saying it had been on final hygiene, and **two were never
+explained either way**; the diagnosis was retracted in full, including a second claim that messaging
+was inoperative, which was *slow* converted into *broken*. **Name those outcomes rather than reducing
+them to a ratio**, which invites rounding the unexplained cases into whichever side you are arguing
+for — and the two unexplained workers are precisely why the reading is ambiguous rather than merely
+mistaken.
 
 **So prefer the DIRECT signal where your tooling offers one** — a live progress line, a status the
-supervisor maintains — over any number of indirect clocks, and **treat the four clocks as the fallback
-they are.** If you have only the clocks, declare a window and re-read rather than acting; the error is
-cheap in exactly one direction.
+supervisor maintains — over any number of indirect clocks. If you have only the clocks, declare a
+window and re-read rather than acting; the error is cheap in exactly one direction.
 
 **And do not answer any of it by flipping the flag on an inference.** *It looks done* is the proxy the
-reaping rules refuse one surface over, and every reason the paragraph above rejects a per-merge
-liveness check still holds. Settle it the way reaping is settled, by a read rather than an inference:
-the agent's own report, or the operator's decision to stop that agent, which settles liveness by making
-it false. Until one of those arrives the change waits, and the honest report says a finished change is
-stranded and why. That rule is unchanged by the above — what changes is how often you should expect to
-reach for it, which is rarely.
-
-**Where that second one is taken, it is taken FIRST.** Stopping the agent and then merging is
+reaping rules refuse one surface over. Settle it by a read rather than an inference: the agent's own
+report, or the operator's decision to stop that agent, which settles liveness by making it false.
+Until one of those arrives the change waits, and the honest report says a finished change is stranded
+and why. **Where the second is taken, it is taken FIRST** — stopping the agent and then merging is
 authorised; merging and then stopping is the same inference with the act appended afterwards, and it
-leaves an identical record — a merged change beside a stopped agent — so nothing later can tell the two
-apart. The coordinator's side of this rule, and the cost of stopping an author who had found further
-work, are under *The stranded sweep* in [`loops.md`](loops.md#the-stranded-sweep); the rule itself is
-one rule and this page states it.
+leaves an identical record, so nothing later can tell the two apart. The coordinator's side is under
+*The stranded sweep* in [`loops.md`](loops.md#the-stranded-sweep).
 
 ---
 
 ## Pasting a block
 
-Three blocks below travel **verbatim** into a dispatch: the **common preamble** into every
-one, the **worktree boundary block** and the **gate-mechanics block** into every editing
-one. Get them there by **extracting mechanically, then pasting the result into the
-prompt.** Both halves are mandatory and they close different failures: the extraction is
-what makes paraphrase impossible — a matched range cannot reword, where a mayor retyping
-two hundred lines of gate mechanics can and does — and the paste is what makes non-receipt
-impossible, because a block that is in the prompt cannot be un-received.
+Three blocks below travel **verbatim** into a dispatch: the **common preamble** into every one, the
+**worktree boundary block** and the **gate-mechanics block** into every editing one. Get them there by
+**extracting mechanically, then pasting the result into the prompt.** Both halves are mandatory and
+they close different failures: the extraction is what makes paraphrase impossible — a matched range
+cannot reword, where a mayor retyping two hundred lines of gate mechanics can and does — and the paste
+is what makes non-receipt impossible, because a block that is in the prompt cannot be un-received.
 
-**Sending the worker to the FILE is not a substitute.** A worker that skims it, or reads
-part of it, has not received the block at all, and nothing in the transcript distinguishes
-that from a worker who read every line — so the first evidence is a worker doing something
-the block forbids. Between a failure prevented by construction and one prevented by a
-reader's diligence, take construction; the context cost is the acknowledged price, and a
-brief is the mayor's scarce output.
+**Sending the worker to the FILE is not a substitute.** A worker that skims it, or reads part of it,
+has not received the block at all, and nothing in the transcript distinguishes that from a worker who
+read every line — so the first evidence is a worker doing something the block forbids. Between a
+failure prevented by construction and one prevented by a reader's diligence, take construction.
 
-**And no dispatch is small enough to earn a condensed block.** The temptation is strongest
-exactly where the block most dwarfs the task — a two-line edit behind a two-hundred-line block —
-and condensing there is the paraphrase the mechanical extraction exists to prevent, arriving
-dressed as proportionality. One mayor did it once, on a session's smallest dispatch, having
-pasted the full block on every larger one; the worker behaved anyway, and the outcome does not
-validate the shortcut.
+**And no dispatch is small enough to earn a condensed block.** The temptation is strongest exactly
+where the block most dwarfs the task, and condensing there is the paraphrase the mechanical extraction
+exists to prevent, arriving dressed as proportionality. Measured: a mayor condensed the gate-mechanics
+block for a two-file rename, and the worker ended its turn waiting to be woken — the exact failure
+that block names, refutes and closes, in text the mayor had read and chose not to send. **And note
+WHICH part went missing**, because it is not random: a mayor condensing drops what looks least
+relevant to this task, and what stranded the worker was a mechanic belonging to the HARNESS rather
+than to the task — precisely what looks least relevant. A condensed block is not a shorter block; it
+is a block with the harness mechanics taken out of it.
 
-**Measured since, on a dispatch smaller still: the worker did not behave.** A mayor condensed the
-gate-mechanics block for a two-file rename, and the worker ended its turn waiting to be woken — the
-exact failure that block names, refutes and closes, in text the mayor had read and chose not to
-send. Nothing new had to be written to prevent it. **And note WHICH part went missing**, because it
-is not random: a mayor condensing drops what looks least relevant to this task, and what stranded
-the worker was a mechanic belonging to the harness rather than to the task — precisely what looks
-least relevant. A condensed block is not a shorter block; it is a block with the harness mechanics
-taken out of it.
+**The pressure is structural, because the block only ever grows.** Every failure it closes adds lines,
+so the better it gets the more it dwarfs a small task — a ratchet turning against the one rule that
+holds it. No wording fixes that, and a block cannot be kept short enough to be safe. The defence is
+that the extraction is MECHANICAL, and a mechanical extraction costs the same on the session's
+smallest dispatch as on its largest: **if you are weighing which parts this worker needs, you have
+stopped extracting and started paraphrasing.**
 
-**The pressure is structural, because the block only ever grows.** Every failure it closes adds
-lines, so the better it gets the more it dwarfs a small task, and the more condensing it reads as
-proportionality — a ratchet turning against the one rule that holds it. No wording fixes that, and
-a block cannot be kept short enough to be safe. The defence is that the extraction is MECHANICAL,
-and a mechanical extraction costs the same on the session's smallest dispatch as on its largest:
-if you are weighing which parts this worker needs, you have stopped extracting and started
-paraphrasing.
+**But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU are
+not part of what travels.** Where the payload is FENCED, the fence settles it: take the fence, and
+every line outside it is yours. Two of the three here are fenced, and their mayor-facing prose sits on
+opposite sides of the payload, so a habit about which end it lives at is wrong half the time. **Only
+the third, which has no fence, opens by naming itself and saying where it stops** — paste that frame
+untouched and the worker receives instructions about pasting blocks into dispatches it will never
+make, and a pointer by name to a neighbouring section, which is the go-and-read-it this page has just
+forbidden. Drop the frame, and add whatever caution the lane needs. Reword and omission are what is
+forbidden. **The test is whether the block still refuses everything it refused before you touched it.**
 
-**But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU
-are not part of what travels.** Where the payload is FENCED, the fence settles it: take the
-fence, and every line outside it is yours. Two of the three here are fenced, and their
-mayor-facing prose sits on opposite sides of the payload — rationale ahead of the fence in one,
-a whole paragraph after the closing fence in the other — so a habit about which end it lives at
-is wrong half the time. **Only the third, which has no fence, opens by naming itself and saying
-where it stops**, so a mechanical extraction carries that frame along: paste it untouched and the
-worker receives instructions about pasting blocks into dispatches it will never make, and a
-pointer by name to a neighbouring section, which is the go-and-read-it this page has just
-forbidden. Drop that frame,
-and add whatever caution the lane needs — the rationale above is paraphrase and non-receipt, and
-neither is defeated by a sentence making the block bite harder on the gate you actually nominated.
-Reword and omission are what is forbidden. **The test is whether the block still refuses everything
-it refused before you touched it.**
+**Anchor the extraction to CONTENT, never to line numbers.** A line range against a living document is
+a measured constant that goes stale exactly where it has to be right.
 
-**Anchor the extraction to CONTENT, never to line numbers.** A line range against a living
-document is a measured constant that goes stale exactly where it has to be right, and an
-extraction that silently returns the wrong two hundred lines is worse than either option
-that trade-off was weighing. Match the block's opening and closing text instead.
+**But match the closing text as a HEADING — anchored to the start of a line — because a block that
+documents its own boundaries contains its own end anchor.** The gate-mechanics block opens by naming
+where it stops, so its CLOSING string occurs twice: once as the real heading, once inside that opening
+sentence. A plain search stops at the mention and the extraction returns the block's opening paragraph
+instead of the block, raising no error, because both anchors were found. **The opening heading is NOT
+doubled, and that asymmetry is the durable part** — a block that says where it stops must name its
+closing anchor, so the trap sits on the closing anchor specifically.
 
-**But match that closing text as a HEADING — anchored to the start of a line — because a block
-that documents its own boundaries contains its own end anchor.** The gate-mechanics block opens by
-naming where it stops, so its CLOSING string occurs twice in this file: once as the real heading,
-once inside that opening sentence. A plain search for it stops at the mention, and the extraction
-returns the block's opening paragraph instead of the block — raising no error, because both anchors
-were found. Measured on this document.
-
-**The opening heading is NOT doubled, and that asymmetry is the durable part.** A block that says
-where it stops must name its closing anchor; whether it also repeats its own heading text is an
-accident of phrasing, and this one stopped repeating it when that sentence was reworded to say
-"from this heading". So the trap sits on the closing anchor specifically, which is where anchoring
-to the start of a line is load-bearing.
-
-That is a worse failure than the stale line range this rule exists to avoid, and worse in the way
-that matters: a stale range returns the wrong two hundred lines, which reads wrong on sight, where
-this returns a plausible opening paragraph that reads like a short block. **So check the extracted
-size before you paste it — and check it as a CLASS, not against a remembered number.** The two
-outcomes are orders of magnitude apart, a few hundred characters against many thousands, so the
-reliable test is whether the extraction ENDS at the closing heading, which cannot drift. A count
-here would be a measured constant about a living document, and the one this passage used to quote
-had drifted about a fifth before a reread caught it — [the same failure](#counts-are-claims-and-they-go-stale-first)
-one section up, wearing the other hat.
+That is worse than the stale line range this rule exists to avoid, and worse in the way that matters:
+a stale range returns the wrong two hundred lines, which reads wrong on sight, where this returns a
+plausible opening paragraph that reads like a short block. **So check the extracted size before you
+paste it — and check it as a CLASS, not against a remembered number.** The two outcomes are orders of
+magnitude apart, so the reliable test is whether the extraction ENDS at the closing heading, which
+cannot drift. A count here would be [a measured constant about a living
+document](#counts-are-claims-and-they-go-stale-first), one section up wearing the other hat.
 
 ---
 
@@ -829,6 +700,10 @@ commits touching worker-owned surfaces — so a bypassed edit-guard is caught fr
 
 ## Common preamble
 
+The tracker commands are placeholders like every other project-specific: substitute your own at
+dispatch time. What travels verbatim is the *reasoning* — every trap below is a property of history
+walks in general, not of one tool.
+
 ```text
 You are implementing <ITEM_ID> in <project + one-line description>.
 
@@ -844,54 +719,52 @@ superseded instructions.
 BUT ORDER IT BY THE TRACKER'S TIMESTAMPS, NOT BY POSITION AND NOT BY DATES IN THE
 PROSE. The bottom of the output is NOT reliably the newest text — audit notes often
 append into the DESCRIPTION block while dated comments render after it, so the last
-lines on screen can be older than material higher up. Neither `bd show <id> | tail` nor
-a HEAD slice of the notes section is a read-the-newest method. Nor is grepping the text
-for dates: a date in the prose is CONTENT, not a mutation time, so an undated scope
-correction is invisible to it and an edited description can be the newest field on the
-bead. Use `bd history <id>`, which lists real mutation times newest-first, and
-`bd comments <id> --json` for comment `created_at`. THE PLAIN LISTING TELLS YOU A NEWER
-MUTATION EXISTS, NOT WHAT IT SAYS — it names no changed field, so for the change itself
-use `bd history <id> --json`, which carries a full snapshot per commit. EACH ENTRY
-NESTS THE ITEM'S FIELDS UNDER `.Issue`; the top level carries only commit metadata, so
-a walk keyed at the top level matches nothing in every snapshot and reports “no change”
-without erroring. WALK ADJACENT PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A
-TEXT-BEARING FIELD (`.Issue.description`, `.Issue.notes`, `.Issue.acceptance_criteria`
-— the update flag is spelled `--acceptance` but the field is not — and
-`.Issue.design`): the history holds duplicate checkpoint snapshots and status-only
-mutations, so the newest pair alone can truthfully say nothing changed while a live
-instruction change sits behind it. AND A WALK THAT ENDS WITHOUT FINDING ONE HAS FOUND
-NOTHING, NOT “NO CHANGE” — say which of the two you have. Histories accumulate
-machine-written no-ops, so a walk bounded anywhere short of the item’s beginning reports
-“no text-bearing change” on an item that has several, and that reads as the revert
-signature whose remedy is to re-close. On a long history, search the text for the marker
-you expect rather than walking to it. If the bead has children, re-enumerate them too: a
-ruling is sometimes recorded as a NEW CHILD BEAD rather than as a note.
+lines on screen can be older than material higher up. Neither a tail of the rendered
+item nor a slice of its notes is a read-the-newest method. Nor is grepping for dates:
+a date in the prose is CONTENT, not a mutation time, so an undated scope correction is
+invisible to it and an edited description can be the newest field on the item. Use the
+tracker's own history listing, which orders real mutation times newest-first, and its
+comment timestamps.
 
-AND THE SNAPSHOT OMITS EMPTY FIELDS, so a key's ABSENCE means “empty on this item”, NOT
-“not tracked”. The key set is per-item and reflects exactly what that item populates, so
+THE PLAIN LISTING TELLS YOU A NEWER MUTATION EXISTS, NOT WHAT IT SAYS — it names no
+changed field, so for the change itself use the structured form that carries a full
+snapshot per revision. THAT SNAPSHOT USUALLY NESTS THE ITEM'S FIELDS UNDER A SUB-KEY,
+the top level carrying only revision metadata, so a walk keyed at the top level matches
+nothing in every snapshot and reports "no change" without erroring.
+
+WALK ADJACENT PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A TEXT-BEARING FIELD
+(description, notes, acceptance criteria, design — and note that a field's UPDATE FLAG
+is often spelled differently from the field itself). Histories hold duplicate checkpoint
+snapshots and status-only mutations, so the newest pair alone can truthfully say nothing
+changed while a live instruction change sits behind it. AND A WALK THAT ENDS WITHOUT
+FINDING ONE HAS FOUND NOTHING, NOT "NO CHANGE" — say which of the two you have. Histories
+accumulate machine-written no-ops, so a walk bounded anywhere short of the item's
+beginning reports "no text-bearing change" on an item that has several, and that reads
+as the revert signature whose remedy is to re-close. On a long history, search the text
+for the marker you expect rather than walking to it. If the item has children,
+re-enumerate them too: a ruling is sometimes recorded as a NEW CHILD ITEM rather than as
+a note.
+
+AND THE SNAPSHOT OMITS EMPTY FIELDS, so a key's ABSENCE means "empty on this item", NOT
+"not tracked". The key set is per-item and reflects exactly what that item populates, so
 there is no schema to read off one item's snapshot — do not derive one. Treat absent and
-null as the same thing, and never read “no change” off a field the item never populated:
+null as the same thing, and never read "no change" off a field the item never populated:
 null hashes constant across every adjacent pair, so an empty field reports a clean walk
-in the very same words as a genuinely unchanged one, and the two are indistinguishable
-in the output. That makes the walk INTERMITTENTLY wrong rather than reliably wrong — the
-identical expression works perfectly on an item that DOES populate the field — which is
-why it survives casual use. `notes` is the field that matters most here, because
-rulings, sequencing fences and audit reopenings are appended there.
+in the very same words as a genuinely unchanged one. That makes the walk INTERMITTENTLY
+wrong rather than reliably wrong — the identical expression works perfectly on an item
+that DOES populate the field — which is why it survives casual use. Notes is the field
+that matters most, because rulings, sequencing fences and audit reopenings land there.
 
 SO CONTROL THE WALK AGAINST A FIELD YOU KNOW VARIES ON THE ITEM IN FRONT OF YOU before
-you believe any “no change”; a control on a different item proves nothing about this
-one. That control is the only reason this paragraph is right: a field list asserted from
-a single item's key set was refuted only when somebody ran the same walk on a second
-item, where the field it called untracked was populated and had changed seven times.
+you believe any "no change"; a control on a different item proves nothing about this one.
 
 TIMESTAMP ORDER DOES NOT ESTABLISH CURRENCY, so a perfect walk can still hand you
 superseded text: the newest note by mutation time can be a faithful re-derivation of a
 list an OLDER note already ruled stale. Where a note QUOTES or SUMMARISES another rather
 than citing a check it made itself, look for an intervening note that overtook it —
-prefer "verified at source at <tip>" over "from its own note on PR #NNNN". AND THE
-CHEAPEST GUARD IS THE TREE, NOT THE ITEM: before you brief or build X, check whether X
-ALREADY EXISTS AT TIP — one directory listing would have ended the dispatch that
-produced this rule.
+prefer "verified at source at <tip>" over a citation of somebody's own earlier note. AND
+THE CHEAPEST GUARD IS THE TREE, NOT THE ITEM: before you brief or build X, check whether
+X ALREADY EXISTS AT TIP.
 
 Where the item and this brief disagree, the ITEM governs — follow it, and say in your
 report what differed.
@@ -912,13 +785,13 @@ tracked record. A fresh maintainer must never need the working tree. Do not prom
 transcripts.
 ```
 
-**A pass that concludes only in the ignored tree concludes where nobody can read it.** Every project keeps
-some scratch tree version control cannot see, and that invisibility is what makes the failure silent: an
-item can cite a design by a path no maintainer has. Two audits were lost exactly that way here, and a mayor
-re-ran an entire three-design programme in one day for want of looking there first — which is why the
-preamble tells the worker to look there first. Widening what version control tracks is not the fix: working
-notes stay local, and only the *conclusion* is promoted, into whichever tracked record already owns the
-surface, as a dated amendment where one exists and a new page only when the evidence stands on its own.
+**A pass that concludes only in the ignored tree concludes where nobody can read it.** Every project
+keeps some scratch tree version control cannot see, and that invisibility is what makes the failure
+silent: an item can cite a design by a path no maintainer has. Two audits were lost exactly that way,
+and a mayor re-ran an entire three-design programme in one day for want of looking there first — which
+is why the preamble tells the worker to look there first. Widening what version control tracks is not
+the fix: working notes stay local, and only the *conclusion* is promoted, into whichever tracked
+record already owns the surface.
 
 ---
 
@@ -973,259 +846,221 @@ A skipped gate needs a one-line reason in the change body. A silent skip fails r
 ## Quality gates — how a gate is run
 
 **This section is the gate-mechanics block.** Paste it verbatim into every editing dispatch,
-adapting only the placeholders, from this heading down to the rule before
-`## Reviewing what comes back`. **`## Quality gates — which gate` is not it and does not stand
-in for it**: that section is addressed to you as you nominate the gate, so pasting it in place
-of this one hands the worker your nomination reasoning and withholds every mechanic it needs to
-run anything at all.
+adapting only the placeholders, from this heading to the rule before `## Reviewing what comes back`.
+**`## Quality gates — which gate` is not it and does not stand in for it** — that section is
+addressed to you as you nominate the gate, so pasting it instead hands the worker your reasoning and
+withholds every mechanic it needs to run anything.
 
-The gate menu settles *which* gate runs; this settles *how*. Scope it to the gate the brief
-names: the wedge paragraph assumes a gate heavy enough that two cannot coexist, and the
-planted-fault paragraphs assume a gate in which a safe, bounded, discriminating fault can be
-planted at a line the worker is already editing. A cheap link validator is *plantable* without
-being *heavyweight* — two different questions. Everything else applies to any dispatch that runs
-anything at all.
+The menu settles *which* gate runs; this settles *how*. The wedge paragraph assumes a gate heavy
+enough that two cannot coexist, and the planted-fault paragraphs a gate in which a bounded,
+discriminating fault can be planted at a line the worker is already editing — a cheap link validator
+is *plantable* without being *heavyweight*. Everything else applies to any dispatch that runs
+anything.
 
-**Split a compound gate before you reach for detaching.** A script chaining two phases often
-splits into two runs that each fit inside the harness ceiling, which keeps every verdict in the
-foreground and removes the strand risk rather than managing it. Read what the script runs before
-concluding it cannot be foregrounded.
+**Split a compound gate before you reach for detaching.** A script chaining two phases often splits
+into two runs that each fit inside the harness ceiling, which keeps every verdict in the foreground
+and removes the strand risk rather than managing it.
 
-**Where it genuinely does not split, detaching is correct — ending the turn is the defect.**
-Detach, then poll both the log and the exit-code file in a bounded loop *within the same turn*.
-Poll both: the log shows progress, the exit file carries the verdict and appears only once the run
-is over. A worker that ends its turn waiting for a completion notification strands — the
-notification does not always arrive, and a turn that has ended has nothing left to wake. Every
-such worker was recovered intact the moment somebody asked it for a status. Word this as the
+**Where it genuinely does not split, detaching is correct — ENDING THE TURN is the defect.** Detach,
+then poll both the log and the exit-code file in a bounded loop *within the same turn*: the log shows
+progress, the exit file carries the verdict and appears only once the run is over. Word this as the
 sanctioned path, not as a concession; a worker who thinks it has erred reads for how to atone and
 straight past the instruction that would save it.
 
-**And state the rule as a terminal condition, because the strand has variants: the turn ends only
-once the exit file exists and its number is quoted.** Stated as a forbidden wait — *do not end the
-turn waiting for a completion notification* — it fails open on the first wait nobody wrote down: a
-worker that ARMED A MONITOR on its exit file and ended its turn presented as compliant and
-stranded identically, because a watcher owned by an agent stops when its agent does. Measured
-twice in one session, both briefs carrying this block verbatim; the second worker read the
-enumerated wording as licence for the un-enumerated variant. **And the terminal condition alone
-did not close it either**: with that sentence in the block, three more workers in one session
-ended their turns on a *watch*, a *notification subscription* and a *background task expected to
-wake them* — each a fresh name for the same wait, and each read as outside the rule because the
-rule named a monitor. So name the class rather than the instances: a Monitor, a watch, a
-subscription, a background task you expect to wake you — every one of these is the same strand,
-because you are the only thing that can read the exit file, and you can only read it while your
-turn is still running.
+**State the rule as a TERMINAL CONDITION, and name the CLASS: the turn ends only once the exit file
+exists and its number is quoted.** Stated as a forbidden wait it fails open on the first wait nobody
+enumerated — workers have stranded on a monitor, a watch, a notification subscription and a
+background task expected to wake them, each a fresh name for the same wait and each read as outside a
+rule that named the others. You are the only thing that can read the exit file, and you can only read
+it while your turn is still running.
 
-**And refute the belief that keeps re-arming it, because the rule alone has not held.** Your own
-tooling likely documents that a backgrounded command "notifies you when it completes" or
-"re-invokes you" — a true statement about a LIVE session, and the reason a worker reads its wait
-as sanctioned rather than forbidden: it is trusting its harness's promise over this block. That
-promise does not survive the end of your turn; once you stop, the completion event goes to your
-coordinator, not to you. Measured after the class was already named here: four stranded
-turn-endings across two workers in one session, each ending on exactly that promise, each
-recovered only by the coordinator sending a status message.
+**Refute the belief that keeps re-arming it, because the rule alone has not held.** Your tooling
+likely documents that a backgrounded command "notifies you when it completes" — true of a LIVE
+session, and the reason a worker reads its wait as sanctioned: it is trusting its harness over this
+block. That promise does not survive the end of your turn; once you stop, the completion event goes
+to your coordinator, not to you. Every stranded worker was recovered intact the moment somebody asked
+it for a status.
 
-**A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit
-file, no error, from a run that was healthy a minute ago. This is contention for the MACHINE, so
-per-attempt naming does nothing for it and every same-file rule around it misses it. To recover,
-correlate your own build artefact's modification time against the candidate runs' start times and
-**kill only the one you can show is yours**; a peer's run recovers by itself once memory frees.
+**A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit file,
+no error, from a run healthy a minute ago. This is contention for the MACHINE, so per-attempt naming
+does nothing for it and every same-file rule around it misses it. Correlate your own build artefact's
+modification time against the candidate runs' start times and **kill only the one you can show is
+yours**; a peer's run recovers by itself once memory frees.
 
-**Read the clock before killing anything on elapsed time.** Ask the system for the time rather
-than inferring it from how much has happened. This fails in both directions — one worker killed a
-healthy run believing seventeen minutes had passed when it had been two, and the loop watching
-from outside reads a worker that has just rebased as stalled.
+**Read the clock before killing anything on elapsed time** — ask the system, never infer it from how
+much has happened. It fails both ways: one worker killed a healthy run believing seventeen minutes
+had passed when it had been two, and a loop watching from outside reads a worker that has just
+rebased as stalled.
 
-**Invoke a backgrounded gate by its ABSOLUTE path**, for two independent reasons. A script that
-derives its repository root from its own invocation path gets a relative one back; and an
-interpreter handed a relative script path resolves it against the working directory first, so a
-wrong directory hands it a *sibling worktree's copy*, which then pins faithfully to the sibling's
-root. One run did exactly that inside another live worker's checkout and reported the resulting
-verdict as its own. A complete, internally consistent run about somebody else's work is far harder
-to catch than a broken one.
+**Invoke a backgrounded gate by its ABSOLUTE path**, for two independent reasons: a script deriving
+its repository root from its own invocation path gets a relative one back, and an interpreter handed
+a relative path resolves it against the working directory, so a wrong directory hands it a *sibling
+worktree's copy* which then pins faithfully to the sibling's root. **A complete, internally
+consistent run about somebody else's work is far harder to catch than a broken one.**
 
 **Verify which tree the gate actually read**, by whichever of two routes it affords:
 
-* Where it prints its root, check that line names your worktree. That check, not any naming rule,
-  is what has caught the observed cross-worktree collisions.
-* Where it prints nothing — and many will not — the proof is **the red from a planted fault**.
-  Plant at a line you are already editing and check the failure names what you planted. Do not
-  expect the reported path to name your worktree; a repository-relative path cannot tell two
-  checkouts apart. **The discrimination is the red itself**: the fault exists only in your tree,
-  so a run that had wandered into a sibling's would have come back green.
+* Where it prints its root, check that line names your worktree. That check, not any naming rule, is
+  what has caught the observed cross-worktree collisions.
+* Where it prints nothing — and many will not — the proof is **the red from a planted fault**, at a
+  line you are already editing, whose failure names what you planted. Do not expect the reported path
+  to name your worktree; a repository-relative path cannot tell two checkouts apart. **The
+  discrimination is the red itself**: the fault exists only in your tree, so a run that had wandered
+  into a sibling's would have come back green.
 
 Where a gate affords neither route, say so in the brief — silent and unplantable is a real pairing
-rather than a corner — and name whatever bounded mechanism it does afford instead. Nominating a
-route the gate cannot supply makes workers improvise, and the improvisation varies.
+rather than a corner — and name whatever bounded mechanism it does afford. Nominating a route the
+gate cannot supply makes workers improvise, and the improvisation varies.
 
 **A green sabotage run is a reason to stop, not to proceed.**
 
 **Never pipe a gate through a filter.** A pipeline's exit status is its *last* command's, so a red
-runner reads green. Redirect to a log, echo the runner's own exit code, and quote that number —
-with the redirect and the echo on **one command line, in one shell**. A separate invocation starts
-a fresh shell whose status is whatever that shell last did, typically the directory change:
-silent, and it yields a plausible zero.
+runner reads green. Redirect to a log, echo the runner's own exit code, and quote that number — with
+the redirect and the echo on **one command line, in one shell**. A separate invocation starts a fresh
+shell whose status is whatever that shell last did, typically the directory change: silent, and it
+yields a plausible zero.
 
 **Quote the number you captured, never one the harness reports about the same run.** That is a
-different measurement and it disagrees routinely — dozens of times across one fleet, including a
-compile failure, a genuine two-assertion failure and a browser run standing over three real ones.
-**Every disagreement surfaced as exit 0.** More than half were deliberately sabotaged runs, where
-believing the reported zero would have read as "the control does not bite" and inverted the
-conclusion.
+different measurement and it disagrees routinely — dozens of times across one fleet, over a compile
+failure, a genuine two-assertion failure and a browser run standing over three real ones. **Every
+disagreement surfaced as exit 0**, and more than half were deliberately sabotaged runs, where
+believing the reported zero would have inverted the conclusion.
 
-**A captured exit code is honest about its own phase and silent about the one before it.** Where
-a gate chains a compile step to a serve step, a failed compile leaves the previously built
-artefact in place and the serve step serves it — so the run executes against stale code, passes,
-and returns its own truthful zero. **Capture discipline cannot reach this**: the runner ran, its
-tests passed, and it is not the component that knows what it was handed. **Gate the second phase
-on the first's captured exit rather than chaining the two and reading the second.** Counts do not
-catch it either — measured, the stale artefact ran 885 tests and read entirely plausibly, and a
-count that does NOT move where you expected is a question rather than an answer.
+**A captured exit code is honest about its own phase and SILENT ABOUT THE ONE BEFORE IT.** Where a
+gate chains a compile step to a serve step, a failed compile leaves the previously built artefact in
+place and the serve step serves it — so the run executes against stale code, passes, and returns its
+own truthful zero. Capture discipline cannot reach this: the runner ran, its tests passed, and it is
+not the component that knows what it was handed. **Gate the second phase on the first's captured exit
+rather than chaining the two and reading the second.** Counts do not catch it either — a stale
+artefact ran 885 tests and read entirely plausibly — and a count that does NOT move where you
+expected is a question rather than an answer.
 
-**An ABSENT exit-code file is NO VERDICT, not a pass.** It reads as success because the log ends
-with the gate's own output and nothing contradicts it. Any death between the last line and the
-exit does it. **A gate you cannot quote a captured number for has not run** — re-run it, and say
-whether you re-ran the whole gate or one step.
+**An ABSENT exit-code file is NO VERDICT, not a pass.** It reads as success because the log ends with
+the gate's own output and nothing contradicts it; any death between the last line and the exit does
+it. **A gate you cannot quote a captured number for has not run** — re-run it, and say whether you
+re-ran the whole gate or one step.
 
 **A search that returns ZERO is not a check that passed.** A wrong pattern answers "no matches" in
-the same voice as "nothing is wrong"; the recurring instance is a backslash-bearing literal quoted
-so the shell strips them. Match fixed strings as fixed strings, and when a search underwrites a
-claim, run it once against something it should find. **And make that control share the SHAPE of
-the target**, because a pattern fails on a feature, and a control that lacks the feature passes
+the same voice as "nothing is wrong". Match fixed strings as fixed strings, and when a search
+underwrites a claim, run it once against something it should find. **And make that control share the
+SHAPE of the target** — a pattern fails on a FEATURE, and a control lacking the feature passes
 without exercising it. Measured: a word-boundary anchor placed after a `$` matched a letter-final
-control and missed every punctuation-final hit, so the census read zero on four real sites while
-its control read green. If the target ends in punctuation, carries a backslash, spans a line, or
-sits behind a comment marker, the control must too — and must carry EVERY one of those features
-the target has, at once, because a control that matches on the axis it shares says nothing about
-the axis it does not.
+control and missed every punctuation-final hit, so the census read zero on four real sites while its
+control read green. If the target ends in punctuation, carries a backslash, spans a line or sits
+behind a comment marker, the control must carry **every** one of those features at once — a control
+that matches on the axis it shares says nothing about the axis it does not.
 
-**But for the line-spanning case that advice is inert, and it is the one case where a matched
-control actively reassures you.** Most search tools take a LINE as their unit, so a target broken
-across two lines is not merely hard to match — it cannot be seen at all, whatever the pattern. A
-control sharing that shape is invisible in exactly the same way: both come back zero, and the
-check reports a clean pattern over an unsearched target. Every other hazard here is caught by a
-control that bites; this one is caught only by changing the instrument. **Run the search three
-times — once line-oriented, once over the text with whitespace collapsed, and once with comment
-markers stripped before collapsing.** Neither of the first two is a superset of the other, and the
-third reaches what neither can. Measured four times in one session: a census found one site
-line-oriented and missed four line-broken ones, then found those four flattened and missed the
-first; a second census caught a stale phrase only when flattened; and twice a hand-written probe
-of a wrapped field reported data loss that had not happened. **The third pass answers the case
-that reads zero on BOTH of the others**: a phrase inside a commented sample broke across lines AND
-the continuation carried a comment marker, which SURVIVES a plain flatten — the collapsed text
-read `the FOUR ;; live emitters` and matched nothing. Stripping the markers first found it, and a
-second stale site the other two had missed. **Wrapped text is the common case, not the exotic
-one** — anything hard-wrapped to a column, which is most prose documents and many tracker fields,
-will break a long enough probe somewhere, and every commented block and fenced sample puts a
-marker at the break. So keep a probe short enough to sit inside one line, and where the target is
-genuinely longer, flatten — and strip the markers — before believing a zero.
+**But for the LINE-SPANNING case that advice is inert, and it is the one case where a matched control
+actively reassures you.** Most search tools take a line as their unit, so a target broken across two
+lines cannot be seen at all, whatever the pattern — and a control sharing that shape is invisible in
+exactly the same way. Both come back zero, and the check reports a clean pattern over an unsearched
+target. Every other hazard here is caught by a control that bites; this one only by changing the
+instrument. **Run the search three times — line-oriented, over the text with whitespace collapsed,
+and with comment markers stripped before collapsing.** Neither of the first two is a superset of the
+other, and the third reaches what neither can: a phrase broken across lines whose continuation
+carries a comment marker survives a plain flatten, collapsing to `the FOUR ;; live emitters`, which
+matches nothing. **Wrapped text is the common case, not the exotic one** — most prose documents and
+many tracker fields are hard-wrapped, and every commented block and fenced sample puts a marker at
+the break. Keep a probe short enough to sit inside one line; where the target is genuinely longer,
+flatten, and strip the markers, before believing a zero.
 
-**This is not a fact about searching, and reading it as one is how it gets past you.** ANY
-instrument that can answer "nothing here" gives the same answer when misused, and a misused one
-raises no error — so its all-clear is complete, well-formed and plausible. Measured: a
-surface-classifier handed revisions where it expects file paths reported every surface as
-unaffected, which is exactly what a genuinely unaffected change looks like. Exercise any such
-instrument once against an input it should flag, whatever kind of instrument it is.
+**This is not a fact about searching, and reading it as one is how it gets past you.** ANY instrument
+that can answer "nothing here" gives the same answer when misused, and a misused one raises no error,
+so its all-clear is complete, well-formed and plausible — a surface classifier handed revisions where
+it expects file paths reported every surface as unaffected, which is exactly what a genuinely
+unaffected change looks like. Exercise any such instrument once against an input it should flag.
 
 **Name every gate artefact for your worktree AND for the attempt**, log and exit file both, in a
 directory version control ignores. A name missing either half fails the gate **open**, and the two
-halves close different holes. The scratch path is keyed to the session, so peers share one
-directory: two workers in one wave wrote the same exit-code filename, and one read a zero a peer
-had left while its own gate was still running. **The worktree suffix cannot close the second
-mechanism, because there both writers are you** — a runtime cap kills the *shell*, what it spawned
-survives holding the same open descriptors, and it writes at its offset while the restart writes
-from zero, so the artefact is spliced rather than clobbered. Measured twice: an `exit 0` sitting
-beside 18 real failures, and an orphan reporting two failures from a run already killed. Expect
-this route more often than the peer collision, since detaching is the sanctioned path and
-kill-and-restart is routine. **And clean the artefacts up: one leftover is enough to make a
-worktree unreapable.**
+halves close different holes. The scratch path is usually keyed to the session, so peers share one
+directory: two workers in one wave wrote the same exit-code filename, and one read a zero a peer had
+left while its own gate was still running. **The worktree suffix cannot close the second mechanism,
+because there both writers are you** — a runtime cap kills the *shell*, what it spawned survives
+holding the same open descriptors, and it writes at its offset while the restart writes from zero, so
+the artefact is SPLICED rather than clobbered (measured: an `exit 0` beside 18 real failures, and an
+orphan reporting two failures from a run already killed). Expect this route more often than the peer
+collision, since detaching is sanctioned and kill-and-restart is routine. **And clean the artefacts
+up: one leftover is enough to make a worktree unreapable.**
 
 **Delete them by their LITERAL path, never through a variable.** A deletion whose target a static
-permission check cannot evaluate is one that check has to stop and ask about, and the ask lands on
-an operator who may not be watching — so the cleanup stalls mid-turn, and the work queued behind it
-stalls with it. What is being guarded is real rather than theoretical: an unset or empty variable
-turns `"$DIR"/*name*` into a glob rooted at the top of the filesystem. Write the directory out in
-full. Where a variable is genuinely unavoidable, make the shell itself refuse an empty one — POSIX
-shells spell that `"${DIR:?}"` — but that removes the hazard and not the prompt, so it is the
-fallback rather than the rule.
+permission check cannot evaluate is one it has to stop and ask about, and the ask lands on an
+operator who may not be watching — so the cleanup stalls mid-turn and the work queued behind it
+stalls with it. The guard is real rather than theoretical: an unset variable turns `"$DIR"/*name*`
+into a glob rooted at the top of the filesystem. Write the directory out in full; where a variable is
+unavoidable, make the shell refuse an empty one (`"${DIR:?}"`), which removes the hazard but not the
+prompt, so it is the fallback rather than the rule.
 
-**Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line
-endings reads clean having changed every line — and **a patch that never applied reads clean too**,
-because "unchanged" and "not attempted" are the same diff. That second one is the dangerous half:
-a plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard
-that fired when nothing was ever broken. Hash before the plant, compare after the restore.
+**Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line endings
+reads clean having changed every line — and **a patch that never applied reads clean too**, because
+"unchanged" and "not attempted" are the same diff. That second one is the dangerous half: a plant
+that silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired
+when nothing was ever broken. Hash before the plant, compare after the restore.
 
 **Commit your own edits before you plant anything**, because the obvious restore — asking version
 control for the file back — returns it to the last COMMITTED state, not to your pre-plant working
-state. Plant from a dirty tree and that restore silently discards the very work the gate was being
-run against, and the run afterwards is green about a tree you did not mean to have. The hash check
-is what catches it, which is the case for doing the hash check rather than an argument against the
-restore. Five cautions on the plant itself:
+state. Plant from a dirty tree and that restore silently discards the work the gate was being run
+against, and the run afterwards is green about a tree you did not mean to have. Five cautions on the
+plant itself:
 
-* **Where line endings are translated, use version control's own content hash against the
-  committed object**, not a byte digest of the working file — a checkout during a rebase rewrites
-  the working file after you hashed it, and a false "restore failed" sends the worker off to doubt
-  the sabotage result, which was the deliverable.
+* **Where line endings are translated, use version control's own content hash against the committed
+  object**, not a byte digest of the working file — a checkout during a rebase rewrites the working
+  file after you hashed it, and a false "restore failed" sends the worker off to doubt the sabotage
+  result, which was the deliverable.
 * **Call it a *blob* hash in the words immediately before the token.** A content hash is
   indistinguishable from a commit id, and a provenance checker classifying each hex token by the
   nearest description on its left will file it as a citation of a commit that exists nowhere.
 * **Anchor a patch to a single line.** A multi-line anchor can match nothing, with no error and no
   edit.
-* **An anchor at the end of a line matches nothing where line endings are translated** — a
-  carriage return sits between the text and the line ending. This defeats a single-line anchor as
-  readily as a multi-line one, so the caution above does not cover it. **Read the match count
-  before you run the gate**: zero is unambiguous and free, where the hash convicts a no-op plant
-  only after a whole run has been spent. Measured, and it is the CHECK rather than the hazard that
-  the measurement is of: a worker's plant matched zero lines because an intervening checkout had
-  restored the translated endings, and the match count caught it before a run was spent. Note what
-  that implies about timing — the endings can change under you *between* one plant and the next, so
-  the count is read per plant rather than once per session.
-* **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied
-  genuinely — the hashes differed — but the file was not in the build's module graph, so the
-  watcher served the pre-plant compile and the witness came back green. A green sabotage run is
-  evidence only once both halves hold: the hash for the source, and positive evidence the runtime
-  observed the plant.
+* **An anchor at the END of a line matches nothing where line endings are translated** — a carriage
+  return sits between the text and the ending — so the single-line rule above does not cover it.
+  **Read the match count before you run the gate**: zero is unambiguous and free, where the hash
+  convicts a no-op plant only after a whole run has been spent. The endings can change under you
+  *between* plants, so read the count per plant, not once per session.
+* **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied genuinely
+  and the file was not in the build's module graph, so the watcher served the pre-plant compile and
+  the witness came back green. A green sabotage run is evidence only once both halves hold: the hash
+  for the source, and positive evidence the runtime observed the plant.
 
 **Scope a plant to the suite under test.** Where the runner executes a whole lane in one block
 without catching exceptions, a plant that crashes any namespace stops every namespace after it and
 the log still looks plausible. Compare namespace and assertion counts against a control run.
 
-**The gates the brief nominated are not the whole obligation, because a project's RATCHET gates
-grade the PATHS you touched rather than the change you made.** A ratchet permits a recorded count
-and refuses any increase: a per-surface floor that a surface carrying baselined debt already sits
-exactly on, or a retired-vocabulary scan whose permitted count is zero. On either shape an ordinary
-new file — or one word in a comment — is a regression, and no brief nominated the gate, because the
-change looked nothing like its subject. So before you open the change, find the ratchets covering
-your paths, run them, and treat each gate's own output as the authority on what it wants: one that
-fails prints the exact spelling it wanted, so a worker who runs it once needs no further guidance.
-A project keeps them together — a checks directory, and the job lists of the workflows that run
-them — which is where to look. **Do not ask for a list of them, and do not write one**: the set
-grows, and an enumeration is a count, which is the thing that goes stale first.
+**The gates the brief nominated are not the whole obligation, because a project's RATCHET gates grade
+the PATHS you touched rather than the change you made.** A ratchet permits a recorded count and
+refuses any increase — a per-surface floor a surface with baselined debt already sits exactly on, or
+a retired-vocabulary scan whose permitted count is zero — so an ordinary new file, or one word in a
+comment, is a regression, and no brief nominated the gate because the change looked nothing like its
+subject. Before you open the change, find the ratchets covering your paths, run them, and treat each
+gate's own output as the authority on what it wants: one that fails prints the exact spelling it
+wanted. A project keeps them together — a checks directory, and the job lists of the workflows that
+run them. **Do not ask for a list of them, and do not write one**: the set grows, and an enumeration
+is a count, which is the thing that goes stale first.
 
 **Two properties of that repair, both learned by getting them wrong.** These gates grade more than
-the lines you think you changed — some read the whole tracked file, comments and docstrings
-included, so a sentence naming the design you REJECTED fails while the code it describes passes;
-others grade a form nobody counts as part of the change, such as an import edge. And a ratchet is
-repaired by changing your own lines, never by moving its floor: raising a recorded count to admit
-the new debt inverts the gate, and walking that debt down is another item's job, so repairing
-pre-existing violations in files you did not otherwise touch is sprawl into it. Read the gate's
-WHOLE output before you fix — it names every surface over its floor, where a number quoted into a
-brief from a failed run names one.
+the lines you think you changed — some read the whole tracked file, comments and docstrings included,
+so a sentence naming the design you REJECTED fails while the code it describes passes; others grade a
+form nobody counts as part of the change, such as an import edge. And **a ratchet is repaired by
+changing your own lines, never by moving its floor**: raising a recorded count to admit new debt
+inverts the gate, and walking that debt down is another item's job, so repairing pre-existing
+violations in files you did not otherwise touch is sprawl into it. Read the gate's WHOLE output
+before you fix — it names every surface over its floor, where a number quoted into a brief from a
+failed run names one.
 
 **Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a
 tree that no longer exists, and nothing warns you: the rebase reports success and the old log still
-says exit 0. One worker rebased four times past eleven landings, and re-running changed the
-artefact rather than reconfirming it — fixes for three of its own findings had merged in the
-interval, so the record it was about to publish carried a count false of the trunk.
+says exit 0. One worker rebased four times past eleven landings, and re-running changed the artefact
+rather than reconfirming it — fixes for three of its own findings had merged in the interval, so the
+record it was about to publish carried a count false of the trunk.
 
 **Diff your branch against its MERGE BASE before you push, and read that diff for what you would
 REVERT.** Not for conflicts — version control reports those, and a clean rebase is exactly the case
 this rule is for. The question is whether your push undoes something a sibling landed while you
-worked, which no gate covers: a revert of a merged change is well-formed, compiles, and passes
-every check the tree has. In a shared document, a stale copy of one region reapplies as a silent
+worked, which no gate covers: a revert of a merged change is well-formed, compiles, and passes every
+check the tree has, and in a shared document a stale copy of one region reapplies as a silent
 deletion of everything that landed in it since. **The base is half the instruction** — compare
 against the point your branch left the trunk, never the trunk's current tip, which buries the one
-hunk that matters under siblings' unrelated work and degrades worst exactly when the trunk has
-moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
+hunk that matters under siblings' unrelated work and degrades worst exactly when the trunk has moved
+most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
 
 ---
 
@@ -1250,7 +1085,13 @@ moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEA
   any other and the question is what produced it. A sequence of measurements and a correction to one measurement
   read identically once compressed to a line: one mayor turned four per-window figures into “the number moved”
   and briefed a worker to fix a figure that was correct. Reports invite this — they are dense, confident, and
-  written by an agent that has just spent its whole context being careful.
+  written by an agent that has just spent its whole context being careful. **A figure and the subject it was
+  measured on arrive in the same sentence, so the compression can pair them WRONGLY** — and re-deriving at the
+  current tip cannot catch that, because the census is correct about the subject you wrote. The tell only appears
+  when a later worker refutes the number for its own subject; **trace a refuted figure back to what it WAS true of
+  before you drop it**, because the thing it was true of is an unfiled finding. Measured here: a figure relayed onto
+  the wrong file was corrected to that file's real count, and the original number turned out to describe two other
+  files nobody had filed.
 * What did it find that you did not ask for? File those **with the owning item named in the new item**, so a later
   audit reopening that owner is recognisable as the same finding rather than a second one. One mayor skipped that and
   created a duplicate of its own within hours.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -732,6 +732,14 @@ snapshot per revision. THAT SNAPSHOT USUALLY NESTS THE ITEM'S FIELDS UNDER A SUB
 the top level carrying only revision metadata, so a walk keyed at the top level matches
 nothing in every snapshot and reports "no change" without erroring.
 
+AND AN EMPTY OR NULL HISTORY IS A STATEMENT ABOUT THE ID, NOT ABOUT THE ITEM. The
+structured form answers null for an id that does not exist, which is indistinguishable
+from "this item has no history" unless you check — and the commonest cause is an id
+that picked up a trailing carriage return on its way through a pipeline. A worker that
+reads null as "the tool does not work here" abandons the newest-first walk and reads
+the fields directly, which is the one thing this whole passage exists to prevent.
+Re-check the id against a known-good one before concluding anything about the tool.
+
 WALK ADJACENT PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A TEXT-BEARING FIELD
 (description, notes, acceptance criteria, design — and note that a field's UPDATE FLAG
 is often spelled differently from the field itself). Histories hold duplicate checkpoint

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -1,121 +1,82 @@
 # Worker dispatch
 
-Copy-adaptable shapes for delegating bounded work to a background worker. Assumes
-a capable agent. Placeholders:
+Copy-adaptable shapes for delegating bounded work to a background worker. Assumes a capable agent.
+Placeholders: `<MAYOR_CHECKOUT>`, `<WORKTREE_PARENT>` (derive it from your version-control tool at
+dispatch time; never hardcode), `<ASSIGNED_WORKTREE>`, `<TRUNK>`, `<ITEM_ID>`.
 
-- `<MAYOR_CHECKOUT>` — the mayor's primary checkout (absolute path)
-- `<WORKTREE_PARENT>` — the directory holding worker worktrees (derive it from your
-  version-control tool at dispatch time; never hardcode a path)
-- `<ASSIGNED_WORKTREE>` — this worker's worktree, a subdirectory of `<WORKTREE_PARENT>`
-- `<TRUNK>` — the branch a worker's change merges into
-- `<ITEM_ID>` — the tracker id
-
-> **Project-specifics live with the project, not here.** Your hot-zone file list,
-> your surface-to-gate matrix, your pre-checkin command and your worktree root are
-> facts about *one* repository. Keep them in that repository's agent-instructions
-> file and pull the concrete values from there at dispatch time. This page is the
-> reusable, OS-neutral method.
+> **Project-specifics live with the project, not here.** Your hot-zone list, your surface-to-gate
+> matrix, your pre-checkin command, your worktree root and your tracker's command spellings are facts
+> about *one* repository. Keep them in that repository's agent-instructions file and pull the concrete
+> values at dispatch time. This page is the reusable, OS-neutral method.
 >
-> **The stance is project-specific too, but it is PASTED rather than pulled, and it
-> lives in its own file.** Keep it as a single quoted block in ONE file and paste
-> that block verbatim into every preamble. Do not send the worker to a file that
-> does not carry a stance — a brief that does sends it somewhere the words are not.
->
-> **And a summary is not a lighter version of a stance.** The lenses say what good
-> looks like; everything after them says when to STOP. A paraphrase keeps the
-> memorable half and drops the restraining one, and what survives does not read as
-> incomplete — it reads as a stance that wants MORE of everything, which is precisely
-> the failure the second half exists to prevent.
+> **The stance is project-specific too, but it is PASTED rather than pulled, and it lives in its own
+> file.** Do not send the worker to a file that does not carry a stance. **And a summary is not a
+> lighter version of a stance**: the lenses say what good looks like, everything after them says when
+> to STOP, and a paraphrase keeps the memorable half and drops the restraining one — after which what
+> survives reads as a stance that wants MORE of everything, which is the failure the second half
+> exists to prevent.
 
 ---
 
 ## Write the brief in this order
 
-The order is what makes it accurate. Each step is a check the next depends on.
+The order is what makes it accurate — each step is a check the next depends on.
 
-**Keep the brief to what is specific to THIS item.** The blocks below travel verbatim into every
-dispatch and already carry the standing rules, so restating them is the commonest way a brief doubles
-in length while adding nothing — and the worker pays for every word twice, once reading and once
-obeying. Measured on one fleet: two-thousand-word briefs sitting on top of a five-thousand-word block
-file, against workers that finished comparable items in a third of the time on briefs of four hundred.
-
-1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by position, and not
-    by dates written in the prose. The mechanics are spelled out for the worker under *Common
-    preamble* below, and every one of them binds the mayor writing the brief exactly as it binds the
-    worker reading it.
-
-    **One cheap query tells you which items will punish skipping that walk: has this item ever been
-    CLOSED and reopened?** The rule above is unconditional, which is why it gets skipped — an
-    unconditional instruction competes with every other unconditional instruction. A closed-to-open
-    transition is the strongest cheap signal that the description is no longer the live instruction:
-    it was written about the defect as originally found, and something later disagreed enough to
-    reopen. Nothing in the rendered item says so — the description still reads as a current bug
-    report, because it once was one. Measured: three briefs in one session written from descriptions
-    whose work had already merged, **all three showing a closed-to-open transition while the control,
-    never closed, showed none**.
-
-    **It is a signal to do the walk, not a substitute for it, and both over-readings are natural.**
-    *Closed* does not mean *shipped* where items close on change-open rather than merge; and a
-    reopening does not always supersede — an item reopened because the defect REGRESSED has an
-    accurate description, and treating it as stale sends the worker hunting a newer instruction that
-    does not exist. **What decides currency is the history and the tree.**
-
-    **The three consequences differ, and only the first is obvious.** The dispatch may re-do finished
-    work; it may point a worker at a defect that no longer exists, whose deliverable is then a
-    refutation; or — the expensive one — it may describe a *smaller* problem than the one the
-    reopening found, so the worker fixes what you asked and the real defect survives with an item now
-    closed over it. The worker's own history walk catches all three, **but do not let that safety net
-    become the plan**: it spends a worker's context re-deriving what one query answers, and the mayor
-    learns nothing, because a brief refuted politely reads much like a brief fulfilled.
-
-    **Read it for two things: a HOLD, and SEQUENCING.** A hold is the newest field often enough that
-    the description cannot be trusted to mention it, so an item reads as an ordinary defect report
-    while the live instruction is *wait*. Sequencing is the mirror case and easier to miss, because
-    the brief's instinct is right by default: a triage note naming the predecessors that had to land
-    first is an **authorisation with a precondition**, so restating a generic fence over it converts a
-    satisfied precondition back into a blocker.
-
-    **Read the INVERSE with more care than either, because it is the one that fails open.** A note
-    lifting a fence names *the fence it lifts*, not the item — so an item can carry a second
-    sequencing the lift says nothing about, and its newest layer then reads *released* while a live
-    precondition sits underneath. The other two merely re-block work that was already clear; this one
-    dispatches into a surface somebody holds, or into one gated by a decision nobody has made.
-    Measured: an item whose fence had been lifted on the holder's own words still sat behind an older
-    note sequencing it behind an unruled operator call — and the *other* half of that older note had
-    genuinely cleared, which is what made the whole of it look discharged. **Where the tracker can
-    express a precondition, encode it there rather than leaving it in prose**: a fence that exists
-    only in a note is re-derived every pass, and a fence re-derived every pass is eventually missed.
-
-    **And a board-wide sweep for hold markers is a candidate filter, never a verdict** — it narrows to
-    a handful, and the hold is then established by READING each one. Why it fails in both directions,
-    and the structured field that is the durable answer, are under *Tracker mechanics* in
-    [`loops.md`](loops.md#tracker-mechanics).
-
+1. **Read the item, ordered by the tracker's TIMESTAMPS** — not by position, not by dates in the prose.
+   The mechanics are in *Common preamble* below and bind the mayor exactly as they bind the worker.
 2. **Check every factual claim you are about to write.** Does the symbol resolve? Does the file say
-    what you think? Is the count still true? Is the ruling you cite *ruled*, or only recommended? A
-    recommendation and a decision read identically in a summary and are opposite in force.
-    **Then one question of a different kind: is this work still OUTSTANDING?** The four above ask
-    whether a claim is TRUE. A note saying "X is all that remains" was true when written and says
-    nothing about now, so checking it at source confirms the wrong thing. Check the TREE. The sentence
-    that says so sits in the common preamble below — inside the block you extract and paste without
-    reading, because its audience looks like the worker.
-
-3. **Establish the fence by asking who is live, not what is open.** A listing of open changes misses a
-    worker that has not pushed yet. **And ask what each nominated gate COMPARES, here, not at
-    dispatch** — a fence derived from files alone misses a gate that couples two surfaces (see
-    *Fences*).
-
+   what you think? Is the count still true? Is the ruling you cite *ruled*, or only recommended?
+3. **Establish the fence by asking who is live, not what is open.**
 4. **Name the discriminator**, if the task is "find every X".
-
 5. **Then** assemble the standard blocks.
+
+### Gotchas
+
+- **Keep the brief to what is specific to THIS item.** The blocks travel verbatim and already carry the
+  standing rules, so restating them is the commonest way a brief doubles in length while adding
+  nothing — and the worker pays for every word twice, reading and obeying. Measured: two-thousand-word
+  briefs on top of a five-thousand-word block file, against workers finishing comparable items in a
+  third of the time on briefs of four hundred.
+- **One cheap query tells you which items punish skipping the history walk: has this item ever been
+  CLOSED and reopened?** The walk rule is unconditional, which is why it gets skipped. A closed-to-open
+  transition is the strongest cheap signal that the description is no longer the live instruction, and
+  nothing in the rendered item says so — it still reads as a current bug report, because it once was
+  one. Measured: three briefs in one session written from descriptions whose work had already merged,
+  all three showing the transition, against a never-closed control showing none.
+- **It is a signal to do the walk, not a substitute for it.** *Closed* does not mean *shipped* where
+  items close on change-open; and a reopening for a REGRESSION leaves the description accurate, so
+  treating it as stale sends the worker hunting an instruction that does not exist.
+- **Three consequences differ and only the first is obvious**: re-doing finished work; pointing a
+  worker at a defect that no longer exists, whose deliverable is then a refutation; or — the expensive
+  one — describing a *smaller* problem than the reopening found, so the worker fixes what you asked and
+  the real defect survives under an item now closed over it. The worker's own walk catches all three,
+  **but do not let that safety net become the plan**: it spends a worker's context re-deriving what one
+  query answers, and a brief refuted politely reads much like a brief fulfilled.
+- **Read for a HOLD and for SEQUENCING.** A hold is the newest field often enough that the description
+  cannot be trusted to mention it. Sequencing is the mirror and easier to miss, because the brief's
+  instinct is right by default: a triage note naming predecessors that had to land first is an
+  **authorisation with a precondition**, so restating a generic fence over it converts a satisfied
+  precondition back into a blocker.
+- **Read the INVERSE with more care than either, because it fails open.** A note lifting a fence names
+  *the fence it lifts*, not the item — so a second sequencing the lift says nothing about can sit
+  underneath while the newest layer reads *released*. The other two re-block work that was clear; this
+  one dispatches into a held surface. **Where the tracker can express a precondition, encode it there**:
+  a fence that exists only in a note is re-derived every pass, and one re-derived every pass is
+  eventually missed.
+- **A board-wide sweep for hold markers is a candidate filter, never a verdict** — narrow to a handful,
+  then READ each one.
+- **Ask one question of a different kind: is this work still OUTSTANDING?** The checks above ask whether
+  a claim is TRUE. A note saying "X is all that remains" was true when written and says nothing about
+  now, so checking it at source confirms the wrong thing. **Check the TREE.**
+- **A fence derived from files alone misses a gate that couples two surfaces** (see *Fences*) — ask what
+  each nominated gate COMPARES, here, not at dispatch.
 
 ---
 
 ## The three sentences that do the most work
 
-The first two go in **every** editing brief. The third goes in every brief whose nominated gate
-affords a safe, bounded, discriminating plant — which is a question about the **gate**, not about the
-deliverable.
+The first two go in **every** editing brief. The third goes in every brief whose nominated gate affords
+a safe, bounded, discriminating plant — a question about the **gate**, not about the deliverable.
 
 > **This brief's premises are CLAIMS, not findings.** Check each at source before
 > acting on it. A verified "already fixed" or "the premise does not hold" is a
@@ -129,509 +90,359 @@ deliverable.
 > **The control is the deliverable.** Show it red when the property is removed,
 > restore, and verify the restore by hashing the bytes.
 
-The first is the highest-yield sentence in the preamble. Read-the-item-first caught five stale briefs
-in a single day: one whose fix had landed two days earlier under a sibling item; one that named the
-wrong audit finding; one told to execute a resolution that had already merged; one a scope correction
-had redefined; and one carrying three wrong path, flag and script details. **Every one of those
-briefs was accurate when it was written**, and the yield is in *the item governs the brief* rather
-than in the direction of reading.
-
-**The third is scoped by the nominated gate's capabilities — not by prose versus code.** A
-documentation correction is emphatically included: the cheap validators over a docs tree red on one
-broken link target or one bad heading anchor and go green again on restore. Where the covering gate
-affords no such plant, the sentence is the unsatisfiable quantifier the method-reread loop is told to
-hunt for — and an unsatisfiable rule does not stop the reader, it makes one up. **That failure was
-measured on the *enforcing* side rather than a worker's**: four editing briefs went out on one tick
-carrying the first two sentences verbatim and none carrying the third, each improvising the same
-omission separately — the tell that the rule was doing no work because it was **unscoped**. Scoping
-it on the shape of the deliverable instead licenses the same omissions with a reason attached.
-
-**Say what a brief whose gate affords no plant does instead, or that gets improvised too.** Both
-wordings are settled below and cover different cases: where no automated gate covers the surface at
-all, *Quality gates — which gate*; where a gate covers it but affords no safe discriminating plant,
-*Quality gates — how a gate is run*. Point at both rather than restating either — naming the
-alternative is what keeps the scoping from reading as permission to prove nothing.
+- **The first is the highest-yield sentence in the preamble.** Read-the-item-first caught five stale
+  briefs in one day: a fix that had landed two days earlier under a sibling item; the wrong audit
+  finding named; a resolution already merged; a scope correction that had redefined the item; and three
+  wrong path, flag and script details. **Every one of those briefs was accurate when written** — the
+  yield is in *the item governs the brief*, not in the direction of reading.
+- **The third is scoped by the GATE's capabilities, not by prose versus code.** A documentation
+  correction is emphatically included: the cheap validators over a docs tree red on one broken link
+  target or bad heading anchor and go green on restore. Where the covering gate affords no such plant,
+  the sentence is an unsatisfiable quantifier — and an unsatisfiable rule does not stop the reader, it
+  makes one up. **Measured on the enforcing side**: four editing briefs went out on one tick carrying
+  the first two sentences verbatim and none carrying the third, each improvising the same omission
+  separately — the tell that the rule was doing no work because it was **unscoped**.
+- **Say what a brief whose gate affords no plant does instead, or that gets improvised too.** Two
+  different cases, both settled below: no automated gate covers the surface at all (*which gate*); a
+  gate covers it but affords no safe plant (*how a gate is run*). Naming the alternative is what keeps
+  the scoping from reading as permission to prove nothing.
 
 ---
 
 ## Name the discriminator
 
-Any task shaped "find every X and fix it" fails without one, because **the phrase is
-usually correct somewhere**. Briefed without a discriminator, a worker changes all of
-them or none.
+Any task shaped "find every X and fix it" fails without one, because **the phrase is usually correct
+somewhere**. Briefed without a discriminator, a worker changes all of them or none.
 
-The discriminator is the question that separates a real hit from a legitimate one. Two
-that recur:
+The discriminator is the question separating a real hit from a legitimate one. Two that recur: *does
+this line claim something about code that runs, or record an open question?* — a design register
+deliberately carries proposed names that do not resolve. And *does this sentence describe the state
+now, or record what was true then?* — a past-tense record is not stale. Without one, a worker sweeping
+a register will "fix" it into a lie.
 
-* *Does this line claim something about code that runs, or record an open question?* A
-  design register deliberately carries proposed names that do not resolve. Those are
-  correct.
-* *Does this sentence describe the state now, or record what was true then?* A
-  past-tense record is not stale.
-
-Without one, a worker sweeping a register will "fix" it into a lie.
-
-**"Bounded repair" bounds the change, not the search.** Grep the exact wording across
-tracked files, read every hit, settle each in the same change, and list in the change
-body what was changed and what was left standing because it was already right. One
-project corrected a single sentence four times across three changes; every repair was
-bounded and correct, and every one was found by the *next* merged-change audit rather
-than by the repair before it. Three round-trips for what one grep closes.
+**"Bounded repair" bounds the change, not the search.** Grep the exact wording across tracked files,
+read every hit, settle each in the same change, and list in the change body what was changed and what
+was left standing because it was already right. One project corrected a single sentence four times
+across three changes; every repair was bounded and correct, and every one was found by the *next*
+merged-change audit rather than by the repair before it.
 
 ---
 
-## Counts are claims, and they go stale first
+## Counts, lists and leans are all claims
 
-A count asserted when an item was filed is the first thing to drift, and a symbol-shaped
-check will not catch it — the symbol still resolves while the count is zero, or triple.
-
-Say so, and require the census be **re-run at the current tip**, reported against the
-item's number. Measured drifts in one session: 8 to 9; "four hits" to 23 lines; "roughly
-6–10" to 23; "4 of 21 cached" to 13 of 21.
-
-Better still, when the number will keep moving: brief the fix to name the **class** rather
-than the count. A rule written as a class does not re-drift.
-
-**An item's LIST OF SITES goes stale the same way, and it is worse than a count, because it
-drifts in MEMBERSHIP rather than in magnitude.** A list looks equally authoritative whether
-or not its entries are still true, and it is wrong in two directions at once: an entry
-somebody else already fixed sends a worker to edit correct text — or to revert a repair —
-while a site the list never had is left live. Four items in one session named sites already
-amended, or asserted a verification a later change had falsified; one named "three of four"
-when the standing state was one.
-
-**So require the list be RE-DERIVED at the current tip, and require the DELTA to be
-reported.** The delta is a deliverable in its own right, not bookkeeping: it is the only
-signal that the item was stale, and without it the next reader inherits the same list with
-the same confidence. Where a worker returns "two of these five were already done", that is
-the item being corrected by the work, which is the system functioning.
-
----
-
-## A lean is a claim too — demand the number that decides it
-
-When a brief poses a choice between two designs and names which one the author favours, that lean is
-as unreliable as any count, and it fails in a worse way: the worker reads it as guidance rather than
-as a premise, so the premises-are-claims sentence does not catch it.
-
-So attach the measurement to the lean in the same breath. *"I think A beats B, and I want the cost
-that decides it, not a preference."*
-
-The evidence is one dispatch where every part of the author's lean was wrong and the number found it.
-The brief guessed that speed was the risk in compiling a doc corpus; the worker measured the compile
-fast enough to kill that argument, then rejected compiling anyway on three grounds the brief had not
-imagined, and the final margin came out around **380x the other way, for the same catch**. That
-brief's fallback was wrong in a checkable way too — it prescribed scoping a rule **per page**, which
-flags 21 sites on a corpus that is correct, where the item's own shape, **per section**, measures 0.
-The worker followed the item over the brief and was right to.
-
-Two rules come out of that. **Ask for the cost whenever you state a lean** — it converts a confident
-wrong brief into a correct outcome, and costs the worker one measurement. And **say plainly that the
-item outranks the brief on scope**.
-
-**A number the brief asserts is a lean too**, and it slips through by the same mechanism: a figure
-stated as guidance is read as instruction, so the premises-are-claims sentence never reaches it.
-Before writing a predecessor's figure into a brief, ask what produced it. One such figure — a bound a
-measurement window had derived from its own most-negative reading — went into the next brief as
-guidance and was reported to the operator before two independent refutations caught it, and one
-question would have caught it first: *what null arm produced that bound?*
+- **A count asserted when an item was filed is the first thing to drift, and a symbol-shaped check will
+  not catch it** — the symbol still resolves while the count is zero, or triple. Require the census
+  **re-run at the current tip**, reported against the item's number. Measured drifts in one session: 8
+  to 9; "four hits" to 23 lines; "roughly 6–10" to 23; "4 of 21 cached" to 13 of 21. **Where the number
+  will keep moving, brief the fix to name the CLASS rather than the count.**
+- **An item's LIST OF SITES is worse, because it drifts in MEMBERSHIP rather than magnitude.** It looks
+  equally authoritative either way and is wrong in two directions at once: an entry somebody already
+  fixed sends a worker to edit correct text — or to revert a repair — while a site the list never had
+  stays live. **Require it RE-DERIVED at tip and the DELTA reported.** The delta is a deliverable, not
+  bookkeeping: it is the only signal the item was stale.
+- **A lean is a claim too, and it fails worse**, because the worker reads it as guidance rather than as
+  a premise, so the premises-are-claims sentence never reaches it. Attach the measurement in the same
+  breath: *"I think A beats B, and I want the cost that decides it, not a preference."* One dispatch had
+  every part of its author's lean wrong and the number found it — the brief guessed speed was the risk,
+  the measurement killed that argument, and the final margin came out around 380x the other way for the
+  same catch. **Say plainly that the item outranks the brief on scope**: that brief's fallback
+  prescribed scoping a rule per page, which flags 21 sites on a corpus that is correct, where the item's
+  own shape — per section — measures 0.
+- **A number the brief asserts is a lean by the same mechanism.** Before writing a predecessor's figure
+  into a brief, ask what produced it. One such figure — a bound a measurement window had derived from
+  its own most-negative reading — went into the next brief as guidance and reached the operator before
+  two independent refutations caught it. One question would have caught it first: *what null arm
+  produced that bound?*
 
 ---
 
 ## Fences
 
-State what the worker owns, then what it may not touch **and who holds it**. Naming the holder tells
-the worker whether a conflict means "rebase" or "stop and report".
+State what the worker owns, then what it may not touch **and who holds it**. Naming the holder tells the
+worker whether a conflict means "rebase" or "stop and report".
 
-**A fence is a claim about FILES, so derive it from what each open change actually touches rather
-than from its name.** A name — of a branch, a worker, a task — cannot distinguish a change holding
-four named files from one holding a whole tree, so a fence written from names is still the guess
-deriving it was meant to replace.
+**A fence is a claim about FILES**, so derive it from what each open change actually touches rather than
+from its name. **It is derived, never remembered — and the worker derives it again at start-up**, so it
+travels as a claim the worker re-checks and its own result wins.
 
-**But check whether your change-listing tool PAGINATES, because a truncated list under-reports
-silently and in the expensive direction.** A hosted API asked for a change's files commonly answers
-with one page and no marker that it stopped: measured, a change of 722 files returned exactly 100,
-and not one of the files a pending fence turned on was among them — a fence derived from that answer
-would have cleared a second worker onto the surface. **A round number is the tell**; treat 100, 250
-or 1000 as a page size until proved otherwise, and for a large change derive the paths from version
-control instead, diffing the trunk against the branch.
-
-**And a listing built from committed history is blind to work already done but not yet committed** —
-the state a freshly dispatched worker stays in until its first commit, so an empty answer is not
-evidence of an empty fence. Ask the worker's own working copy too, and read a change clean by both as
-*not started yet* rather than as owning nothing: what it will touch is recorded on the item it was
-dispatched under, not in version control.
-
-**And an item's own scope claim is a name too, wearing a reviewer's authority.** A review that files
-a dozen items will call them *src-only* or *parallel-safe* at the altitude it worked at, and every
-collision such a wave produces is invisible from there: four items editing one file in four regions;
-a *test-only* cut that keeps a file a sibling was told would be deleted; a *src-only* lane that must
-cross into a held tree by one line. Measured on one wave: ten items dispatched under that claim,
-three same-file collisions, every one caught by routing after the fact and none by the fence. Read
-each item's cited files against its siblings' before you paste a fence — the citations are usually
-there, and the claim was made without doing that. **A fence built from the claim is the guess the
-claim's author skipped, not a fence.**
-
-**A fence is derived, never remembered — and the worker derives it again at start-up.** A list
-assembled from memory of who you dispatched is stale inside the dispatch's own lifetime, so the fence
-travels as a claim the worker re-checks, like every other premise, and its own result wins. **That
-re-check is the load-bearing half, because the two staleness directions cost differently.** Too BROAD
-costs one re-derivation. Too NARROW omits a worker dispatched after you last looked, and two workers
-on one surface merge-conflict and can silently revert each other — accuracy alone cannot reach that,
-because it expires between writing the brief and reading it.
-
-Hot-zone files — anything sequential, where two concurrent editors conflict by construction — take
-one toucher at a time. If a remedy needs one, the instruction is **stop and report**, not edit. **A
-citation is not permission**: briefs routinely cite a specification section as context, and a worker
-can read that as licence to edit it.
-
-**A GENERATED file is the one same-file overlap that sequencing does not fix.** A manifest or export
-regenerated from the tree is touched by every change that moves what it derives from, and serialising
-those changes serialises the fleet for nothing: two regenerations conflict textually and agree
-semantically. Brief every toucher instead — regenerate after rebasing, never hand-merge, and where a
-job diffs the committed file against a fresh generation, run exactly that job locally.
-
-**And N changes that each touch ONE LINE of one shared index are the second exception.** A catalogue,
-a roster, a table of rows: eight items each editing a different row are not a collision worth a
-sequence. Brief every worker to isolate that edit as its own final commit, merge in landing order,
-and let each later change rebase — the conflict, when it comes, is one line in one commit. Write the
-lane rule on every item that shares the file, in the same words, so no worker discovers it at rebase
-time.
-
-**But a gate that reconciles two surfaces couples them into ONE change, and sequencing those
-deadlocks.** The one-toucher rule reasons about files, and it is right about files. Some checkers
-hold one surface against another in both directions — a catalogue against the emitters it lists, a
-schema against its fixtures, a manifest against the modules it names — and under such a gate neither
-half is green alone: the change deleting the emitters reds until the rows go, and the change striking
-the rows reds until the emitters go. Fence the two halves to two items and each waits on the other's
-merge. Nothing in a file list shows it. **Ask what each nominated gate COMPARES**, and when two items
-hold the two sides of one comparison, brief both halves to one worker — or route the second half into
-the live change and re-scope the item that held it. Where a one-toucher file is held only for a
-region an item does not need yet, the fence can sit INSIDE the brief instead of in front of it: the
-worker does the unheld part first, takes the held file only on a trunk that already carries the
-holder's merge, and stops and reports if it reaches that point first.
-
-**The unit is the block, not the file.** Two items dispatched into the same paragraph of one document
-because they were nominally different concerns conflicted; the second change could not merge, and by
-the time its worker was resumed the hygiene loop had reaped its worktree — two costs from one
-scheduling error. If two items touch the same section, sequence them.
-
-**Complementary work is not duplicate work.** When two items attack one defect from different sides —
-one making a silent failure loud, one stopping a document teaching the failing shape — say so in
-both, or one gets closed as a duplicate of the other.
+- **That re-check is the load-bearing half, because the two staleness directions cost differently.** Too
+  BROAD costs one re-derivation. Too NARROW omits a worker dispatched after you last looked, and two
+  workers on one surface merge-conflict and can silently revert each other — accuracy alone cannot reach
+  that, because it expires between writing the brief and reading it.
+- **Check whether your change-listing tool PAGINATES.** A hosted API commonly answers with one page and
+  no marker that it stopped: measured, a change of 722 files returned exactly 100, and not one of the
+  files a pending fence turned on was among them. **A round number is the tell** — treat 100, 250 or
+  1000 as a page size until proved otherwise, and for a large change diff the trunk against the branch.
+- **A listing built from committed history is blind to work already done but not committed** — the state
+  a freshly dispatched worker stays in until its first commit. Read a change clean by both as *not
+  started yet*, never as owning nothing.
+- **An item's own scope claim is a name too, wearing a reviewer's authority.** A review that files a
+  dozen items calls them *src-only* or *parallel-safe* at the altitude it worked at, and every collision
+  such a wave produces is invisible from there: four items editing one file in four regions; a
+  *test-only* cut that keeps a file a sibling was told would be deleted; a *src-only* lane that must
+  cross into a held tree by one line. Measured: ten items dispatched under that claim, three same-file
+  collisions, every one caught by routing after the fact and none by the fence. **A fence built from the
+  claim is the guess the claim's author skipped, not a fence.**
+- **Hot-zone files take one toucher at a time**, and where a remedy needs one the instruction is **stop
+  and report**, not edit. **A citation is not permission**: briefs routinely cite a specification section
+  as context, and a worker can read that as licence to edit it.
+- **A GENERATED file is the one same-file overlap sequencing does not fix.** Two regenerations conflict
+  textually and agree semantically, so serialising them serialises the fleet for nothing. Brief every
+  toucher to regenerate after rebasing, never hand-merge, and run the job that diffs committed against
+  fresh.
+- **N changes each touching ONE LINE of a shared index are the second exception.** Brief every worker to
+  isolate that edit as its own final commit, merge in landing order, let each later change rebase — the
+  conflict, when it comes, is one line in one commit. Write the lane rule on every item sharing the file,
+  in the same words, so no worker discovers it at rebase time.
+- **But a gate that reconciles two surfaces couples them into ONE change, and sequencing those
+  deadlocks.** Some checkers hold one surface against another in both directions — a catalogue against
+  the emitters it lists, a schema against its fixtures — and neither half is green alone: the change
+  deleting the emitters reds until the rows go, and the change striking the rows reds until the emitters
+  go. **Nothing in a file list shows it.** Ask what each nominated gate COMPARES, and brief both halves
+  to one worker, or route the second into the live change. Where a one-toucher file is held only for a
+  region an item does not need yet, the fence can sit INSIDE the brief: do the unheld part first, take
+  the held file only on a trunk carrying the holder's merge, and stop and report if you get there first.
+- **The unit is the block, not the file.** Two items dispatched into the same paragraph because they
+  were nominally different concerns conflicted; the second could not merge, and by the time its worker
+  was resumed the hygiene loop had reaped its worktree — two costs from one scheduling error.
+- **Complementary work is not duplicate work.** When two items attack one defect from different sides,
+  say so in both, or one gets closed as a duplicate of the other.
 
 ---
 
 ## Choosing solo or cluster
 
-Pick by **kind first, then priority, then size**. Do not reflexively dispatch one-worker-per-item,
-and do not reflexively bundle everything.
+Pick by **kind first, then priority, then size**. Do not reflexively dispatch one-worker-per-item, and
+do not reflexively bundle everything.
 
-* **Highest priority → always SOLO.** A dedicated worker and its own change, so it merges on its own
-  green and is never blocked by a cluster sibling.
-* **Second tier → SOLO by default.** Cluster several only when they are genuinely small,
-  same-surface and low-risk.
-* **Many small low-priority same-surface items → CLUSTER.** This is the primary clustering case. It
-  stops you handling dozens of trivia serially.
-* **Any LARGE item → SOLO**, whatever its priority. Never pad a meaty item into a cluster, and never
-  bundle two large ones — bundles of four or more items time out routinely where single-item workers
-  succeed.
-* **A measurement window → SOLO, Shape 6**, picked by kind rather than size and never folded into a
-  cluster.
-* **One item too large for one worker → SPLIT by disjoint file, one worker each, and NOBODY CLAIMS
-  IT.** The reverse of a cluster, for an item whose slices are each a full session. A claim marks the
-  item one worker's, and the ready list, the stranded sweep and every other slice's worker then read
-  it that way; so each worker appends a claim note and a result note instead, and the mayor closes
-  the item when the last slice has landed, citing every change.
+* **Highest priority → always SOLO**, so it merges on its own green and is never blocked by a sibling.
+* **Second tier → SOLO by default.** Cluster only when genuinely small, same-surface and low-risk.
+* **Many small low-priority same-surface items → CLUSTER.** The primary clustering case.
+* **Any LARGE item → SOLO**, whatever its priority. Bundles of four or more time out routinely where
+  single-item workers succeed.
+* **A measurement window → SOLO, Shape 6**, by kind rather than size.
+* **One item too large for one worker → SPLIT by disjoint file, one worker each, and NOBODY CLAIMS IT.**
+  A claim marks the item one worker's, and the ready list, the stranded sweep and every other slice's
+  worker read it that way; so each worker appends a claim note and a result note instead, and the mayor
+  closes the item when the last slice lands, citing every change.
 
-**Three of those rules consume a SIZE, and the size you are holding is usually a TITLE.** Sizing
-happens at the listing, and a listing prints names. This page already argues that a name is not
-evidence about *files*, and that an item's own scope claim is a name wearing a reviewer's authority;
-magnitude is the third thing a name gets wrong, and the one no fence catches, because it corrupts the
-decision before any fence is derived. Measured: an item whose title named one test that could pass
-vacuously — the archetypal small same-surface cluster candidate — carried a body that deleted four
-public tools, removed a subsystem, and ran to seven acceptance criteria with explicit non-goals.
+**Three of those rules consume a SIZE, and the size you are holding is usually a TITLE.** Sizing happens
+at the listing, and a listing prints names. A name is not evidence about files; magnitude is the third
+thing it gets wrong, and the one no fence catches, because it corrupts the decision before any fence is
+derived. Measured: an item whose title named one test that could pass vacuously — the archetypal small
+cluster candidate — carried a body that deleted four public tools, removed a subsystem, and ran to seven
+acceptance criteria with explicit non-goals.
 
-**So open every candidate before you cluster it, and read for SHAPE rather than for content** —
-acceptance criteria, non-goals, the length of the evidence, whether the body names a few files or
-names a subsystem. None of that requires understanding the work, which is why it is cheap. The
-asymmetry is what settles it: a misread item does not merely arrive oversized, it poisons the change
-its siblings ride in. **And where a title and its body disagree, correct it on the item** rather than
-only in your own decision — the listing is what the next reader sees, and a retitle is the only
-repair that does not have to be made twice.
+**So open every candidate before you cluster it, and read for SHAPE rather than content** — acceptance
+criteria, non-goals, the length of the evidence, whether the body names a few files or a subsystem. None
+of that requires understanding the work, which is why it is cheap. The asymmetry settles it: a misread
+item does not merely arrive oversized, it poisons the change its siblings ride in. **And where a title
+and its body disagree, correct it on the item**, since the listing is what the next reader sees.
 
-**One agent owns a surface; surfaces run in parallel.** That is how you avoid serial handling:
-same-surface items ride one agent, which never collides with itself, while genuinely separable
-surfaces dispatch as concurrent agents.
-
-**The serial exceptions**, where same-surface work is *meant* to be sequential: a deliberately serial
-epic, and a single tightly-coupled module whose core files many items touch. That surface is its own
-serial lane — sequence its changes, later ones rebasing on the earlier merges, never resolving a
-conflict by taking one side wholesale. On a coupled surface even solo high-priority work cannot run
-in parallel.
+**One agent owns a surface; surfaces run in parallel.** The serial exceptions are a deliberately serial
+epic and a tightly-coupled module whose core files many items touch — sequence those, later changes
+rebasing on earlier merges, never resolving a conflict by taking one side wholesale.
 
 ---
 
 ## Dispatch shapes
 
-**Shape 1 — Solo.** One item, one change. Item id and verbatim title; two to four paragraphs of
-context with `file:line` citations; numbered concrete steps; a dedicated worktree and branch; the
-boundary block; claim the item — unless it is a slice of a split item, which nobody claims (see
-*Choosing solo or cluster*); gates with exact commands; push and open the change **as a draft** with
-a `## Quality gates` section; report the change URL, a per-step summary and test deltas.
+**Shape 1 — Solo.** One item, one change. Item id and verbatim title; two to four paragraphs of context
+with `file:line` citations; numbered concrete steps; a dedicated worktree and branch; the boundary
+block; claim the item — unless it is a slice of a split item; gates with exact commands; push and open
+the change **as a draft** with a `## Quality gates` section; report the change URL, a per-step summary
+and test deltas. *A coverage or rigour pass must add at least one adversarial or negative case per
+surface* — assertion-count growth alone only exercises the happy path.
 
-*A coverage or rigour pass must add at least one adversarial or negative case per surface.*
-Assertion-count growth alone only exercises the happy path.
+**Shape 2 — Cluster.** Several small same-surface items, one change. Order commits smallest-cleanup to
+biggest-correctness-fix, so a failing item cannot strand the small wins. Claim each item immediately
+before its commit, so history mirrors tracker state and a stalled cluster leaves a clean partial trail.
+Gates after each commit, full regression after all. Keep to three to six items; beyond that run
+successive cluster changes, each opening with what it finished and listing the remainder, never a
+half-item uncommitted. Disjoint-surface "small-misc" clusters are valid at the tail of a drain — the
+binding rule is hot-zone parallelism, not strict same-surface.
 
-**Shape 2 — Cluster.** Several small same-surface items, one change. Order commits
-smallest-cleanup to biggest-correctness-fix, so a failing item cannot strand the small wins.
-Claim each item immediately before its commit, so history mirrors tracker state and a stalled
-cluster leaves a clean partial trail. Gates after each commit and a full regression after all.
-Keep a cluster to three to six small items; beyond that run successive cluster changes, each
-opening with what it finished and listing the remainder, never a half-item uncommitted.
-Disjoint-surface "small-misc" clusters are valid at the tail of a drain — the binding rule is
-hot-zone parallelism, not strict same-surface.
-
-**Shape 3 — Audit (read-only).** A finding, not a fix. Goal, surface paths, and prior findings to
-avoid re-discovering; the boundary block; write the findings document to the version-ignored working
-tree FIRST, never commit it, never link it from committed files; file follow-on items one at a time,
-appending each id to the audit item's notes so progress survives a timeout; close with a verdict,
-severity counts and cross-references; no change by default.
+**Shape 3 — Audit (read-only).** A finding, not a fix. Goal, surface paths, and prior findings to avoid
+re-discovering; the boundary block; write the findings document to the version-ignored tree FIRST, never
+commit it, never link it from committed files; file follow-on items one at a time, appending each id to
+the audit item's notes so progress survives a timeout; close with a verdict, severity counts and
+cross-references; no change by default.
 
 **An audit brief needs the stance more than an implementation brief does.** The audit is *producing*
-findings, and a project that rejects findings as often as it actions them will reject the weak ones
-at the cost of a dispatch each. Tell it plainly: eight sourced findings beat thirty plausible ones,
-and a finding whose remedy the project's stance excludes is worse than none. Two or three worked
-examples of a good finding beat asking for "a careful review". The mayor may reorganise or reject
-findings; not every finding is actioned.
+findings, and a project that rejects findings as often as it actions them will reject the weak ones at
+the cost of a dispatch each. Tell it plainly: eight sourced findings beat thirty plausible ones, and a
+finding whose remedy the stance excludes is worse than none. Two or three worked examples beat asking
+for "a careful review". The mayor may reorganise or reject findings.
 
 **Shape 4 — Cluster reviewer (read-only, no dispatch).** Shapes the next wave. List in-flight workers
-and their surfaces first, and do not recommend touching those. Enumerate recently filed items and the
-ready queue. Per item decide: add to an in-flight cluster; form a new cluster (three or more items on
-a shared non-hot-zone surface); solo (correctness, large, decision-resolved or cross-cutting); or
-defer. Output the net next-dispatch shape in two or three sentences. **Do not change tracker state.**
+and their surfaces first and do not recommend touching those; enumerate recently filed items and the
+ready queue; per item decide add-to-cluster, new cluster (three or more on a shared non-hot-zone
+surface), solo (correctness, large, decision-resolved or cross-cutting), or defer. Output the net
+next-dispatch shape in two or three sentences. **Do not change tracker state.**
 
-**When items arrive faster than the mayor can read them, ask this shape for the brief inputs as
-well**, per item: the premise check at the current tip (each cited line holds, drifted to what, or
-does not hold; every asserted count re-run), the surfaces it would edit and which are hot-zone,
-same-file collisions against the live and queued sets, the gates by exact command with the
-heavyweight ones marked, and each ambiguity a worker would otherwise improvise, with a
-recommendation. That is the part of a brief the mayor cannot write without reading the tree, and the
-part that goes stale first.
+**When items arrive faster than the mayor can read them, ask this shape for the brief inputs too**, per
+item: the premise check at the current tip (each cited line holds, drifted to what, or does not hold;
+every asserted count re-run), the surfaces it would edit and which are hot-zone, same-file collisions
+against the live and queued sets, the gates by exact command with the heavyweight ones marked, and each
+ambiguity a worker would otherwise improvise, with a recommendation. That is the part of a brief the
+mayor cannot write without reading the tree, and the part that goes stale first.
 
 **Shape 5 — Fix a failing check.** The failing check name and log lines; two or three root-cause
-hypotheses; a worktree off the **existing** branch, not a new one; the boundary block; **run the
-ACTUAL failing gate locally**, not a proxy that already passed; fix surgically, or file a follow-on
-if it is deeper than scope and the stance allows a safe exit; push to the existing branch, never the
-trunk; update its `## Quality gates` section.
+hypotheses; a worktree off the **existing** branch, not a new one; the boundary block; **run the ACTUAL
+failing gate locally**, not a proxy that already passed; fix surgically, or file a follow-on if it is
+deeper than scope and the stance allows a safe exit; push to the existing branch, never the trunk;
+update its `## Quality gates` section. *Never override a failing touched-surface gate* — diagnosis often
+beats the failure log, so test the hypothesis before fixing.
 
-*Never override a failing touched-surface gate.* Diagnosis often beats the failure log — test the
-hypothesis before fixing.
+**Shape 6 — Measurement window.** The five shapes above tell a worker to iterate until the gate goes
+green. A measurement worker must do the opposite, and that inversion is the whole shape: it is not there
+to produce a number, it is there to find out whether a trustworthy number can be produced at all.
 
-**Shape 6 — Measurement window.** The five shapes above all tell a worker to iterate until the gate
-goes green. A measurement worker must do the opposite, and that inversion is the whole shape: it is
-not there to produce a number, it is there to find out whether a trustworthy number can be produced
-at all.
-
-- **The controls are the arbiter, not the worker's judgement about the machine.** A worker asked
-  whether its own machine was quiet enough will always find a reason it was. If a control fails, or
-  an ordering guard refuses, the run refuses and the worker reports the refusal.
+- **The controls are the arbiter, not the worker's judgement about the machine.** A worker asked whether
+  its own machine was quiet enough will always find a reason it was.
 - **A refusal is a deliverable, not a failure.** If everything refuses, the window succeeded: you now
-  know the rig cannot see what you hoped it would, which is what you dispatched it to find out. Say
-  this in the brief, or the worker reads its refusal as its own failure and goes hunting for a way to
-  turn it green.
+  know the rig cannot see what you hoped. Say so in the brief, or the worker reads its refusal as its
+  own failure and hunts for a way to turn it green.
 - **Never "fix" a refusal by loosening a gate.** Every gate in a rig is there because something once
-  passed that should not have. Widening a threshold to admit today's run retro-admits that failure
-  too, and the series loses the one property that made it worth running.
-- **Do not improve the rig mid-window.** No new instrument, no extra rungs, no third estimator: a
-  rung added between runs makes the series two instruments. File the improvement as its own window.
+  passed that should not have; widening a threshold retro-admits that failure too.
+- **Do not improve the rig mid-window.** A rung added between runs makes the series two instruments.
 - **Do not restate a published figure on thin evidence.** Four runs disagreeing with a number are a
   reason to look again, not a mandate to move it.
-- **Verify the machine with real counters, not the convenient one.** One system's headline CPU
-  counter read 93% while the true value was 11%. Prefer the counter saying whether anything is
-  actually *waiting for a core*, and **read it on its own, never inside a measured run** — sampled
-  beside anything heavy it measures the sampler, and inside a run it measures the benchmark. Bracket
-  the run, and say plainly that nothing is claimed about within-run quietness beyond the bracketing.
-- **Only a CLOCK estimand needs the quiet machine.** A census of monotone counters — allocations,
-  recomputations, calls — reads the same on a loaded box, so it may run beside anything and must not
-  consume a drain. Classify the estimand before you schedule it; getting it wrong wastes an idle
-  machine in one direction and produces a worthless-but-measured-looking number in the other.
+- **Verify the machine with real counters, not the convenient one.** One system's headline CPU counter
+  read 93% while the true value was 11%. Prefer the counter saying whether anything is actually *waiting
+  for a core*, and **read it on its own, never inside a measured run** — beside anything heavy it
+  measures the sampler, inside a run it measures the benchmark. Bracket the run, and say plainly that
+  nothing is claimed about within-run quietness beyond the bracketing.
+- **Only a CLOCK estimand needs the quiet machine.** A census of monotone counters reads the same on a
+  loaded box, so it must not consume a drain. Classify the estimand before you schedule it; getting it
+  wrong wastes an idle machine one way and produces a worthless-but-measured-looking number the other.
 - **While a clock window runs, every OTHER dispatch carries a clause reserving the machine** — naming
   the heavyweight gates that worker may not run, **and** saying that *if the only gate covering your
-  surface is a heavy one, stop and report* is a correct outcome. Without that second half a worker
-  held off the machine runs the gate anyway, to satisfy the surface-gate menu the same brief hands
-  it. The failure is silent in both directions: the window returns a plausible worthless number, and
-  that number gets published and cited.
-- **One run at a time, never concurrent.** Concurrency is precisely the contention the window exists
-  to exclude, so two runs the worker believes are independent still are not.
-- **Your published sentences are claims too, and what slips is the prose ONE LAYER ABOVE the
-  number**: a worker that has just spent an hour being rigorous writes its summary in ordinary
-  confident English, and ordinary confident English overclaims. Three measurement changes merged in
-  one day, all exemplary on the run itself, all three overstating their published claim — one calling
-  three values *run-medians* where the code stored the arithmetic MEAN of five per-round ratios, its
-  whole stated basis; one saying a spread "loosely brackets" a figure sitting *above* the maximum of
-  its own ratios. No audit overturned a measurement or a refusal; what they corrected is the sentence
-  a future reader will quote, which is how a measured result becomes a false premise in someone
-  else's brief. So: name the evidence licensing each summarising statement, check the arithmetic of
-  any comparison, name the estimator you actually computed rather than the one the surrounding prose
-  habitually says, and do not attribute a spread to one cause unless your data excludes the others.
-- **An impossible reading cannot bound the quantity.** Let an observed delta *y* be an unknown
-  positive true cost *t* plus estimator error *e*. A reading of *y* = −0.0062 proves only that the
-  negative error excursion exceeded 0.0062 + *t*: it neither makes ±0.0062 a calibrated symmetric
-  floor nor upper-bounds *t*. **A most-negative observation is a statement about the ERROR TERM, not
-  about the quantity** — and comparing most-negative readings from *different* positive-cost arms at
-  two window widths cannot establish a floor-scaling factor either. **Where a bound is inferred from
-  estimator error or noise-floor behaviour, name the NULL OR CONTROL ARM that produced it**;
-  otherwise report the term as UNRESOLVED. A bound resting on a direct analytic argument or an
-  independently calibrated error figure needs no arm at all — say which warrant you have.
+  surface is a heavy one, stop and report* is a correct outcome. Without that second half the worker
+  runs the gate anyway, to satisfy the surface-gate menu the same brief hands it.
+- **One run at a time, never concurrent.** Concurrency is the contention the window exists to exclude.
+- **Your published sentences are claims too, and what slips is the prose ONE LAYER ABOVE the number.** A
+  worker that has just spent an hour being rigorous writes its summary in ordinary confident English,
+  and ordinary confident English overclaims. Three measurement changes merged in one day, all exemplary
+  on the run itself, all three overstating their published claim — one calling three values
+  *run-medians* where the code stored the arithmetic MEAN of five per-round ratios, its whole stated
+  basis; one saying a spread "loosely brackets" a figure sitting *above* the maximum of its own ratios.
+  No audit overturned a measurement or a refusal; what they corrected is the sentence a future reader
+  will quote. So name the evidence licensing each summarising statement, check the arithmetic of any
+  comparison, name the estimator you actually computed, and do not attribute a spread to one cause
+  unless your data excludes the others.
+- **An impossible reading cannot bound the quantity.** Let an observed delta *y* be an unknown positive
+  true cost *t* plus estimator error *e*. A reading of *y* = −0.0062 proves only that the negative error
+  excursion exceeded 0.0062 + *t*: it neither makes ±0.0062 a calibrated symmetric floor nor
+  upper-bounds *t*. **A most-negative observation is a statement about the ERROR TERM**, and comparing
+  most-negative readings from *different* positive-cost arms at two window widths cannot establish a
+  floor-scaling factor either. **Where a bound is inferred from estimator error, name the NULL OR
+  CONTROL ARM that produced it**; otherwise report the term as UNRESOLVED.
 
-Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what
-was **not** concluded. A window that publishes nothing still reports everything.
+Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what was
+**not** concluded. A window that publishes nothing still reports everything.
 
 ---
 
 ## Publishing the change
 
-**Push continuously, and publish the change as a DRAFT.** Pushed commits are the only durable worker
-state — a worker that dies mid-run takes its local commits with it — so the change goes up as soon as
-commits exist rather than at the end, and a gate still running is declared in the `## Quality gates`
-section as reliance on CI rather than waited out in silence.
+**Push continuously, and publish as a DRAFT.** Pushed commits are the only durable worker state, so the
+change goes up as soon as commits exist, and a gate still running is declared in the `## Quality gates`
+section as reliance on CI rather than waited out in silence. **Mark it ready for review as the last act
+before reporting done.**
 
-**Mark it ready for review as the last act before reporting done.** That one line is what stops
-push-as-you-go colliding with a merge loop that merges the moment CI goes green, because the merge
-criterion tests the CHANGE and nothing in it can see whether the author has finished. Twice in one
-session a change was merged out from under a live worker: once the host's delete-on-merge removed the
-branch and the worker's next push recreated it as a duplicate change with a byte-identical diff; once
-a merge landed mid-gate, and the remainder took a whole extra change and review cycle. Neither merge
-was wrong on the criterion — both were green on every clause.
-
-**Use the host's own draft flag rather than a rule to remember.** Merge commands refuse a draft, so
-the interlock is enforced where it cannot be forgotten. The rejected alternative — having the mayor
-check worker liveness before every merge — works, but must be remembered on every merge forever, and
-it re-introduces exactly the worktree-activity sweep the merge loop deliberately does not do.
-
-**But the flag is only as good as the author eventually setting it, and it fails in BOTH directions.**
-Neither direction is visible from the change.
-
-**Stale-OPEN — a fix dispatch inherits a flag somebody else already set.** A fix worker goes onto an
-EXISTING change whose original author finished and marked it ready, so the flag is set before the
-second worker arrives and nothing in the change records that anyone is inside it now. The merge loop
-reads a ready change, the criterion passes, and the merge lands under a live worker — the exact
-failure the flag exists to prevent, arriving by the one path where the flag was never the current
-worker's to set. **The remedy belongs to the DISPATCHER, because the worker cannot supply it**: a rule
-the protected party is unable to execute is not a rule. Converting the change back to draft is part of
-dispatching a fix, done before the worker begins — and **confirm the state took rather than trusting
-the call**, since a host that ignores the request fails silently and leaves exactly the gap you were
-closing.
-
-**Stuck-CLOSED — an author appears to go silent holding a green draft. Read this one carefully,
-because the reading is usually wrong.** What gets read as a stopped worker is: no writes, tip unmoved,
-worktree clean, everything pushed, a direct message unanswered for half an hour, and a draft sitting
-exactly at band with nothing failing.
-
-**Every signal in that list is also what a worker in its FINAL MINUTES looks like.** A worker
-finishing up — one last foreground gate, deleting gate logs, unlinking a shared-dependency link,
-tidying a scratch directory — writes outside the worktree and outside version control, and is too busy
-to answer. **The four indirect signals do not fail independently; they fail together, for one cause.**
-
-**Which makes the frozen reading AMBIGUOUS, and that is the whole finding — not that it means the
-opposite.** Frozen-across-three-readings feels like the most damning pattern available, and it is
-compatible with a stopped worker and with healthy foreground work alike, so it identifies neither.
-Re-reading the same four clocks cannot break the tie: an hour of freeze is the same non-signal as a
-minute of it. Measured twice — on the first occasion five workers were reported dormant, **three
-completed alive with full reports**, one saying it had been on final hygiene, and **two were never
-explained either way**; the diagnosis was retracted in full, including a second claim that messaging
-was inoperative, which was *slow* converted into *broken*. **Name those outcomes rather than reducing
-them to a ratio**, which invites rounding the unexplained cases into whichever side you are arguing
-for — and the two unexplained workers are precisely why the reading is ambiguous rather than merely
-mistaken.
-
-**So prefer the DIRECT signal where your tooling offers one** — a live progress line, a status the
-supervisor maintains — over any number of indirect clocks. If you have only the clocks, declare a
-window and re-read rather than acting; the error is cheap in exactly one direction.
-
-**And do not answer any of it by flipping the flag on an inference.** *It looks done* is the proxy the
-reaping rules refuse one surface over. Settle it by a read rather than an inference: the agent's own
-report, or the operator's decision to stop that agent, which settles liveness by making it false.
-Until one of those arrives the change waits, and the honest report says a finished change is stranded
-and why. **Where the second is taken, it is taken FIRST** — stopping the agent and then merging is
-authorised; merging and then stopping is the same inference with the act appended afterwards, and it
-leaves an identical record, so nothing later can tell the two apart. The coordinator's side is under
-*The stranded sweep* in [`loops.md`](loops.md#the-stranded-sweep).
+- **That one line is what stops push-as-you-go colliding with a merge loop.** The merge criterion tests
+  the CHANGE and nothing in it can see whether the author has finished. Twice in one session a change
+  was merged out from under a live worker: once delete-on-merge removed the branch and the worker's next
+  push recreated it as a duplicate with a byte-identical diff; once a merge landed mid-gate and the
+  remainder took a whole extra change and review cycle. **Neither merge was wrong on the criterion.**
+- **Use the host's own draft flag rather than a rule to remember.** Merge commands refuse a draft, so
+  the interlock is enforced where it cannot be forgotten. The rejected alternative — checking worker
+  liveness before every merge — works but must be remembered forever, and re-introduces the
+  worktree-activity sweep the merge loop deliberately does not do.
+- **Stale-OPEN: a fix dispatch inherits a flag somebody else already set.** The original author finished
+  and marked it ready, so the interlock is open before the second worker starts and nothing in the
+  change records that anyone is inside it now. **The remedy belongs to the DISPATCHER** — a rule the
+  protected party cannot execute is not a rule. Convert the change back to draft before the worker
+  begins, and **confirm the state took**, since a host that ignores the request fails silently.
+- **Stuck-CLOSED: an author appears to go silent holding a green draft — and the reading is usually
+  wrong.** What gets read as a stopped worker is no writes, tip unmoved, worktree clean, everything
+  pushed, a direct message unanswered for half an hour, and a draft at band with nothing failing.
+  **Every signal in that list is also what a worker in its FINAL MINUTES looks like** — one last
+  foreground gate, deleting gate logs, unlinking a shared-dependency link, tidying scratch — all outside
+  the worktree and outside version control, and too busy to answer. **The four signals do not fail
+  independently; they fail together, for one cause.**
+- **Which makes the frozen reading AMBIGUOUS, and that is the whole finding.** It is compatible with a
+  stopped worker and with healthy foreground work alike, so it identifies neither, and re-reading the
+  same clocks cannot break the tie. Measured twice: five workers reported dormant, three completed alive
+  with full reports, two never explained either way; the diagnosis was retracted in full, including a
+  second claim that messaging was inoperative, which was *slow* converted into *broken*. **Name those
+  outcomes rather than reducing them to a ratio**, which invites rounding the unexplained cases into
+  whichever side you are arguing for.
+- **Prefer the DIRECT signal where your tooling offers one** — a live progress line, a supervisor status
+  — over any number of indirect clocks. With only clocks, declare a window and re-read rather than
+  acting; the error is cheap in exactly one direction.
+- **Do not answer any of it by flipping the flag on an inference.** Settle it by a read: the agent's own
+  report, or the operator's decision to STOP that agent, which settles liveness by making it false.
+  **Where the second is taken, it is taken FIRST** — merging then stopping is the same inference with
+  the act appended afterwards, and both orders leave a merged change beside a stopped agent, so nothing
+  in the record can later tell them apart.
 
 ---
 
 ## Pasting a block
 
-Three blocks below travel **verbatim** into a dispatch: the **common preamble** into every one, the
-**worktree boundary block** and the **gate-mechanics block** into every editing one. Get them there by
-**extracting mechanically, then pasting the result into the prompt.** Both halves are mandatory and
-they close different failures: the extraction is what makes paraphrase impossible — a matched range
-cannot reword, where a mayor retyping two hundred lines of gate mechanics can and does — and the paste
-is what makes non-receipt impossible, because a block that is in the prompt cannot be un-received.
+Three blocks below travel **verbatim**: the **common preamble** into every dispatch, the **worktree
+boundary block** and the **gate-mechanics block** into every editing one. Get them there by **extracting
+mechanically, then pasting the result into the prompt.** Both halves are mandatory and close different
+failures — the extraction makes paraphrase impossible, and the paste makes non-receipt impossible.
 
-**Sending the worker to the FILE is not a substitute.** A worker that skims it, or reads part of it,
-has not received the block at all, and nothing in the transcript distinguishes that from a worker who
-read every line — so the first evidence is a worker doing something the block forbids. Between a
-failure prevented by construction and one prevented by a reader's diligence, take construction.
-
-**And no dispatch is small enough to earn a condensed block.** The temptation is strongest exactly
-where the block most dwarfs the task, and condensing there is the paraphrase the mechanical extraction
-exists to prevent, arriving dressed as proportionality. Measured: a mayor condensed the gate-mechanics
-block for a two-file rename, and the worker ended its turn waiting to be woken — the exact failure
-that block names, refutes and closes, in text the mayor had read and chose not to send. **And note
-WHICH part went missing**, because it is not random: a mayor condensing drops what looks least
-relevant to this task, and what stranded the worker was a mechanic belonging to the HARNESS rather
-than to the task — precisely what looks least relevant. A condensed block is not a shorter block; it
-is a block with the harness mechanics taken out of it.
-
-**The pressure is structural, because the block only ever grows.** Every failure it closes adds lines,
-so the better it gets the more it dwarfs a small task — a ratchet turning against the one rule that
-holds it. No wording fixes that, and a block cannot be kept short enough to be safe. The defence is
-that the extraction is MECHANICAL, and a mechanical extraction costs the same on the session's
-smallest dispatch as on its largest: **if you are weighing which parts this worker needs, you have
-stopped extracting and started paraphrasing.**
-
-**But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU are
-not part of what travels.** Where the payload is FENCED, the fence settles it: take the fence, and
-every line outside it is yours. Two of the three here are fenced, and their mayor-facing prose sits on
-opposite sides of the payload, so a habit about which end it lives at is wrong half the time. **Only
-the third, which has no fence, opens by naming itself and saying where it stops** — paste that frame
-untouched and the worker receives instructions about pasting blocks into dispatches it will never
-make, and a pointer by name to a neighbouring section, which is the go-and-read-it this page has just
-forbidden. Drop the frame, and add whatever caution the lane needs. Reword and omission are what is
-forbidden. **The test is whether the block still refuses everything it refused before you touched it.**
-
-**Anchor the extraction to CONTENT, never to line numbers.** A line range against a living document is
-a measured constant that goes stale exactly where it has to be right.
-
-**But match the closing text as a HEADING — anchored to the start of a line — because a block that
-documents its own boundaries contains its own end anchor.** The gate-mechanics block opens by naming
-where it stops, so its CLOSING string occurs twice: once as the real heading, once inside that opening
-sentence. A plain search stops at the mention and the extraction returns the block's opening paragraph
-instead of the block, raising no error, because both anchors were found. **The opening heading is NOT
-doubled, and that asymmetry is the durable part** — a block that says where it stops must name its
-closing anchor, so the trap sits on the closing anchor specifically.
-
-That is worse than the stale line range this rule exists to avoid, and worse in the way that matters:
-a stale range returns the wrong two hundred lines, which reads wrong on sight, where this returns a
-plausible opening paragraph that reads like a short block. **So check the extracted size before you
-paste it — and check it as a CLASS, not against a remembered number.** The two outcomes are orders of
-magnitude apart, so the reliable test is whether the extraction ENDS at the closing heading, which
-cannot drift. A count here would be [a measured constant about a living
-document](#counts-are-claims-and-they-go-stale-first), one section up wearing the other hat.
+- **Sending the worker to the FILE is not a substitute.** A worker that skims it has not received the
+  block, and nothing in the transcript distinguishes that from one that read every line — so the first
+  evidence is a worker doing something the block forbids. Between a failure prevented by construction
+  and one prevented by a reader's diligence, take construction.
+- **No dispatch is small enough to earn a condensed block.** The temptation is strongest exactly where
+  the block most dwarfs the task, and condensing there is the paraphrase the extraction exists to
+  prevent, arriving dressed as proportionality. Measured: a mayor condensed the gate block for a
+  two-file rename and the worker ended its turn waiting to be woken — the exact failure that block
+  names, refutes and closes, in text the mayor had read and chose not to send. **And note WHICH part
+  went missing**: a mayor condensing drops what looks least relevant to *this task*, and what stranded
+  the worker was a mechanic belonging to the HARNESS. **A condensed block is not a shorter block; it is
+  a block with the harness mechanics taken out of it.**
+- **The pressure is structural, because the block only ever grows.** Every failure it closes adds lines,
+  so the better it gets the more it dwarfs a small task — a ratchet turning against the one rule that
+  holds it. The defence is that the extraction is MECHANICAL and costs the same on the smallest dispatch
+  as the largest: **if you are weighing which parts this worker needs, you have stopped extracting and
+  started paraphrasing.**
+- **"Verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU are not
+  part of what travels.** Where the payload is FENCED, the fence settles it. Two of the three here are
+  fenced and their mayor-facing prose sits on opposite sides of the payload, so a habit about which end
+  is wrong half the time. **Only the third, unfenced, opens by naming itself and saying where it stops**
+  — paste that frame untouched and the worker receives instructions about pasting blocks into dispatches
+  it will never make. Drop the frame; add whatever caution the lane needs. **The test is whether the
+  block still refuses everything it refused before you touched it.**
+- **Anchor the extraction to CONTENT, never to line numbers.** A line range against a living document is
+  a measured constant that goes stale exactly where it has to be right.
+- **But match the closing text as a HEADING, anchored to the start of a line**, because a block that
+  documents its own boundaries contains its own end anchor: the gate block's CLOSING string occurs
+  twice, once as the real heading and once inside its opening sentence. A plain search stops at the
+  mention and returns the block's opening paragraph instead of the block, raising no error, because both
+  anchors were found. **The opening heading is NOT doubled, and that asymmetry is the durable part.**
+- **Check the extracted size — as a CLASS, not against a remembered number.** The two outcomes are
+  orders of magnitude apart, so the reliable test is whether the extraction ENDS at the closing heading,
+  which cannot drift. A count here would be [a measured constant about a living
+  document](#counts-lists-and-leans-are-all-claims).
 
 ---
 
 ## The worktree boundary block
 
 **The concept.** A worker edits only its assigned worktree, never the mayor checkout. The shell's working
-directory is not enough protection: some edit tools resolve a relative path against the agent's session
-root rather than the repository root, so a write can land in the mayor checkout *even after a
-start-of-session guard passed* — the leak happens mid-session, in one tool call. A guard script can be
-fooled by that resolution; the real backstop is the worker re-verifying its repository root before every
-edit. New-file leaks are the worst case: a brand-new ignored file routed into the mayor checkout shows
-nothing in the worker's own status, so it fails silently.
+directory is not enough: some edit tools resolve a relative path against the agent's session root rather
+than the repository root, so a write can land in the mayor checkout *even after a start-of-session guard
+passed* — the leak happens mid-session, in one tool call. The real backstop is the worker re-verifying
+its repository root before every edit. New-file leaks are the worst case: a brand-new ignored file routed
+into the mayor checkout shows nothing in the worker's own status.
 
 Paste this verbatim into every editing dispatch. Adapt only the placeholders.
 
@@ -685,24 +496,25 @@ actually caught both observed collisions.
 If you create a link into shared dependencies, remove the LINK (never its target)
 before you report done: later cleanup follows it and deletes what it points at.
 And the link is WRITABLE through, not only deletable through: an installer a gate
-runs (`npm ci`, `npm install`, or any tool that reinstalls a dependency tree)
-rewrites the SHARED target, not your copy — one emptied the coordinator's real
-tree while the worker's own read as a fresh install. If a nominated gate runs an
-installer, do not link that tree: install your own from the lockfile, or STOP and
-say the gate cannot run against a link. And kill any poll loops you armed before you report done — each survivor fires
-its own completion notification after the work has landed, costing a turn apiece.
+runs rewrites the SHARED target, not your copy — one emptied the coordinator's
+real tree while the worker's own read as a fresh install. If a nominated gate runs
+an installer, do not link that tree: install your own from the lockfile, or STOP
+and say the gate cannot run against a link.
+
+And kill any poll loops you armed before you report done — each survivor fires its
+own completion notification after the work has landed, costing a turn apiece.
 ```
 
-A project may add a **mayor-side commit guard** — a pre-commit hook in the mayor checkout that refuses
-commits touching worker-owned surfaces — so a bypassed edit-guard is caught from the other side.
+A project may add a **mayor-side commit guard** — a pre-commit hook in the mayor checkout refusing
+commits that touch worker-owned surfaces — so a bypassed edit-guard is caught from the other side.
 
 ---
 
 ## Common preamble
 
-The tracker commands are placeholders like every other project-specific: substitute your own at
-dispatch time. What travels verbatim is the *reasoning* — every trap below is a property of history
-walks in general, not of one tool.
+The tracker commands are placeholders like every other project-specific: substitute your own at dispatch
+time. What travels verbatim is the *reasoning* — every trap below is a property of history walks in
+general, not of one tool.
 
 ```text
 You are implementing <ITEM_ID> in <project + one-line description>.
@@ -795,57 +607,47 @@ transcripts.
 
 **A pass that concludes only in the ignored tree concludes where nobody can read it.** Every project
 keeps some scratch tree version control cannot see, and that invisibility is what makes the failure
-silent: an item can cite a design by a path no maintainer has. Two audits were lost exactly that way,
-and a mayor re-ran an entire three-design programme in one day for want of looking there first — which
-is why the preamble tells the worker to look there first. Widening what version control tracks is not
-the fix: working notes stay local, and only the *conclusion* is promoted, into whichever tracked
-record already owns the surface.
+silent: an item can cite a design by a path no maintainer has. Two audits were lost exactly that way, and
+a mayor re-ran an entire three-design programme in one day for want of looking there first — which is why
+the preamble tells the worker to look there first. Widening what version control tracks is not the fix;
+only the *conclusion* is promoted, into whichever tracked record already owns the surface.
 
 ---
 
 ## Quality gates — which gate
 
-Every editing dispatch runs gates before opening a change, and lists what ran in a change-body section
-headed **exactly** `## Quality gates`, with pass and fail counts. The readers are the mayor's merge sweep
-and the merged-change audits — agents, not machinery — so the exact heading is a reader's convenience,
-letting them jump to it in a long body rather than read the whole thing. **A heading that does not conform
-is a note to the worker and nothing more**: never grounds to edit somebody else's change body, and never a
-merge blocker, since the five clauses are the criterion and this is not among them.
+Every editing dispatch runs gates before opening a change and lists what ran in a change-body section
+headed **exactly** `## Quality gates`, with pass and fail counts. The readers are agents, not machinery,
+so the exact heading is a reader's convenience. **A heading that does not conform is a note to the worker
+and nothing more** — never grounds to edit somebody else's change body, and never a merge blocker.
 
 - **Nominate the NARROWEST gate that covers the diff — gate time is the dominant cost of a dispatch.**
-  Measured on one project: CI ran the whole required matrix in 22 minutes across parallel runners, while
-  that project's own pre-checkin script — sequential, one core — took 62 minutes for a *subset*. The merge
-  criterion reads CI, never the local run, so a local gate that duplicates CI buys wall-clock rather than
-  information. It answers *did I break something obvious* once; every further run of it is CI's job.
-  **So do not brief a re-run after a rebase, and do not brief red-to-green iteration on a heavyweight
+  Measured: CI ran a whole required matrix in 22 minutes across parallel runners while that project's own
+  pre-checkin script — sequential, one core — took 62 minutes for a *subset*. The merge criterion reads
+  CI, never the local run, so a local gate duplicating CI buys wall-clock rather than information.
+- **So do not brief a re-run after a rebase, and do not brief red-to-green iteration on a heavyweight
   gate** — push, and let CI's automatic re-run be the evidence about the new base. Local iteration is
-  right only for the focused failing test the worker is writing. The re-run is easy to miss because each
-  one is individually justified: a rebase really does invalidate the previous green.
+  right only for the focused failing test the worker is writing. **The re-run is easy to miss because
+  each one is individually justified**: a rebase really does invalidate the previous green.
 - **Gate the transitive surface, not just the file you changed.** A public-surface change breaks its
-  *consumers*, not itself. Gate every artefact reachable from the diff through import edges.
-- **Local-green is not CI.** "Green locally" usually means the subset the worker ran; the red gate is one it
-  skipped. The merge decision is CI's, not the worker's hand-off. So the brief must say *which* required
-  checks the local gate omits — and say it by citing **one path**, not by re-listing them, because the
-  required set moves. Make the project *derive* that list rather than document it. Two shapes
-  make a hand-written one wrong inside a week: a required status context the local runner has no
-  lane in at all, and a required check that is a **step inside a job the runner does run**, which
-  no skipped-tier enumeration can see and which reports under that job's name however little it
-  resembles what the step does.
+  *consumers*, not itself.
+- **Local-green is not CI.** "Green locally" usually means the subset the worker ran; the red gate is one
+  it skipped. **Say WHICH required checks the local gate omits by citing one PATH, not by re-listing
+  them**, and make the project *derive* that list. Two shapes make a hand-written one wrong inside a
+  week: a required status context the local runner has no lane in at all, and a required check that is a
+  **step inside a job the runner does run**, which no skipped-tier enumeration can see and which reports
+  under that job's name however little it resembles what the step does.
 - **Never nominate a gate that does not cover the surface being edited.** Site builds, linters and test
   runners all carry exclusion lists, and a gate run over an excluded path exits green having verified
-  nothing — the same fail-open defect worth hunting anywhere else, except it is now the brief telling the
-  worker to trust it. **Read the exclusion config before naming the gate.** Read the exclusion's own carve-outs
-  too, because an exclusion may itself name exceptions — a construct the gate skips everywhere but reports in
-  named trees — and **understating coverage misreports as surely as overstating it**, sending a worker to
-  hand-check what the gate already proved and to record a gap that is not there. Where a surface genuinely has
-  no automated coverage, the honest brief says *no automated gate covers this surface; the worker verifies it
-  by hand and says so in the change body* — and the change body then reports what was checked and the counts.
-
-- **Read what each nominated gate RUNS before telling the worker to link shared dependencies.** A link
-  into a shared dependency tree is writable through, and a gate that reinstalls dependencies as a step
-  rewrites the shared tree rather than the worker's copy — measured: a conformance runner's `npm ci`
-  emptied the coordinator's real tree through the link the brief had told the worker to make. Where a
-  gate does that, the brief says so and tells the worker to install its own tree from the lockfile.
+  nothing — the same fail-open defect, except it is now the brief telling the worker to trust it.
+  **Read the exclusion config, and its own carve-outs**, because an exclusion may name exceptions.
+  **Understating coverage misreports as surely as overstating it**, sending a worker to hand-check what
+  the gate already proved. Where a surface genuinely has no automated coverage, the honest brief says so
+  and the change body reports what was checked by hand, with counts.
+- **Read what each nominated gate RUNS before telling the worker to link shared dependencies.** A gate
+  that reinstalls dependencies as a step rewrites the shared tree rather than the worker's copy —
+  measured: a conformance runner's install emptied the coordinator's real tree through the link the brief
+  had told the worker to make.
 
 A skipped gate needs a one-line reason in the change body. A silent skip fails review.
 
@@ -853,256 +655,208 @@ A skipped gate needs a one-line reason in the change body. A silent skip fails r
 
 ## Quality gates — how a gate is run
 
-**This section is the gate-mechanics block.** Paste it verbatim into every editing dispatch,
-adapting only the placeholders, from this heading to the rule before `## Reviewing what comes back`.
-**`## Quality gates — which gate` is not it and does not stand in for it** — that section is
-addressed to you as you nominate the gate, so pasting it instead hands the worker your reasoning and
-withholds every mechanic it needs to run anything.
+**This section is the gate-mechanics block.** Paste it verbatim into every editing dispatch, adapting
+only the placeholders, from this heading to the rule before `## Reviewing what comes back`. **`## Quality
+gates — which gate` is not it and does not stand in for it** — that section is addressed to you as you
+nominate the gate, so pasting it instead hands the worker your reasoning and withholds every mechanic it
+needs to run anything.
 
-The menu settles *which* gate runs; this settles *how*. The wedge paragraph assumes a gate heavy
-enough that two cannot coexist, and the planted-fault paragraphs a gate in which a bounded,
-discriminating fault can be planted at a line the worker is already editing — a cheap link validator
-is *plantable* without being *heavyweight*. Everything else applies to any dispatch that runs
-anything.
+The menu settles *which* gate runs; this settles *how*. The wedge paragraph assumes a gate heavy enough
+that two cannot coexist, and the planted-fault paragraphs a gate in which a bounded, discriminating fault
+can be planted at a line the worker is already editing — a cheap link validator is *plantable* without
+being *heavyweight*. Everything else applies to any dispatch that runs anything.
 
-**Split a compound gate before you reach for detaching.** A script chaining two phases often splits
-into two runs that each fit inside the harness ceiling, which keeps every verdict in the foreground
-and removes the strand risk rather than managing it.
+### Running it
 
-**Where it genuinely does not split, detaching is correct — ENDING THE TURN is the defect.** Detach,
-then poll both the log and the exit-code file in a bounded loop *within the same turn*: the log shows
-progress, the exit file carries the verdict and appears only once the run is over. Word this as the
-sanctioned path, not as a concession; a worker who thinks it has erred reads for how to atone and
-straight past the instruction that would save it.
+- **Split a compound gate before you reach for detaching.** A script chaining two phases often splits
+  into two runs that each fit inside the harness ceiling, which keeps every verdict in the foreground and
+  removes the strand risk rather than managing it.
+- **Where it genuinely does not split, detaching is correct — ENDING THE TURN is the defect.** Detach,
+  then poll both the log and the exit-code file in a bounded loop *within the same turn*: the log shows
+  progress, the exit file carries the verdict and appears only once the run is over. This is the
+  sanctioned path, not a concession; a worker who thinks it has erred reads for how to atone and straight
+  past the instruction that would save it.
+- **State it as a TERMINAL CONDITION and name the CLASS: the turn ends only once the exit file exists
+  and its number is quoted.** Stated as a forbidden wait it fails open on the first wait nobody
+  enumerated — workers have stranded on a monitor, a watch, a notification subscription and a background
+  task expected to wake them, each a fresh name for the same wait and each read as outside a rule that
+  named the others. You are the only thing that can read the exit file, and you can only read it while
+  your turn is still running.
+- **Refute the belief that keeps re-arming it, because the rule alone has not held.** Your tooling likely
+  documents that a backgrounded command "notifies you when it completes" — true of a LIVE session, and
+  the reason a worker reads its wait as sanctioned: it is trusting its harness over this block. That
+  promise does not survive the end of your turn. Every stranded worker was recovered intact the moment
+  somebody asked it for a status.
+- **A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit file,
+  no error, from a run healthy a minute ago. This is contention for the MACHINE, so per-attempt naming
+  does nothing for it. Correlate your own build artefact's modification time against the candidate runs'
+  start times and **kill only the one you can show is yours**; a peer's recovers once memory frees.
+- **Read the clock before killing anything on elapsed time** — ask the system, never infer it from how
+  much has happened. One worker killed a healthy run believing seventeen minutes had passed when it had
+  been two; the loop watching from outside reads a worker that has just rebased as stalled.
+- **Invoke a backgrounded gate by its ABSOLUTE path**, for two reasons: a script deriving its repository
+  root from its own invocation path gets a relative one back, and an interpreter handed a relative path
+  resolves it against the working directory, so a wrong directory hands it a *sibling worktree's copy*
+  which then pins faithfully to the sibling's root. **A complete, internally consistent run about
+  somebody else's work is far harder to catch than a broken one.**
 
-**State the rule as a TERMINAL CONDITION, and name the CLASS: the turn ends only once the exit file
-exists and its number is quoted.** Stated as a forbidden wait it fails open on the first wait nobody
-enumerated — workers have stranded on a monitor, a watch, a notification subscription and a
-background task expected to wake them, each a fresh name for the same wait and each read as outside a
-rule that named the others. You are the only thing that can read the exit file, and you can only read
-it while your turn is still running.
+### Believing it
 
-**Refute the belief that keeps re-arming it, because the rule alone has not held.** Your tooling
-likely documents that a backgrounded command "notifies you when it completes" — true of a LIVE
-session, and the reason a worker reads its wait as sanctioned: it is trusting its harness over this
-block. That promise does not survive the end of your turn; once you stop, the completion event goes
-to your coordinator, not to you. Every stranded worker was recovered intact the moment somebody asked
-it for a status.
+- **Verify which tree the gate actually read.** Where it prints its root, check that line names your
+  worktree — that check, not any naming rule, is what has caught the observed collisions. Where it prints
+  nothing, the proof is **the red from a planted fault** at a line you are already editing. Do not expect
+  the reported path to name your worktree; a repository-relative path cannot tell two checkouts apart.
+  **The discrimination is the red itself**: the fault exists only in your tree. Where a gate affords
+  neither route, say so in the brief and name whatever bounded mechanism it does afford — nominating a
+  route the gate cannot supply makes workers improvise.
+- **A green sabotage run is a reason to stop, not to proceed.**
+- **Never pipe a gate through a filter.** A pipeline's exit status is its *last* command's, so a red
+  runner reads green. Redirect to a log, echo the runner's own exit code, and quote that number — with
+  the redirect and the echo on **one command line, in one shell**, because a separate invocation starts a
+  fresh shell whose status is whatever that shell last did, typically the directory change.
+- **Quote the number you captured, never one the harness reports about the same run.** That is a
+  different measurement and it disagrees routinely — dozens of times across one fleet, over a compile
+  failure, a two-assertion failure and a browser run standing over three real ones. **Every disagreement
+  surfaced as exit 0**, and more than half were sabotaged runs where believing the reported zero would
+  have inverted the conclusion.
+- **A captured exit code is honest about its own phase and SILENT ABOUT THE ONE BEFORE IT.** Where a gate
+  chains compile to serve, a failed compile leaves the previous artefact in place and the serve step
+  serves it — so the run executes against stale code, passes, and returns its own truthful zero. Capture
+  discipline cannot reach this. **Gate the second phase on the first's captured exit.** Counts do not
+  catch it either: a stale artefact ran 885 tests and read entirely plausibly, and **a count that does
+  NOT move where you expected is a question rather than an answer.**
+- **An ABSENT exit-code file is NO VERDICT, not a pass** — it reads as success because the log ends with
+  the gate's own output and nothing contradicts it. **A gate you cannot quote a captured number for has
+  not run.**
 
-**A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit file,
-no error, from a run healthy a minute ago. This is contention for the MACHINE, so per-attempt naming
-does nothing for it and every same-file rule around it misses it. Correlate your own build artefact's
-modification time against the candidate runs' start times and **kill only the one you can show is
-yours**; a peer's run recovers by itself once memory frees.
+### Searching, and any instrument that can say "nothing here"
 
-**Read the clock before killing anything on elapsed time** — ask the system, never infer it from how
-much has happened. It fails both ways: one worker killed a healthy run believing seventeen minutes
-had passed when it had been two, and a loop watching from outside reads a worker that has just
-rebased as stalled.
+- **A search that returns ZERO is not a check that passed.** Match fixed strings as fixed strings, and
+  when a search underwrites a claim, run it once against something it should find.
+- **Make that control share the SHAPE of the target**, because a pattern fails on a FEATURE and a control
+  lacking the feature passes without exercising it. Measured: a word-boundary anchor placed after a `$`
+  matched a letter-final control and missed every punctuation-final hit, so the census read zero on four
+  real sites while its control read green. If the target ends in punctuation, carries a backslash, spans
+  a line or sits behind a comment marker, the control must carry **every** one of those at once.
+- **For the LINE-SPANNING case that advice is inert, and it is the one case where a matched control
+  actively reassures you.** Most search tools take a line as their unit, so a target broken across two
+  lines cannot be seen at all — and a control sharing that shape is invisible identically. **Run the
+  search three times: line-oriented, over the text with whitespace collapsed, and with comment markers
+  stripped before collapsing.** Neither of the first two is a superset of the other, and the third reaches
+  what neither can — a phrase broken across lines whose continuation carries a comment marker survives a
+  plain flatten. **Wrapped text is the common case, not the exotic one.**
+- **Separate CODE from COMMENT before you count**, or a census reports prose hits in the reassuring
+  direction for a retirement.
+- **This is not a fact about searching.** ANY instrument that can answer "nothing here" gives the same
+  answer when misused, and a misused one raises no error, so its all-clear is complete and plausible — a
+  surface classifier handed revisions where it expects file paths reported every surface as unaffected,
+  which is exactly what a genuinely unaffected change looks like.
 
-**Invoke a backgrounded gate by its ABSOLUTE path**, for two independent reasons: a script deriving
-its repository root from its own invocation path gets a relative one back, and an interpreter handed
-a relative path resolves it against the working directory, so a wrong directory hands it a *sibling
-worktree's copy* which then pins faithfully to the sibling's root. **A complete, internally
-consistent run about somebody else's work is far harder to catch than a broken one.**
+### Artefacts
 
-**Verify which tree the gate actually read**, by whichever of two routes it affords:
+- **Name every gate artefact for your worktree AND for the attempt**, log and exit file both, in a
+  version-ignored directory. A name missing either half fails the gate **open**, and the two halves close
+  different holes: the scratch path is usually keyed to the session, so peers share one directory — two
+  workers in one wave wrote the same exit-code filename and one read a zero a peer had left. **The
+  worktree suffix cannot close the second mechanism, because there both writers are you**: a runtime cap
+  kills the *shell*, what it spawned survives holding the same descriptors, and it writes at its offset
+  while the restart writes from zero, so the artefact is SPLICED rather than clobbered — measured as an
+  `exit 0` beside 18 real failures, and an orphan reporting two failures from a run already killed.
+- **Clean them up: one leftover is enough to make a worktree unreapable.** **Delete them by their LITERAL
+  path, never through a variable** — a deletion whose target a static permission check cannot evaluate is
+  one it has to stop and ask about, and the ask lands on an operator who may not be watching, so the
+  cleanup stalls mid-turn. An unset variable also turns `"$DIR"/*name*` into a glob rooted at the top of
+  the filesystem.
 
-* Where it prints its root, check that line names your worktree. That check, not any naming rule, is
-  what has caught the observed cross-worktree collisions.
-* Where it prints nothing — and many will not — the proof is **the red from a planted fault**, at a
-  line you are already editing, whose failure names what you planted. Do not expect the reported path
-  to name your worktree; a repository-relative path cannot tell two checkouts apart. **The
-  discrimination is the red itself**: the fault exists only in your tree, so a run that had wandered
-  into a sibling's would have come back green.
+### Planting a fault
 
-Where a gate affords neither route, say so in the brief — silent and unplantable is a real pairing
-rather than a corner — and name whatever bounded mechanism it does afford. Nominating a route the
-gate cannot supply makes workers improvise, and the improvisation varies.
+- **Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line endings
+  reads clean having changed every line — and **a patch that never applied reads clean too**, because
+  "unchanged" and "not attempted" are the same diff. That second is the dangerous half: a plant that
+  silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired when
+  nothing was ever broken.
+- **Commit your own edits before you plant anything**, because asking version control for the file back
+  returns it to the last COMMITTED state, not your pre-plant working state — so planting from a dirty
+  tree silently discards the work the gate was being run against.
+- **Use version control's own content hash against the committed object**, not a byte digest of the
+  working file, and **treat a match by EITHER the default form or the no-filters form as a good restore**
+  — which form reproduces a committed blob is a per-file fact, and a false "restore failed" sends the
+  worker off to doubt the sabotage result, which was the deliverable.
+- **Call it a *blob* hash in the words immediately before the token**, or a provenance checker
+  classifying hex tokens by the nearest description on their left will file it as a citation of a commit
+  that exists nowhere.
+- **Anchor a patch to a single line** — a multi-line anchor can match nothing, with no error and no edit.
+- **An anchor at the END of a line matches nothing where line endings are translated**, so the
+  single-line rule does not cover it. **Read the match count before you run the gate**: zero is
+  unambiguous and free, where the hash convicts a no-op plant only after a run has been spent. The
+  endings can change under you *between* plants, so read the count per plant.
+- **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied genuinely and
+  the file was not in the build's module graph, so the watcher served the pre-plant compile and the
+  witness came back green. A green sabotage run is evidence only once both halves hold.
+- **Scope a plant to the suite under test.** Where the runner executes a whole lane in one block without
+  catching exceptions, a plant that crashes any namespace stops every namespace after it and the log
+  still looks plausible. **Compare namespace and assertion counts against a control run.**
 
-**A green sabotage run is a reason to stop, not to proceed.**
+### Gates nobody nominated
 
-**Never pipe a gate through a filter.** A pipeline's exit status is its *last* command's, so a red
-runner reads green. Redirect to a log, echo the runner's own exit code, and quote that number — with
-the redirect and the echo on **one command line, in one shell**. A separate invocation starts a fresh
-shell whose status is whatever that shell last did, typically the directory change: silent, and it
-yields a plausible zero.
-
-**Quote the number you captured, never one the harness reports about the same run.** That is a
-different measurement and it disagrees routinely — dozens of times across one fleet, over a compile
-failure, a genuine two-assertion failure and a browser run standing over three real ones. **Every
-disagreement surfaced as exit 0**, and more than half were deliberately sabotaged runs, where
-believing the reported zero would have inverted the conclusion.
-
-**A captured exit code is honest about its own phase and SILENT ABOUT THE ONE BEFORE IT.** Where a
-gate chains a compile step to a serve step, a failed compile leaves the previously built artefact in
-place and the serve step serves it — so the run executes against stale code, passes, and returns its
-own truthful zero. Capture discipline cannot reach this: the runner ran, its tests passed, and it is
-not the component that knows what it was handed. **Gate the second phase on the first's captured exit
-rather than chaining the two and reading the second.** Counts do not catch it either — a stale
-artefact ran 885 tests and read entirely plausibly — and a count that does NOT move where you
-expected is a question rather than an answer.
-
-**An ABSENT exit-code file is NO VERDICT, not a pass.** It reads as success because the log ends with
-the gate's own output and nothing contradicts it; any death between the last line and the exit does
-it. **A gate you cannot quote a captured number for has not run** — re-run it, and say whether you
-re-ran the whole gate or one step.
-
-**A search that returns ZERO is not a check that passed.** A wrong pattern answers "no matches" in
-the same voice as "nothing is wrong". Match fixed strings as fixed strings, and when a search
-underwrites a claim, run it once against something it should find. **And make that control share the
-SHAPE of the target** — a pattern fails on a FEATURE, and a control lacking the feature passes
-without exercising it. Measured: a word-boundary anchor placed after a `$` matched a letter-final
-control and missed every punctuation-final hit, so the census read zero on four real sites while its
-control read green. If the target ends in punctuation, carries a backslash, spans a line or sits
-behind a comment marker, the control must carry **every** one of those features at once — a control
-that matches on the axis it shares says nothing about the axis it does not.
-
-**But for the LINE-SPANNING case that advice is inert, and it is the one case where a matched control
-actively reassures you.** Most search tools take a line as their unit, so a target broken across two
-lines cannot be seen at all, whatever the pattern — and a control sharing that shape is invisible in
-exactly the same way. Both come back zero, and the check reports a clean pattern over an unsearched
-target. Every other hazard here is caught by a control that bites; this one only by changing the
-instrument. **Run the search three times — line-oriented, over the text with whitespace collapsed,
-and with comment markers stripped before collapsing.** Neither of the first two is a superset of the
-other, and the third reaches what neither can: a phrase broken across lines whose continuation
-carries a comment marker survives a plain flatten, collapsing to `the FOUR ;; live emitters`, which
-matches nothing. **Wrapped text is the common case, not the exotic one** — most prose documents and
-many tracker fields are hard-wrapped, and every commented block and fenced sample puts a marker at
-the break. Keep a probe short enough to sit inside one line; where the target is genuinely longer,
-flatten, and strip the markers, before believing a zero.
-
-**This is not a fact about searching, and reading it as one is how it gets past you.** ANY instrument
-that can answer "nothing here" gives the same answer when misused, and a misused one raises no error,
-so its all-clear is complete, well-formed and plausible — a surface classifier handed revisions where
-it expects file paths reported every surface as unaffected, which is exactly what a genuinely
-unaffected change looks like. Exercise any such instrument once against an input it should flag.
-
-**Name every gate artefact for your worktree AND for the attempt**, log and exit file both, in a
-directory version control ignores. A name missing either half fails the gate **open**, and the two
-halves close different holes. The scratch path is usually keyed to the session, so peers share one
-directory: two workers in one wave wrote the same exit-code filename, and one read a zero a peer had
-left while its own gate was still running. **The worktree suffix cannot close the second mechanism,
-because there both writers are you** — a runtime cap kills the *shell*, what it spawned survives
-holding the same open descriptors, and it writes at its offset while the restart writes from zero, so
-the artefact is SPLICED rather than clobbered (measured: an `exit 0` beside 18 real failures, and an
-orphan reporting two failures from a run already killed). Expect this route more often than the peer
-collision, since detaching is sanctioned and kill-and-restart is routine. **And clean the artefacts
-up: one leftover is enough to make a worktree unreapable.**
-
-**Delete them by their LITERAL path, never through a variable.** A deletion whose target a static
-permission check cannot evaluate is one it has to stop and ask about, and the ask lands on an
-operator who may not be watching — so the cleanup stalls mid-turn and the work queued behind it
-stalls with it. The guard is real rather than theoretical: an unset variable turns `"$DIR"/*name*`
-into a glob rooted at the top of the filesystem. Write the directory out in full; where a variable is
-unavoidable, make the shell refuse an empty one (`"${DIR:?}"`), which removes the hazard but not the
-prompt, so it is the fallback rather than the rule.
-
-**Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line endings
-reads clean having changed every line — and **a patch that never applied reads clean too**, because
-"unchanged" and "not attempted" are the same diff. That second one is the dangerous half: a plant
-that silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired
-when nothing was ever broken. Hash before the plant, compare after the restore.
-
-**Commit your own edits before you plant anything**, because the obvious restore — asking version
-control for the file back — returns it to the last COMMITTED state, not to your pre-plant working
-state. Plant from a dirty tree and that restore silently discards the work the gate was being run
-against, and the run afterwards is green about a tree you did not mean to have. Five cautions on the
-plant itself:
-
-* **Where line endings are translated, use version control's own content hash against the committed
-  object**, not a byte digest of the working file — a checkout during a rebase rewrites the working
-  file after you hashed it, and a false "restore failed" sends the worker off to doubt the sabotage
-  result, which was the deliverable.
-* **Call it a *blob* hash in the words immediately before the token.** A content hash is
-  indistinguishable from a commit id, and a provenance checker classifying each hex token by the
-  nearest description on its left will file it as a citation of a commit that exists nowhere.
-* **Anchor a patch to a single line.** A multi-line anchor can match nothing, with no error and no
-  edit.
-* **An anchor at the END of a line matches nothing where line endings are translated** — a carriage
-  return sits between the text and the ending — so the single-line rule above does not cover it.
-  **Read the match count before you run the gate**: zero is unambiguous and free, where the hash
-  convicts a no-op plant only after a whole run has been spent. The endings can change under you
-  *between* plants, so read the count per plant, not once per session.
-* **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied genuinely
-  and the file was not in the build's module graph, so the watcher served the pre-plant compile and
-  the witness came back green. A green sabotage run is evidence only once both halves hold: the hash
-  for the source, and positive evidence the runtime observed the plant.
-
-**Scope a plant to the suite under test.** Where the runner executes a whole lane in one block
-without catching exceptions, a plant that crashes any namespace stops every namespace after it and
-the log still looks plausible. Compare namespace and assertion counts against a control run.
-
-**The gates the brief nominated are not the whole obligation, because a project's RATCHET gates grade
-the PATHS you touched rather than the change you made.** A ratchet permits a recorded count and
-refuses any increase — a per-surface floor a surface with baselined debt already sits exactly on, or
-a retired-vocabulary scan whose permitted count is zero — so an ordinary new file, or one word in a
+**The gates the brief nominated are not the whole obligation, because a project's RATCHET gates grade the
+PATHS you touched rather than the change you made.** A ratchet permits a recorded count and refuses any
+increase — a per-surface floor a surface with baselined debt already sits exactly on, or a
+retired-vocabulary scan whose permitted count is zero — so an ordinary new file, or one word in a
 comment, is a regression, and no brief nominated the gate because the change looked nothing like its
 subject. Before you open the change, find the ratchets covering your paths, run them, and treat each
-gate's own output as the authority on what it wants: one that fails prints the exact spelling it
-wanted. A project keeps them together — a checks directory, and the job lists of the workflows that
-run them. **Do not ask for a list of them, and do not write one**: the set grows, and an enumeration
-is a count, which is the thing that goes stale first.
+gate's own output as the authority: one that fails prints the exact spelling it wanted. **Do not ask for
+a list of them, and do not write one** — the set grows, and an enumeration is a count.
 
-**Two properties of that repair, both learned by getting them wrong.** These gates grade more than
-the lines you think you changed — some read the whole tracked file, comments and docstrings included,
-so a sentence naming the design you REJECTED fails while the code it describes passes; others grade a
-form nobody counts as part of the change, such as an import edge. And **a ratchet is repaired by
-changing your own lines, never by moving its floor**: raising a recorded count to admit new debt
-inverts the gate, and walking that debt down is another item's job, so repairing pre-existing
-violations in files you did not otherwise touch is sprawl into it. Read the gate's WHOLE output
-before you fix — it names every surface over its floor, where a number quoted into a brief from a
-failed run names one.
+- **These gates grade more than the lines you think you changed.** Some read the whole tracked file,
+  comments and docstrings included, so a sentence naming the design you REJECTED fails while the code it
+  describes passes; others grade a form nobody counts as part of the change, such as an import edge.
+- **A ratchet is repaired by changing your own lines, never by moving its floor.** Raising a recorded
+  count to admit new debt inverts the gate, and walking that debt down is another item's job. Read the
+  gate's WHOLE output before you fix — it names every surface over its floor.
 
-**Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a
-tree that no longer exists, and nothing warns you: the rebase reports success and the old log still
-says exit 0. One worker rebased four times past eleven landings, and re-running changed the artefact
-rather than reconfirming it — fixes for three of its own findings had merged in the interval, so the
-record it was about to publish carried a count false of the trunk.
+### Before you push
 
-**Diff your branch against its MERGE BASE before you push, and read that diff for what you would
-REVERT.** Not for conflicts — version control reports those, and a clean rebase is exactly the case
-this rule is for. The question is whether your push undoes something a sibling landed while you
-worked, which no gate covers: a revert of a merged change is well-formed, compiles, and passes every
-check the tree has, and in a shared document a stale copy of one region reapplies as a silent
-deletion of everything that landed in it since. **The base is half the instruction** — compare
-against the point your branch left the trunk, never the trunk's current tip, which buries the one
-hunk that matters under siblings' unrelated work and degrades worst exactly when the trunk has moved
-most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
+- **Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a tree
+  that no longer exists, and nothing warns you: the rebase reports success and the old log still says
+  exit 0. One worker rebased four times past eleven landings, and re-running changed the artefact rather
+  than reconfirming it — fixes for three of its own findings had merged in the interval.
+- **Diff your branch against its MERGE BASE and read that diff for what you would REVERT.** Not for
+  conflicts — a clean rebase is exactly the case this rule is for. The question is whether your push
+  undoes something a sibling landed while you worked, which no gate covers: a revert of a merged change
+  is well-formed, compiles and passes every check the tree has, and in a shared document a stale copy of
+  one region reapplies as a silent deletion of everything that landed in it since. **The base is half the
+  instruction** — compare against the point your branch left the trunk, never the trunk's current tip,
+  which buries the one hunk that matters and degrades worst exactly when the trunk has moved most. In the
+  dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
 
 ---
 
 ## Reviewing what comes back
 
 * Did it check the premises, or accept them?
-* Is there a control, and does it fail for the right reason? Ask specifically whether the control could catch its own
-  case.
+* Is there a control, and does it fail for the right reason? **Ask specifically whether the control could
+  catch its own case.**
 * Which numbers are captured, and which are reported by the harness?
-* What did it decline to do, and why? A report with no refusals, on a task that had a plausible one, is worth a second
-  look.
-* **Where it CONTRADICTS the brief, that is evidence about the brief.** Read it as such before defending or
-  re-explaining: verify the worker's claim at source, and if it holds, the brief was wrong. This is not a courtesy.
-  Measured across one session: seven briefs carried a defect — a hold the item recorded and the brief did not, work the
-  item had already split, a sequencing precondition the item had discharged and the brief re-fenced, and a ruling made
-  from a page's confident prose without checking the spec that owned it. **A worker surfaced every one. The coordinator
-  caught none.** The clause that makes this work is the preamble's *these premises are claims, not findings*, which
-  reads like a guard for the WORKER and functions as error-correction for the COORDINATOR — so never trim it to save
-  room, and never treat the pushback it produces as friction. A dispatch that comes back saying *the premise does not
-  hold* has done its job.
-* Are you about to quote a figure or a phrase OUT of this report and into the next brief? Then it is a claim like
-  any other and the question is what produced it. A sequence of measurements and a correction to one measurement
-  read identically once compressed to a line: one mayor turned four per-window figures into “the number moved”
-  and briefed a worker to fix a figure that was correct. Reports invite this — they are dense, confident, and
-  written by an agent that has just spent its whole context being careful. **A figure and the subject it was
-  measured on arrive in the same sentence, so the compression can pair them WRONGLY** — and re-deriving at the
-  current tip cannot catch that, because the census is correct about the subject you wrote. The tell only appears
-  when a later worker refutes the number for its own subject; **trace a refuted figure back to what it WAS true of
-  before you drop it**, because the thing it was true of is an unfiled finding. Measured here: a figure relayed onto
-  the wrong file was corrected to that file's real count, and the original number turned out to describe two other
-  files nobody had filed.
-* What did it find that you did not ask for? File those **with the owning item named in the new item**, so a later
-  audit reopening that owner is recognisable as the same finding rather than a second one. One mayor skipped that and
-  created a duplicate of its own within hours.
+* What did it decline to do, and why? A report with no refusals, on a task that had a plausible one, is
+  worth a second look.
+* **Where it CONTRADICTS the brief, that is evidence about the brief.** Verify the claim at source, and
+  if it holds, the brief was wrong. Measured across one session: seven briefs carried a defect — a hold
+  the item recorded and the brief did not, work the item had already split, a sequencing precondition the
+  item had discharged and the brief re-fenced, and a ruling made from a page's confident prose without
+  checking the spec that owned it. **A worker surfaced every one. The coordinator caught none.** The
+  clause that makes this work is the preamble's *these premises are claims*, which reads like a guard for
+  the WORKER and functions as error-correction for the COORDINATOR — so never trim it, and never treat
+  the pushback it produces as friction.
+* **Are you about to quote a figure or phrase OUT of this report and into the next brief?** Then it is a
+  claim like any other. A sequence of measurements and a correction to one measurement read identically
+  once compressed to a line: one mayor turned four per-window figures into "the number moved" and briefed
+  a worker to fix a figure that was correct. **A figure and the subject it was measured on arrive in the
+  same sentence, so the compression can pair them WRONGLY** — and re-deriving at the current tip cannot
+  catch that, because the census is correct about the subject you wrote. **Trace a refuted figure back to
+  what it WAS true of before you drop it**, because that thing is an unfiled finding.
+* What did it find that you did not ask for? File those **with the owning item named in the new item**,
+  so a later audit reopening that owner is recognisable as the same finding rather than a second one.
 
 ---
 
@@ -1110,33 +864,32 @@ most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
 
 - Back-compatibility shims by default → the stance is explicit in every preamble.
 - Same-file races between concurrent workers → in-flight surfaces enumerated.
-- Two halves of one gate-coupled invariant fenced to two items, each red until the other merges → ask what each
-  gate compares; one worker takes both halves, or the second is routed into the live change.
-- Edits leaking into the mayor checkout, especially silent new-file leaks → the boundary block plus a post-write check
-  of both trees.
+- Two halves of one gate-coupled invariant fenced to two items, each red until the other merges → ask
+  what each gate compares; one worker takes both halves.
+- Edits leaking into the mayor checkout, especially silent new-file leaks → the boundary block plus a
+  post-write check of both trees.
 - Cross-worktree contamination via stashes → the no-stash rule.
-- A peer overwriting a worker's scratch file, or an orphaned child of a killed gate writing over the run that replaced
-  it — either way a worker reads the survivor as its own, including a gate exit code belonging to a different run,
-  which merges on a green nobody earned → artefacts named for both the worktree and the attempt, plus the gate-root
-  check, which is the half observed to actually catch it.
-- Worktree cleanup deleting *through* a link into the shared tree it points at → the worker unlinks before reporting
+- A peer overwriting a worker's scratch file, or an orphaned child of a killed gate writing over the run
+  that replaced it — either way a worker reads the survivor as its own, including a gate exit code from a
+  different run, which merges on a green nobody earned → artefacts named for both the worktree and the
+  attempt, plus the gate-root check, which is the half observed to actually catch it.
+- Worktree cleanup deleting *through* a link into the shared tree → the worker unlinks before reporting
   done, and the cleanup path disarms before removing.
-- A change merged out from under a worker still working on it → it is published as a draft and marked ready
-  only as the author's last act, which the host enforces by refusing to merge a draft. **Except on a fix
-  dispatch, where the flag was already set by somebody else and protects nothing** — and the same flag
-  strands a finished change when its author goes silent. Both are under *Publishing the change*.
-- "Green locally" merged into a red CI gate → gate the transitive surface; merge on CI, not on the hand-off; a real
-  failure gets a fix worker, never an override.
+- A change merged out from under a live worker → published as a draft, marked ready only as the author's
+  last act, which the host enforces by refusing to merge a draft. **Except on a fix dispatch, where the
+  flag was already set by somebody else** — and the same flag strands a finished change when its author
+  goes silent.
+- "Green locally" merged into a red CI gate → gate the transitive surface; merge on CI, not on the
+  hand-off; a real failure gets a fix worker, never an override.
 - A passing synthetic test that routes around the real bug → reproduce the actual failing path.
 - Clusters split that should be one change, or the reverse → the cluster reviewer pre-validates shape.
 - Stalled workers losing analysis → findings first, and one-item-at-a-time tracker creates.
-- Re-discovering known issues → name recent landings and prior findings.
-- A brief that was accurate when written but stale when read → the item governs the brief, newest material found by tracker timestamp.
+- A brief accurate when written but stale when read → the item governs the brief.
 - Generic prompts → require `file:line` citations and concrete fix sketches.
-- A measurement worker iterating until the number looked right → Shape 6: the controls arbitrate, a refusal is a
-  deliverable, and the rig does not change mid-window.
+- A measurement worker iterating until the number looked right → Shape 6: the controls arbitrate, a
+  refusal is a deliverable, and the rig does not change mid-window.
 
 ---
 
-*Record three or four exemplary dispatches per project — a solo, a cluster, an audit, a fix. A few good examples teach
-a new mayor more than thirty mediocre ones.*
+*Record three or four exemplary dispatches per project — a solo, a cluster, an audit, a fix. A few good
+examples teach a new mayor more than thirty mediocre ones.*

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -262,272 +262,204 @@ the same number. The two readings differ by one question, and the answer is in t
 
 ### Merging
 
-Check also that the diff matches its tracker item, that scope did not sprawl, that
-failure output stays actionable, and that the quality-gates section is present.
+Check also that the diff matches its tracker item, that scope did not sprawl, that failure output
+stays actionable, and that the quality-gates section is present.
 
-**Read the FILE LIST against the item, not just the count — "scope did not sprawl" does not
-cover it.** Sprawl is EXTRA work and announces itself, because extra files read as new work. The
-opposite shape does not: a change that silently REVERTS merged work is green, well-formed,
-compiles, and passes every gate the tree has. One here carried twenty-four files at 611 insertions
-against 910 deletions, out of a worktree whose base had moved, putting back a symbol belonging to
-a retired subsystem — the branch's content was OLDER than the trunk's. **So a path the item does
-not explain is a finding whichever DIRECTION it runs**, and direction is the test rather than
-size: for a surprising file, ask whether something PRESENT on the branch is ABSENT from the trunk.
+**Read the FILE LIST against the item, not just the count.** Sprawl is EXTRA work and announces
+itself. The opposite shape does not: **a change that silently REVERTS merged work is green,
+well-formed, compiles, and passes every gate the tree has** — one carried 611 insertions against 910
+deletions out of a worktree whose base had moved, putting back a symbol of a retired subsystem. So a
+path the item does not explain is a finding whichever DIRECTION it runs, and direction is the test
+rather than size: for a surprising file, ask whether something PRESENT on the branch is ABSENT from
+the trunk.
 
 **Do not reach for a gate here.** A revert is mechanically indistinguishable from a change that is
 not one; the only discriminator is whether the reader EXPECTED those paths, so a gate would be a
-control that cannot catch its own case. The worker-side half — diff against the merge base before
-pushing — is on every brief; this is the mayor-side half, for the worker that never ran it.
+control that cannot catch its own case.
 
 Merge every green change **regardless of author**, including the operator's own.
 
-**GREEN AND MERGEABLE ARE SEPARATE FACTS, and the five clauses only ever measured the
-first.** A fully green rollup can still conflict with the trunk: the clauses read the
-CHANGE's own checks, and not one of them looks at what LANDED while those checks were
-running. So ask the trunk directly before merging — `git merge-tree --write-tree <trunk>
-<head>` writes a tree revision and exits zero when the merge is clean.
+**GREEN AND MERGEABLE ARE SEPARATE FACTS, and the five clauses only ever measured the first.** The
+clauses read the change's own checks; not one looks at what LANDED while those checks ran. Ask the
+trunk directly — a three-way merge into a scratch tree answers without touching your checkout.
 
-**Its failure exit is TWO different verdicts, and the status cannot tell them apart.** A
-real conflict and a head revision your checkout has never heard of both come back
-non-zero. **Read the message, not the code.** *not something we can merge* is the second
-case — the object is simply missing locally, which is routine whenever the change was
-rebased through the host's own update-branch control rather than by a worker's push,
-because no worktree here ever fetched the commit that created. Fetch that head and ask
-again; the same command then answers honestly. Measured here: a change reported
-unmergeable on that message alone, and after its head was fetched the identical command
-returned a tree revision and the change merged cleanly. Reading the first answer as a
-conflict would have dispatched a rebase worker at a change that needed nothing — which is
-the expensive direction, because the worker finds nothing wrong and says so.
+**Its failure exit is TWO different verdicts and the status cannot tell them apart: read the
+message, not the code.** A real conflict and *a head revision your checkout has never heard of* both
+return non-zero, and the second is routine whenever the change was rebased through the host's own
+update-branch control rather than by a worker's push. Fetch that head and ask again. Reading the
+first answer as a conflict dispatches a rebase worker at a change that needs nothing — the expensive
+direction, because the worker finds nothing wrong and says so. **Only a genuine conflict warrants
+that dispatch.**
 
-Only a genuine conflict warrants that dispatch.
+**Prefer server-side head-branch deletion to a client-side delete flag.** A branch still checked out
+in a worktree cannot be deleted locally, and clients typically abandon the *remote* deletion along
+with the local one — so the flag orphans a remote branch on every merge whose worker has not yet
+reported. **A surviving remote ref is never grounds to reap a worktree early.**
 
-**Prefer server-side head-branch deletion over a client-side delete flag.** A branch still
-checked out in a worktree cannot be deleted locally, and clients typically abandon the *remote*
-deletion along with the local one — so the flag orphans a remote branch on every merge whose
-worker has not yet reported. The repository setting has none of that: the server deletes the head
-branch as the merge lands and does not care what a worktree holds. Zero orphans by construction.
-A manual remote delete then survives only for a ref that outlives a verified merge — head-ref
-protection, or a head living in a fork the server will not touch. **A surviving remote ref is
-never grounds to reap a worktree early.**
+**"Base branch was modified" usually means stale — until something is moving the base.** The
+rejection reads like a lost race, so the reflex is to retry; usually the branch is simply behind and
+the remedy is to update it. But any automation that writes to the trunk after a merge makes the race
+real, and then no amount of updating fixes it — one change was refused thirty times, and updating
+made it worse, because CI restarts and another automated commit lands inside that window. **Merge
+the whole queue FIRST, then give the straggler a genuinely empty window.** If it refuses more than
+about three times while blocking nothing, **shelve it**: persistence on an item blocking nothing is
+its own gold-plating.
 
-**"Base branch was modified" usually means stale — until something is moving the
-base.** The rejection reads like a lost race, so the reflex is to retry; seven
-retries here proved otherwise, the branch was simply behind, and the remedy is to
-update it and re-check.
-
-But any automation that writes to the trunk after a merge makes the race real. A post-merge hook
-that commits asynchronously means the base never holds still during a burst, and the next merge is
-refused for a reason no amount of updating fixes — **one change here was refused thirty times**,
-and updating the branch made it worse before better, because CI restarts and another hook commit
-lands inside that window. The remedy is counterintuitive: **merge the whole queue FIRST, then give
-the straggler a genuinely empty window.** Raising its priority is just more attempts against a
-moving base. If a change refuses more than about three times while blocking nothing, **shelve it**
-— persistence on an item blocking nothing is its own gold-plating.
-
-**A change that reports merge CONFLICTS is a third refusal, and neither remedy above fits — its
-author does.** Where several green changes share one serial-lane file, each merge flips the
-remaining ones to conflicting; that is the lane working as designed, not a defect, and the
-conflict is one hunk in one commit. It is not a red change either, so the fix-worker path under
-*When a change is not green* is not the move. Message the author first — a live worker resumes
-in its own worktree with its context intact, and two such resumes here each recovered in minutes
-— and dispatch a fix worker onto the existing branch only when the author is gone. Brief either
-one to keep BOTH intents, hunk by hunk, never taking a side wholesale. **And state your believed
-cause as a claim**: the mayor's attribution of a conflict is a premise like any other, made at
-the moment of least information, and both authors resumed here refuted the stated cause and
-found the real one — a different sibling's landing than the one just merged.
+**A change reporting merge CONFLICTS is a third refusal, and its author is the remedy.** Where
+several green changes share one serial-lane file, each merge flips the rest to conflicting — the
+lane working as designed, and one hunk in one commit. It is not a red change, so the fix-worker path
+does not apply. Message the author first; a live worker resumes with its context intact. Dispatch a
+fix worker onto the existing branch only when the author is gone, and brief either to keep BOTH
+intents hunk by hunk, never taking a side wholesale. **State your believed cause as a claim** — an
+attribution made at the moment of least information, and authors resumed here have refuted it and
+found the real one.
 
 ### After each merge
 
-**Fetch the trunk, then fast-forward onto the remote-tracking ref** — two commands rather
-than a pull, chained so that a failed fetch cannot be followed by a merge against a stale
-ref. Name remote and branch on the fetch; the bare form silently no-ops when an automated
-push races it. Then **verify the tree, not the message**: compare the local head against
-the remote head. A pull printed `Updating <old>..<new>` twice in one session here while
-the head had not moved at all.
+**Fetch the trunk, then fast-forward onto the remote-tracking ref** — two commands rather than a
+pull, chained so a failed fetch cannot be followed by a merge against a stale ref. Name remote and
+branch on the fetch; the bare form silently no-ops when an automated push races it. Then **verify
+the tree, not the message**: compare the local head against the remote head, because a pull will
+print `Updating <old>..<new>` on a head that did not move.
 
-If they disagree, **read both again before believing it.** Any automation that writes
-to the trunk after a merge can land between the two reads, so a perfectly synchronised
-checkout reports a mismatch. One disagreement is not evidence; this false alarm fired
-four times in one session and was never real.
-
-Read the *fetch's* own exit code for the same reason. A failed fetch and a subsequent
+**If they disagree, read both again before believing it.** Automation writing to the trunk can land
+between the two reads, so a perfectly synchronised checkout reports a mismatch. One disagreement is
+not evidence. Read the *fetch's* own exit code for the same reason: a failed fetch and a subsequent
 "Already up to date" print into the same buffer, and the reassuring line is the lie.
 
-**Do not collapse that pair back into a pull.** A pull picks its merge target out of a scratch
-file any concurrent git process in the same checkout can rewrite — most exposed being the shared
-checkout every agent reaches into to add a worktree — and a captured target does not fail
-honestly. Measured here: in one arrangement it silently fast-forwarded the trunk **onto a feature
-branch**; in another it aborted wearing the divergence message below, on a clean tree zero commits
-ahead, where that remedy is inert. **A failure that borrows another cause's message cannot be
-discriminated by message text**, so the repair is to retire the command that reads the shared
-file, not to add a third case. A remote-tracking ref cannot be captured that way: it is written
-atomically, and every concurrent fetcher sets it to the trunk head or newer, both of which still
-fast-forward. The exposure **grows with fleet size** — dispatching immediately after merging puts
-the concurrent fetches and the fast-forward in the same seconds.
+**Do not collapse that pair back into a pull.** A pull picks its merge target out of a scratch file
+any concurrent process in the same checkout can rewrite — most exposed being the shared checkout
+every agent reaches into to add a worktree — and a captured target does not fail honestly: measured
+once silently fast-forwarding the trunk **onto a feature branch**, and once aborting with the
+divergence message below on a clean, undiverged tree where that remedy is inert. **A failure that
+borrows another cause's message cannot be discriminated by message text**, so retire the command
+that reads the shared file rather than adding a third case. A remote-tracking ref cannot be captured
+that way. The exposure grows with fleet size.
 
-**An aborted fast-forward has two causes with different remedies, and the message says
-which** — and it says which only because the pair above no longer reads the shared file.
-Both reproduce unchanged under that pair, so the change costs nothing here. Naming remote
-and branch cures the silent no-op but neither abort, so read the text before reaching for a
-familiar fix:
+**An aborted fast-forward has two causes with different remedies, and the message says which** — but
+only because the pair above no longer reads the shared file. Naming remote and branch cures the
+silent no-op and neither abort, so read the text before reaching for a familiar fix:
 
-* **"Local changes would be overwritten"** — uncommitted tracker state. Checkpoint it
-  first, *then* clear, *then* retry. Clearing before checkpointing reverts whatever the
-  tracker just recorded.
-* **"Not possible to fast-forward"** — genuine divergence, usually your own checkpoint
-    against commits that landed while you made it. Rebase, then **push**: the rebase
-    replays your commit on top and leaves you ahead by one, and the equality check cannot
-    pass until it lands. **That intermediate state is expected, not a second failure.**
-    Both obvious reflexes are wrong — repeating the pull stays ahead, and forcing equality
-    discards the very checkpoint the drill exists to protect.
+* **"Local changes would be overwritten"** — uncommitted tracker state. Checkpoint, *then* clear,
+  *then* retry. Clearing first reverts whatever the tracker just recorded.
+* **"Not possible to fast-forward"** — genuine divergence, usually your own checkpoint against
+  commits that landed while you made it. Rebase, then **push**: you are left ahead by one and the
+  equality check cannot pass until it lands. **That intermediate state is expected, not a second
+  failure.** Both reflexes are wrong — repeating the pull stays ahead, forcing equality discards the
+  checkpoint the drill exists to protect. **Rebase onto the remote-tracking REF, not with a pull
+  carrying a rebase flag**, which reads the same shared file this drill just retired: **a remedy
+  inherits the hazards of whatever it reads**, so choose it by what it reads rather than by what it
+  is called.
+* **A truncated abort, or a ref-level race** — re-fetch and re-read. Reach for neither remedy above.
 
-    **Rebase onto the remote-tracking REF, not with a pull.** *Rebase* names an outcome, and
-    the command that first comes to hand for it is a pull carrying a rebase flag — which reads
-    the same shared scratch file this drill just retired for the fast-forward. The argument two
-    paragraphs up applies here unchanged and is easy to miss, because it was made about the
-    step rather than about the remedy for that step's own failure: retiring the reading command
-    in one place and readmitting it in the next is no protection at all. Measured under a
-    saturated fleet: with remote and branch both named, the pull form aborted a second time
-    wearing the contamination message — peers adding worktrees had left several refs in that
-    file — while rebasing onto the ref succeeded immediately on the same tree. **A remedy
-    inherits the hazards of whatever it reads**, so choose it by what it reads, not by what it
-    is called.
+**Never wire a remedy behind a pipe.** `pull … | tail -1 || fallback` never runs the fallback,
+because the pipeline's status is the filter's and the filter succeeded.
 
-* **A truncated abort, or a ref-level race** — re-fetch and re-read. Do not reach for
-    any remedy above.
-
-**Never wire a remedy behind a pipe.** `pull … | tail -1 || fallback` never runs the
-fallback, because the pipeline's status is the filter's and the filter succeeded.
-
-Then verify the worker closed its tracker item (close it with a concrete cross-reference
-if not). **If anything was routed into this change** — a finding messaged to its holder
-rather than dispatched — **verify it landed in the diff** before closing its owner. A
+Then verify the worker closed its item (close it with a concrete cross-reference if not). **If
+anything was routed into this change, verify it landed in the diff** before closing its owner — a
 routed item is exactly the kind a worker may reasonably decline.
 
 ### When a change is not green
 
-A real, repeated failure on the touched surface is not a flake and is never an override
-candidate. Once you have established the failure is the change's own and not the trunk's
-— clause 2 above says what establishes it, and a gate that never ran on the trunk does
-not — dispatch a fix worker onto the **existing** branch that runs the **actual** failing
-gate, not a proxy that already passed.
+A real, repeated failure on the touched surface is not a flake and is never an override candidate.
+Once you have established the failure is the change's own and not the trunk's — clause 2 says what
+establishes it, and a gate that never ran on the trunk does not — dispatch a fix worker onto the
+**existing** branch, running the **actual** failing gate rather than a proxy that already passed.
 
-**If that change is already marked ready, convert it back to draft first, and confirm the state
-took.** The flag is set by whoever finished last, so a fix dispatch inherits one the previous
-author set and the interlock is open before the second worker starts — [the exception the
-criterion names](#the-criterion), and the only one this loop has to remember, because this loop
-is what creates it. It belongs here rather than in the brief: the worker cannot set a flag that
-is already ready, and by the time it could, the merge has landed underneath it.
+**If that change is already marked ready, convert it back to draft first and confirm the state
+took.** The flag is set by whoever finished last, so a fix dispatch inherits one the previous author
+set and the interlock is open before the second worker starts. It belongs to the dispatcher rather
+than to the brief: the worker cannot set a flag that is already ready, and by the time it could the
+merge has landed underneath it.
 
-**But a red on a change still published as a DRAFT belongs to its author, for as long as that
-author is alive.** The draft flag means the worker has not finished, and a worker briefed to push as
-it goes will publish reds by design: one here deleted a gate's witness in its first commit and the
-gate itself in its third, so the draft read three required jobs red for the twenty minutes between,
-each one a job the change was in the middle of removing. A fix worker dispatched onto that branch is
-a second worker on one branch, which is the collision every fence exists to prevent, and it arrives
-wearing the loop's own instruction. So on a draft: read the failing job against the diff so far —
-a red whose subject the change is deleting is sequencing, not a defect — and either wait for the
-ready mark or message the author. The fix-worker path opens only once the author has marked the
-change ready, or has stopped, which the stranded sweep establishes and this loop does not.
+**But a red on a change still published as a DRAFT belongs to its author while that author is
+alive.** A worker briefed to push as it goes publishes reds by design — one deleted a gate's witness
+in its first commit and the gate itself in its third, so three required jobs read red for the twenty
+minutes between, each a job the change was in the middle of removing. A fix worker sent there is a
+second worker on one branch, the collision every fence exists to prevent, arriving wearing this
+loop's own instruction. **So on a draft, read the failing job against the diff so far** — a red whose
+subject the change is deleting is sequencing, not a defect — and wait for the ready mark or message
+the author.
 
-**A failure BEFORE any repository code ran is the second case, and the failing step names
-itself** — an action download rate-limited, a runner setup step dying. The diff cannot have caused
-it, so no second observation is needed: re-run the failed jobs and hold the re-run to the same
-clauses. **But re-running is not a cure** — when SEVERAL changes fail that way rather than one job
-twice, fleet size is the cause and the mayor says so.
+**A failure BEFORE any repository code ran is the second case, and the failing step names itself**
+— a dependency download rate-limited, a runner setup step dying. The diff cannot have caused it, so
+no second observation is needed: re-run and hold the re-run to the same clauses. **But re-running is
+not a cure** — when SEVERAL changes fail that way rather than one job twice, fleet size is the cause
+and the mayor says so.
 
-**And a check that never TERMINATES is a third case that neither remedy fits.** It has not
-failed, so nothing above is triggered; it has not passed, so clause 3 rejects the change for
-as long as it runs — which is exactly when the pressure to override arrives. **It is not a
-sixth clause**: clause 3 already blocks the change, and correctly, and what is missing is only
-what to DO about it.
+**A check that never TERMINATES is a third case neither remedy fits.** It has not failed, so nothing
+above triggers; it has not passed, so clause 3 blocks the change for as long as it runs — which is
+exactly when the pressure to override arrives. It is not a sixth clause: clause 3 already blocks
+correctly, and what is missing is only what to DO.
 
-**Recognise it on the clock, against that job's OWN normal cost — measured, never
-remembered.** A remembered constant cannot detect a delta, and job costs move; the recent
-successful runs of the same job are the baseline, and reading them costs one query. Measured
-here: a job whose last successes took 1.4 to 1.7 minutes was forty-nine minutes in and still
-going. **A timeout kill usually reports as CANCELLED rather than as a failure**, which clause
-2 handles correctly — cancelled is not passed — while saying nothing about *why*. Elapsed
-time against the job's declared cap tells them apart: landing ON the cap is a timeout kill,
-finishing well inside it is a superseding push or a hand cancel, and both numbers are
-readable. Expect rollup jobs to go red seconds afterwards; those fail BECAUSE of the
-cancellation and are consequences rather than findings, so counting them as independent
-failures overstates the problem and points at the wrong remedy.
+**Recognise it on the clock, against that job's OWN normal cost — measured, never remembered.** Job
+costs move, so a remembered constant cannot detect a delta; the job's recent successful runs are the
+baseline and reading them costs one query.
 
-**Then discriminate, because the two causes take opposite remedies.** UNRELATED jobs
-overrunning in the SAME run is infrastructure — a diff cannot slow two jobs that share no
-surface with it or with each other — so cancel and re-run, and hold the re-run to the same
-five clauses like any other. ONE job overrunning alone, on a surface the diff touches, is a
-hang the change introduced: dispatch a fix worker onto the existing branch that reproduces
-it, exactly as a failing gate does. **A "cancel and re-run" written without that
-discriminator is worse than no remedy at all**, because the reflex it teaches burns another
-wall-clock hour and hides the infinite loop a worker just wrote. Neither case is ever an
-override.
+**But a SKIPPED run is reported as a successful one, and it contributes a zero-length sample.**
+Where a job is conditional — surface-armed, path-filtered, gated on another job — most of its recent
+"successes" never executed, and their start and end times are equal. A baseline drawn from them
+collapses toward zero, after which every real run reads as overrunning by orders of magnitude. **It
+fails in the alarming direction**, manufacturing a hang rather than hiding one, and the remedy it
+invites is the cancel-and-re-run this section warns costs another wall-clock hour. **Discard the
+zero-length samples before averaging, and check the survivors are a plausible sample size** — one
+real run is a data point, not a baseline. The workflow's own total is a sanity check only: it bounds
+the job from above and can be dominated by something else.
 
-**A job with no declared timeout is the only reason this case needs a mayor-side remedy.** A
-capped job converts a wedge into a fast, legible failure inside its own cap and reports
-itself; an uncapped one inherits whatever the host defaults to, which is measured in hours,
-so nothing ever converts it and the check simply never terminates. Cap the jobs — and keep
-the remedy above for the ones that hang anyway.
+**A timeout kill usually reports as CANCELLED rather than as a failure**, which clause 2 handles
+correctly while saying nothing about *why*. Elapsed time against the job's declared cap tells them
+apart: landing ON the cap is a timeout kill, finishing well inside it is a superseding push or a
+hand cancel. Expect rollup jobs to go red seconds afterwards — those fail BECAUSE of the
+cancellation, so counting them as independent failures overstates the problem and points at the
+wrong remedy.
+
+**Then discriminate, because the two causes take opposite remedies.** UNRELATED jobs overrunning in
+the SAME run is infrastructure — a diff cannot slow two jobs that share no surface with it or with
+each other — so cancel and re-run, held to the same five clauses. ONE job overrunning alone, on a
+surface the diff touches, is a hang the change introduced: dispatch a fix worker that reproduces it.
+**A "cancel and re-run" written without that discriminator is worse than no remedy at all**, because
+the reflex burns another hour and hides the infinite loop a worker just wrote. Neither case is ever
+an override.
+
+**A job with no declared timeout is the only reason this case needs a mayor-side remedy at all.** A
+capped job converts a wedge into a fast, legible failure and reports itself; an uncapped one inherits
+a host default measured in hours. Cap the jobs, and keep the remedy above for the ones that hang
+anyway.
 
 ---
 
 ## 2. Dispatch
 
-**Re-read the raw ready list every tick.** Do not infer the backlog from
-notifications, and do not trust a filter that returned empty — an empty filter is not a
-dry backlog. One mayor under-saturated at one to three workers while a hundred items
-were ready, because a homegrown filter kept answering empty.
+**Re-read the raw ready list every tick.** Do not infer the backlog from notifications, and do not
+trust a filter that returned empty — an empty filter is not a dry backlog. One mayor under-saturated
+at one to three workers while a hundred items were ready, because a homegrown filter kept answering
+empty.
 
-**Read the host's alert channel before the ready list.** Where a nightly system of record
-reports its own failures somewhere the tracker is not — a hosted issue that the workflow opens
-and then edits in place, say — that report reaches no dispatch until something copies it across,
-because the loops read the tracker and the review queue and nothing else. Measured: an alerter
-opened its issue on the first red night, notified three more times across the week, and the
-redness was still found by hand on day seven, because nothing in the loop read the channel it
-wrote to. So the short tick makes one read of that channel, before the ready list, and ensures
-every open alert has exactly one open tracker item keyed on the alert's own URL. Once it does,
-later ticks do nothing: the alert stays the live counter and signature record, and the item is
-the dispatch edge, which the same tick can then fill. Two misreadings of that read both fail open.
-A failed read is "did not sweep this tick", never "nothing red" — an empty result on a clean exit
-is the only "nothing red" there is. And where the alert carries a recovery delay, closing only
-after several consecutive greens, "item closed, alert still open" is the expected state for the
-nights after a fix lands, not a new failure; re-file only when the alert itself says the failure
-has returned since the close, and never by reopening the closed item, whose close reason is a
-normative record. The query, the label and the field that carries the URL are repository values,
-and they live in the agent-instructions file, per the rule at the head of this page.
+**Where a system of record reports its own failures somewhere the tracker is not — a nightly alert
+channel, say — read that channel before the ready list.** The loops read the tracker and the review
+queue and nothing else, so such a report reaches no dispatch until something copies it across. Give
+every open alert exactly one open item keyed on the alert's own identifier; later ticks then do
+nothing, the alert staying the live counter and the item being the dispatch edge. Two misreadings
+both fail open: **a failed read is "did not sweep this tick", never "nothing red"**, and where the
+alert closes only after several consecutive greens, *item closed, alert still open* is the expected
+state after a fix lands rather than a new failure.
 
-**When that file carries no such values, the read is not owed — do not reconstruct one.** A
-repository whose alert channel has gone quiet may retire this read deliberately, and the
-retirement is spelled as the ABSENCE of those values rather than as a note saying so. That
-absence reads exactly like an oversight, and a standing loop prompt can go on naming the sweep
-long after the values it pointed at are gone — so the coordinator looks where they should be,
-finds nothing, and invents a query. **An invented query is worse than no read at all.** Measured:
-the one invented was the label-filtered issue index, which that repository's own alerter refuses
-in a source comment — the index is eventually consistent, and had already made the alerter open a
-duplicate alert when it lagged. It then returned a reassuring empty result on every tick of a long
-session. THE EMPTY RESULT WAS CORRECT, which is why nothing on screen betrayed it: the channel
-genuinely held no open alerts, so the wrong instrument and the right one agreed, and their
-agreement is not evidence. Values present, do the read; values absent, skip it and report nothing.
+**Where your agent-instructions file carries no query for that channel, the read is not owed — do
+not reconstruct one.** A project whose alert channel has gone quiet retires this read by the ABSENCE
+of those values, which reads exactly like an oversight, so the coordinator looks, finds nothing, and
+invents a query. **An invented query is worse than no read at all**, and its failure is undetectable
+when the channel is genuinely empty: the wrong instrument and the right one agree, and their
+agreement is not evidence.
 
-**Read the newest note first, and order the item by the tracker's own timestamps** — not by
-position, and not by dates written in the prose. The mechanics are set out for the worker under
-[*Common preamble*](dispatch-prompt-template.md#common-preamble) in
-`dispatch-prompt-template.md`, and they bind
-the mayor reading the item exactly as they bind the worker: `bd show | tail` is not a
-read-the-newest method, `bd history <id>` lists real mutation times newest-first,
-`bd history <id> --json` carries the snapshot that says *what* changed, and you walk adjacent
-pairs newest-first to the first change to a text-bearing field.
+**Order each item by the tracker's own timestamps, not by position and not by dates in its prose.**
+The mechanics are set out for the worker under [*Common
+preamble*](dispatch-prompt-template.md#common-preamble) and bind the mayor identically.
 
-**A child bead is one of two carriers, and naming one reads as exhaustive.** Re-enumerate an
-item's children — a ruling is sometimes recorded as a new child rather than as a note — but a
-ruling that discharges a slice is more often the CLOSE REASON of a bead already CLOSED and linked
-as a *dependency*, which is normative text rather than an archival note. So read the dependency
-list as well as the children, and read each linked item's status and close reason before you brief
-from the item's own words. **Enumerating by id prefix is not enumerating**: a generated id does not
-share the parent's prefix, so a prefix filter returns the children while silently omitting the bead
-that governs. That is how one dispatch went out to delete a tree that a closed dependency had ruled
-KEEP, its ruling having sat on the item's own dependency list the whole time.
+**A ruling can arrive as a child item OR as the close reason of a CLOSED dependency**, and the
+second is commoner for a ruling that discharges a slice — normative text rather than an archival
+note. Read the dependency list as well as the children, with each linked item's status and close
+reason. **Enumerating by id prefix is not enumerating**: a generated id need not share the parent's
+prefix, so a prefix filter returns the children while silently omitting the item that governs.
 
 Filter out before shaping anything:
 
@@ -535,192 +467,117 @@ Filter out before shaping anything:
 * items gated on another's merge;
 * items whose surface a live worker holds;
 * items colliding in a hot-zone file;
-* items whose resource is exclusive and currently contended — but this exclusion has a release
-  condition, and it is the only one on the list that the loop itself must eventually lift. Where
-  the exclusive items are all that REMAINS, the filter has stopped protecting the fleet and is
-  simply refusing the backlog. Say so, stop refilling, let the fleet drain, and take that work
-  deliberately. A filter with no release condition becomes a permanent fence.
+* items whose resource is exclusive and currently contended — **the only exclusion with a release
+  condition the loop must eventually lift.** Where the exclusive items are all that REMAINS, the
+  filter has stopped protecting the fleet and is simply refusing the backlog: say so, let the fleet
+  drain, and take that work deliberately. A filter with no release condition becomes a permanent
+  fence.
 
-**A ready list overstates readiness by a lot.** In practice roughly a fifth of "ready"
-items were genuinely dispatchable; the rest were fenced by something the tracker cannot
-represent. **Record the fence on the item** when you find it, with what clears it, or
-every tick re-derives the same conclusion.
+**A ready list overstates readiness by a lot** — roughly a fifth of "ready" items were genuinely
+dispatchable, the rest fenced by something the tracker cannot represent. **Record the fence on the
+item it fences, with what clears it, at the top, and in the same words every time.** The tick that
+reads it back is scanning rather than reading, so a fence written truthfully in the middle of a long
+field does not exist for the next tick — and a fence recorded on the item that *causes* it rather
+than the item it *blocks* is never met by its own reader. What does the work is the sameness rather
+than the wording.
 
-**And record it where a scan will find it, on the item it fences, in the same words every
-time.** The tick that reads a fence back is scanning rather than reading — it has the whole
-list to get through — so a fence written truthfully in the middle of a long field is a fence
-that does not exist for the next tick, and the rule above is satisfied while its stated purpose
-fails. Measured on one item: probed for the six phrases its peers used to mark exactly that
-state, all six came back absent, and it read as the only free item on the board — the answer
-was there, in different words, and cost a full read of twenty-odd thousand characters to reach
-a conclusion one line could have given. A second item the same session cost a full read for the
-neighbouring reason: the sentence naming its hold sat on the item that fenced it rather than on
-the item fenced, where its own reader would never meet it. Pick one marker, put it at the top,
-and reuse it verbatim. What does the work is the sameness rather than the wording, because a
-scan is only ever as good as its phrase roster and it answers *clear* in the same voice whether
-the item is clear or the roster is short.
+**But a marker makes a DISCHARGED hold findable exactly as well as a live one.** So the marker is
+written by whoever SETS the hold and **struck by whoever discharges it, in the same act** — not left
+standing with a correction beneath. Where the tracker will not let you edit the original, append the
+marker's negation in the same words, so a scan returns EVERY occurrence and **the newest governs**; a
+hold can be set, discharged, then set again on a different question. **Treat a banner with no
+discharge beneath it as a claim about the past.**
 
-**But a marker makes a DISCHARGED hold findable exactly as well as a live one, and that is the
-cost of the rule above rather than an argument against it.** A scan cannot tell the two apart:
-the banner is the same string either way, and the note that discharged it is somewhere below,
-where the scan was introduced precisely so nobody has to read. Measured: an item sat in the
-awaiting-a-decision pile for a whole session, reported to the operator that way every tick,
-while a note further down recorded the ruling and said in terms that the header was discharged
-and the work should be dispatched. The scan found the header. It was right that the header was
-there and wrong about everything that mattered.
+**Verify before dispatching, not after.** Check that the alleged broken symbol, missing file or stale
+convention is still there. If it landed already, close as a verified duplicate.
 
-So the marker is written by whoever SETS the hold, and **it is struck by whoever discharges it,
-in the same act** — not left standing with a correction beneath. If your tracker will not let you
-edit the original text, add the marker's negation in the same words, so that a scan for the
-banner returns EVERY occurrence and **the newest one governs** — a hold can be set, discharged,
-and then set again on a different question, so finding a discharge is not finding the end. **Treat
-a banner with no discharge beneath it as a claim about the past**: check who set it and whether
-what they were waiting for has since happened, before you report it as the current state.
+**A count is a claim too, and a symbol-shaped check does not test it.** A census item asserts a
+number, so the symbol still resolves while the count is zero or triple. Re-run the item's own census
+at the current tip.
 
-**Verify before dispatching, not after.** Grep that the alleged broken symbol, missing
-file or stale convention is still there. If it already landed, close as a verified
-duplicate.
+**Exclude any generated export from a tree-wide census.** A whole-database export inside the working
+tree carries every title, description and comment, so it matches almost any identifier — inflating
+the census into something that reads exactly like a correct one and sends its worker to sites that
+do not exist, while flooding a context-bounded worker with tracker rows. Exclude it in the brief as
+much as in your own check.
 
-**A count is a claim too, and a symbol-shaped grep does not check it.** A census item
-("54 chains", "15 hits", "eleven sites") asserts a number, not a symbol, so the symbol
-still resolves while the count is zero or triple. Re-run the item's own census at the
-current trunk tip.
-
-Measured drifts in one session: 8 → 9, "four hits" → 23 lines, "roughly 6–10" → 23,
-"4 of 21 cached" → 13 of 21. Two items once went out in one wave against work merged
-fifteen hours earlier; both workers returned a correct "already fixed", so the waste was
-two dispatches rather than a wrong result.
-
-**Exclude any generated export from a tree-wide census.** Where the tracker keeps a
-whole-database export inside the working tree, it carries every title, description and comment
-and therefore matches almost any identifier a census greps for. Both halves of the cost are
-real and the second is the dangerous one: one such grep returned a hundred kilobytes of tracker
-rows before a single real hit, a material loss in a context-bounded worker; and nothing in the
-output announces that a tracker row is not a source file, so an inflated census reads exactly
-like a correct one and sends its worker looking for sites that do not exist. Exclude it in the
-brief as much as in your own check.
-
-**The sibling that discharges an item is usually the one whose fence sent the work
-elsewhere.** A tree fenced off from item A is exactly the tree item B is free to take.
-Read *across* a split's siblings before dispatching any one child, and treat a parent's
-remainder table as stale until re-derived.
+**The sibling that discharges an item is usually the one whose fence sent the work elsewhere.** A
+tree fenced off from item A is exactly the tree item B is free to take. Read *across* a split's
+siblings before dispatching any child, and treat a parent's remainder table as stale until
+re-derived.
 
 ### Shape and saturation
 
-Target a fixed number of concurrent workers — six is a workable ceiling for one
-operator — and refill the instant a slot frees. Dispatch low-priority items to stay
-saturated; the goal is a backlog trending to zero.
+Target a fixed number of concurrent workers — six is a workable ceiling for one operator — and
+refill the instant a slot frees. Dispatch low-priority items to stay saturated; the goal is a
+backlog trending to zero.
 
-**A heavyweight gate is an exclusive resource, and that ceiling does not bound it.** The
-parallel-or-sequential split reasons about *surfaces*; a gate heavy enough that two runs
-cannot coexist is contention for the *machine*, so six workers on six disjoint surfaces can
-still wedge one another inside it — measured once, and both runs hung rather than failed.
-Sequence dispatches that will all run one, or take the re-run knowingly. **This is the
-constraint a measurement window is already fenced under, seen from the other side**: a window
-is held for a quiet machine, and a heavyweight gate is what makes the machine loud. Keep one
-vocabulary for the two rather than inventing a second.
+**Contention comes in four shapes and the ceiling bounds only the first.**
 
-**And the fleet shares one ALLOWANCE — the same shape a third time, and the one the ceiling
-hides best.** Surfaces are contention for files and a heavyweight gate is contention for the
-machine; the account quota every worker draws on is contention for a resource with no local
-evidence at all, since nothing in a worktree, a gate log or a run listing says how much of it
-is left. So N workers are not N independent bets — they fail TOGETHER, mid-run, on a limit none
-of them approached alone. Measured here: a saturated fleet of six died inside the same minute,
-three of them holding work that was not on the remote. **The remedy is not a smaller fleet**,
-which would trade a recoverable failure for a permanently slower one; it is that *push
-continuously* is what makes a fleet-wide kill survivable. Read a worker that has not pushed for
-a long stretch as the exposure it is, and expect the salvage under *The stranded sweep* to be
-wanted for the whole fleet at once rather than for one worker.
+1. **Surfaces** — contention for files. This is what the parallel-or-sequential split reasons about.
+2. **A heavyweight gate** — contention for the MACHINE. Six workers on six disjoint surfaces can
+   still wedge one another inside one, and a wedge presents as a hang rather than a failure.
+   Sequence dispatches that will all run one, or take the re-run knowingly.
+3. **The shared ALLOWANCE** — a quota with no local evidence at all, since nothing in a worktree, a
+   gate log or a run listing says how much is left. N workers are therefore not N independent bets:
+   they fail TOGETHER, mid-run, on a limit none approached alone. **The remedy is not a smaller
+   fleet**, which trades a recoverable failure for a permanently slower one; it is that *push
+   continuously* makes a fleet-wide kill survivable, and that salvage is then wanted for the whole
+   fleet at once.
+4. **The tracker itself — where YOU are the competitor.** The first three degrade the workers; this
+   one degrades the mayor, because a saturated fleet reads and writes the item store continuously
+   and your own queries queue behind it.
 
-**And the fourth shape is the one where YOU are the competitor: the tracker itself.** The
-three above degrade the workers. This one degrades the mayor, because a fleet at the ceiling
-is a fleet reading and writing the item store continuously — every brief's history walk, every
-verdict, every close — and the mayor's own queries queue behind them. Measured at six workers:
-four consecutive coordinator commands exceeded a two-minute ceiling in one cycle, including a
-plain listing and, with some irony, the note recording this observation; all are second-scale
-on an idle fleet.
+**What makes the fourth worth writing down is the misreading, not the slowness.** A timeout on the
+item store presents exactly as a corrupt or wedged store, and both reflex remedies are wrong:
+re-running adds load to the overloaded thing, and *restoring the store's export from version-control
+history* looks like recovery while silently reverting every item recorded since that revision.
+**Treat a coordinator timeout as contention until something else proves corruption**, and ask the
+store one thing per command while saturated.
 
-**What makes it worth writing down is not the slowness but the misreading.** A timeout on the
-item store presents exactly as a corrupt or wedged store, and the reflex remedies are both
-wrong: re-running adds load to the thing that is overloaded, and *restoring the store's export
-from version-control history* — which looks like recovery — silently reverts every item recorded
-since that revision. **Treat a coordinator timeout as contention until something else proves
-corruption.** The one export observed apparently hung here had in fact completed.
+**Take a first look that does not touch the store**: compare the committed export against the
+working copy by size, and check the tree is clean. **But be exact about what that establishes** — it
+reads the export and the working tree, never the database, so it cannot tell you that a timed-out
+mutation committed, nor that the store holds nothing newer. **And equal counts are not equality**:
+one checkpoint passed its row-count floor at 1,938 against 1,938 having dropped three items and
+reverted two statuses, because the two sides substituted one-for-one. Size is a smoke test against
+truncation. Verify properly once the contention clears.
 
-**Take a first look that does not touch the store at all**: compare the committed export against the
-working copy by size or line count, and check the working tree is clean. That costs the resource
-under load nothing, and it answered in a second what re-running could not answer in three minutes.
-And ask the store for one thing per command while saturated: two queries chained in one invocation
-time out where each alone returns.
+**A queued measurement window makes an otherwise-free slot not free.** While a window needing a
+quiet machine is queued, an item whose gate is heavyweight is a cost charged to that window rather
+than a slot to refill: hold the fleet thin on purpose, record that on the window's item with what
+releases it, and keep dispatching work whose gates leave the machine quiet. **Quiet is a property of
+the whole set of gates an item arms, and no single classifier's answer describes that set** —
+enumerate them. Documentation usually clears the bar, but earn that per item rather than per
+category.
 
-**But be exact about what that look establishes, because it is easy to promote and the promotion is
-this document's own measured fault.** It reads the EXPORT and the working tree — never the database.
-So it cannot tell you that a mutation which timed out committed, that the store holds nothing newer
-than the file, or that the store is healthy. A clean tree proves only that the tracked export matches
-the revision. **And equal counts are not equality**: one project's checkpoint passed its row-count
-floor at 1,938 against 1,938 and silently dropped three items and reverted two newer statuses,
-because the two sides had substituted one-for-one. Size is a smoke test against truncation, which is
-what it was built for. Once the contention clears, verify the store against the export the way the
-project's own checkpoint does — by stable id, modification time and status — before saying anything
-is consistent or that nothing is owed.
+**And where a window registers that no peer WRITES inside its bracket, any write voids the run
+however cheap it is.** Merging a change and creating a worktree cost the machine almost nothing and
+are both writes, so a rule ordered by cost gets those exactly backwards: for such a window the fleet
+is empty rather than thin, and you merge nothing either. Have the window record that condition as a
+test — capturing the trunk tip and the worktree list at both brackets — so a violation is reported
+rather than assumed.
 
-**A queued measurement window makes an otherwise-free slot not free.** The drain clause in
-the filter list does not reach this case — it lifts only once the exclusive items are all
-that remains — so where ordinary work is still available, nothing above holds you back and
-refilling is itself what fences the window. While a window needing a quiet machine is queued
-and unstarted, an item whose gate is heavyweight is not a slot to refill but a cost charged
-to that window: hold the fleet thin on purpose, say so on the window's own item with what
-releases the hold, and keep dispatching work whose gate leaves the machine quiet.
-Quiet is a property of the whole set of gates an item arms, and **no single classifier's
-answer describes that set** — enumerate what covers the item and confirm each of those
-gates leaves the machine quiet. Documentation and prose usually clear that bar and are what
-keeps the fleet busy while a window waits, but earn that per item rather than granting it
-per category. The instruction is to stop making the machine loud, not to stop working.
-But that test answers loudness alone, and a window may register more than quiet. Where
-one registers that no peer writes inside its bracket, **any write voids the run however
-cheap it is** — merging a change and creating a worktree each cost the machine almost
-nothing and each is a write, so a rule ordered by cost gets those two exactly backwards;
-for such a window the fleet is empty rather than thin, and you merge nothing either. Have
-the window record that condition as a test rather than an assurance, capturing the trunk
-tip and the worktree list at both brackets, so a violation is reported rather than assumed.
+**An empty fleet is not a quiet machine.** The processes a gate starts routinely outlive it: the run
+ends, the change merges, the tree is reaped, and build servers and browsers stay resident with
+nothing pointing at them. So a mayor can hold the fleet thin, empty it, merge nothing, and still be
+handed a machine it has measured nothing about. **But counting those processes is the same error one
+level down** — presence is not load, and a count answers presence. One idle box carried a hundred-odd
+resident processes accounting for 0.14 of 2.6 busy cores between them, the largest consumer being an
+editor. **Measure LOAD, at both brackets.**
 
-**An empty fleet is not a quiet machine.** Everything above treats loudness as something
-the mayor causes — gates it arms, work it dispatches — so the remedy it reaches for is to
-dispatch less and finally nothing. That closure does not hold, because the processes a gate
-starts routinely outlive it: the run ends, the change merges, the worktree is reaped, and
-build servers and browser processes stay resident with nothing left pointing at them.
-Measured on an idle project with no worker in flight, no work outstanding and two worktrees
-removed minutes earlier: well over a hundred resident processes and a port still bound, not
-one of them a gate anybody had armed. So a mayor can follow every word of this section —
-hold the fleet thin, enumerate what the item arms, empty the fleet, merge nothing — and
-still be handed a machine it has measured nothing about. **But do not stop at counting
-those processes, which is the same error one level down and is how this clause was first
-written.** A five-second per-process census of that same box put total load at 2.6 cores of
-24: the hundred-odd processes accounted for 0.14 of it between them, the largest single
-consumer was an editor, and they were resident and IDLE. Presence is not load, and a count
-answers presence — so stopping there swaps one proxy for another while feeling like
-measurement, and it feels like measurement precisely because the instruction was to measure
-the machine. **Measure LOAD, at both brackets — not the fleet that was supposed to have
-quietened the box, and not a census of what happens to be resident on it.** The test
-named just above does not reach this: a trunk tip and a worktree list say nothing about
-what is still running.
+Pick the shape by kind first, then priority, then size — the shapes are under [*Dispatch
+shapes*](dispatch-prompt-template.md#dispatch-shapes).
 
-Pick the shape by kind first, then priority, then size. The shapes are under
-[*Dispatch shapes*](dispatch-prompt-template.md#dispatch-shapes) in `dispatch-prompt-template.md`.
-
-**The unit is the block, not the file.** The tell is that the two items read as *nominally
-different concerns*, which is why the collision is invisible at the moment you schedule them,
-and cheap to avoid only there. What it cost once, and the sequencing remedy, are under
-[*Fences*](dispatch-prompt-template.md#fences) in `dispatch-prompt-template.md` — deliberately not
-repeated here.
+**The unit is the block, not the file.** Two items that read as *nominally different concerns* can
+still land in the same paragraph, which is why the collision is invisible when you schedule them and
+cheap to avoid only there. The remedy is under [*Fences*](dispatch-prompt-template.md#fences).
 
 **Dispatch immediately on clear.** A clear, unblocked item goes out now, not next tick.
 
-**And write the dispatch's record line as you dispatch it.** The mayor-local line that lets a later
-tick find this worker's completion report is written here and read in the hygiene loop. What it must
-carry, which field the reap test uses, and why an untracked file needs its fields specified
-somewhere else at all, are under *Reaping* there — deliberately not repeated here, because a field
-list kept in two places is a field list that will disagree with itself.
+**And write the dispatch's record line as you dispatch it** — the line a later tick uses to find this
+worker's completion report. What it must carry is under *Reaping*, deliberately not repeated here: a
+field list kept in two places will disagree with itself.
 
 ### Routing a finding onto a live worker's file
 
@@ -787,157 +644,98 @@ directory you do not exclusively own**, not the one a rule happens to name.
 
 ## 3. Backlog reread
 
-**Dispatch reads the ready list; this loop reads everything else.** A ready list answers
-*what could go out right now*, so by construction it omits held items, blocked items and
-items a live worker already holds — and those are the ones that fail quietly. A dispatchable
-item that goes wrong is caught on the next tick, because the tick is looking straight at it;
-a held item that should have been released is caught by nobody, because nothing in the short
-loop reads it again.
+**Dispatch reads the ready list; this loop reads everything else.** A ready list omits held,
+blocked and worker-held items by construction — and those are the ones that fail quietly, because
+nothing in the short loop ever looks at them again.
 
-So on a medium cadence, read **all** open items from the raw list — not a saved filter, not
-the ready view, not what you remember filing. On each one order the material by the tracker's
-own timestamps rather than by position, and re-enumerate any children; *Dispatch* above
-explains why.
+So read **all** open items from the raw list — not a saved filter, not the ready view, not what you
+remember filing — ordering each by the tracker's timestamps and re-enumerating children, as
+*Dispatch* explains.
 
-**And every note you leave here becomes the NEWEST text on that item.** The currency rules are
-written for the reader, and reader and writer are not symmetric: a reader can walk past a stale note
-that sits below newer text, but nothing defends against a stale note that IS the newest text — a
-newest-first walk lands on it and stops. So a note built by re-deriving an item's state from its
-DESCRIPTION, rather than from the notes that already overtook it, is newer by timestamp and older in
-substance, and it buries the true state under your own signature. **The tell is mechanical: a note
-repeating a figure some later note retracted is a note that re-derived instead of re-checking.**
-Cite the check you made, or say plainly that you are summarising and from what.
+**Every note you leave here becomes the NEWEST text on that item.** Reader and writer are not
+symmetric: a reader can walk past a stale note below newer text, but nothing defends against a stale
+note that IS the newest text — a newest-first walk lands on it and stops. A note re-derived from the
+DESCRIPTION rather than from the notes that overtook it is newer by timestamp and older in
+substance. **The tell is mechanical: a note repeating a figure some later note retracted re-derived
+instead of re-checking.** Cite the check you made, or say you are summarising and from what.
 
-**And check, ONCE, whether your tracker's update verb appends or REPLACES.** Every rule above
-assumes an item accumulates — that notes accrete, that currency is a walk over that accumulation.
-That is a property of the TOOL, not of the item, and where the verb replaces, the walk you are
-teaching a reader to make runs over text you have already deleted. Expect no error and no warning:
-the item afterwards looks well-maintained, because what remains is your note, correctly formatted,
-saying something true. Two mayors on one project hit this two DAYS apart, and the second read the
-first's account of it four hours after repeating it. The short interval is the alarming half: a
-fresh, accurate account of the hazard was sitting in the same tracker and still did not reach the
-next reader, which is why this belongs here rather than only on an item. **If your tracker exports
-to a versioned file,
-the loss is fully recoverable** — the pre-damage text sits in any checkpoint predating the write, so
-this is a reason to check the verb rather than to panic about the damage.
+**So do not re-record a fence already recorded where a scan will meet it.** *Dispatch* says write
+the fence; this loop says re-test it. Run together on a cadence they produce a note per fenced item
+per pass, each true, each the newest text, until the item's newest layer is a stack of no-ops.
+**Write only what the item does not already carry** — a fence that CLEARED, a changed condition, a
+question its existing text leaves a reader to derive. *Unchanged* is a finding about your tick and
+belongs in the tick's report.
+
+**Check ONCE whether your tracker's update verb appends or REPLACES.** Every rule above assumes
+items accumulate; where the verb replaces, the walk you are teaching readers to make runs over text
+you deleted. No error, no warning, and the item afterwards looks well-maintained. Where the tracker
+exports to a versioned file the loss is fully recoverable, so this is a reason to check the verb
+rather than to fear the damage.
 
 Five things surface here and nowhere else.
 
-**A fence that has cleared.** The dispatch tick records the fence on the item and moves on,
-and nothing removes it when the condition is met. An item sequenced behind another's merge
-becomes dispatchable the moment that change lands, and the tracker does not notice: the
-short tick keeps skipping it because it is still not *ready*, and the note is the only
-record that anything is being waited on at all. Re-testing those conditions is this loop's
-most productive minute — **recording a fence is worth nothing without the loop that reads
-it back.**
+**1. A fence that has cleared.** The dispatch tick records a fence and nothing removes it when the
+condition is met; the item never returns to *ready*, so only a full read notices. **Recording a
+fence is worth nothing without the loop that reads it back.**
 
-**A dependency that has outlived what it was enforcing.** The item is still blocked, the
-thing it was waiting for shipped, and only a full read notices. The remedy, and why it
-needs its reasoning written onto the item, is under *Tracker mechanics* below.
+**2. A dependency that has outlived what it was enforcing** — the thing it waited for shipped, and
+the item is still blocked. Force the close and write the reasoning on the item (*Tracker mechanics*).
 
-**A closure that reverted.** Verifying at the moment you close is not enough, so re-check
-what this session closed. **But read the item's notes before re-closing anything** — what a
-reappearance usually is, and what the reflex destroys, is under *Tracker mechanics* below.
+**3. A closure that reverted.** Verifying at the moment you close is not enough. **Read the item's
+notes before re-closing anything** (*Tracker mechanics*). And the window is not your own tick: a
+closure can revert in a session nobody is auditing and sit reopened for days.
 
-**A hold that is costing more than it is holding.** Separate *needs a decision* from *needs
-work under a decision already made* — the second is dispatchable now, and it tends to sit in
-the first pile. For the ones that genuinely need the operator, record what the hold is
-costing: which items are behind it, and what stops if it stays. A hold with no cost written
-on it reads as free, and the cheapest-looking item in a list is the one that stays there
-longest.
+**4. A hold costing more than it is holding.** Separate *needs a decision* from *needs work under a
+decision already made* — the second is dispatchable now and tends to sit in the first pile. For the
+rest, record what the hold costs: which items are behind it, and what stops if it stays. A hold with
+no cost written on it reads as free.
 
-**But read WHY the hold was set before you write what it costs, because the count reads the
-same either way.** An oversight and a deliberate dormancy put the identical number of items
-behind a hold, so a queue length alone converts into urgency whichever one you are looking at.
-Where the item records a disposition — parked pending a decision nobody has taken yet, with a
-reactivation trigger and an act that does not expire — the queue behind it is parked by the same
-decision and there is no cost until somebody wants the thing it gates. **Cost is only cost
-against a want.** This is the harder half to catch, because the instruction above tells you
-exactly what to count, and counting feels like compliance: a mayor who stops the moment it has
-the number stops one paragraph short of the disposition that changes what the number means.
+**But read WHY it was set before writing what it costs, because the count reads the same either
+way.** An oversight and a deliberate dormancy put identical numbers behind a hold. Where the item
+records a disposition — parked pending a decision nobody has taken, with a reactivation trigger —
+the queue behind it is parked by the same decision. **Cost is only cost against a want**, and
+counting feels like compliance, so a mayor who stops at the number stops one paragraph short.
 
-**And the mirror of that case: a hold that expires on a DATE while its reason does not.** Where
-the tracker can defer an item until a date, the date is a hold it enforces and then silently
-stops enforcing. An item parked for something no date can settle therefore returns to the ready
-list on its own, carrying its priority and an empty blocker column — and reading as MORE
-legitimate than an ordinary item, because a reappearance looks like something happened. Nothing
-happened; a date passed. Measured on one board: four deferred items, three of them sharing a
-single date, every one with no dependency recorded, and two of them the heads of chains holding
-four more items behind them. Each needed an operator act the date says nothing about.
+**The mirror case: a hold that expires on a DATE while its reason does not.** A deferred item
+returns to the ready list on its own, carrying its priority and an empty blocker column, reading as
+MORE legitimate than an ordinary item because a reappearance looks like something happened. Nothing
+happened; a date passed. **Read defer dates across the whole deferred set** — they get set in
+batches, so a cluster lapsing together makes the list look suddenly and misleadingly rich. Where the
+reason will outlive the date, write that on the item BEFORE the date arrives: afterwards nothing
+prompts anybody, because this is the one hold that removes its own evidence.
 
-**So read the defer dates across the whole deferred set rather than on the item in front of
-you** — they cluster, because they get set in batches, and a cluster lapsing together makes the
-list look suddenly and misleadingly rich. Where the reason will outlive the date, write that on
-the item BEFORE the date arrives. Afterwards nothing in the list prompts anybody, which is the
-whole difficulty: this is the one hold that removes its own evidence.
+**5. An item that is already DONE.** The four above interrogate the item's metadata; none asks
+whether the WORLD already contains what it wants. Such an item presents as perfectly healthy — open,
+unblocked, correctly prioritised, and pointless — and the short tick cannot catch it, because that
+tick looks straight at dispatchable items and this one *is* dispatchable.
 
-**And the fifth: an item that is already DONE.** The four above all interrogate the item's
-own metadata — its fences, its dependencies, its status, its hold. None of them asks whether
-the WORLD already contains what the item wants, so an item whose work has landed presents as
-perfectly healthy: open, unblocked, correctly prioritised, and finished. Nothing in the short
-tick catches it either, because that tick reads the ready list and looks straight at
-dispatchable items, and this one *is* dispatchable — it is simply pointless.
+**Check the TREE in bulk here**, not one item at a time at dispatch, which is too late and too
+narrow. For each open id, search the trunk's merged history for it. Three mechanics decide whether
+the sweep is honest:
 
-Measured on one board in one session: an item recorded as *ruling needed* had had its ruling
-made, executed and merged, and was escalated to the operator **twice** as a live decision
-before anybody looked at the tree; a second was dispatched, and its worker's entire deliverable
-was refuting the premise, the work having merged the previous day. Both had been validated
-against their own text and their siblings, carefully and repeatedly, which is exactly what made
-them feel checked.
+* **Search the whole commit MESSAGE, not the subject.** Where an identifier goes is a house style
+  nobody enforces, so assume the body. Subject-only fails OPEN — zero is the answer that causes a
+  dispatch, and it looks identical to a correct one.
+* **Flatten each commit to one record before matching**, or a line-oriented search splits one change
+  across several and attributes an identifier to its neighbour.
+* **Anchor the identifier so it ends where it ends**, or a shorter id matches every longer sibling.
 
-**The rule already exists and is in the wrong loop.** *Check whether the work is still
-outstanding — check the TREE, not the item* is stated where a brief is written: one item at a
-time, at the moment of dispatch, which is both too late and too narrow. This is the loop that
-reads every open item, so this is where the check belongs in BULK, before a dispatch is spent
-on it. The sweep is one command — for each open id, search the trunk's merged history for that
-id — and it costs a minute against a backlog of any size.
+**A matching commit is a POINTER, never a closure.** Some hits are partial work; some are the very
+change the item was filed AGAINST — a fact the title usually carries in a word like *still*. Confirm
+at source before closing.
 
-**Search the whole commit MESSAGE, not the subject line.** Formatting that history to subjects
-alone is the obvious way to write this sweep, and it fails OPEN. A change whose subject describes
-the work without naming the item returns zero — and zero is the answer that causes a dispatch,
-indistinguishable on screen from a correct one. Measured: a sweep in that form reported an item
-outstanding whose work had already merged, and a worker was spent establishing that; re-running it
-over full messages surfaced four further open items already named on the trunk, one of them
-verified done at source minutes later. Where an identifier goes is a house style nobody enforces,
-so assume the body.
+**And the sweep has an inverse that fails the other way: work that HAS landed on an item still
+legitimately live.** Where a process audits merged changes, an audit reopens the item that owned a
+residual, so the tree confirms the original deliverable exactly as it would for a finished item.
+This is the more dangerous direction, because the tree AGREES with closing and only the notes carry
+the finding. **The tree answers *did this work land*, never *is this item finished*; when the two
+disagree, the notes govern.**
 
-**Two mechanics make the corrected form right rather than merely wider.** A body is multi-line, so
-a line-oriented search over full messages splits one change across several records and attributes
-an identifier to a neighbouring commit — flatten each change to one record before matching. And
-where identifiers share a prefix, a fixed-string match for the shorter one also matches every
-longer sibling, inflating a hit count for an item that has none; anchor the match so the
-identifier must end where it ends.
+In-progress items are read here for scope and fences; *is this worker alive?* belongs to the
+stranded sweep.
 
-**And the sweep has an inverse that fails the other way: an item whose work HAS landed and which is
-still live.** Where a process audits merged changes, an audit can reopen the item that owned a
-residual — so the tree confirms the original deliverable, exactly as it would for a finished item,
-and the reopening is invisible to every check the sweep makes. It is the more dangerous direction,
-because here the tree AGREES with closing. Measured: an item read as delivered on four independent
-tree checks — its symbol renamed everywhere, its replacement documented in the normative reference
-*citing the item's own id*, its branch fully merged — while a live audit note recorded a defect in
-the arm that same change had introduced. Only the notes carried it. So the tree answers *did this
-work land*, never *is this item finished*; when the two disagree, the notes govern.
-
-**But a matching commit is a POINTER, never a closure.** Some hits are partial work; some are
-the very change the item was filed AGAINST, which is a fact the item's own title usually
-carries in a word like *still*. Closing on a subject match is the same error one level up —
-believing a record instead of reading the tree — so confirm in the source that the symbol is
-gone, or the text now reads correctly, before closing anything. On the same board the sweep
-returned nine matches, of which two were genuinely complete, one was the change its item
-complained about, and the rest were siblings that proved nothing either way.
-
-**One correction to the third item above while you are here**: *re-check what this session
-closed* is the right instinct with the wrong window. A closure can revert in a session nobody
-is auditing and sit reopened for days, so the reappearance to look for is not confined to
-your own tick — which is another way this loop's bulk read finds what a short one cannot.
-
-In-progress items are read here too, but their liveness question belongs to the stranded
-sweep in the next loop. Read them for scope and for fences; leave *is this worker still
-alive?* to the loop that owns it.
-
-**Most passes find nothing, and a pass that finds nothing is complete.** What is not
-complete is a pass that reports nothing without having read the raw list. Inferring the
-backlog from the ready view is the exact failure this loop exists to go behind.
+**Most passes find nothing, and a pass that finds nothing is complete.** What is not complete is a
+pass that reports nothing without having read the raw list.
 
 ---
 
@@ -971,247 +769,102 @@ and name the dispatch. Otherwise one line is enough.
 
 ### The stranded sweep
 
-Look for items marked in-progress. If no live worker holds one, it may be stranded.
+**Start from the worktrees, not from the in-progress list.** Unless your dispatches claim their
+items, a live worker's items still read *open*, so that list is empty by construction rather than by
+health and a streak of clean sweeps is a streak of reads of an empty set. Enumerate worktrees, map
+each to its items, and read in-progress items as one more signal.
 
-**But start from the worktrees, because that set is routinely empty while workers are running.**
-Unless your dispatches explicitly claim their items, a worker holds items that still read *open*, so
-this loop's nominal input is empty by construction rather than by health. Measured here: the
-in-progress list returned nothing while a worker was provably alive — files written seconds earlier,
-a gate process burning CPU — and the three items it held all read open. A *"nothing in progress,
-sweep clean"* report is then not evidence of anything, and a streak of them is a streak of reads of
-an empty set.
+The cost of missing a strand is not a stale tree: a dead worker's items look dispatchable, and the
+next tick sends a **second worker to the same branch**.
 
-**The failure is worse than a missed strand**: a dead worker's items sit open, look dispatchable, and
-the next dispatch tick sends a **second worker to the same branch**. So enumerate the worktrees
-first, sweep each for recent file activity, and map trees to items. Where an item *is* marked
-in-progress, read it too — a real signal, never the complete one.
+**Every signal below is indirect, and they share one blind spot.** A worker in its final minutes —
+last gate, then tidying scratch files and links — works outside the worktree, outside version
+control, and is too busy to answer. Tip, fetch clock, write clock and a direct message then read as
+dead *together, for one cause*, so corroborating one with another proves nothing. **Frozen on every
+clock is AMBIGUOUS**: it is what healthy foreground work looks like and what a stopped worker looks
+like, and re-reading the same clocks never converts it into evidence — an hour of freeze is the same
+non-signal as a minute. A freeze measured in hours is unremarkable on a heavyweight gate.
 
-**Discriminate before acting.** A long-running worker and a stranded one look identical from outside,
-and both readings went wrong in a single day here, in opposite directions.
+**So if your tooling reports a running agent directly, read that first** and treat the clocks as the
+fallback. A harness event meaning *this agent has stopped* is not one more signal to weigh — it is
+the diagnosis, and it outranks everything here.
 
-1. **Has the *tip revision* on that item's branch changed since the last tick?** Record the revision
-    id, never a count of changes: **an *ahead* count survives a rebase unchanged**, and rebasing onto a
-    moved trunk is what a briefed worker does constantly, so a count fails on the common case. A
-    healthy worker here was called unchanged across two ticks, having rebased two minutes before the
-    second read with all its work committed.
+1. **Tip revision — record the revision id, never an ahead count.** An ahead count is rebase-
+    invariant, and rebasing is what a briefed worker does constantly, so it fails on the common case.
+    Read the ref the worker's commit updates *directly* and prefer a read that performs no refresh:
+    the local ref moves on commit, the published ref only on push, and the published one lags in the
+    direction that reads as death.
 
-    **Read the tip from whichever ref the worker's commit updates DIRECTLY, and prefer a read that
-    performs no refresh** — a refresh exposes the shared fetch-head trap under *After each merge*,
-    which is on this path too and is silent here. Where workers share one repository metadata
-    directory, the local ref moves the moment a worker commits while the *published* ref moves only
-    when that worker pushes: the published one lags, in the direction that reads as death.
+    **An unchanged tip says nothing alone** — a worker inside a long gate commits nothing by design.
 
-    **An unchanged tip says nothing on its own** — a worker inside a long gate commits nothing by
-    design, so a still tip is the *expected* reading for the commonest healthy state. Corroborate with
-    worktree activity, and note that **the corroboration is a WRITE clock, so a worker that is only
-    READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
-    on twenty-three minutes of no writes. **So look for a signal OUTSIDE the worktree too — where your
-    tracker records that a worker claimed its item, only a running agent could have done that, and it
-    lands in the tracker rather than the tree, where no file-activity clock can ever see it.** That is
-    the one positive signal a purely reading worker still produces, and the opening minutes of every
-    dispatch are exactly when you need it, because the first thing every brief tells a worker to do is
-    read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
-    the worktrees in the first place.
+2. **Activity clocks, and three ways they say "nothing" for different reasons.**
+    * A worker that is only READING writes nothing. The opening minutes of every dispatch are exactly
+      this, because every brief tells the worker to read first.
+    * A worker that POLLS edits nothing for hours, but a fetch ordinarily writes a clock in that
+      worktree's own metadata. Read it twice, 30–60s apart. **Movement proves life and needs no
+      corroboration**; stillness restores the ambiguity, and absence says only that no fetch wrote
+      there — the write is suppressible, so a poller can be invisible to this test.
+    * A span shorter than the worktree's own age counts the checkout rather than the worker, and
+      returns a large number that reads as proof of life. **The worktree's age is its CREATION time,
+      not its modification time**, which the writes you are hunting keep bumping. Run the clock at two
+      different spans before believing either.
 
-    **And if your tooling maintains a live status for a running agent, read THAT before any of these.**
-    Every signal in this step is indirect — it infers a worker from the traces it leaves — and they
-    share a blind spot wide enough to matter: a worker in its **final minutes**, running a last gate and
-    then tidying scratch files and shared-dependency links, works outside the worktree and outside
-    version control and is too busy to answer. Tip, fetch clock, write clock and a direct message then
-    read as dead *together*, for one cause, which is why corroborating one with another does not help
-    here. **So frozen on every clock, across any number of readings, is AMBIGUOUS — it is exactly what
-    healthy foreground work looks like, and exactly what a stopped worker looks like.** It cannot
-    identify either, and no amount of re-reading the same four clocks converts it into evidence; a
-    freeze that has run an hour is still the same non-signal it was in the first minute. Measured twice
-    in one day: five workers were called dormant and **three of them completed alive, two were never
-    explained either way**; a sixth, recorded later as another instance, also completed. **Do not count
-    a live control among them** — one moving worker was the control for that measurement, and folding
-    it into the numerator is how this count was first written down wrong. On the second occasion the
-    supervisor's own one-line progress string named the phase outright while the four clocks said
-    otherwise. Where no direct
-    status exists, declare a window and re-read rather than acting: not because waiting resolves the
-    ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
-    costs a duplicate worker in a live worktree.
+    **Where your tracker records a claim, that is the one positive signal a purely reading worker
+    produces**, and it lands outside the tree where no file clock can see it. Its absence proves
+    nothing.
 
-    **Say what the window is FOR, though, because a rule that only forbids leaves the interval empty
-    and a coordinator fills an empty interval with more measurement.** The re-read catches exactly one
-    thing — movement, which is proof of life and needs no corroboration — so read it twice, record the
-    freeze, and go do something else; the tenth reading answers what the second did. And carry a sense
-    of the scale, because that is what makes the non-signal bearable rather than ominous: **a freeze
-    measured in hours is unremarkable on a heavyweight gate.** Measured across one session — six
-    readings over ninety minutes, every one identical, while five workers whose transcripts had not
-    gained a byte were all alive and all completed normally, at durations from an hour and forty
-    minutes to nearly three hours. The coordinator who knows that stops after the second reading; the
-    one who does not keeps going, because silence that long feels like it has to mean something.
+3. **Message, and read the reply rather than the send.** Resuming beats redispatching — the context
+    is still there. The commonest strand by far is a worker that detached a long gate and then ended
+    its turn waiting for an event nothing sends; those recover intact the moment somebody asks for a
+    status.
 
-    **That clock says "no activity" in four voices and you can only tell them apart with a control.**
-    Besides the reading worker and the poller treated just below, a path that resolves to nothing
-    answers identically — and so does a span shorter than the worktree's own age, where every file is
-    recent and the count is the checkout rather than the worker. That last one is the counter-intuitive
-    half, because it returns a large number that reads as proof of life: measured once at *the same
-    count* over fifteen minutes and over six hours. **And the age itself is the worktree's CREATION
-    time, not its last-modification time**, which the very writes you are trying to detect keep
-    bumping: the wrong clock reads right on an idle tree, where the age does not matter, and seconds
-    old on a live one, where the age is the whole question. Run the clock twice at different spans
-    before believing either reading.
+    **A send may be ACCEPTED for an agent that is already stopped** — acceptance is a queue
+    confirmation, not a liveness report, and for a stopped agent the promised delivery never comes.
+    So *no live task* is rarely something the tool reports; read it as a request unanswered across a
+    window you declare, corroborated by the discriminators above. The error is cheap in one direction
+    only: a late reply costs nothing, acting on a wrong *no task* destroys the run.
 
-    **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
-    nothing and commits nothing, so both clocks above stay still for hours — but a fetch ordinarily
-    writes as it reads, into exactly one place: the fetch-head file in that item's OWN metadata
-    directory, which each linked worktree gets its own copy of the first time a fetch writes that
-    clock there. Read that file twice, thirty to sixty seconds apart. **Movement is proof of life and
-    needs no corroboration**, which makes this the one test in this section that answers without a
-    control; stillness restores the ambiguity rather than resolving it, so it only ever answers in one
-    direction. **Its PRESENCE says nothing about life** — a stopped worker leaves its copy behind,
-    frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **And
-    its ABSENCE says less than it looks like saying**: only that no fetch has written that clock
-    there, which is not the same as no fetch having run, because the write is suppressible by a flag
-    on the fetch itself — a poller configured that way is invisible to this test altogether. So read
-    absence as a reason to reach for another signal rather than as a history of the tree, though it
-    stays a hint about one you did not create: measured here at four of seven, the three without being
-    trees this method did not make. Measured on a poller that six consecutive sweeps had read as
-    silent, on both of the other clocks, while it fetched every forty-two seconds. **And do not let
-    the fetch-head trap under *After each merge* talk you out of it**: that rule is about the SHARED
-    file being unusable as a merge TARGET because any concurrent process rewrites it. The per-item
-    copy is unusable for that same reason and useful for precisely it — here you are reading the
-    rewriting, not the contents.
+4. **Only with no live task AND no tip movement:** push existing commits, set the item back to open
+    with what was found and salvaged, and redispatch.
 
-    **The most convincing false signature is on none of the discredited lists: a change fully green at
-    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads
-    as a worker that finished and forgot to publish — a real state, and the one step 2 exists to catch
-    — but a worker presenting exactly so was on attempt three of its local gate. **A green rollup is
-    evidence about the PUSHED tree, not about the worker**, and a clean tree is what you see *between*
-    edits. It belongs on the list because it reads strong and not one of its four parts observes the
-    agent.
+    **Read WHY it stopped first — the reason chooses the remedy, and quota death, crash, timeout and
+    a detached-gate strand look identical from outside.** Where the stop names an exhausted shared
+    allowance, redispatch is not a remedy: every attempt fails identically and every attempt spends.
+    Salvage, **merge whatever is green** — integration draws on none of that allowance and may unblock
+    the queue — then stop dispatching.
 
-    **A change carries two clocks recording two different EVENTS, so name the event before you read a
-    clock.** The *authored* time is the author timestamp recorded on the change; the *committed* time is
-    the committer timestamp on the object as it currently stands, and it moves every time that object is
-    rewritten. A rebase rewrites the second and replays the first unchanged, so where a project merges by
-    rebase they differ on essentially every landed change — two honest readers called one change
-    forty-three minutes old and seventy-five seconds old, and neither had misread.
+    **A stated reset is a floor, not the only release.** An operator act can restore the allowance
+    early with nothing telling you. Spend one resume probe on the worker with the most context to
+    lose, and read the probe's LIVENESS rather than waiting for words: an agent under an exhausted
+    allowance dies within seconds of resuming, so minutes of running is positive evidence. Stillness
+    is not the converse.
 
-    Liveness asks *did this worker do something recently*, which is the rewrite event, so it reads the
-    committed time. A date in prose asks something else, and **which** something else is the whole
-    question — a record that says only "dated" has not been specified. **Name the event in the sentence**
-    — "authored on", "last rewritten on" — and where that event is one the change itself records, the
-    clock follows from it. Do not write a rule that says prose takes one clock: that trades a defect for
-    its mirror, and the error is invisible once made, because both are real timestamps on the same change
-    and each is correct for its own event.
+**Two clocks on a change record two different EVENTS — name the event before reading one.** The
+authored time is replayed unchanged by a rebase; the committed time is rewritten by it, and by
+amends and squashes too. Liveness asks *did this worker do something recently*, which is the rewrite
+event. Do not write a rule assigning one clock to prose and the other to liveness: both are real and
+each is correct for its own event. **For a date tying a change to an EXTERNAL event — a run, an
+outage — neither clock is proof**; an author date can be set to any value, so use an anchor that
+event recorded, or a chronology you declare and stand behind.
 
-    **Where the event is not one the change records, no clock on the change answers.** Rebase is not the
-    only rewrite: amending, or squashing a fixup, moves the committed time while carrying the original
-    author timestamp forward, and an author date can be set explicitly to any value — so the authored
-    time is no proof of when content was written, and a queued or deferred integration leaves the
-    committed time recording a rewrite rather than an arrival. Ancestry is sound where the fields are
-    not, and it settles ORDER only. **A date tying a change to an EXTERNAL event — a run, a measurement,
-    an outage — therefore needs an anchor that event itself recorded, or a chronology you declare and
-    stand behind.** One change here called its first commit a pre-run registration: authored nine seconds
-    before the first sample, committed twenty minutes after the last, and neither number establishes the
-    claim.
+**A finished change is not a strand, and publishing it is still not yours to infer.** A green change
+whose published head matches its tip, needing only the flag its author sets last, invites you to set
+that flag. Do not: the flag is the interlock precisely because a merge command refuses a draft.
 
-2. **Is there a live task to message?** Message first — resuming beats redispatching, because the
-    worker's context is still there. **The commonest strand by far is a worker that detached a long gate
-    and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
-    day; every one recovered intact the moment somebody asked for a status.
+**The sanctioned route is the operator's decision to STOP that agent, which settles liveness by
+making it false — then merge, in that order.** Stopping is an act with a definite outcome where
+every clock above is an inference with none. Reversing the order reaches the same end state by the
+forbidden route and is indistinguishable afterwards. Verify the change against §1 in full; do not
+reopen the stopped worker's items.
 
-    **Where the harness itself delivers an agent-stopped event, that event outranks every clock in this
-    section for that agent.** An event defined to fire only when nothing of the agent's remains alive is
-    not one more signal to weigh: arriving from a worker whose last message says it is WAITING for
-    something, it is the diagnosis itself — the awaited wake no longer exists, whatever the worker
-    believed it had armed. Resume without further discrimination; the clocks above are for workers whose
-    harness reports nothing.
+**It is not an escape hatch from the ambiguity.** It authorises publishing a change whose author you
+have positive reason to think is finished — it is not a way to resolve a freeze the clocks cannot
+read, and putting that freeze to the operator spends their attention on a question time usually
+answers by itself. The residual risk belongs to stopping, not to merging: you may kill an unpushed
+fix. What bounds it is that you merge the PUBLISHED head, which CI graded.
 
-    **But whether that question has an answer depends on your messaging tool, and it may not.**
-    Measured twice here, a send to an agent stopped mid-turn was ACCEPTED — success returned and
-    delivery promised at the agent's *next tool round*, which for a stopped agent never comes.
-    Acceptance is a queue confirmation, not a liveness report. **The reply is the read; the send is
-    not**, and the asymmetry is total: a reply proves life, while silence proves only that nothing
-    has been delivered yet.
-
-    So the clause below is UNSATISFIABLE if you read *no live task* as something the tool reports
-    — where it behaves this way it never will, and a precondition that cannot be met either blocks
-    a legitimate redispatch forever or gets discharged by an invented proxy, which is the failure
-    this section exists to prevent. Read it instead as a request left unanswered across a window you
-    declare and stand behind, corroborated by the other discriminators. **The error is cheap in one
-    direction only, and it favours waiting**: a late reply costs nothing, because a live worker
-    resumes, while acting on a wrong *no task* destroys the run.
-
-3. **Only with no live task AND no tip movement:** push any existing commits — pure durability — then
-    set the item back to open with a note on what was found and salvaged, and redispatch.
-
-    **Read WHY the worker stopped before acting on that last word.** Where the stop reason names an
-    exhausted allowance with a stated reset, redispatch is not a remedy: *a remedy that draws on the
-    resource whose exhaustion caused the failure is not a remedy*, so every attempt fails identically
-    until the reset and every attempt spends. Salvage still applies in full — record the reason and the
-    reset time, and stop dispatching rather than retrying. **Merging is unaffected**, and that is the
-    half that still pays: integrating a finished change draws on none of that allowance, and a change
-    whose author has already stopped can still be the one unblocking everything queued behind it. So
-    the order is salvage, merge whatever is green, then stop. **The reason text, not the symptom,
-    chooses the remedy** — a quota death, a crash, a timeout and step 2's detached-gate strand look
-    identical from outside.
-
-    **But the stated reset is a floor, not the only release.** An allowance can be restored by an
-    operator act — re-authenticating, changing plan — well before the clock the harness quoted, and
-    nothing tells the mayor it happened. So before holding the fleet for the whole interval, spend ONE
-    resume message on the worker with the most context to lose: a refusal confirms the hold at no
-    cost beyond what the hold was already costing, and an answer means the interval was over. Measured
-    here: three workers died on a stated reset an hour away; the operator re-authenticated within
-    minutes; one probe resumed all three. Hold on the clock only once the probe has refused.
-
-    **But a probe's ANSWER is not the only reading of it, and its LIVENESS arrives far sooner.**
-    The rule above is written around a reply, and a reply is what step 2 rightly calls the read —
-    yet a resumed worker that is *working* has not replied and will not for many minutes, so a
-    mayor waiting for words waits out most of the interval the probe existed to cut short. Ask the
-    harness whether that agent is RUNNING instead. It costs one call, and it is decisive in one
-    direction: an agent under an exhausted allowance dies within seconds of being resumed, so
-    minutes of running is positive evidence the allowance came back. **Stillness is not the
-    converse** — an empty listing restores the ambiguity rather than settling it — so read this
-    exactly as the per-item fetch-head clock is read under *The stranded sweep*: movement proves
-    life and needs no corroboration, absence only sends you to another signal. Measured here: six
-    workers died together on a reset two and a half hours out, the operator re-authenticated, and
-    the probe read *running* five minutes in; all six were resumed on that reading, none
-    redispatched, and every one kept its context.
-
-**A finished change is not a strand — but publishing it is still not yours to infer.** Everything
-above prices redispatch, and prices it to favour waiting because acting on a wrong *no task* destroys
-a live run. A second case sits beside it: a change already green at the band, its published head
-matching its branch tip, needing only the publish flag its author sets last. The pull is to set that
-flag yourself. **Do not reach for a new signal to justify it** — the flag is the interlock precisely
-because a merge command refuses a draft, and an interlock you can talk yourself past is not one.
-
-**Use the authorisation the [dispatch template](dispatch-prompt-template.md#publishing-the-change)
-already names: the operator's decision to STOP that agent, which settles liveness by making it false.**
-Stop it, then merge. That is an act with a definite outcome where every clock above is an inference
-with none, and it needs no new discriminator — a stopped agent cannot be working, so the question the
-four clocks could not answer stops being asked. Verify the change against §1 in full, exactly as for
-any other change, and do not reopen the stopped worker's items or redispatch them.
-
-**But it is not an escape hatch from the ambiguity above, and reading it as one is the natural
-mistake, because it is the only ACT on offer in a section that otherwise says wait.** It authorises
-publishing a change whose author you have positive reason to think is finished; it is not a way to
-resolve a freeze the clocks cannot read. Putting that freeze to the operator as a decision spends
-their attention on a question time usually answers by itself, and it arrives dressed as diligence,
-which is why it is worth naming: measured once, five agents were escalated as possibly stopped, all
-five were alive, and every one reported normally within the hour — the operator's answer, had it
-come, would have been to destroy four live runs.
-
-**The ORDER is the whole rule, and reversing it looks identical afterwards.** Merging first and
-stopping second reaches the same end state by the forbidden route: the merge rests on an inference and
-the act that would have settled it arrives too late to have authorised anything. Both orders leave a
-merged change and a stopped agent, so the record cannot tell them apart later — which is why this says
-*stop, then merge* rather than *make sure the agent ends up stopped*. Written the day it was got wrong
-twice.
-
-**The residual risk is real and belongs to stopping, not to merging: you may be killing work you
-cannot see.** An author who closed its items and then discovered something further presents exactly
-like one that is finished. What bounds it is that you merge the PUBLISHED head, which CI graded, so the
-loss is an unpushed fix rather than a regression introduced, and the remedy is a follow-up change. That
-is a cost to weigh before stopping — it is not a reason to merge without stopping, which trades a
-bounded loss for an unbounded one.
-
-**Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
-a coherent change.
+**Never build a commit from someone else's uncommitted work.** Only that worker knows whether it
+forms a coherent change.
 
 ---
 
@@ -1226,367 +879,202 @@ window reports. Nothing in it is urgent.
 
 ### Reaping
 
-**Only a worker's own completion report authorises reaping its worktree.** Not a merged
-change. Not a clean tree. Not elapsed time. Not directory age.
+**Only a worker's own completion report authorises reaping its worktree.** Not a merged change, not
+a clean tree, not elapsed time, not directory age, not "no commits and no open change", not clean
+and merged together. All six were adopted in one session and all six were wrong — cleanliness
+perversely so, because a worker that has pushed everything exactly as briefed shows a clean tree
+throughout a twenty-minute gate, so *the better the discipline the likelier the kill*.
 
-Six proxies were adopted in a single session, each plausible when adopted, each wrong:
+Reap a live worktree and you destroy the run, and **the wreckage does not announce itself as
+infrastructure**: gates die naming real, present files as missing, which reads to the worker as a
+genuine regression.
 
-* **change state** — merged means the *work* landed, not that the worker stopped;
-* **elapsed time**;
-* **directory mtime** — read 250 minutes stale on a tree being committed to as it was read;
-* **worker shape** — no commits, no open change;
-* **cleanliness** — perversely, because a worker that has pushed everything exactly as briefed
-  shows a clean tree throughout a twenty-minute gate, so *the better the discipline the likelier
-  the kill*;
-* **clean AND merged together**, which still took two full gate runs.
+**The report must say the work is FINISHED.** An interim status, a progress note, a partial hand-off
+and a change-opened announcement are the agent speaking, not reporting done. The operational test:
+**can you quote the sentence where this agent says it is done?** If not, the tree stays.
 
-Reap a worktree while its agent is still running and you destroy that run — and the wreckage
-does not announce itself as infrastructure. Gates die naming real, present files as missing,
-which twice read as a genuine regression to the worker that received it. Once it landed on a
-*negative control*, inverting a meta-test about exit codes.
-
-The signal that has never lied is a read rather than an inference: the agent's own completion
-report.
-
-**And the report has to say the work is FINISHED.** An interim status, a progress note, a partial
-hand-off and a change-opened announcement are all the agent *speaking* rather than the agent
-*reporting done*. A worktree was reaped, repository metadata and all, while the last message its
-worker had sent read *"Holding for the gate — not done yet, and I won't report a colour I don't
-have."* The operational test is therefore: **can you quote the sentence where this agent says it
-is done?** If not, the worktree stays.
-
-**A gate the worker backgrounded is still that worker running.** Where the harness caps foreground
-commands well below what a full gate needs, long gates are *always* backgrounded — so this is the
-common case, not an edge one.
-
-**One worker is not one worktree.** A worker may build a second for its gate run, so an unfamiliar
-worktree belongs to someone until its agent reports.
+**A gate the worker backgrounded is still that worker running** — and where the harness caps
+foreground commands below what a full gate needs, that is the common case rather than an edge one.
+**One worker is not one worktree**: a worker may build a second for its gate run, so an unfamiliar
+tree belongs to someone until its agent reports.
 
 A stale directory is the entire cost of waiting.
 
-**Never pair a merge with a reap in the same breath, and never put the reap in the merge loop.**
-The merge loop is the natural home for cleanup, because a merged change is the moment a tree
-*looks* finished — and that pull is exactly the failure. A rule encoded in a loop condition is not
-a rule being followed; it is a rule delegated to a predicate that cannot see what you know. Reaping
-is a separate, deliberate step, run from a list of names for which you can point at the completion
-report you received. *"I think it is done"* is the inference this rule exists to forbid, and calling
-it "reported" does not change what it is.
+**Never pair a merge with a reap, and never put the reap in the merge loop.** A merged change is the
+moment a tree *looks* finished, which is exactly the pull. A rule encoded in a loop condition is a
+rule delegated to a predicate that cannot see what you know.
 
-**Clearing the mayor's context destroys its ability to QUOTE a report, so record which worktree
-belongs to which agent at DISPATCH time** — one line per dispatch, in a mayor-local file the project
-does not track. The reap test is unchanged; this only supplies a route to the sentence once the
-context that held it is gone. After one clear, fourteen worktrees existed and exactly three had a
-quotable report, all three dispatched after it. The rule failed safe; the cost is monotone
-accumulation. **Dispatch time, not report time** — dispatch always precedes the report, so the line
-is on disk before a clear can matter.
+#### Finding the report
 
-**Nothing validates that line, so specify its fields somewhere tracked.** The file is mayor-local
-and version-ignored by design: no gate reads it, no review sees it, and its own header is the only
-description of it that exists. That is precisely the condition under which a header and its rows
-drift apart unobserved, and here they did — both carried five fields, so no count disagreed, but the
-names sat one place to the left of the contents and a reader addressing a field BY NAME got its
-neighbour's value. Reading the last field as the header named it returned a well-formed answer for
-seventeen of thirty worktrees, and every one of those answers was an identifier rather than the
-report it was taken for. **Name the fields, in the order a dispatch writes them, in the project's
-own agent-instructions file**, and have the local header cite that record instead of standing as its
-own authority.
+**Record which worktree belongs to which agent at DISPATCH time**, one line per dispatch in a
+mayor-local file. Clearing the mayor's context destroys its ability to quote a report; this supplies
+a route back to the sentence. Dispatch time, not report time — dispatch always precedes the report,
+so the line is on disk before a clear can matter. The rule itself is unchanged, and the cost of
+following it is monotone accumulation of unreapable trees.
 
-**Two of those fields belong to this rule and the rest belong to the project**: the worktree,
-because it is the thing you are deciding about, and the agent id, because it is the entire route to
-the report. **The reap test reads no field of that line at all** — it reads the report, which the id
-leads you to. So a field holding the report TEXT is the operator's call recorded at the end of this
-section, not a column this rule turns on, and a header that names one before that call is made is
-describing a field no dispatch writes.
+**Nothing validates that line, so specify its fields somewhere tracked.** A version-ignored file's
+own header is the only description of it that exists, which is the condition under which a header
+and its rows drift apart unobserved — and here they did, both carrying five fields so no count
+disagreed, while a reader addressing a field BY NAME got its neighbour's value. **Two fields belong
+to this rule and the rest to the project**: the worktree, and the agent id. **The reap test reads no
+field of that line at all** — it reads the report, which the id leads you to.
 
-**What the id buys is the TRANSCRIPT, not a live conversation.** Messaging does not reach across a
-clear: eight agents whose ids had been recorded exactly as prescribed all answered *"no transcript
-found"*, while an agent dispatched by the current session resumed on the identical call. Their
-transcripts were intact on disk nonetheless, and seven of the eight opened their last message with
-precisely the sentence the reap test demands. **Reading it is a READ, not an inference**, so it
-satisfies the test as written and adds no further proxy.
+**The id buys the TRANSCRIPT, not a live conversation.** Messaging does not reach across a clear.
+**And an id may key several locations** — a per-agent scratch sink is one, the store holding the
+session's own transcript another. An empty file keyed by the id is a fact about *that location*,
+never about the id, and a sink that is empty for most agents and non-empty for one or two reads as a
+survey rather than as an artefact. Enumerate the id's remaining locations before concluding anything.
 
-**An id is a way to FIND the report, never an answer in itself**: within the dispatching session,
-message first, because that distinguishes *alive* from *finished* and a transcript cannot. And
-**beware a per-agent scratch sink that merely shares the id** — one was empty for seven of those
-eight while their real transcripts sat complete elsewhere, *also* empty for a current-session agent
-that finished normally, and for the eighth held a hardlink to the real transcript, so the wrong
-file returned one plausible non-empty result and made the wrong conclusion self-consistent.
+**With no id recorded, the report is unindexed rather than missing.** Search transcripts for the
+worktree's own path — a dispatch names it and so does the report — and read a bounded TAIL, since
+these are whole-session logs. **But the match is many-to-one and most hits are not the worker's
+own**: the dispatching session names that path, and so does every peer brief listing in-flight write
+surfaces. Three tests separate them, and the first is not sufficient alone:
 
-**An empty file keyed by the id says nothing whatever about whether a report exists** — it is a
-fact about that one location, never about the id. Measured again later, at larger scale: the sink
-read empty for fifteen of seventeen worktrees, every one of those fifteen transcripts sat complete
-elsewhere, and fourteen of them opened with the completion sentence the test demands. The two
-non-empty ones are what made it read as a survey rather than an artefact — a wholly empty result
-would have looked broken and sent the reader looking. So the id names a FILE only once you know
-which file is the agent's OWN; until then it names a directory to search. **And an id may key
-several locations rather than one** — the scratch sink is one of them and the store holding the
-session's own transcript is another, under a different root and a different naming convention — so
-the step between an empty sink and the path search below is to enumerate the id's remaining
-locations and read those, which is cheap and exact where the search is neither. Measured later
-still, across forty candidate worktrees in a single pass: the sink was empty for thirty-one of
-them, and a second id-keyed location held a complete transcript for all thirty-one, no misses.
-Twenty-nine of those opened with the completion sentence; the other two ended on interim status and
-were correctly refused the reap, so enumerating the locations discriminates in both directions
-rather than merely finding reports. The search below was needed for exactly two of the forty, and
-both were trees with no recorded id at all — which is what that search is for. Read emptiness as
-*not found here*, never as *not written* — the cost of the wrong reading is the whole point of this
-section, since it converts "no report exists" into a standing residue that nothing will ever clear.
+* **Count the hits per file.** A worker's own log names its tree tens to hundreds of times against a
+  peer's once or twice. But ranking on this can still hand you a peer that simply worked longer.
+* **The report's own stated root is decisive.** A file whose report names a different root is not
+  that worker's, however often your path appears in it.
+* **Where a directory name has been reused, separate the incarnations by the branch the tree carries
+  NOW** — the earlier one names a branch that is gone and tends to end mid-flight.
 
-**When no id was recorded at all, the report is not missing — only unindexed.** Search the
-transcripts for the worktree's own path, which a dispatch names and so does the report that ends
-the work, then read a bounded TAIL of a file that matches rather than opening it, because these are
-append-only logs of whole sessions and routinely run to megabytes. **But the match is many-to-one,
-and most of its hits are not the worker's own** — the dispatching session's own transcript names
-that path, and so does every peer brief that lists the in-flight write surfaces, because this
-method requires naming them — so identify a file as the WORKER'S OWN before anything in it counts
-as that worker's report; reaping on a peer's mention of a worktree is reaping on someone else's,
-which is strictly worse than leaving the tree standing.
+**A worktree the MAYOR occupied has no agent**, so the search comes back empty for that reason alone
+— and empty is the reap test's blocking condition, which makes such a tree permanently unreapable.
+**The rule does not bend: for that tree the mayor IS the agent**, and its authorising report is the
+mayor's own knowledge. Identify it by the branch the work was PUBLISHED from — an author's tree is
+on it, while an auditor, reviewer or monitor carries a branch named for what it inspects. **Tip
+revision cannot identify an occupant**, only the work. **And do not promote occupancy into a proxy**:
+a tree at the trunk with nothing of its own is the ordinary state of a worker just created, the most
+dangerous tree to remove rather than the safest. Expect automated processes to hold trees too, at
+commits they did not author and under recycled names.
 
-**Three tests separate them, and the obvious one is not sufficient by itself.** COUNT the hits per
-file: a worker's own log names its worktree tens to hundreds of times where a peer names it once or
-twice, so the gap is two orders of magnitude rather than a judgement call. But **ranking by that
-count can still hand you the wrong file** — measured across eleven trees, the top scorer for one of
-them was a peer that had simply worked longer beside it. The decisive test is the report's own
-claim about where it ran: a worker states its worktree root, so a file whose report names a
-DIFFERENT root is not that worker's however often your path appears in it. And where a directory
-name has been reused, both incarnations match — separate those by the branch the tree carries NOW,
-because the earlier one names a branch that is no longer there and tends to end mid-flight rather
-than in a report.
+A transcript path the platform documents as an implementation detail is not a contract, and retention
+sweeps typically DELETE rather than truncate — so whether to hold report text somewhere of your own
+is the operator's call.
 
-**A worktree the MAYOR occupied has no agent, so the search comes back empty for that reason
-alone.** Work an operator declines to delegate still needs a tree, and such a tree never had a
-worker to write a transcript. The empty search then reads as *no report exists*, which is the reap
-test's blocking condition, and the tree becomes permanently unreapable — the empty-sink error one
-level up: an absent transcript is a fact about the SEARCH, and one of the things it can mean is
-that nobody was ever there. **The rule does not bend, because for that tree the mayor IS the
-agent** and its authorising report is the mayor's own knowledge that the work is finished. What has
-to come first is identification, and the tip revision alone will not do it: it names the WORK, not
-the occupant, because an auditor, a reviewer, a bisect or a monitor all sit at a commit they did
-not write. Ask instead whether the tree is on the branch the work was PUBLISHED from — an author's
-is, and a process inspecting that work carries a branch of its own, named for the thing it
-inspects. **And do not promote occupancy into a proxy.** A tree sitting at the trunk with nothing
-of its own is the ordinary state of a worker just created and not yet committed — the most
-dangerous tree to remove, not the safest. It corroborates an identification; it never substitutes
-for one. **Expect automated processes to hold worktrees too**, at commits they did not author and
-under directory names they recycle: one observed here reappeared at a path two minutes after that
-path was cleared, and its predecessor had been mistaken for the author's own tree on exactly the
-tip-revision reasoning this paragraph now refuses.
-
-A transcript path the platform documents as an implementation detail is not a contract, and
-local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report
-text somewhere of your own is the operator's call.
-
-**Reaping on the report is correct and still costs something**: a worker can need its tree *after*
-it reports, because its change hits a conflict. Pushed commits make that survivable — it recreates
-the tree on the existing branch and continues. **Do not add a second condition to a rule whose
-strength is that it has one.** Nothing, though, requires reaping the moment the report arrives:
-a reported tree whose change is still OPEN is exactly the tree its author resumes into when that
-change hits a conflict, so deferring its reap until the merge lands is free insurance — measured
-here, two of three deferred trees were needed again within the hour, and both recoveries were
-in-place resumes with full context rather than redispatches into recreated trees. The rule stays
-one-condition; the deferral is scheduling, not authorisation.
+**Reaping on the report is correct and still costs something**: a worker can need its tree after
+reporting, when its change hits a conflict. Pushed commits make that survivable. **Do not add a
+second condition to a rule whose strength is that it has one** — but nothing requires reaping the
+moment the report arrives, and deferring until the change merges is free insurance.
 
 ### Removing
 
-**If your project links or junctions shared dependencies into worker worktrees, never remove a
+**If your project links or junctions a shared dependency tree into worker worktrees, never remove a
 worktree with the plain command.** It follows the link and deletes *through* it, emptying the shared
-tree it points at — silently, exiting successfully, breaking every local build until the
-dependencies are reinstalled. It has happened more than once in this project. **And removal is not
-the only write that follows a link**: an installer a gate runs inside the worktree rewrites the shared
-target the same way, so a tree can be emptied while its worker is still alive and no cleanup has run.
-The brief-side rule is under *Quality gates — which gate* in `dispatch-prompt-template.md`; here, count
+tree — silently, exiting successfully, breaking every local build. **And removal is not the only
+write that follows a link**: an installer a gate runs inside the worktree rewrites the shared target
+the same way, so a tree can be emptied while its worker is still alive and no cleanup has run. Count
 every shared tree a worker's gates could have reinstalled, not only the ones a removal touches.
 
-Put the safe sequence in a **script**, not in prose. Prose was tried and the class recurred anyway.
-The script should: snapshot every real shared-dependency tree; unlink each *link* under the worktree
-— the link only, never a recursive delete; verify each is gone; then remove the worktree; then
-re-check the snapshot and **fail loudly if the signature moved**, naming the recovery command.
+Put the safe sequence in a **script**, not in prose — prose was tried and the class recurred. It
+should snapshot every shared tree, unlink each *link* under the worktree (the link only, never a
+recursive delete), verify each is gone, remove the worktree, then re-check the snapshot and **fail
+loudly if the signature moved**, naming the recovery command.
 
-**Verify the shared tree's file count either side of a batch**, captured at runtime. A remembered
-constant cannot detect a delta, and a top-level count alone cannot see files vanishing from under
-packages whose directories survive — so count immediate entries *and* recursive files.
+**Capture the snapshot at runtime and count both sides the SAME WAY.** A remembered constant cannot
+detect a delta; a top-level count cannot see files vanishing from under surviving directories, so
+count immediate entries *and* recursive files. And a listing that hides entries does not merely
+undercount — it turns the comparison into an offset, and in one direction that offset **CANCELS a
+real loss of its own size**: two hidden entries make a tree read the same before and after two
+visible ones are destroyed. The other direction is only a false alarm, which is the cheaper half and
+the one you meet first.
 
-**And count both sides the SAME WAY.** A listing that hides entries does not merely undercount — it
-turns the comparison into an offset, and in one direction that offset CANCELS a real loss of its own
-size. Measured here on a tree of 103 immediate entries, two of them hidden: the hiding form reads 101
-before, and the showing form reads 101 again after two visible entries have been destroyed. No delta,
-two entries gone. The other direction is only a false alarm, which is the cheaper half and the one you
-will meet first — it cost a real detour here before the flags were compared.
+**So make the decisive control a clock rather than a count** — the newest modification time inside
+the tree, which a removal moves and a change of listing options cannot. Note which entry carries it
+before you start, and check whether that entry is one the listing form suppresses.
 
-**So make the decisive control a clock rather than a count**: the newest modification time inside the
-tree, which a removal moves and a change of listing options cannot. Note which entry carries it before
-you start. On the tree measured here that entry was itself one of the two hidden ones, so the listing
-form that suppressed the count also suppressed the control — worth checking rather than assuming, in
-either direction.
-
-**Sweep with a narrow force flag, never a blanket one.** A disposable-only force removes a tree
-only when every untracked path is build or gate output, and refuses any tree holding a modified
-tracked file, a note or a draft. That guard is not hypothetical: when it was written, one worktree
-held four analysis files for an **open** item and three others carried uncommitted source and doc
-edits. A blanket force would have destroyed all of it silently — far worse than a worktree that will
-not reap.
+**Sweep with a narrow force flag, never a blanket one.** A disposable-only force removes a tree only
+when every untracked path is build or gate output, and refuses one holding a modified tracked file,
+a note or a draft. Not hypothetical: when that guard was written, four worktrees held uncommitted
+analysis or source edits a blanket force would have destroyed silently — far worse than a worktree
+that will not reap.
 
 **A refusal to remove has modes that are not interchangeable.** Nine worktrees were once read as
 locked, waited out for two days, and were all simply dirty:
 
-* **Dirty** — the tree holds modified or untracked files. **Waiting never clears this.**
-* **Held** — the disposable sweep stopped because the tree holds something that is not build output.
-  Nothing was deleted.
-* **Locked** — the tree is clean and intact and a live process still holds a handle. This one is
-  genuinely transient: note it and retry later.
+* **Dirty** — modified or untracked files. **Waiting never clears this.**
+* **Held** — the disposable sweep stopped on something that is not build output. Nothing was deleted.
+* **Locked** — clean and intact, a live process holding a handle. Genuinely transient: note and retry.
 * **Partial** — a *husk*. The tool deregistered the worktree and deleted its metadata, then hit the
-  lock and stopped. It no longer appears in the worktree listing, pruning has nothing to clear, and a
-  status check inside it *fails and prints nothing* — which is exactly why a clean/dirty test reads a
-  husk as clean. Retrying the ordinary path is futile — the registered-worktree check refuses a
-  husk forever. **But do not reach for a raw recursive delete, which is the operation the top of
-  this section forbids**: a husk still holds every file the worktree had, any linked dependency
-  directory among them, so a plain delete follows that link and empties what it points at. Reach
-  for the tool's acknowledged-husk path, which disarms the link before deleting anything; the
-  paragraph below states the two conditions it is gated on, and a tool that offers no such path
-  is one to fix rather than to work around. **A partial removal kills a running gate exactly as a
-  complete one does** — never read it as "nothing happened".
+  lock and stopped. It no longer appears in the listing, pruning has nothing to clear, and a status
+  check inside it *fails and prints nothing* — which is why a clean/dirty test reads a husk as clean.
+  Retrying the ordinary path is futile; the registered-worktree check refuses a husk forever. **But
+  do not reach for a raw recursive delete, which is the operation the top of this section forbids** —
+  a husk still holds every file the worktree had, links among them. Use the tool's acknowledged-husk
+  path, which disarms the link before deleting anything; a tool offering no such path is one to fix
+  rather than work around. **A partial removal kills a running gate exactly as a complete one does.**
 
-**A husk is identified, never inferred.** "The tool does not list it, and it has no metadata" is true
-of a husk and equally true of an ordinary directory, a mistyped argument and an unrelated project.
-One tool handed a temp directory created seconds earlier unlinked the dependencies inside it, called
-it a destroyed tree and recommended deleting it. So refuse an unregistered path outright unless the
-caller acknowledges it **and** its contents are recognisable as this repository's, established from
-version control's own object database. Never spray that acknowledgement across a sweep list.
+**A husk is identified, never inferred.** "Not listed, no metadata" is equally true of an ordinary
+directory, a mistyped argument and an unrelated project — one tool handed a temp directory created
+seconds earlier unlinked the dependencies inside it and called it a destroyed tree. Refuse an
+unregistered path unless the caller acknowledges it **and** its contents are recognisable as this
+repository's, established from version control's own object database. Never spray that
+acknowledgement across a sweep list.
 
 ### Branches
 
 Delete merged local and remote worker branches — **never one whose change is not verifiably merged**.
 
-**Enumerate the remote set separately, because it is not a subset of the local one.** Everything else in
-this loop starts from the worktrees, which is right for reaping and blind here: a branch whose worktree
-was removed and whose local ref was deleted still exists on the remote, and nothing you are looking at
-mentions it. One sat merged and undeleted through two hygiene passes, surfacing only when the remote list
-happened to be printed.
+**Enumerate the remote set separately: it is not a subset of the local one.** Everything else in this
+loop starts from the worktrees, which is right for reaping and blind here — a branch whose worktree
+and local ref are both gone still exists on the remote, and nothing you are looking at mentions it.
 
-**"Verifiably merged" needs a test, and where the project merges by REBASE the two obvious ones are
-both wrong — in opposite directions.** A rebase replays every commit under a new identity, so a
-merged branch never becomes an ancestor of the trunk and never stops reading as *ahead* of it:
-ancestry reports fully merged work as unmerged, and the ahead count says the same thing for the same
-reason. That is the rebase invariance *The stranded sweep* explains above, asked on containment
-rather than on liveness, which is why that paragraph is the cross-reference here rather than
-something to restate.
+**Where the project merges by REBASE, the two obvious containment tests are both wrong.** A rebase
+replays every commit under a new identity, so a merged branch never becomes an ancestor of the trunk
+and never stops reading as *ahead* of it. Ancestry keeps merged branches forever; the ahead count
+destroys unmerged ones.
 
-**The test is patch-equivalence**, which asks what each commit *does* rather than which object it
-is: an equivalent patch already upstream means the work is contained. In the dominant toolchain that
-is `cherry`, which marks the two answers `-` and `+`. It earns its place over either half of a rule
-that only ever fails safe one way. Measured here across 63 worktrees: 60 branches read one to three
-commits ahead of the trunk, 58 of those fully merged and one carrying three genuinely new commits.
-Deleting on ancestry would have kept all 58 forever; deleting on the ahead count alone would have
-destroyed those three.
+**The test is patch-equivalence** — what each commit *does* rather than which object it is. Its two
+answers are not symmetric, and reading them as symmetric is the error to avoid:
 
-**But its two answers are not equally strong, and reading them as symmetric is the error this
-paragraph exists to stop.** `-` is proof of containment. `+` is only the ABSENCE of proof — not
-evidence that the commit carries unmerged work. A patch identity is computed over the diff
-*including its context lines*, so a sibling change landing in neighbouring lines of the same file
-changes your commit's context, changes its identity, and leaves work that is fully present upstream
-reading `+`. Measured here: a branch whose change had already MERGED still showed one `+` commit; every
-line that commit added was present at the trunk's tip, character for character. The sibling that moved
-the context was another change to the same file.
+* **Contained is proof.** Delete only on it, and nothing is ever destroyed.
+* **Not-contained is only the ABSENCE of proof.** Patch identity is computed over the diff including
+  its CONTEXT lines, so a sibling change landing in neighbouring lines of the same file changes your
+  commit's identity and leaves fully-merged work reading as unmerged.
 
-**So the rule is safe and its reading is not.** Deleting only on `-` never destroys anything, which
-is why the criterion stands unchanged — but a mayor who reads `+` as *this branch has unmerged work*
-will hunt for work that landed weeks ago, and a branch list read as a backlog is a list of phantoms.
-The cheap triage is to take the lines that commit ADDED and look for them at the tip: where they are
-all there, the likeliest reading is that the content landed and only the context moved. Run it first
-because it costs seconds and tells you where to point the real check — never because it finishes one.
+**So the rule is safe and its reading is not.** A mayor who reads *not contained* as *this branch
+has unmerged work* hunts for work that landed weeks ago, and a branch list read as a backlog is a
+list of phantoms. Cheap triage: look for the lines that commit ADDED at the tip. **But that is
+triage and it is wrong in both directions** — a line search has no notion of path, multiplicity or
+order and cannot see a deletion at all, so a commit whose substance is a removal scans clean having
+been inspected for nothing, while a rename or reformat upstream hides work that is fully present.
+**To CONCLUDE, compare the commit's whole patch against the tip at the paths it touches, deletions
+included.** Ask what the instrument compared, not what it answered: a scan returning EVERYTHING
+reads as corroboration where a scan returning nothing at least reads as silence.
 
-**But it is triage, not a verdict, and it is wrong in BOTH directions — which is the correction this
-paragraph carries.** A line search has no notion of path, location, multiplicity or order, and it
-cannot see a deletion at all. So *all present* is satisfied by lines that exist somewhere at the tip
-while this branch's actual change is wholly absent — the more generic the added lines, the more
-certain that is, and a commit whose substance is a deletion or a replacement scans clean having been
-inspected for nothing. And *any absent* is equally weak in reverse: upstream can carry the same work
-through a rename, a reformat or a follow-on rewrite, so the change is fully present and the exact
-line is not. **To CONCLUDE either way, compare the commit's whole patch against the tip at the paths
-it touches, deletions included** — a three-way comparison from the branch's parent is enough, and it
-is the only thing here that answers the question actually asked.
+**Containment is not the only question. A branch with unlanded commits and no proposed change may be
+a DELIBERATELY RETAINED RECORD.** A spike is the standard case: its findings are promoted as prose
+and its diff is meant never to land, so *pushed, unlanded, nothing proposed* describes the design.
+Ask the tracker who owns it — and ask three things most defaults get wrong:
 
-**This matters even though the rule already forbids deleting on it.** The damage from a wrong
-*landed* reading is not a lost branch — it is a mayor who stops looking, files nothing, and leaves
-real unmerged work sitting under a name that now reads as residue. The cost of the two errors stays
-asymmetric, which is why the conservative half survives untouched: believing `+` costs you a search,
-while believing a wrongly-derived `-` costs you the work.
+* **Include CLOSED items**, because a retention ruling lives on a closed item by definition.
+* **Do not filter TO closed either**, which hides an open item carrying a live release condition.
+  Ask for all statuses.
+* **Search the full export, not the title index.** Such rulings are written in close reasons, which
+  a title search cannot see at any status.
 
-**And note the shape of the mistake, because it recurs wherever an instrument is cheap.** This
-document already warns that [a search returning ZERO is not a check that
-passed](dispatch-prompt-template.md#quality-gates--how-a-gate-is-run); the inversion is the same
-defect and reads even better, because a scan returning EVERYTHING looks like corroboration rather
-than like silence. Ask what the instrument compared, not what it answered.
+**Every defence above finds a record that EXISTS. The case with no record is a LIVE worker's
+branch** — a dispatch in flight has written its name into no item, so the strongest query above
+returns zero, and zero authorises deletion. **Subtract the live set before reading any zero as an
+orphan**: the branches the worktree listing reports, and the ledger rows whose worker has not
+reported.
 
-**Containment is not the only question, and the other one has its own reassuring failure: a branch
-carrying unlanded commits and no proposed change may be a DELIBERATELY RETAINED RECORD rather than
-residue.** A spike is the standard case — its findings are promoted to the trunk as prose and its
-diff is meant never to land, so *pushed, unlanded, no change proposed* describes the design rather
-than an oversight. Ask the tracker who owns a branch before filing it as orphaned; the retention, if
-there is one, is written down. **But ask with CLOSED items INCLUDED, because a retention ruling
-lives on a closed item by definition** — the item that closed saying *"retained as the experiment's
-record"* IS the artefact you are looking for. Where the tracker hides closed items by default, and
-most do, the obvious query returns nothing, or returns the sweep's OWN earlier filing, and *nobody
-owns this branch* is precisely the answer that authorises deleting it. Measured here: the default
-search for one such branch returned a single hit — a previous sweep's item — while the same search
-over all statuses returned the rulings that had already settled it twice.
+**Key destructive operations on identity, never on a name.** Branch names repeat and prefix-match,
+so a search term matches siblings and may rank one first — reading one branch's state as another's.
+Ask for the exact head-ref field and compare for equality yourself.
 
-**And do not stop at widening the status, because that swaps one blind spot for another.** Filtering
-to closed items alone hides an OPEN item carrying the standing decision, which is where a live
-release condition tends to sit; ask for all statuses, not for closed ones. **Then check what the
-search reads at all.** Where it matches titles only — again the common default — a retention
-recorded in a CLOSE REASON is invisible to it at every status, and that is exactly where such
-rulings are written. So when the answer would authorise a destructive act, search the tracker's full
-export, which carries descriptions, notes and close reasons, rather than its title index. The
-asymmetry from the `-`/`+` rule above governs here too: mistaking a record for residue destroys it,
-while mistaking residue for a record costs a branch nobody was using.
+**But equality over a LISTING still filters a WINDOW, and that failure is silent.** A listing returns
+the most recent N; your test is correct and its answer is only as wide as the listing, and a zero
+over the wrong range reads exactly like a zero over the right one. **Prefer an instrument that takes
+the identity as INPUT** — filtering at the source, before paging, caps how many MATCHES return
+rather than how far back it looked, so it cannot turn a proposed branch into one that reads as never
+proposed. Pass an explicit limit anyway: a reused name can carry several changes, and completeness
+still matters where their states do. **An empty answer is still not a licence to delete** — it
+settles that this query matched nothing, not that you asked the right repository, states, spelling
+or credentials. **Exercise the query in both directions before trusting it.**
 
-**Every defence above finds a record that EXISTS; the case with no record yet is a LIVE worker's
-branch.** A dispatch in flight has not written its branch name into any item, so it returns zero from
-the full export at all statuses — the strongest form prescribed here — and zero is precisely the
-answer that authorises deleting it. Measured here across five pushed worker branches: two were named
-by owner records, one of them by a spike whose own text says *do not delete*, while the other three
-read zero and every one was a live dispatch — including the branch this paragraph was written on. The
-two non-zero answers are the positive control, so the instrument is working correctly and still
-answering a different question than the sweep is asking. **So subtract the live set before reading any
-zero as an orphan**: the branches `git worktree list` reports, and the dispatch ledger rows whose
-worker has not reported. Both are in hand at that moment, and this is *The stranded sweep*'s rule
-asked on branches rather than on items. The criterion does not move — only the reading — but here the
-wrong reading acts against live work rather than costing a search.
-
-**Key destructive operations on identity, never on a name.** Branch names repeat across sessions and
-prefix-match each other. A search for `head:feature-x` also returns the change for `feature-x2`, and
-may rank the sibling *first*, so a loop reading the top row reads one branch's state as another's.
-Here it read "open" for a branch whose own change had merged, and merely skipped it — but the same
-shape reversed deletes a live worker's branch on its sibling's verdict. **Ask for the exact head-ref
-field and compare it for equality yourself.** A search term substring-matches; only equality
-identifies.
-
-**But comparing it yourself still leaves you filtering a WINDOW, and that failure is the silent one.**
-A listing returns the most recent N changes; your equality test over it is correct and its answer is
-only as wide as the listing. Measured here: a filter over the four hundred most recent changes
-reported that nothing proposed two branches whose commits predate that window entirely — and a zero
-over the wrong range reads exactly like a zero over the right one. The sibling trap at least leaves a
-wrong row on screen; this leaves nothing at all. **So prefer an instrument that takes the identity as
-INPUT** — most forges accept the head reference as a query parameter, which asks the whole set at once
-rather than a recent window. **That filtering happens at the source, BEFORE any paging, which makes it
-a different instrument rather than a wider window.** Its limit therefore caps how many MATCHES come
-back, not how far back it looked: a capped query returns the newest matches rather than none, so it
-cannot turn a branch that was proposed into one that reads as never proposed. An empty answer here is
-a real absence of matches, unlike the zero above, which was an artefact of the range — and a truncated
-answer usually announces itself, reporting a total or a further page beside the rows it hands you.
-**The limit still bounds COMPLETENESS, so pass an explicit one.** An at-limit result may omit older
-changes for a reused branch name — one name here carried five — so enumerate or paginate whenever
-their states or identities matter and not merely their existence. **An empty answer is still not on
-its own a licence to delete**, but for reasons that have nothing to do with paging: it settles that
-THIS query matched nothing, not that you asked the right repository, the right states and the right
-head spelling, nor that your credentials can see every change that exists, nor that nobody else owns
-the branch. Settle those separately, and let the asymmetry above govern — mistaking a record for
-residue destroys it. **Exercise it in both directions before trusting it**, because a query that
-silently matches nothing returns the reassuring answer to every question. Measured here: the
-equality query returned the one merged change for a branch that had one, and returned NOTHING for a
-prefix of that same branch name — where the search form returned SIX changes for that prefix and
-ranked the full branch's own first, which is the paragraph above reproduced at this tip.
+Throughout, the asymmetry governs: mistaking a record for residue destroys it, mistaking residue for
+a record costs a branch nobody was using.
 
 Then prune stale remote-tracking refs and clear any stray stashes.
 
@@ -1607,91 +1095,72 @@ inventing another proxy.** A stale directory is cheap. A destroyed run is not.
 ## 6. Method reread
 
 **This loop earns its place, but not by re-reading.** Re-reading unchanged files spends context for
-nothing.
+nothing. Do two things instead:
 
-Do two things instead:
-
-1. **Check what changed** since the last pass — in these documents, and in your loop command files.
+1. **Check what changed** since the last pass — in these documents and in your loop command files.
    When a method rule changes, re-read the matching command file. A link checker catches renamed
    files, not semantic drift.
 2. **Check the rules you have been *enforcing* against what the tree actually does.** That is where
-   the drift lives. Twice this found a rule the documents asserted universally that the tree did not
-   support — and one of those had been introduced by a merge the mayor approved.
+   the drift lives — twice this found a rule the documents asserted universally that the tree did
+   not support, one of them introduced by a merge the mayor approved.
 
 Watch specifically for:
 
-* **A measured constant that has gone stale.** The check-count band is the standing example: it is
-  written down, it moves, and it goes stale exactly where it has to be right.
-* **Unsatisfiable quantifiers.** *"Every gate prints X"* when a third of them do not. Workers facing
-  an unsatisfiable rule do not stop — they improvise, and the improvisation varies. **When a rule says
+* **A measured constant that has gone stale.** The check-count band is the standing example: written
+  down, moving, and stale exactly where it has to be right.
+* **Unsatisfiable quantifiers.** *"Every gate prints X"* when a third do not. Workers facing an
+  unsatisfiable rule do not stop — they improvise, and the improvisation varies. **When a rule says
   *every*, check the quantifier.**
 * **Blocks that have diverged from the command files that paste them.** Two copies of one rule
   disagree within days.
-* **A hazard recorded without the test that discharges it.** *"Beware X"* with nothing saying how
+* **A hazard recorded without the test that discharges it** — *"beware X"* with nothing saying how
   to tell X from the legitimate case that looks identical. Whoever wrote it had just performed that
-  test, so it read as part of the observation rather than as a separate thing needing words; the
-  reader arrives having performed none of it and must reconstruct the test while looking at the very
-  evidence the hazard produces. Three in one session, all in one section, and the one I had read
-  within the hour was the one I walked into. This document already says a remedy written without its
-  discriminator **is worse than no remedy at all** — that judgement applies to its own prose, and
-  this loop is the only place that checks whether it does.
+  test, so it read as part of the observation rather than as something needing words. This document
+  says elsewhere that a remedy without its discriminator is worse than no remedy; that judgement
+  applies to its own prose, and this loop is the only place that checks whether it does.
 
 **Read a loop's page when you are about to do that loop's work, whatever this loop's cadence says.**
-The cadence is decoupled from need: a destructive or unfamiliar step performed hours before its page
-comes round is a step taken without it, and the reread that follows finds nothing wrong because the
-damage is already done. One branch sweep here re-derived, at length, a test its own page states
-outright. That is not an argument for re-reading everything — it is the reason this loop is a drift
-check rather than the only time a page gets opened.
+A destructive or unfamiliar step performed hours before its page comes round is a step taken without
+it, and the reread that follows finds nothing wrong because the damage is already done.
 
-Report one or two lines unless you find real drift. If you find drift, fix the document or the command
-file — do not just note it.
+Report one or two lines unless you find real drift. If you find drift, fix the document or the
+command file — do not just note it.
 
 **But the repair is the step most likely to need repairing, and it fails in one particular way: a
 correction tends to overshoot into the INVERSE of the claim it replaces.** A wrong sentence is
 usually wrong by asserting too much, and the evidence that exposes it feels like evidence for the
-opposite — so the fix arrives with the confidence the original had, pointing the other way, and
-reads as *more* reliable because it was written in response to being caught. Two in one session,
-both in this loop's own output: *"those workers are dormant"*, refuted, became *"frozen clocks are
-the signature of a run about to report"* when the supported claim was that the reading is ambiguous;
-and a containment scan demoted from a verdict to triage kept a clause saying it *"settles the common
-case"*, two sentences from the words *"triage, not a verdict"*. Both were caught by an outside
-reader, not by the loop that wrote them.
+opposite — so the fix arrives with the original's confidence pointing the other way, reading as
+*more* reliable because it was written in response to being caught.
 
-**The discharging test is one question, and it costs nothing: what would you expect to SEE that is
+**The discharging test is one question and it costs nothing: what would you expect to SEE that is
 different if the new claim were false?** If the only answer is *the evidence that refuted the old
-one*, nothing has been established — that evidence rules the old claim out and leaves the replacement
-standing among several survivors, which is the old error re-pointed. Workers completing alive refutes
-*dormant*, and a stopped run shows the same frozen clock as one about to report, so nothing observed
-tells those two apart. The containment scan's misses refute *this settles it*, and a scan that is
-right usually and one that is right rarely produce identical output, so *settles the common case*
-rests on a frequency nobody measured. Where the honest answer is that the observation supports
-neither side, **say so plainly and let the guidance rest on the asymmetric cost of the two errors
-instead** — that is a real reason to wait, and it survives the next counterexample,
-which a re-pointed claim does not. Being wrong twice about the same sentence is the ordinary case
-here, and this loop is where the second round is supposed to be caught.
+one*, nothing has been established — that evidence rules the old claim out and leaves the
+replacement standing among several survivors, which is the old error re-pointed. Where the honest
+answer is that the observation supports neither side, **say so and let the guidance rest on the
+asymmetric cost of the two errors instead**: that is a real reason to act one way, and it survives
+the next counterexample where a re-pointed claim does not.
+
+**And the fix is bounded in change, not in search.** What this loop finds is mechanical, so a defect
+in one place usually has siblings — [*"Bounded repair" bounds the change, not the
+search*](dispatch-prompt-template.md#name-the-discriminator) binds the mayor's own repairs exactly
+as it binds a worker's.
+
+**Weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
+usually not the repair. Two remedies that worked landed the other way: an item whose OLDEST field
+was rewritten to open with its disposition, after three workers had been dispatched at work that
+should not exist; and a guard that refused an edit the rule had already forbidden in words. Both
+changed the artefact a reader meets rather than the instruction they had read and recited. **And a
+guard is not a rule that cannot fail** — one added in an evening was run the next hour and misread,
+because a check executed carelessly returns the same reassuring answer as no check at all.
 
 **Where the project arms a mayor-side commit guard, the mayor's own repair goes through a
-mayor-occupied worktree** — the guard refuses the mayor checkout for every non-tracker surface,
-these documents included, and that refusal is the guard working, not an exemption to negotiate.
-Author the fix in a worktree of your own, publish it as an ordinary change, and merge it on the
-ordinary criterion; the dispatch ledger's mayor-row convention already names such a tree. Two
-mechanical gotchas, measured: the refused commit exits non-zero with the files still STAGED, so
-read the commit's own exit rather than the output tail — the refusal scrolls away under later
-lines; and those staged files then abort the next rebase-pull with a message that never names
-the refusal that caused it, so restore them before pulling rather than diagnosing the pull. **And the fix is bounded in change, not in search.** What this loop finds is
-mechanical, so a defect in one place usually has siblings: [*"Bounded repair" bounds the change, not the
-search*](dispatch-prompt-template.md#name-the-discriminator) is set out for the worker and binds the
-mayor's own repairs exactly as it binds a worker's. Measured here: a pointer repaired in this loop left
-three identical siblings standing, and a later pass found them rather than the repair did.
-
-**But weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
-usually not the repair. Two remedies landed the other way in one session: an item whose OLDEST field
-was rewritten to open with its disposition, after three workers had been dispatched at work that
-should not exist and each had correctly refused; and a commit guard that refused an edit the rule had
-already forbidden in words. Both changed the artefact a reader meets rather than the instruction they
-had read and recited. **And a guard is not a rule that cannot fail**: one added on an evening was RUN
-the next hour and misread, because a check executed carelessly returns the same reassuring answer as
-no check at all.
+mayor-occupied worktree.** The guard refuses the mayor checkout for every non-tracker surface, these
+documents included, and that refusal is the guard working. Author the fix in a worktree of your own
+and merge it on the ordinary criterion. Two mechanical gotchas: **the refused commit exits non-zero
+with the files still STAGED**, so read the commit's own exit rather than the output tail — the
+refusal scrolls away under later lines; and those staged files then abort the next update with a
+message that never names the refusal that caused it, so restore them rather than diagnosing the
+update.
 
 ---
 
@@ -1699,140 +1168,93 @@ no check at all.
 
 These belong to no single loop and bite in all of them.
 
-
 **An instrument can be RIGHT and still answer a different question from the one you asked.** The
-rule about an instrument that says *"nothing here"* covers the case where its answer is wrong.
-This is the other case, and the remedy for the first is inert against it: exercise the instrument
-against an input it should flag and it comes back GREEN, because nothing is malfunctioning. Four
-in one session, one from each of four loops — a count of running workers read as *the machine is
-quiet*; a count of resident processes read as *the machine is busy*; a marker scan finding a
-banner read as *this item is held*; a note true when written read as *true now*. Every answer was
-correct and every reading was wrong. **Write the question the instrument answers, in its own
-terms, beside the question you are asking.** The gap is invisible in the answer and obvious the
-moment both sentences are on the page. This is the harder half to catch, because a wrong answer
-gives you something to be suspicious of and a right one does not.
+rule about an instrument that says *"nothing here"* covers a wrong answer; the remedy for that —
+exercise it against an input it should flag — is inert here, because nothing is malfunctioning and
+the control comes back green. Four in one session, one per loop: a count of running workers read as
+*the machine is quiet*; a count of resident processes read as *the machine is busy*; a marker scan
+finding a banner read as *this item is held*; a note true when written read as *true now*. **Write
+the question the instrument answers, in its own terms, beside the question you are asking.** The gap
+is invisible in the answer and obvious once both sentences are on the page — and this is the harder
+half, because a wrong answer gives you something to be suspicious of and a right one does not.
 
-**Take the marker scan in that list further, because it fails in BOTH directions and the remedy follows
-from that rather than from either half.** It over-reports: an item that QUOTES a marker — recounting
-another item's hold, or listing the very strings the scan searches for — matches, and so does one whose
-marker has been struck and whose text says so. It also under-reports: a hold written in ordinary prose
-carries no marker at all, and one item reached the ready list reading free on a probe of **six** distinct
-marker phrases while its own text said *"what remains is one decision"*. **And a second scan built to
-discriminate the two fails the same way**, because the standing marker text itself instructs whoever
-rules to strike it, so the word *struck* appears inside every live marker.
+**A marker scan fails in BOTH directions, so it is a CANDIDATE FILTER and never a verdict.** It
+over-reports items that QUOTE a marker or whose marker has been struck, and under-reports holds
+written in ordinary prose. A second scan built to discriminate fails the same way, because marker
+text typically instructs whoever rules to strike it, so the word *struck* appears inside every live
+marker. Narrow to a handful, then READ each candidate, and **report the number you read, never the
+number you scanned**. Where a project wants this machine-checkable the durable answer is a
+structured field rather than a marker in prose — an operator's decision, but every failure here is a
+consequence of encoding state in text that also discusses state.
 
-**So a marker scan is a CANDIDATE FILTER and never a verdict.** It narrows a board to a handful; the
-hold is then established by READING each candidate, which is affordable at that size and is the only
-thing that separates a live marker from one quoted, discussed, or already struck. Report the number you
-read, never the number you scanned. **Where a project wants this machine-checkable, the durable answer
-is a structured field on the item rather than a marker in prose** — that is a tracker change and an
-operator's decision, but every failure above is a consequence of encoding state in text that also
-discusses state.
+**A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked
+when X is later reopened for an unrelated residual. Force the close and **write the reasoning on the
+item**: what the dependency enforced, that it was satisfied, and why the reopen does not re-block
+merged work.
 
-**A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked if X
-is later reopened by an audit for an unrelated residual — even though the thing it was waiting for
-shipped. Force the close and **write the reasoning on the item**: what the dependency was enforcing,
-that it was satisfied, and why the reopen does not re-block work that already merged. This happened five
-times in one session; each was legitimate.
+**Items usually close on change-*open*, not change-*merge*** — so "closed" does not mean "on the
+trunk". Check the merge before treating a dependency as discharged.
 
-**Items usually close on change-*open*, not change-*merge*.** So "closed" does not mean "on the trunk".
-Check the merge before treating a dependency as discharged.
+**Verify closures by reading the status field keyed on the item ID.** Keyed on an internal row
+identifier, a re-import reports phantom losses; searching the whole record matches the word "open"
+inside a title.
 
-**Verify closures by reading the status field, keyed on the item id.** Two ways that audit lies: keyed on
-an internal row identifier, a re-import regenerates them and the diff reports phantom losses; and
-searching the whole record matches the word "open" inside a title.
+**A command's echoed output is not confirmation that it did anything.** This is the gate-behind-a-
+filter rule reaching every command the mayor runs. Trimming output to the last line hides it
+perfectly: where a close carries a long reason, the last line *is* the reason text, so a refusal and
+an acceptance look identical.
 
-**A command's echoed output is not confirmation that it did anything.** The rule against reading a gate's
-verdict off a filter is the same failure in a different suit, and it reaches every command the mayor runs, not
-just gates. Two instances in one session, both from trimming output to keep a log short. Four closes were sent
-with long reasons and their output trimmed to the last line — which, when the reason is long, *is* the reason
-text, so a refused close and an accepted one looked identical; all four evaporated and were found cycles later
-reading open with no reason recorded. Nine worktree removals were then counted for a string the script prints on
-the way out whether it acts or refuses; every one had exited non-zero saying "nothing was touched", and all nine
-were still there. A maintenance script that refuses safely is doing its job; the failure is the caller who does
-not look.
+**Exit status and mutation are two different questions, and only the first is cheap.** A non-zero
+status is proof the command refused, so **always read it**. A *zero* proves the command reported
+success, not that state changed — an idempotent call legitimately does nothing, and a durable
+operation can acknowledge locally before the postcondition you care about is true. **When you need a
+state change, or a durable one, re-read the target as well.**
 
-**But the exit status and the mutation are two different questions, and only the first is cheap.** A non-zero
-status is proof the command refused, so **always read it** — that alone would have caught both incidents above.
-A *zero* status proves only that the command reported success, not that state changed: an idempotent call
-legitimately succeeds having done nothing, and a durable operation can acknowledge locally before the remote or
-the postcondition you actually care about is true. **So when the outcome you need is a state change or a durable
-one — or when a successful no-op is possible — re-read the exact target as well.** Never take the printed output
-for either answer.
-
-**A tracker write can silently revert.** Items verified closed can read open again cycles later — a
-rollback to an earlier snapshot, a re-import over the top — and nothing in the loop surfaces it, so the
-session's "closed" count quietly overstates. Verifying at the moment you close is not enough. Each cycle,
-re-check everything closed this session and re-close what genuinely reverted, with evidence.
-
-**That rule records the hazard but leaves its discriminating test open — WHEN in the cycle — and the
-answer is: across the sequence that exports the tracker, restores it from version control and publishes
-it.** *Each cycle* puts the re-read at the next loop, so a revert stays live for as long as a loop is
-long; one caught that way had been standing over an hour and surfaced by accident during an unrelated
-read rather than by the rule. That publish sequence is the one disturbance every cycle reliably
-contains, and it sits between the close and the next re-read, so it is where to look rather than
-somewhere to look eventually.
-
-**Read BOTH sides of it, not just after.** Measured in one session: two closes verified only at close
-time were both gone by the next read, while a third — re-read immediately before *and* after that
-sequence, then confirmed by parsing the published export for that item's own status field — held. A
-single check afterwards tells you a close is missing but not which side of the sequence lost it, and
-the two have different remedies. **Do not infer the mechanism from the coincidence**: a sequence
-containing several steps is not evidence about which step moved the state, and naming a culprit you
-have not isolated converts a reliable check into a wrong explanation that will be repeated.
+**A tracker write can silently revert** — a rollback, a re-import over the top — so the session's
+"closed" count quietly overstates. **Re-check what you closed across the sequence that exports the
+tracker, restores it from version control and publishes it**, reading BOTH sides of that sequence: a
+single check afterwards tells you a close is missing but not which side lost it, and the two have
+different remedies. **Do not infer the mechanism from the coincidence** — a multi-step sequence is
+no evidence about which step moved the state.
 
 **But a status change made by a LIVE worker is that worker speaking, not corruption.** The rule
-above trains you to read an unexpected status as a bad write, and it supplies no competing
-reading, so the wrong one arrives with nothing to check it. A worker that un-claims an item is
-often saying something precise — commonly that only part of it was shippable and the rest is the
-operator's, which holding the item would bury. Its report is the authority on what it meant, and
-the report is usually minutes behind the status. **Where a worker is alive on the item, read the
-report before you act on the clock**: tracker history timestamps cluster tightly enough that a
-one-second gap is no evidence of a machine write, and reversing a worker's deliberate signal
-destroys the message.
+above trains you to read an unexpected status as a bad write and supplies no competing reading. A
+worker that un-claims an item is often saying something precise — commonly that part of it is the
+operator's. Its report is the authority and usually lags the status by minutes, so read the report
+before acting on the clock.
 
-**But read the item's notes before re-closing anything.** If your process audits merged changes, expect
-closed items to reappear: twelve did in one session, and every one was a legitimate audit reopening the
-item that owned a residual. **The reflex to re-close a "reverted" item destroys a real finding and looks
-like tidiness.** Expect chains — a fix lands, its audit reopens for a second carrier, that fix's audit
-reopens for a third. Two or three rounds converge.
+**Read the item's notes before re-closing anything.** Where a process audits merged changes, expect
+closed items to reappear, and expect chains: a fix lands, its audit reopens for a second carrier,
+that fix's audit for a third. **The reflex to re-close a "reverted" item destroys a real finding and
+looks like tidiness.**
 
-**A reopen that records no finding is not yet a finding.** The rule above assumes the reopen carries its
-residual; sometimes one arrives as a bare status flip — close reason wiped, nothing appended, no new item
-filed — and then there is nothing to read and nothing to dispatch. Both reflexes are wrong: re-closing on
-the bare flip destroys a finding the reopening process may still be mid-writing, and treating the item as
-ready dispatches a worker at work nobody has named. Mark it as awaiting its finding, in the same scan-findable
-words each time, and give the writer one full pass of this loop. If nothing has landed by then, re-close,
-restoring the original close reason — the flip cleared it — and recording the reopen's emptiness alongside.
-Measured against the twelve above: two such flips in one session, distinguishable from the legitimate
-reopens around them only by the absence of any recorded residual.
+**A reopen that records no finding is not yet a finding.** A bare status flip — close reason wiped,
+nothing appended — leaves nothing to read and nothing to dispatch, and both reflexes are wrong:
+re-closing destroys a finding still being written, treating it as ready dispatches a worker at work
+nobody has named. Mark it as awaiting its finding, in the same scan-findable words each time, and
+give the writer one full pass. Then re-close, restoring the original reason the flip cleared and
+recording the reopen's emptiness.
 
-**And a wiped closure makes any brief that CITES it unsatisfiable.** A worker sent to read closure text
-the reopen deleted finds an empty field, and reads the absence as its own failure rather than the
-tracker's. Restore the text or cite where it was preserved, **before** dispatching. Having verified the
-preservation yourself is no protection: the verification and the brief are separate acts, and one mayor
-here confirmed a closure had been preserved into notes and an hour later still pointed a worker at the
-erased field.
+**And a wiped closure makes any brief that CITES it unsatisfiable** — a worker sent to read text the
+reopen deleted finds an empty field and reads the absence as its own failure. Restore the text or
+cite where it was preserved, **before** dispatching. Having verified the preservation yourself is no
+protection: verification and briefing are separate acts.
 
 **Checkpoint tracker state on the heartbeat.** Many trackers auto-stage but never commit, so a long
-session's state strands locally. Commit and push it each cycle.
+session's state strands locally.
 
-**A checkpoint is two operations, and the harness can kill it between them.** The export contends
-with every worker's tracker writes, so under a full fleet a checkpoint that took seconds on an empty
-board can outrun a command cap. Measured twice in one session: one kill left the commit made and the
-push not, and the re-run reported *nothing to checkpoint* — true, and the remote was still behind.
-Verify the remote against the local head after every checkpoint; the script's message answers only
-the commit.
+**A checkpoint is two operations and the harness can kill it between them.** The export contends
+with every worker's tracker writes, so under a full fleet it can outrun a command cap: one kill left
+the commit made and the push not, and the re-run reported *nothing to checkpoint* — true, with the
+remote still behind. **Verify the remote against the local head after every checkpoint**; the
+script's message answers only the commit.
 
-**Long tracker text does not travel as a shell argument.** A batch of notes handed to the tracker
-CLI as quoted strings can fail to parse at the shell before a single note is written, and the
-failure names a line, not the character — and a quoted heredoc is not a cure, as one project's own
-memory had claimed. Write the text to a file with a tool that is not a shell, and drive the tracker
-from that file with a script: the transport then has no quoting to get wrong. Two batches of nine
-notes each died this way in one session; the third, through a file, wrote all nine.
+**Long tracker text does not travel as a shell argument.** A batch of notes passed as quoted strings
+can fail to parse before a single note is written, and a quoted heredoc is not a cure. Write the
+text with a tool that is not a shell and drive the tracker from that file, so the transport has no
+quoting to get wrong.
 
-**If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict in it
-by taking one side wholesale — both sides are full exports, so picking one discards every item the other
-recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch carries a
-snapshot from when its worktree was created, so committing it time-travels the tracker — items closed
-since reopen, items filed since vanish.
+**If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict
+in it by taking one side wholesale — both sides are full exports, so picking one discards every item
+the other recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch
+carries a snapshot from when its worktree was created, so committing it time-travels the tracker.

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -441,15 +441,11 @@ delete), verify, remove, re-check, and **fail loudly if the signature moved**.
   holding a modified tracked file, a note or a draft; when that guard was written, four worktrees held
   uncommitted work a blanket force would have destroyed silently.
 - **A refusal has four modes and they are not interchangeable** — nine worktrees were once read as
-  locked, waited out for two days, and were all simply dirty.
-
-  | mode | meaning | remedy |
-  |---|---|---|
-  | Dirty | modified or untracked files | waiting never clears it |
-  | Held | the sweep stopped on something that is not build output | nothing was deleted |
-  | Locked | clean and intact, a live process holding a handle | genuinely transient; retry |
-  | Partial | a **husk** | the acknowledged-husk path only |
-
+  locked, waited out for two days, and were all simply dirty. **Dirty** is modified or untracked
+  files, and waiting never clears it. **Held** means the sweep stopped on something that is not
+  build output, and nothing was deleted. **Locked** is clean and intact with a live process holding
+  a handle — genuinely transient, so note it and retry. **Partial** is a *husk*, and only the
+  acknowledged-husk path touches it.
 - **A husk no longer appears in the listing, pruning has nothing to clear, and a status check inside it
   fails and prints nothing** — which is why a clean/dirty test reads it as clean. **Do not reach for a
   raw recursive delete**: a husk still holds every file the worktree had, links among them. **A partial

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1,1260 +1,610 @@
 # The loops
 
-The mayor runs on a cadence. Register these five with a scheduler once, and let
-the cadence carry the session.
-
-**Codify each loop body as a single command file in your own repository**, so
-there is one source of truth per loop. Re-pasted prose drifts, and two copies of
-a rule disagree within days. This page is the generic body; your copy pins the
-concrete values.
-
-**What is generic here and what is yours.** Everything below is the method. The
-values it needs — your gate command, your tracker CLI, your hot-zone file list,
-your worktree parent directory, your check-count band — are facts about one
-repository, and they belong in that repository's agent-instructions file. A loop
-body that hardcodes them is a loop body that goes stale in someone else's clone,
-including yours after a refactor.
+The mayor runs on a cadence. Register these with a scheduler once and let the cadence carry the
+session.
 
 | Loop | Cadence | Job |
 |---|---|---|
-| Merge + dispatch | short (~10–15 min) | Merge everything green; copy open nightly alerts into the tracker; refill the fleet |
-| Backlog reread | medium (~60 min) | Re-read *all* open items from the raw list |
-| Posture + stranded sweep | medium (~60 min) | Restate the stance; find genuinely stranded work |
-| Hygiene | long (~2 h) | Prune worktrees and branches |
-| Method reread | long (~60 min) | Check these documents against what the tree does |
+| Merge + dispatch | ~15 min | Merge everything green; refill the fleet |
+| Posture + stranded sweep | ~60 min | Restate the stance; find genuinely stranded work |
+| Hygiene | ~2 h | Prune worktrees and branches |
+| Method reread | ~60 min | Check these documents against what the tree does |
 
-Some people prefer merge and dispatch as separate loops. One loop is simpler and
-has a real advantage: a merge frees a worker slot, and the same tick refills it.
+**Codify each loop body as one command file in your repository**, holding your concrete values — gate
+command, tracker CLI, hot-zone list, worktree parent, check-count band. Two copies of a rule disagree
+within days, so keep that file a thin pointer to this one.
 
-**Five loops, six bodies.** Merge and dispatch share one tick, but each is long
-enough to want a heading of its own, so they are written separately below. The
-numbering follows the bodies; the cadence follows the table.
-
-**Loops fire on time, not on state.** Several ticks legitimately have nothing to
-do. *"Nothing to merge, fleet saturated, here is why"* is a complete report. A
-loop that manufactures work to look busy is worse than a quiet one.
-
-**Run the merge loop on most signals, not only on its cadence.** Any time you are
-re-invoked — a worker completing, an operator message, another loop's tick — sweep
-the open PRs and merge whatever is already green. Checking is cheap and it keeps
-the pipeline moving. What you must never do is *block* on CI: no watch commands,
-no polling loops that occupy the session. One-shot queries, merge what passes now,
-re-check the rest on the next signal.
-
-**And the same holds for any long LOCAL operation** — a bulk cleanup, a dependency install, a
-batch of tracker queries. The operator cannot distinguish a session busy on one from a session
-that has stalled, and will read a long silence as the latter. Run it detached and stay
-answerable.
+**Loops fire on time, not on state.** *"Nothing to merge, fleet saturated, here is why"* is a complete
+report; a loop that manufactures work is worse than a quiet one. Run the merge loop on any
+re-invocation, not only its cadence — but never *block* on CI. One-shot queries, merge what passes
+now, re-check next signal. Same for any long local operation: run it detached and stay answerable,
+because the operator cannot tell a busy session from a stalled one.
 
 ---
 
 ## 1. Merge
 
-### The criterion
-
-Merge only on **all five** clauses. Each exists because a signal that looked green
-turned out not to mean that. There is no bypass. An administrative override is for
-the host's own mergeability-recompute lag, which is not a check at all, and only
-once every clause is already met.
-
-**A change still published as a draft is not a merge candidate, and no number of
-clauses makes it one.** The five test the CHANGE — whether what is proposed is
-green — and none of them can see whether its author has finished with it: workers
-push as they go because pushed commits are the only durable worker state, so *green*
-and *done* are separate facts and this criterion only ever measured the first.
-Marking a change ready for review is the worker's last act, and hosts refuse to merge
-a draft, so the interlock costs this loop nothing to remember. See
-[*Publishing the change*](dispatch-prompt-template.md#publishing-the-change) in
-`dispatch-prompt-template.md`.
-
-**With one exception this loop DOES have to remember, because it is the loop that creates
-it.** The flag protects whoever is inside the change, and it is set by whoever finished
-last — so a fix dispatch onto an EXISTING ready change inherits a flag its original author
-set, and nothing in the change records that somebody is inside it now. The interlock is then
-already open before the second worker starts. **So converting that change back to draft is
-part of dispatching the fix, not part of the fix**: do it yourself, before the worker begins,
-and confirm the state took rather than assuming the call did. The fix worker marks it ready
-last, exactly as any other worker does.
-
-Resolve the head first — the branch name **and** the head revision — because
-clauses 4 and 5 are both keyed to it.
+Resolve the head first — branch **and** head revision; clauses 4 and 5 are keyed to it. Merge only on
+all five:
 
 1. **A non-empty rollup, in the band this repository actually produces.**
 2. **Every check in a passing or skipped state.**
 3. **Nothing non-terminal in the rollup.**
-4. **Every workflow run at the change's current head revision COMPLETED.**
+4. **Every workflow run at the current head revision COMPLETED.**
 5. **The check set was computed against the workflow matrix on the trunk now.**
 
-Each hides a way to be wrong, unpacked below.
+No bypass. An administrative override is for the host's mergeability-recompute lag — not a check — and
+only once all five are met.
 
-### Clause 1 — zero failures is not green
+**A draft is never a candidate.** The five test the CHANGE; none sees whether the author has finished.
+Marking ready is the worker's last act. The one case this loop must remember, because it creates it:
+**a fix dispatch onto an existing ready change inherits a flag its first author set** — convert it back
+to draft before the worker starts, and confirm the state took.
 
-Zero-failures-zero-pending is also exactly what an **empty** rollup reports — what
-a change shows in the seconds before its workflow runs are created, and what
-everything shows while the CI provider is down. One change merged here on a rollup
-read as 0/0/0 eleven seconds before its runs existed; during a provider outage the
-same day, six changes at once reported mergeable with zero checks.
+### Gotchas
 
-So require a **count**, and require it to be in the band this repository actually
-produces. A rollup carrying a fraction of the checks a full one carries is no
-greener than an empty one.
+- **Zero failures and zero pending is also what an EMPTY rollup reports** — the seconds before runs
+  exist, and everything during a provider outage.
+- **The band moves; never trust a written number.** Measure it on changes merged *after* the last
+  matrix change.
+- **Below band has three causes.** With live runs at the head it is a set still building — wait.
+  Without, it is clause 1. A change that ADDS a required job legitimately reads band-plus-one.
+- **Cancelled is *completed*,** so a tally keyed on completion counts it green. Read conclusions; treat
+  everything but success and skipped as not passed.
+- **Skipped says nothing about the trunk** — a surface-armed job is skipped on the trunk push that
+  broke it. When a change reds a gate the trunk is green on, check whether that job ever RAN there; if
+  not you have uncertainty, not a verdict, and only reproducing the gate on the base settles ownership.
+  **A right answer reached by the refuted inference is still a defect**, because the inference is what
+  you carry to the next case.
+- **Never enumerate the blocking states** — requested, waiting and pending exist beside queued and
+  in-progress, so a list fails open on the first one nobody wrote down. Require the terminal state.
+- **A settled rollup is not a quiet branch:** a queued run's checks are not attached to the head yet.
+- **A run triggered by anything but the change event contributes NOTHING to that rollup, ever.** A full
+  count is the more dangerous reading, because a short one sends you looking. Query the runs whatever
+  the count says.
+- **Key the run query to branch AND head revision.** Neither, and a truncated global listing reports
+  "no live runs" for a branch with four. Branch alone, and it blocks forever on superseded runs — a
+  guard that blocks forever is not safe, it is differently wrong.
+- **Case-fold both surfaces.** A CLI commonly reports check states in one case and run statuses in
+  another; one crossing fails closed, the other open.
+- **Pass the full-length revision as the host reports it, never one extended by hand** — an abbreviated
+  or fabricated one matches nothing and clears the clause vacuously. A full rollup beside an empty run
+  list is the tell.
+- **Clause 5 is reading, not counting**, and every field you can read says green. Count the structural
+  lines landed on trunk since the merge base, then read them: nine cache-step lines add no job; four
+  lines adding a job name with its condition are a new required check; a display rename changes nothing.
+- **A job added to a workflow your changes never run contributes no check** — unqualified, that bullet
+  fails closed. Read which events start each named file.
+- **A renamed job reads as a pure addition** if you inspect added lines only. Count removals too: added
+  == removed with corresponding names is a rename, and the band moves by zero.
+- **The set can narrow from the BRANCH.** A retirement legitimately reads below band; the count cannot
+  tell a narrowing from a silent disarm, so read which key left and check it against what the change
+  deleted.
+- **Do clause 5 BEFORE merging.** Afterwards it is easy to reason the drift was harmless; it usually
+  is, and *usually* is what the other four exist to refuse.
 
-**Measure the band; never trust a number written down.** It moves as the matrix
-grows — in one programme the figure here moved four times in three days. Measure it
-on changes merged *after* the last matrix change, because a change branched before a
-new job landed is computed against the superseded matrix and legitimately reads
-band-minus-one, which the count alone cannot distinguish from a change genuinely one
-job short. Update the branch and re-check before judging this clause.
+### Reviewing what you merge
 
-**A third cause is commoner than both, and its remedy is neither: the set is still BEING BUILT.**
-A change opened moments ago legitimately reads a small fraction of the band while its runs are
-created, and the count climbs to full over the following minutes. Updating the branch there
-repairs nothing and restarts the wait. Clause 4 already separates the cases, so read it first when
-the count is short: below band **with** live runs at the head is a set still building, and the
-answer is to wait; below band with **none** is the case this clause is actually about.
+Check the diff against its item, that scope did not sprawl, and that the quality-gates section is
+present. Merge every green change **regardless of author**.
 
-**And one reading above the band is correct.** A change that adds a required job
-sees that job in its own rollup, so it legitimately reads band-plus-one before the
-standing band has moved — the arming proving itself rather than a miscount, and the
-one case where a total above the band is not a reason to look further.
-
-### Clause 2 — cancelled is not passed
-
-A cancelled check is *completed*. A tally keyed on completion therefore counts it
-as green. One change here was reported as "85 of 86 concluded, one check from
-complete" when the truth was 79 passed, 6 cancelled and 1 pending — six re-runs
-across four workflows away from mergeable, not one.
-
-Count only the conclusions that mean the work ran and was fine. Read every other
-value, cancellation included, as a check that has not passed.
-
-**Skipped is accepted, and it says nothing about the trunk.** A surface-armed job is
-skipped on every change that touches none of its surfaces — including, on the trunk, the
-push that broke it. One gate here was skipped on the breaking commit and on every push
-after, while the trunk's rollup read green throughout; it surfaced only when a change
-happened to touch a surface that armed it. So when a change reds a gate the trunk is
-green on, **check whether that job actually ran on the trunk** before concluding the
-change caused it.
-
-**If it did not, what you have is uncertainty, not a verdict.** The reflex — this change
-reds it, so this change broke it — dispatches a fix worker onto that change's branch and
-puts a workaround on a possibly innocent one; but the correction is not the opposite
-reflex. A job that never ran on the trunk is silent about *both* sides: no evidence the
-trunk is broken, and none that the change is clean. Only running the gate settles it.
-Reproduce the actual failing check on a clean checkout of the change's base, or set up an
-equivalent controlled comparison. If it fails there, the defect is the trunk's and the fix
-belongs on a new branch off it; if it passes, the change owns the failure and the fix
-belongs on the change's own branch.
-
-**A right answer reached by the refuted inference is still a defect**, because the
-inference is what you carry to the next case. One mayor here called a red change innocent
-on the bare ground that its failing gate is skipped on trunk pushes, reproducing the gate
-nowhere; a sibling landed shortly after, the failure cleared, and the call now reads correct
-in the record. The outcome did not validate the reasoning, and nothing left in the record
-tells the two apart.
-
-### Clause 3 — require the terminal state, do not enumerate the bad ones
-
-Do not test this by listing the states that block. The vocabulary is longer than it
-looks — queued and in-progress are not the whole of it; hosts also return requested,
-waiting and pending — and a rule that enumerates the bad states fails open on the
-first state nobody wrote down, the same fail-open shape this whole section exists to
-close.
-
-Invert it: require the terminal state. Anything else blocks and is re-checked next
-tick.
-
-### Clause 4 — a settled rollup is not a quiet branch
-
-A queued run's checks are not attached to the head commit yet, so the rollup cannot
-report what it does not yet know is coming. One change here read `ok=78 canc=0
-fail=0 pend=0 total=78` — settled by every field it exposed — while the branch's own
-run listing showed two runs queued. Merging there ships it two workflows short.
-
-**And the checks may not be LATE — they may be absent by construction.** A run triggered by
-something other than the change event — a manual dispatch, a schedule — executes against the same
-head revision and contributes NOTHING to that change's rollup, ever. The rollup is not behind; it
-will never mention that run however long you wait. Measured here: a change whose rollup sat at the
-FULL band, every check passed or skipped, terminal state clean, while a dispatched run against its
-exact head revision ran on for a further sixteen minutes and put not one check in the rollup — whose
-entire contents came from the four workflows the change event had triggered. **That is the opposite
-reading from the case above, and the more dangerous one**: a short count announces itself and sends
-you looking, where a full one closes the question. The heading is the rule and the count is not the
-trigger, so query the runs whatever the count says.
-
-So query the branch's runs as well as the rollup, and key that query to the branch
-**and** to the current head revision. It fails in both directions and both have
-already bitten:
-
-* Keyed to neither — a global run listing truncated to the most recent N — a branch
-  with four queued runs never appeared in the window at all, and the check reported
-  "no live runs" for a branch that had four.
-* Keyed to the branch but not the revision, it over-blocks: two changes sat at
-  full-count for three ticks on runs still queued against a revision from before a
-  re-trigger commit. A stale-revision run is not evidence about this head. **A guard
-  that blocks forever is not safe, it is differently wrong.**
-
-**Two mechanical traps live in this clause, both one character from correct, and they
-fail in opposite directions:**
-
-* **Case.** Your CLI may report check states in one case and run statuses in
-  another. A comparison written against the wrong one counts every *finished* run as
-  non-terminal, and every change reads blocked. This one fails **closed** — it never
-  ships a bad merge, and it never announces itself either, presenting as a CI queue
-  that will not drain. The tell is that every change reads identically blocked; real
-  CI does not stall a whole queue in lockstep. Case-fold the comparison.
-* **Abbreviated revisions.** A run query filtered by an abbreviated revision may match
-  nothing and return an empty list — which reads as "no live runs" and passes this
-  clause **vacuously**. Pass the full revision — **as read from the host, never one
-  extended by hand**: a fabricated full-length revision matches nothing identically,
-  while satisfying a "full revision" rule in form. The impossible pairing is the tell —
-  a change with a full rollup and an empty run list is not quiet, it is mis-queried;
-  re-read the head from the host and run the query again.
-
-### Clause 5 — reading, not counting
-
-This is the newest clause and the least visible, because every field you can read
-says green.
-
-Two changes merged four minutes apart here. The first added a required browser job;
-the second was still checked against the base from before it, so the browser check
-it should have run came back *skipped* and the newly required one never appeared in
-its rollup at all. *"All required checks passed"* was a true statement about the old
-matrix and said nothing about the matrix already on the trunk. That tree happened to
-be green — an audit established it by hand afterwards — but the guard had not known,
-which is the entire problem.
-
-Note the cost structure: this is the direct price of the merge-the-queue-first
-remedy below. **A burst is precisely when the base moves under a check set.**
-
-So count the structural lines that landed on the trunk since the change's merge
-base — job names, dependencies, conditions, action references — and then **read
-them**. The count alone gives opposite verdicts for the same number:
-
-* nine changed lines that are all cache steps add no job and rename no check. The
-  matrix is intact; merge.
-* four changed lines that add a job name with its own condition **are** a new
-  required check — *but only where your changes run that workflow at all*. A job added
-  to a workflow that nothing but a schedule or a manual button starts appears in no
-  change's rollup, so the check set is intact and the merge should proceed. Unqualified
-  this bullet fails **closed**, blocking a merge that should have gone; it is a
-  qualification to the bullet rather than a case of its own because the bullet is what a
-  skimming reader acts on. The diff that gave you the count also names the files it came
-  from — read which events run each, keep only the keys in workflows your changes run,
-  and where any survive, update the branch and re-check.
-
-A display-name rename is a third case and reads like the second: the check set is
-identical, the count is unchanged, only a label moved. That is intact — but you only
-know by reading.
-
-Do this **before** merging. It is easy to merge and then reason that the drift was
-harmless; it usually is, and "usually" is what the other four clauses exist to refuse.
-
-**And the set can move the other way, from the branch rather than the trunk.** Everything
-above is about keys ARRIVING underneath a change; a change that retires a surface REMOVES
-them, so its rollup legitimately reads below the band — and any programme that deletes a
-subsystem produces a run of such changes, so this is not an edge case for the whole length
-of that work. **The count cannot tell a legitimate narrowing from a silent disarm.
-Read which key left, and check it against what the change itself deleted.** A check whose
-entire subject went in the same change is retirement; a check that leaves while its subject
-still stands is the fail-open shape the programme exists to hunt, and it arrives wearing
-the same number. The two readings differ by one question, and the answer is in the diff.
-
-### Merging
-
-Check also that the diff matches its tracker item, that scope did not sprawl, that failure output
-stays actionable, and that the quality-gates section is present.
-
-**Read the FILE LIST against the item, not just the count.** Sprawl is EXTRA work and announces
-itself. The opposite shape does not: **a change that silently REVERTS merged work is green,
-well-formed, compiles, and passes every gate the tree has** — one carried 611 insertions against 910
-deletions out of a worktree whose base had moved, putting back a symbol of a retired subsystem. So a
-path the item does not explain is a finding whichever DIRECTION it runs, and direction is the test
-rather than size: for a surprising file, ask whether something PRESENT on the branch is ABSENT from
-the trunk.
-
-**Do not reach for a gate here.** A revert is mechanically indistinguishable from a change that is
-not one; the only discriminator is whether the reader EXPECTED those paths, so a gate would be a
-control that cannot catch its own case.
-
-Merge every green change **regardless of author**, including the operator's own.
-
-**GREEN AND MERGEABLE ARE SEPARATE FACTS, and the five clauses only ever measured the first.** The
-clauses read the change's own checks; not one looks at what LANDED while those checks ran. Ask the
-trunk directly — a three-way merge into a scratch tree answers without touching your checkout.
-
-**Its failure exit is TWO different verdicts and the status cannot tell them apart: read the
-message, not the code.** A real conflict and *a head revision your checkout has never heard of* both
-return non-zero, and the second is routine whenever the change was rebased through the host's own
-update-branch control rather than by a worker's push. Fetch that head and ask again. Reading the
-first answer as a conflict dispatches a rebase worker at a change that needs nothing — the expensive
-direction, because the worker finds nothing wrong and says so. **Only a genuine conflict warrants
-that dispatch.**
-
-**Prefer server-side head-branch deletion to a client-side delete flag.** A branch still checked out
-in a worktree cannot be deleted locally, and clients typically abandon the *remote* deletion along
-with the local one — so the flag orphans a remote branch on every merge whose worker has not yet
-reported. **A surviving remote ref is never grounds to reap a worktree early.**
-
-**"Base branch was modified" usually means stale — until something is moving the base.** The
-rejection reads like a lost race, so the reflex is to retry; usually the branch is simply behind and
-the remedy is to update it. But any automation that writes to the trunk after a merge makes the race
-real, and then no amount of updating fixes it — one change was refused thirty times, and updating
-made it worse, because CI restarts and another automated commit lands inside that window. **Merge
-the whole queue FIRST, then give the straggler a genuinely empty window.** If it refuses more than
-about three times while blocking nothing, **shelve it**: persistence on an item blocking nothing is
-its own gold-plating.
-
-**A change reporting merge CONFLICTS is a third refusal, and its author is the remedy.** Where
-several green changes share one serial-lane file, each merge flips the rest to conflicting — the
-lane working as designed, and one hunk in one commit. It is not a red change, so the fix-worker path
-does not apply. Message the author first; a live worker resumes with its context intact. Dispatch a
-fix worker onto the existing branch only when the author is gone, and brief either to keep BOTH
-intents hunk by hunk, never taking a side wholesale. **State your believed cause as a claim** — an
-attribution made at the moment of least information, and authors resumed here have refuted it and
-found the real one.
+- **Read the FILE LIST, not the count.** Sprawl announces itself; a change that silently REVERTS merged
+  work is green, compiles and passes every gate. Direction is the test: for a surprising file, ask
+  whether something present on the branch is absent from the trunk. **No gate can catch this** — a
+  revert is mechanically indistinguishable from a change that is not one.
+- **Green and mergeable are separate facts.** Ask the trunk with a three-way merge into a scratch tree.
+- **That test's non-zero exit is two verdicts.** A real conflict and *a head revision your checkout has
+  never heard of* both fail; the second is routine after a host-side branch update. Read the message,
+  fetch, ask again. Only a genuine conflict warrants a rebase dispatch.
+- **Prefer server-side branch deletion to a client-side delete flag** — clients abandon the remote
+  deletion along with the local one, orphaning a ref on every merge whose worker has not reported. **A
+  surviving remote ref is never grounds to reap a worktree early.**
+- **"Base branch was modified" usually means stale — until something is moving the base.** Where
+  automation writes to the trunk the race is real and updating makes it worse: merge the queue first,
+  then give the straggler an empty window. Shelve it after about three refusals if it blocks nothing.
+- **Merge CONFLICTS are the author's, not a fix worker's.** On a shared serial-lane file each merge
+  flips the rest to conflicting — the lane working as designed. Message the author; brief whoever takes
+  it to keep BOTH intents hunk by hunk; **state your believed cause as a claim**, made at the moment of
+  least information.
 
 ### After each merge
 
-**Fetch the trunk, then fast-forward onto the remote-tracking ref** — two commands rather than a
-pull, chained so a failed fetch cannot be followed by a merge against a stale ref. Name remote and
-branch on the fetch; the bare form silently no-ops when an automated push races it. Then **verify
-the tree, not the message**: compare the local head against the remote head, because a pull will
-print `Updating <old>..<new>` on a head that did not move.
+Fetch the trunk, then fast-forward onto the remote-tracking ref — two commands chained, remote and
+branch named on the fetch. Verify the local head equals the remote head. Verify the worker closed its
+item, and that anything routed into the change landed in the diff.
 
-**If they disagree, read both again before believing it.** Automation writing to the trunk can land
-between the two reads, so a perfectly synchronised checkout reports a mismatch. One disagreement is
-not evidence. Read the *fetch's* own exit code for the same reason: a failed fetch and a subsequent
-"Already up to date" print into the same buffer, and the reassuring line is the lie.
-
-**Do not collapse that pair back into a pull.** A pull picks its merge target out of a scratch file
-any concurrent process in the same checkout can rewrite — most exposed being the shared checkout
-every agent reaches into to add a worktree — and a captured target does not fail honestly: measured
-once silently fast-forwarding the trunk **onto a feature branch**, and once aborting with the
-divergence message below on a clean, undiverged tree where that remedy is inert. **A failure that
-borrows another cause's message cannot be discriminated by message text**, so retire the command
-that reads the shared file rather than adding a third case. A remote-tracking ref cannot be captured
-that way. The exposure grows with fleet size.
-
-**An aborted fast-forward has two causes with different remedies, and the message says which** — but
-only because the pair above no longer reads the shared file. Naming remote and branch cures the
-silent no-op and neither abort, so read the text before reaching for a familiar fix:
-
-* **"Local changes would be overwritten"** — uncommitted tracker state. Checkpoint, *then* clear,
-  *then* retry. Clearing first reverts whatever the tracker just recorded.
-* **"Not possible to fast-forward"** — genuine divergence, usually your own checkpoint against
-  commits that landed while you made it. Rebase, then **push**: you are left ahead by one and the
-  equality check cannot pass until it lands. **That intermediate state is expected, not a second
-  failure.** Both reflexes are wrong — repeating the pull stays ahead, forcing equality discards the
-  checkpoint the drill exists to protect. **Rebase onto the remote-tracking REF, not with a pull
-  carrying a rebase flag**, which reads the same shared file this drill just retired: **a remedy
-  inherits the hazards of whatever it reads**, so choose it by what it reads rather than by what it
-  is called.
-* **A truncated abort, or a ref-level race** — re-fetch and re-read. Reach for neither remedy above.
-
-**Never wire a remedy behind a pipe.** `pull … | tail -1 || fallback` never runs the fallback,
-because the pipeline's status is the filter's and the filter succeeded.
-
-Then verify the worker closed its item (close it with a concrete cross-reference if not). **If
-anything was routed into this change, verify it landed in the diff** before closing its owner — a
-routed item is exactly the kind a worker may reasonably decline.
+- **Verify the tree, not the message** — a pull prints `Updating <old>..<new>` on a head that did not
+  move.
+- **One disagreement is not evidence**: automation can land between the two reads. Read the fetch's own
+  exit code too — a failed fetch and a following "Already up to date" print into the same buffer.
+- **Never collapse the pair into a pull.** A pull takes its target from a scratch file any concurrent
+  process in the checkout rewrites, and it does not fail honestly — measured once silently
+  fast-forwarding the trunk **onto a feature branch**, and once aborting with the divergence message on
+  a clean tree where that remedy is inert. **A failure that borrows another cause's message cannot be
+  discriminated by message text.**
+- **An aborted fast-forward has two causes and the message says which.** *"Local changes would be
+  overwritten"* is uncommitted tracker state: checkpoint, *then* clear, *then* retry — clearing first
+  reverts what the tracker just recorded. *"Not possible to fast-forward"* is divergence: rebase, then
+  **push**. You are left ahead by one and **that is expected, not a second failure** — repeating the
+  pull stays ahead, forcing equality discards the checkpoint.
+- **A remedy inherits the hazards of whatever it reads**, so rebase onto the ref, not with a pull
+  carrying a rebase flag.
+- **Never wire a remedy behind a pipe** — the pipeline's status is the filter's, so the fallback never
+  runs.
 
 ### When a change is not green
 
-A real, repeated failure on the touched surface is not a flake and is never an override candidate.
-Once you have established the failure is the change's own and not the trunk's — clause 2 says what
-establishes it, and a gate that never ran on the trunk does not — dispatch a fix worker onto the
-**existing** branch, running the **actual** failing gate rather than a proxy that already passed.
+A repeated failure on the touched surface is never an override. Once clause 2 establishes the failure
+is the change's own, dispatch a fix worker onto the **existing** branch, running the **actual** failing
+gate. If the change is already ready, convert it to draft first.
 
-**If that change is already marked ready, convert it back to draft first and confirm the state
-took.** The flag is set by whoever finished last, so a fix dispatch inherits one the previous author
-set and the interlock is open before the second worker starts. It belongs to the dispatcher rather
-than to the brief: the worker cannot set a flag that is already ready, and by the time it could the
-merge has landed underneath it.
-
-**But a red on a change still published as a DRAFT belongs to its author while that author is
-alive.** A worker briefed to push as it goes publishes reds by design — one deleted a gate's witness
-in its first commit and the gate itself in its third, so three required jobs read red for the twenty
-minutes between, each a job the change was in the middle of removing. A fix worker sent there is a
-second worker on one branch, the collision every fence exists to prevent, arriving wearing this
-loop's own instruction. **So on a draft, read the failing job against the diff so far** — a red whose
-subject the change is deleting is sequencing, not a defect — and wait for the ready mark or message
-the author.
-
-**A failure BEFORE any repository code ran is the second case, and the failing step names itself**
-— a dependency download rate-limited, a runner setup step dying. The diff cannot have caused it, so
-no second observation is needed: re-run and hold the re-run to the same clauses. **But re-running is
-not a cure** — when SEVERAL changes fail that way rather than one job twice, fleet size is the cause
-and the mayor says so.
-
-**A check that never TERMINATES is a third case neither remedy fits.** It has not failed, so nothing
-above triggers; it has not passed, so clause 3 blocks the change for as long as it runs — which is
-exactly when the pressure to override arrives. It is not a sixth clause: clause 3 already blocks
-correctly, and what is missing is only what to DO.
-
-**Recognise it on the clock, against that job's OWN normal cost — measured, never remembered.** Job
-costs move, so a remembered constant cannot detect a delta; the job's recent successful runs are the
-baseline and reading them costs one query.
-
-**But a SKIPPED run is reported as a successful one, and it contributes a zero-length sample.**
-Where a job is conditional — surface-armed, path-filtered, gated on another job — most of its recent
-"successes" never executed, and their start and end times are equal. A baseline drawn from them
-collapses toward zero, after which every real run reads as overrunning by orders of magnitude. **It
-fails in the alarming direction**, manufacturing a hang rather than hiding one, and the remedy it
-invites is the cancel-and-re-run this section warns costs another wall-clock hour. **Discard the
-zero-length samples before averaging, and check the survivors are a plausible sample size** — one
-real run is a data point, not a baseline. The workflow's own total is a sanity check only: it bounds
-the job from above and can be dominated by something else.
-
-**A timeout kill usually reports as CANCELLED rather than as a failure**, which clause 2 handles
-correctly while saying nothing about *why*. Elapsed time against the job's declared cap tells them
-apart: landing ON the cap is a timeout kill, finishing well inside it is a superseding push or a
-hand cancel. Expect rollup jobs to go red seconds afterwards — those fail BECAUSE of the
-cancellation, so counting them as independent failures overstates the problem and points at the
-wrong remedy.
-
-**Then discriminate, because the two causes take opposite remedies.** UNRELATED jobs overrunning in
-the SAME run is infrastructure — a diff cannot slow two jobs that share no surface with it or with
-each other — so cancel and re-run, held to the same five clauses. ONE job overrunning alone, on a
-surface the diff touches, is a hang the change introduced: dispatch a fix worker that reproduces it.
-**A "cancel and re-run" written without that discriminator is worse than no remedy at all**, because
-the reflex burns another hour and hides the infinite loop a worker just wrote. Neither case is ever
-an override.
-
-**A job with no declared timeout is the only reason this case needs a mayor-side remedy at all.** A
-capped job converts a wedge into a fast, legible failure and reports itself; an uncapped one inherits
-a host default measured in hours. Cap the jobs, and keep the remedy above for the ones that hang
-anyway.
+- **A red on a DRAFT belongs to its author while that author is alive.** A worker pushing as it goes
+  publishes reds by design — one deleted a gate's witness in its first commit and the gate in its
+  third. Read the failing job against the diff so far.
+- **A failure before any repository code ran names itself** — re-run it. But when SEVERAL changes fail
+  that way rather than one job twice, fleet size is the cause and re-running is not a cure.
+- **A check that never TERMINATES fits neither remedy.** Clause 3 blocks it correctly; what is missing
+  is what to DO. Recognise it against that job's OWN recent cost, measured.
+- **A SKIPPED run reports as a success and contributes a ZERO-LENGTH sample.** For a conditional job
+  most recent "successes" never executed, so the baseline collapses toward zero and every real run
+  reads as overrunning. It fails in the alarming direction, manufacturing a hang. Discard the
+  zero-length samples and check the survivors are a plausible sample size.
+- **A timeout kill usually reports as CANCELLED.** Landing ON the declared cap is a timeout; finishing
+  well inside it is a superseding push or a hand cancel. Rollup jobs go red *because* of the
+  cancellation — counting them as independent failures points at the wrong remedy.
+- **Discriminate before cancelling.** Unrelated jobs overrunning in one run is infrastructure — cancel
+  and re-run. ONE job overrunning on a surface the diff touches is a hang the change introduced. **A
+  "cancel and re-run" without that discriminator is worse than no remedy**: it burns an hour and hides
+  the infinite loop a worker just wrote.
+- **An uncapped job is the only reason this needs a mayor-side remedy.** Cap the jobs.
 
 ---
 
 ## 2. Dispatch
 
-**Re-read the raw ready list every tick.** Do not infer the backlog from notifications, and do not
-trust a filter that returned empty — an empty filter is not a dry backlog. One mayor under-saturated
-at one to three workers while a hundred items were ready, because a homegrown filter kept answering
-empty.
+Re-read the raw ready list every tick, ordering each item by the tracker's own timestamps. Filter out:
+operator holds; items gated on another's merge; surfaces a live worker holds; hot-zone collisions;
+contended exclusive resources. Then shape, dispatch, and write the ledger line as you go.
 
-**Where a system of record reports its own failures somewhere the tracker is not — a nightly alert
-channel, say — read that channel before the ready list.** The loops read the tracker and the review
-queue and nothing else, so such a report reaches no dispatch until something copies it across. Give
-every open alert exactly one open item keyed on the alert's own identifier; later ticks then do
-nothing, the alert staying the live counter and the item being the dispatch edge. Two misreadings
-both fail open: **a failed read is "did not sweep this tick", never "nothing red"**, and where the
-alert closes only after several consecutive greens, *item closed, alert still open* is the expected
-state after a fix lands rather than a new failure.
+Target a fixed ceiling — six is workable for one operator — and refill the instant a slot frees.
+Dispatch low-priority items to stay saturated. Pick shape by kind, then priority, then size. **A clear,
+unblocked item goes out now, not next tick.**
 
-**Where your agent-instructions file carries no query for that channel, the read is not owed — do
-not reconstruct one.** A project whose alert channel has gone quiet retires this read by the ABSENCE
-of those values, which reads exactly like an oversight, so the coordinator looks, finds nothing, and
-invents a query. **An invented query is worse than no read at all**, and its failure is undetectable
-when the channel is genuinely empty: the wrong instrument and the right one agree, and their
-agreement is not evidence.
+### Gotchas
 
-**Order each item by the tracker's own timestamps, not by position and not by dates in its prose.**
-The mechanics are set out for the worker under [*Common
-preamble*](dispatch-prompt-template.md#common-preamble) and bind the mayor identically.
+- **An empty filter is not a dry backlog.** One mayor sat at one to three workers while a hundred items
+  were ready, because a homegrown filter kept answering empty.
+- **The exclusive-resource filter is the only exclusion with a release condition, and the loop must
+  lift it.** Where the exclusives are all that REMAINS, the filter has stopped protecting the fleet and
+  is refusing the backlog — drain deliberately and take that work.
+- **Where failures are reported outside the tracker** — a nightly alert channel — read it before the
+  ready list, one open item per alert keyed on the alert's own id. **A failed read is "did not sweep",
+  never "nothing red"**, and *item closed, alert still open* is the expected state after a fix lands.
+- **Where your instructions carry no query for that channel, the read is not owed — do not invent
+  one.** An invented query is undetectable when the channel is empty: the wrong instrument and the right
+  one agree, and their agreement is not evidence.
+- **A ruling can be a child item OR the close reason of a CLOSED dependency.** **Enumerating by id
+  prefix is not enumerating** — a generated id need not share the parent's prefix, so a prefix filter
+  returns the children and omits the item that governs.
+- **A ready list overstates readiness by a lot** — roughly a fifth were genuinely dispatchable.
+  **Record the fence on the item it fences, with what clears it, at the top, and in the same words every
+  time.** The tick reading it back is scanning, not reading; a fence recorded on the item that *causes*
+  it is never met by its own reader. The sameness does the work, not the wording.
+- **A marker finds a DISCHARGED hold as well as a live one.** Whoever discharges it strikes it in the
+  same act. Where you cannot edit the original, append the negation in the same words so a scan returns
+  every occurrence and **the newest governs**.
+- **Verify before dispatching.** If it landed already, close as a verified duplicate.
+- **A count is a claim, and a symbol-shaped check does not test it** — the symbol still resolves while
+  the count is zero or triple. Re-run the item's census at tip.
+- **An item's LIST OF SITES is worse than a count**, because it drifts in MEMBERSHIP: an entry somebody
+  already fixed sends a worker to edit correct text, while a site the list never had stays live.
+  Re-derive it at tip and require the DELTA reported.
+- **Exclude any generated export from a tree-wide census** — a whole-database export matches almost any
+  identifier and floods a context-bounded worker with tracker rows.
+- **Check whether the work is already DONE in the tree**, which no metadata check asks. Search the whole
+  commit MESSAGE (subject-only fails open); flatten each commit to one record, or a line-oriented search
+  attributes an identifier to its neighbour; anchor the identifier, or a shorter id matches every longer
+  sibling. **A matching commit is a POINTER, never a closure** — some hits are the very change the item
+  was filed AGAINST, a fact the title often carries in a word like *still*.
+- **The inverse fails the other way: work that HAS landed on an item still legitimately live.** Where a
+  process audits merged changes, a reopen leaves the tree confirming the original deliverable exactly as
+  for a finished item. **The tree answers *did this work land*, never *is this item finished*.**
+- **The sibling that discharges an item is usually the one whose fence sent the work elsewhere.** Read
+  across a split's siblings, and treat a parent's remainder table as stale until re-derived.
+- **The unit is the block, not the file.** Two items that read as different concerns can land in the
+  same paragraph — invisible when you schedule them, cheap to avoid only there.
 
-**A ruling can arrive as a child item OR as the close reason of a CLOSED dependency**, and the
-second is commoner for a ruling that discharges a slice — normative text rather than an archival
-note. Read the dependency list as well as the children, with each linked item's status and close
-reason. **Enumerating by id prefix is not enumerating**: a generated id need not share the parent's
-prefix, so a prefix filter returns the children while silently omitting the item that governs.
+### Contention comes in four shapes; the ceiling bounds only the first
 
-Filter out before shaping anything:
+**Surfaces** are what the parallel-or-sequential split reasons about. A **heavyweight gate** is
+contention for the MACHINE — six workers on six disjoint surfaces still wedge one another, and a wedge
+presents as a hang. The **shared allowance** has no local evidence at all, so N workers are not N
+independent bets: they fail TOGETHER, mid-run, on a limit none approached alone. And **the tracker
+itself, where YOU are the competitor** — the first three degrade the workers, this one degrades the
+mayor.
 
-* items awaiting an operator decision or hold;
-* items gated on another's merge;
-* items whose surface a live worker holds;
-* items colliding in a hot-zone file;
-* items whose resource is exclusive and currently contended — **the only exclusion with a release
-  condition the loop must eventually lift.** Where the exclusive items are all that REMAINS, the
-  filter has stopped protecting the fleet and is simply refusing the backlog: say so, let the fleet
-  drain, and take that work deliberately. A filter with no release condition becomes a permanent
-  fence.
-
-**A ready list overstates readiness by a lot** — roughly a fifth of "ready" items were genuinely
-dispatchable, the rest fenced by something the tracker cannot represent. **Record the fence on the
-item it fences, with what clears it, at the top, and in the same words every time.** The tick that
-reads it back is scanning rather than reading, so a fence written truthfully in the middle of a long
-field does not exist for the next tick — and a fence recorded on the item that *causes* it rather
-than the item it *blocks* is never met by its own reader. What does the work is the sameness rather
-than the wording.
-
-**But a marker makes a DISCHARGED hold findable exactly as well as a live one.** So the marker is
-written by whoever SETS the hold and **struck by whoever discharges it, in the same act** — not left
-standing with a correction beneath. Where the tracker will not let you edit the original, append the
-marker's negation in the same words, so a scan returns EVERY occurrence and **the newest governs**; a
-hold can be set, discharged, then set again on a different question. **Treat a banner with no
-discharge beneath it as a claim about the past.**
-
-**Verify before dispatching, not after.** Check that the alleged broken symbol, missing file or stale
-convention is still there. If it landed already, close as a verified duplicate.
-
-**A count is a claim too, and a symbol-shaped check does not test it.** A census item asserts a
-number, so the symbol still resolves while the count is zero or triple. Re-run the item's own census
-at the current tip.
-
-**Exclude any generated export from a tree-wide census.** A whole-database export inside the working
-tree carries every title, description and comment, so it matches almost any identifier — inflating
-the census into something that reads exactly like a correct one and sends its worker to sites that
-do not exist, while flooding a context-bounded worker with tracker rows. Exclude it in the brief as
-much as in your own check.
-
-**The sibling that discharges an item is usually the one whose fence sent the work elsewhere.** A
-tree fenced off from item A is exactly the tree item B is free to take. Read *across* a split's
-siblings before dispatching any child, and treat a parent's remainder table as stale until
-re-derived.
-
-### Shape and saturation
-
-Target a fixed number of concurrent workers — six is a workable ceiling for one operator — and
-refill the instant a slot frees. Dispatch low-priority items to stay saturated; the goal is a
-backlog trending to zero.
-
-**Contention comes in four shapes and the ceiling bounds only the first.**
-
-1. **Surfaces** — contention for files. This is what the parallel-or-sequential split reasons about.
-2. **A heavyweight gate** — contention for the MACHINE. Six workers on six disjoint surfaces can
-   still wedge one another inside one, and a wedge presents as a hang rather than a failure.
-   Sequence dispatches that will all run one, or take the re-run knowingly.
-3. **The shared ALLOWANCE** — a quota with no local evidence at all, since nothing in a worktree, a
-   gate log or a run listing says how much is left. N workers are therefore not N independent bets:
-   they fail TOGETHER, mid-run, on a limit none approached alone. **The remedy is not a smaller
-   fleet**, which trades a recoverable failure for a permanently slower one; it is that *push
-   continuously* makes a fleet-wide kill survivable, and that salvage is then wanted for the whole
-   fleet at once.
-4. **The tracker itself — where YOU are the competitor.** The first three degrade the workers; this
-   one degrades the mayor, because a saturated fleet reads and writes the item store continuously
-   and your own queries queue behind it.
-
-**What makes the fourth worth writing down is the misreading, not the slowness.** A timeout on the
-item store presents exactly as a corrupt or wedged store, and both reflex remedies are wrong:
-re-running adds load to the overloaded thing, and *restoring the store's export from version-control
-history* looks like recovery while silently reverting every item recorded since that revision.
-**Treat a coordinator timeout as contention until something else proves corruption**, and ask the
-store one thing per command while saturated.
-
-**Take a first look that does not touch the store**: compare the committed export against the
-working copy by size, and check the tree is clean. **But be exact about what that establishes** — it
-reads the export and the working tree, never the database, so it cannot tell you that a timed-out
-mutation committed, nor that the store holds nothing newer. **And equal counts are not equality**:
-one checkpoint passed its row-count floor at 1,938 against 1,938 having dropped three items and
-reverted two statuses, because the two sides substituted one-for-one. Size is a smoke test against
-truncation. Verify properly once the contention clears.
-
-**A queued measurement window makes an otherwise-free slot not free.** While a window needing a
-quiet machine is queued, an item whose gate is heavyweight is a cost charged to that window rather
-than a slot to refill: hold the fleet thin on purpose, record that on the window's item with what
-releases it, and keep dispatching work whose gates leave the machine quiet. **Quiet is a property of
-the whole set of gates an item arms, and no single classifier's answer describes that set** —
-enumerate them. Documentation usually clears the bar, but earn that per item rather than per
-category.
-
-**And where a window registers that no peer WRITES inside its bracket, any write voids the run
-however cheap it is.** Merging a change and creating a worktree cost the machine almost nothing and
-are both writes, so a rule ordered by cost gets those exactly backwards: for such a window the fleet
-is empty rather than thin, and you merge nothing either. Have the window record that condition as a
-test — capturing the trunk tip and the worktree list at both brackets — so a violation is reported
-rather than assumed.
-
-**An empty fleet is not a quiet machine.** The processes a gate starts routinely outlive it: the run
-ends, the change merges, the tree is reaped, and build servers and browsers stay resident with
-nothing pointing at them. So a mayor can hold the fleet thin, empty it, merge nothing, and still be
-handed a machine it has measured nothing about. **But counting those processes is the same error one
-level down** — presence is not load, and a count answers presence. One idle box carried a hundred-odd
-resident processes accounting for 0.14 of 2.6 busy cores between them, the largest consumer being an
-editor. **Measure LOAD, at both brackets.**
-
-Pick the shape by kind first, then priority, then size — the shapes are under [*Dispatch
-shapes*](dispatch-prompt-template.md#dispatch-shapes).
-
-**The unit is the block, not the file.** Two items that read as *nominally different concerns* can
-still land in the same paragraph, which is why the collision is invisible when you schedule them and
-cheap to avoid only there. The remedy is under [*Fences*](dispatch-prompt-template.md#fences).
-
-**Dispatch immediately on clear.** A clear, unblocked item goes out now, not next tick.
-
-**And write the dispatch's record line as you dispatch it** — the line a later tick uses to find this
-worker's completion report. What it must carry is under *Reaping*, deliberately not repeated here: a
-field list kept in two places will disagree with itself.
+- **The remedy for the allowance is not a smaller fleet**, which trades a recoverable failure for a
+  permanently slower one. *Push continuously* makes a fleet-wide kill survivable.
+- **A coordinator timeout presents exactly as a corrupt store, and both reflexes are wrong**: re-running
+  adds load to the overloaded thing, and restoring the export from version-control history silently
+  reverts every item recorded since. Treat it as contention until something proves corruption.
+- **A no-store first look reads the export and the tree, never the database** — so it cannot tell you a
+  timed-out mutation committed. **And equal counts are not equality**: one checkpoint passed its floor
+  at 1,938 against 1,938 having dropped three items and reverted two statuses, the sides substituting
+  one-for-one.
+- **A queued measurement window makes an otherwise-free slot not free.** Hold the fleet thin on purpose
+  and keep dispatching work whose gates leave the machine quiet. **Quiet is a property of the whole set
+  of gates an item arms** — no single classifier describes that set.
+- **Where a window registers that no peer WRITES in its bracket, any write voids it however cheap.**
+  Merging a change and creating a worktree cost nothing and are both writes, so a rule ordered by cost
+  gets those backwards.
+- **An empty fleet is not a quiet machine** — gate processes outlive their gates. **But counting them is
+  the same error one level down**: presence is not load. One idle box carried a hundred-odd processes
+  accounting for 0.14 of 2.6 busy cores. Measure LOAD, at both brackets.
 
 ### Routing a finding onto a live worker's file
 
-Under fan-out, findings keep landing on files somebody already holds — from an audit,
-from another worker's report, from your own reading.
+Resolve an exact owner, then route-and-note or queue-and-note. **An owner plus one note is the whole
+safeguard** — no registry, no tracking field, no script.
 
-**Resolve an exact owner first.** Update or reopen the item that already owns the
-finding, or file one when none does. **Filing is not dispatching** — the first wording of
-this rule conflated them, and it is a second *dispatch*, not a second item, that puts two
-workers on one file.
+- **Filing is not dispatching.** It is a second *dispatch*, not a second item, that puts two workers on
+  one file.
+- **That the holder's change is still OPEN is a precondition** — test it before testing reachability.
+  Where it has merged there is nothing for the fix to land in, and a reachable agent is not a route.
+- **Routing does not create an owner.** The message lives in one transcript, so if that agent dies or
+  reasonably declines — declining is often correct — the finding evaporates and the audit that found it
+  has already run.
+- **Sometimes routing is wrong**: it widens a deliberately bounded fence mid-flight. Queue the owner and
+  note on the in-flight item that the work is owned elsewhere and is **not** part of this repair.
 
-**Then route it**, rather than waiting for the holder to finish and losing the context it
-was found in: message the worker that holds the file, and the fix lands inside the change
-that is already open. Six routed findings landed that way in one evening, none
-conflicting, several fixed minutes after they were found. **That the change is still open is
-a precondition rather than scene-setting**: routing works because there is an open change for
-the fix to land in, so test that before testing whether the agent is reachable. Where the
-holder's change has already merged there is nothing for the fix to land in, and a reachable
-agent is not a route — take queue-and-note below, even though no fence is being widened.
+### Two standing conditions
 
-**But routing does not create an owner, and that is the half people drop.** The message
-lives in one agent's transcript, so if that agent dies, times out, or reasonably declines the
-extra item — declining is often correct — the finding evaporates, and the audit that found it
-has already run. An audit caught exactly this: a mayor had *"routed it only to a transient
-worker, leaving no durable owner"*, the sole record being a close reason on a **different**
-item — a record on the wrong object, because nobody reads a closed item looking for open work.
-So put **one note on the owning item** saying what was routed, to whom, and what happens if it
-does not land.
+**Quiescent is a valid state.** At the tail of a drain, dispatch is one-unblocks-the-next, not fan-out.
+Hold, surface what needs the operator, and do not manufacture work.
 
-**Sometimes routing is the wrong move altogether.** It widens a deliberately bounded fence
-mid-flight, which is how a bounded repair becomes an unbounded one. Then leave that owner
-queued or sequenced instead, and note the overlap on the in-flight item — saying explicitly
-that the item is owned elsewhere and is **not** part of the in-flight repair, so nobody
-reading that item's newest notes adopts it.
-
-Route-and-note, or queue-and-note. An owner plus one note is common to both and is the whole
-safeguard. It does not want to grow past that: no routing registry, no tracking field, no
-script.
-
-### Quiescent is a valid state
-
-At the tail of a drain, dispatch is one-unblocks-the-next, not fan-out. Hold, surface what
-needs the operator, and do not manufacture work.
-
-### You are one of the concurrent writers
-
-The scratch area dispatched agents share is keyed to the SESSION, not to a worktree, and the
-mayor writes there too — change bodies, working notes, gate artefacts — while N workers do.
-Every naming rule you paste into a brief binds you equally. The block that carries it is
-written in a second person aimed at a dispatched agent, so it does not read as addressed to
-you: one mayor enforced that rule on eight dispatches and then lost its own change body to a
-peer, under exactly the bare name the rule forbids. **A rule scoped to a ROLE exempts whoever
-does not identify with the role** — when a hazard belongs to a shared resource, scope it to
-the resource.
-
-Naming one shared area re-creates that exemption one level down. Reaching for a system temp
-directory feels like stepping out of a shared area into a private one, and it is the reverse:
-every session on the machine writes there, where the session scratch area holds only the
-current session's agents. It changes the resource without changing the hazard, and it reads
-as exempt precisely because it is not the area the rule names — so the scope is **every
-directory you do not exclusively own**, not the one a rule happens to name.
+**You are one of the concurrent writers.** The scratch area is keyed to the SESSION, not to a worktree,
+and the mayor writes there too. **A rule scoped to a ROLE exempts whoever does not identify with the
+role** — one mayor enforced the naming rule on eight dispatches and then lost its own change body to a
+peer under exactly the bare name it forbids. **And naming one shared area re-creates that exemption one
+level down**: a system temp directory feels private and is the reverse. The scope is every directory
+you do not exclusively own.
 
 ---
 
-## 3. Backlog reread
-
-**Dispatch reads the ready list; this loop reads everything else.** A ready list omits held,
-blocked and worker-held items by construction — and those are the ones that fail quietly, because
-nothing in the short loop ever looks at them again.
-
-So read **all** open items from the raw list — not a saved filter, not the ready view, not what you
-remember filing — ordering each by the tracker's timestamps and re-enumerating children, as
-*Dispatch* explains.
-
-**Every note you leave here becomes the NEWEST text on that item.** Reader and writer are not
-symmetric: a reader can walk past a stale note below newer text, but nothing defends against a stale
-note that IS the newest text — a newest-first walk lands on it and stops. A note re-derived from the
-DESCRIPTION rather than from the notes that overtook it is newer by timestamp and older in
-substance. **The tell is mechanical: a note repeating a figure some later note retracted re-derived
-instead of re-checking.** Cite the check you made, or say you are summarising and from what.
-
-**So do not re-record a fence already recorded where a scan will meet it.** *Dispatch* says write
-the fence; this loop says re-test it. Run together on a cadence they produce a note per fenced item
-per pass, each true, each the newest text, until the item's newest layer is a stack of no-ops.
-**Write only what the item does not already carry** — a fence that CLEARED, a changed condition, a
-question its existing text leaves a reader to derive. *Unchanged* is a finding about your tick and
-belongs in the tick's report.
-
-**Check ONCE whether your tracker's update verb appends or REPLACES.** Every rule above assumes
-items accumulate; where the verb replaces, the walk you are teaching readers to make runs over text
-you deleted. No error, no warning, and the item afterwards looks well-maintained. Where the tracker
-exports to a versioned file the loss is fully recoverable, so this is a reason to check the verb
-rather than to fear the damage.
-
-Five things surface here and nowhere else.
-
-**1. A fence that has cleared.** The dispatch tick records a fence and nothing removes it when the
-condition is met; the item never returns to *ready*, so only a full read notices. **Recording a
-fence is worth nothing without the loop that reads it back.**
-
-**2. A dependency that has outlived what it was enforcing** — the thing it waited for shipped, and
-the item is still blocked. Force the close and write the reasoning on the item (*Tracker mechanics*).
-
-**3. A closure that reverted.** Verifying at the moment you close is not enough. **Read the item's
-notes before re-closing anything** (*Tracker mechanics*). And the window is not your own tick: a
-closure can revert in a session nobody is auditing and sit reopened for days.
-
-**4. A hold costing more than it is holding.** Separate *needs a decision* from *needs work under a
-decision already made* — the second is dispatchable now and tends to sit in the first pile. For the
-rest, record what the hold costs: which items are behind it, and what stops if it stays. A hold with
-no cost written on it reads as free.
-
-**But read WHY it was set before writing what it costs, because the count reads the same either
-way.** An oversight and a deliberate dormancy put identical numbers behind a hold. Where the item
-records a disposition — parked pending a decision nobody has taken, with a reactivation trigger —
-the queue behind it is parked by the same decision. **Cost is only cost against a want**, and
-counting feels like compliance, so a mayor who stops at the number stops one paragraph short.
-
-**The mirror case: a hold that expires on a DATE while its reason does not.** A deferred item
-returns to the ready list on its own, carrying its priority and an empty blocker column, reading as
-MORE legitimate than an ordinary item because a reappearance looks like something happened. Nothing
-happened; a date passed. **Read defer dates across the whole deferred set** — they get set in
-batches, so a cluster lapsing together makes the list look suddenly and misleadingly rich. Where the
-reason will outlive the date, write that on the item BEFORE the date arrives: afterwards nothing
-prompts anybody, because this is the one hold that removes its own evidence.
-
-**5. An item that is already DONE.** The four above interrogate the item's metadata; none asks
-whether the WORLD already contains what it wants. Such an item presents as perfectly healthy — open,
-unblocked, correctly prioritised, and pointless — and the short tick cannot catch it, because that
-tick looks straight at dispatchable items and this one *is* dispatchable.
-
-**Check the TREE in bulk here**, not one item at a time at dispatch, which is too late and too
-narrow. For each open id, search the trunk's merged history for it. Three mechanics decide whether
-the sweep is honest:
-
-* **Search the whole commit MESSAGE, not the subject.** Where an identifier goes is a house style
-  nobody enforces, so assume the body. Subject-only fails OPEN — zero is the answer that causes a
-  dispatch, and it looks identical to a correct one.
-* **Flatten each commit to one record before matching**, or a line-oriented search splits one change
-  across several and attributes an identifier to its neighbour.
-* **Anchor the identifier so it ends where it ends**, or a shorter id matches every longer sibling.
-
-**A matching commit is a POINTER, never a closure.** Some hits are partial work; some are the very
-change the item was filed AGAINST — a fact the title usually carries in a word like *still*. Confirm
-at source before closing.
-
-**And the sweep has an inverse that fails the other way: work that HAS landed on an item still
-legitimately live.** Where a process audits merged changes, an audit reopens the item that owned a
-residual, so the tree confirms the original deliverable exactly as it would for a finished item.
-This is the more dangerous direction, because the tree AGREES with closing and only the notes carry
-the finding. **The tree answers *did this work land*, never *is this item finished*; when the two
-disagree, the notes govern.**
-
-In-progress items are read here for scope and fences; *is this worker alive?* belongs to the
-stranded sweep.
-
-**Most passes find nothing, and a pass that finds nothing is complete.** What is not complete is a
-pass that reports nothing without having read the raw list.
-
----
-
-## 4. Posture, and the stranded sweep
+## 3. Posture, and the stranded sweep
 
 ### Posture
 
-**Keep the project's stance as a single quoted block in exactly one file, and paste that
-block verbatim into every dispatch preamble.** This loop is that file's natural home,
-because it is also the loop that re-reads it.
+Keep the stance as a single quoted block in exactly one file and paste it verbatim into every preamble.
+Reassert any **voice** the operator asked for — voice drift returns within about ten turns, which is
+why it belongs in a loop. Then one line: orchestration, not implementation.
 
-**Never summarise a stance** — [`dispatch-prompt-template.md`](dispatch-prompt-template.md)
-carries why a paraphrase fails. Which clauses turn out to be load-bearing is worth knowing in advance, because a summary
-sheds those first. In one project: *"trust the programmer"* rejects a nagging diagnostic;
-*"close minutiae rather than actioning it"* lets an item die with its reasoning recorded
-instead of consuming a worker; *"a finding is a CLAIM"* stops an audit's output being
-mistaken for a queue. The licence to refuse is load-bearing too — in one session three of
-six dispatches came back as reasoned refusals, each worth more than the work would have
-been, because a migration performed on a false premise costs far more than a tracker item.
-
-Also reassert any **voice** the operator has asked for. Voice drift returns within about ten
-turns, which is exactly why it belongs in a recurring loop rather than in one session's
-memory.
-
-Then reassert in **one line**: orchestration, not implementation.
-
-If recent dispatches have drifted — the mayor coding, a missing boundary block, the stance
-absent or *paraphrased* rather than pasted, an override misused, minutiae actioned instead of
-closed, an audit finding dispatched without its premise checked at source — flag it explicitly
-and name the dispatch. Otherwise one line is enough.
+- **Never summarise a stance**, because a summary sheds the load-bearing clauses first: *trust the
+  programmer* rejects a nagging diagnostic; *close minutiae rather than actioning it* lets an item die
+  with its reasoning recorded instead of consuming a worker; *a finding is a CLAIM* stops an audit's
+  output being mistaken for a queue.
+- **Name the dispatch when you flag drift** — the mayor coding, a missing boundary block, a stance
+  paraphrased rather than pasted, an override misused, minutiae actioned instead of closed. Otherwise
+  one line is enough.
 
 ### The stranded sweep
 
-**Start from the worktrees, not from the in-progress list.** Unless your dispatches claim their
-items, a live worker's items still read *open*, so that list is empty by construction rather than by
-health and a streak of clean sweeps is a streak of reads of an empty set. Enumerate worktrees, map
-each to its items, and read in-progress items as one more signal.
+**Start from the worktrees**, not the in-progress list, which is empty by construction unless your
+dispatches claim their items. Map trees to items, then ask in order: **has the tip revision moved? is
+there a live task to message? only with neither**, push any existing commits, reopen the item with what
+was salvaged, and redispatch.
 
-The cost of missing a strand is not a stale tree: a dead worker's items look dispatchable, and the
-next tick sends a **second worker to the same branch**.
-
-**Every signal below is indirect, and they share one blind spot.** A worker in its final minutes —
-last gate, then tidying scratch files and links — works outside the worktree, outside version
-control, and is too busy to answer. Tip, fetch clock, write clock and a direct message then read as
-dead *together, for one cause*, so corroborating one with another proves nothing. **Frozen on every
-clock is AMBIGUOUS**: it is what healthy foreground work looks like and what a stopped worker looks
-like, and re-reading the same clocks never converts it into evidence — an hour of freeze is the same
-non-signal as a minute. A freeze measured in hours is unremarkable on a heavyweight gate.
-
-**So if your tooling reports a running agent directly, read that first** and treat the clocks as the
-fallback. A harness event meaning *this agent has stopped* is not one more signal to weigh — it is
-the diagnosis, and it outranks everything here.
-
-1. **Tip revision — record the revision id, never an ahead count.** An ahead count is rebase-
-    invariant, and rebasing is what a briefed worker does constantly, so it fails on the common case.
-    Read the ref the worker's commit updates *directly* and prefer a read that performs no refresh:
-    the local ref moves on commit, the published ref only on push, and the published one lags in the
-    direction that reads as death.
-
-    **An unchanged tip says nothing alone** — a worker inside a long gate commits nothing by design.
-
-2. **Activity clocks, and three ways they say "nothing" for different reasons.**
-    * A worker that is only READING writes nothing. The opening minutes of every dispatch are exactly
-      this, because every brief tells the worker to read first.
-    * A worker that POLLS edits nothing for hours, but a fetch ordinarily writes a clock in that
-      worktree's own metadata. Read it twice, 30–60s apart. **Movement proves life and needs no
-      corroboration**; stillness restores the ambiguity, and absence says only that no fetch wrote
-      there — the write is suppressible, so a poller can be invisible to this test.
-    * A span shorter than the worktree's own age counts the checkout rather than the worker, and
-      returns a large number that reads as proof of life. **The worktree's age is its CREATION time,
-      not its modification time**, which the writes you are hunting keep bumping. Run the clock at two
-      different spans before believing either.
-
-    **Where your tracker records a claim, that is the one positive signal a purely reading worker
-    produces**, and it lands outside the tree where no file clock can see it. Its absence proves
-    nothing.
-
-3. **Message, and read the reply rather than the send.** Resuming beats redispatching — the context
-    is still there. The commonest strand by far is a worker that detached a long gate and then ended
-    its turn waiting for an event nothing sends; those recover intact the moment somebody asks for a
-    status.
-
-    **A send may be ACCEPTED for an agent that is already stopped** — acceptance is a queue
-    confirmation, not a liveness report, and for a stopped agent the promised delivery never comes.
-    So *no live task* is rarely something the tool reports; read it as a request unanswered across a
-    window you declare, corroborated by the discriminators above. The error is cheap in one direction
-    only: a late reply costs nothing, acting on a wrong *no task* destroys the run.
-
-4. **Only with no live task AND no tip movement:** push existing commits, set the item back to open
-    with what was found and salvaged, and redispatch.
-
-    **Read WHY it stopped first — the reason chooses the remedy, and quota death, crash, timeout and
-    a detached-gate strand look identical from outside.** Where the stop names an exhausted shared
-    allowance, redispatch is not a remedy: every attempt fails identically and every attempt spends.
-    Salvage, **merge whatever is green** — integration draws on none of that allowance and may unblock
-    the queue — then stop dispatching.
-
-    **A stated reset is a floor, not the only release.** An operator act can restore the allowance
-    early with nothing telling you. Spend one resume probe on the worker with the most context to
-    lose, and read the probe's LIVENESS rather than waiting for words: an agent under an exhausted
-    allowance dies within seconds of resuming, so minutes of running is positive evidence. Stillness
-    is not the converse.
-
-**Two clocks on a change record two different EVENTS — name the event before reading one.** The
-authored time is replayed unchanged by a rebase; the committed time is rewritten by it, and by
-amends and squashes too. Liveness asks *did this worker do something recently*, which is the rewrite
-event. Do not write a rule assigning one clock to prose and the other to liveness: both are real and
-each is correct for its own event. **For a date tying a change to an EXTERNAL event — a run, an
-outage — neither clock is proof**; an author date can be set to any value, so use an anchor that
-event recorded, or a chronology you declare and stand behind.
-
-**A finished change is not a strand, and publishing it is still not yours to infer.** A green change
-whose published head matches its tip, needing only the flag its author sets last, invites you to set
-that flag. Do not: the flag is the interlock precisely because a merge command refuses a draft.
-
-**The sanctioned route is the operator's decision to STOP that agent, which settles liveness by
-making it false — then merge, in that order.** Stopping is an act with a definite outcome where
-every clock above is an inference with none. Reversing the order reaches the same end state by the
-forbidden route and is indistinguishable afterwards. Verify the change against §1 in full; do not
-reopen the stopped worker's items.
-
-**It is not an escape hatch from the ambiguity.** It authorises publishing a change whose author you
-have positive reason to think is finished — it is not a way to resolve a freeze the clocks cannot
-read, and putting that freeze to the operator spends their attention on a question time usually
-answers by itself. The residual risk belongs to stopping, not to merging: you may kill an unpushed
-fix. What bounds it is that you merge the PUBLISHED head, which CI graded.
-
-**Never build a commit from someone else's uncommitted work.** Only that worker knows whether it
-forms a coherent change.
+- **The failure is worse than a missed strand**: a dead worker's items read open, look dispatchable,
+  and the next tick sends a **second worker to the same branch**.
+- **Record the tip REVISION, never an ahead COUNT** — a count survives a rebase, which is what a briefed
+  worker does constantly.
+- **Read the ref the commit updates directly, and prefer a read that performs no refresh.** The local
+  ref moves on commit; the published one only on push, so it lags in the direction that reads as death.
+- **An unchanged tip says nothing** — a worker inside a long gate commits nothing by design.
+- **The corroborating activity clock is a WRITE clock, so a worker that is only READING touches
+  nothing.** Twice in one day a worker grepping its own gate log was called stranded on twenty-three
+  minutes of silence.
+- **A tracker claim is the one positive signal a purely reading worker still produces**, and it lands
+  outside the tree where no file clock sees it. Its absence proves nothing.
+- **If your tooling maintains a live status for a running agent, read THAT before any clock.**
+- **Frozen on every clock is AMBIGUOUS, across any number of readings.** A worker in its final minutes —
+  last gate, then tidying scratch files and links — works outside the worktree and outside version
+  control and is too busy to answer, so all four signals read dead *together, for one cause*. Measured
+  twice in one day: five workers called dormant, three completed alive, two never explained. **Do not
+  count a live control in the numerator** — that is how the figure was first written down wrong.
+- **Say what the re-read window is FOR**, or a coordinator fills an empty interval with more
+  measurement. It catches exactly one thing: movement, which proves life and needs no corroboration.
+  Read twice, record, go elsewhere — the tenth reading answers what the second did. **A freeze measured
+  in hours is unremarkable on a heavyweight gate**: six readings over ninety minutes, all identical,
+  five workers all alive and completing between an hour forty and nearly three hours.
+- **That activity clock says "no activity" in four voices**: a reading worker; a poller; a path that
+  resolves to nothing; and a span shorter than the worktree's own age, which returns a LARGE number that
+  reads as proof of life — measured at the same count over fifteen minutes and over six hours. **And the
+  age is CREATION time, not last modification**, which the writes you are detecting keep bumping.
+- **A POLLER edits and commits nothing, so both clocks stay still for hours** — but a fetch writes as it
+  reads, into that worktree's own fetch-head file. Read it twice, thirty to sixty seconds apart.
+  Movement proves life and needs no control; stillness restores the ambiguity. **Presence says nothing**
+  — a stopped worker leaves its copy behind frozen — **and absence says only that no fetch wrote there**,
+  which a flag on the fetch can suppress. Measured on a poller six sweeps had read as silent while it
+  fetched every forty-two seconds.
+- **The most convincing false signature is on none of the discredited lists**: green at band, clean
+  worktree, tip minutes old, still a DRAFT. It reads as a worker that finished and forgot to publish — a
+  real state — but a worker presenting exactly so was on attempt three of its local gate. **Not one of
+  its four parts observes the agent.**
+- **A change carries two clocks recording two EVENTS.** A rebase rewrites the committed time and replays
+  the authored one, so under rebase-merge they differ on essentially every change — two honest readers
+  called one change forty-three minutes old and seventy-five seconds old. **Liveness is the rewrite
+  event, so read the committed time, and name the event in the sentence.** Where the event is not one the
+  change records, no clock answers: ancestry settles ORDER only.
+- **The commonest strand by far is a worker that detached a long gate and then ended its turn**, waiting
+  for a completion event nothing sends. Seven in one day; every one recovered intact the moment somebody
+  asked for a status. **Message first — resuming beats redispatching.**
+- **A harness agent-stopped event outranks every clock for that agent.** From a worker whose last message
+  says it is WAITING, it is the diagnosis itself: the awaited wake no longer exists. Resume without
+  further discrimination.
+- **A send to a stopped agent may be ACCEPTED** — delivery promised at a next tool round that never
+  comes. **Acceptance is a queue confirmation, not a liveness report; the reply is the read and the send
+  is not.** So read *no live task* as a request unanswered across a window you declare, or the clause is
+  unsatisfiable and gets discharged by an invented proxy.
+- **The error is cheap in one direction only, and it favours waiting.** A late reply costs a tick; acting
+  on a wrong *no task* destroys the run.
+- **Read WHY the worker stopped.** Where the stop reason names an exhausted allowance, *a remedy drawing
+  on the resource whose exhaustion caused the failure is not a remedy* — every attempt fails identically
+  and every attempt spends. Salvage, **merge whatever is green — merging is unaffected and is the half
+  that still pays** — then stop. **The reason text, not the symptom, chooses the remedy**: a quota death,
+  a crash, a timeout and a detached-gate strand look identical from outside.
+- **The stated reset is a floor, not the only release.** An operator act can restore the allowance early
+  and nothing tells the mayor. Spend ONE resume message on the worker with most context to lose, and
+  **read its LIVENESS rather than waiting for words** — an agent under an exhausted allowance dies within
+  seconds, so minutes of *running* is positive evidence. Stillness is not the converse.
+- **A finished change is not a strand — but publishing it is still not yours to infer.** The draft flag
+  is the interlock precisely because a merge command refuses a draft. Use the authorisation the dispatch
+  template names: **the operator's decision to STOP that agent, which settles liveness by making it
+  false. Stop, then merge.**
+- **The ORDER is the whole rule and reversing it looks identical afterwards.** Both orders leave a merged
+  change beside a stopped agent, so nothing in the record can later tell them apart.
+- **That authorisation is not an escape hatch from the ambiguity**, and reading it as one is the natural
+  mistake, because it is the only ACT on offer in a section that otherwise says wait. Measured once: five
+  agents escalated as possibly stopped, all five alive, and the operator's answer would have destroyed
+  four live runs.
+- **The residual risk belongs to stopping, not to merging.** You merge the PUBLISHED head, which CI
+  graded, so the loss is an unpushed fix rather than a regression introduced.
+- **Never build a commit from someone else's uncommitted work.**
 
 ---
 
-## 5. Hygiene
-
-**A measurement window makes this whole loop unsafe, and this is the only loop where that is not
-obvious.** Removing a worktree changes the worktree list, which a window registering an
-exclusivity condition captures at both of its brackets — so a reap during one is recorded as a
-violation and can cost the window its runs. The dispatch loop states the condition; nothing carries
-it here, and hygiene is the loop that performs the measured action. Hold the whole loop until the
-window reports. Nothing in it is urgent.
+## 4. Hygiene
 
 ### Reaping
 
-**Only a worker's own completion report authorises reaping its worktree.** Not a merged change, not
-a clean tree, not elapsed time, not directory age, not "no commits and no open change", not clean
-and merged together. All six were adopted in one session and all six were wrong — cleanliness
-perversely so, because a worker that has pushed everything exactly as briefed shows a clean tree
-throughout a twenty-minute gate, so *the better the discipline the likelier the kill*.
+**Only a worker's own completion report authorises reaping its worktree.** Not a merged change, not a
+clean tree, not elapsed time, not directory age, not "no commits and no open change", not clean and
+merged together — all six were adopted in one session and all six were wrong.
 
-Reap a live worktree and you destroy the run, and **the wreckage does not announce itself as
-infrastructure**: gates die naming real, present files as missing, which reads to the worker as a
-genuine regression.
+**The operational test: can you quote the sentence where this agent says it is done?** If not, the tree
+stays. A stale directory is the entire cost of waiting.
 
-**The report must say the work is FINISHED.** An interim status, a progress note, a partial hand-off
-and a change-opened announcement are the agent speaking, not reporting done. The operational test:
-**can you quote the sentence where this agent says it is done?** If not, the tree stays.
+- **Cleanliness is perversely the worst proxy**: a worker that pushed everything exactly as briefed
+  shows a clean tree throughout a twenty-minute gate — *the better the discipline the likelier the kill*.
+- **The wreckage does not announce itself as infrastructure.** Gates die naming real, present files as
+  missing, which reads to the worker as a genuine regression.
+- **An interim status, a progress note, a partial hand-off and a change-opened announcement are the
+  agent speaking, not reporting done.**
+- **A gate the worker backgrounded is still that worker running**, and **one worker is not one
+  worktree** — a worker may build a second for its gate run, so an unfamiliar tree belongs to someone
+  until its agent reports.
+- **Never pair a merge with a reap, or put the reap in the merge loop.** A merged change is the moment a
+  tree *looks* finished, which is exactly the pull, and a rule encoded in a loop condition is delegated
+  to a predicate that cannot see what you know.
+- **Deferring the reap until the change merges is free insurance** — a worker can need its tree after
+  reporting, when its change hits a conflict. Do not make that a second condition on a rule whose
+  strength is having one.
 
-**A gate the worker backgrounded is still that worker running** — and where the harness caps
-foreground commands below what a full gate needs, that is the common case rather than an edge one.
-**One worker is not one worktree**: a worker may build a second for its gate run, so an unfamiliar
-tree belongs to someone until its agent reports.
+**Finding the report.** Record worktree and agent id at DISPATCH time, one line per dispatch in a
+mayor-local file; clearing the mayor's context destroys its ability to quote a report, and this is the
+route back to the sentence. **Two fields belong to this rule and the rest to the project.** The reap
+test reads no field of that line at all — it reads the report, which the id leads you to.
 
-A stale directory is the entire cost of waiting.
-
-**Never pair a merge with a reap, and never put the reap in the merge loop.** A merged change is the
-moment a tree *looks* finished, which is exactly the pull. A rule encoded in a loop condition is a
-rule delegated to a predicate that cannot see what you know.
-
-#### Finding the report
-
-**Record which worktree belongs to which agent at DISPATCH time**, one line per dispatch in a
-mayor-local file. Clearing the mayor's context destroys its ability to quote a report; this supplies
-a route back to the sentence. Dispatch time, not report time — dispatch always precedes the report,
-so the line is on disk before a clear can matter. The rule itself is unchanged, and the cost of
-following it is monotone accumulation of unreapable trees.
-
-**Nothing validates that line, so specify its fields somewhere tracked.** A version-ignored file's
-own header is the only description of it that exists, which is the condition under which a header
-and its rows drift apart unobserved — and here they did, both carrying five fields so no count
-disagreed, while a reader addressing a field BY NAME got its neighbour's value. **Two fields belong
-to this rule and the rest to the project**: the worktree, and the agent id. **The reap test reads no
-field of that line at all** — it reads the report, which the id leads you to.
-
-**The id buys the TRANSCRIPT, not a live conversation.** Messaging does not reach across a clear.
-**And an id may key several locations** — a per-agent scratch sink is one, the store holding the
-session's own transcript another. An empty file keyed by the id is a fact about *that location*,
-never about the id, and a sink that is empty for most agents and non-empty for one or two reads as a
-survey rather than as an artefact. Enumerate the id's remaining locations before concluding anything.
-
-**With no id recorded, the report is unindexed rather than missing.** Search transcripts for the
-worktree's own path — a dispatch names it and so does the report — and read a bounded TAIL, since
-these are whole-session logs. **But the match is many-to-one and most hits are not the worker's
-own**: the dispatching session names that path, and so does every peer brief listing in-flight write
-surfaces. Three tests separate them, and the first is not sufficient alone:
-
-* **Count the hits per file.** A worker's own log names its tree tens to hundreds of times against a
-  peer's once or twice. But ranking on this can still hand you a peer that simply worked longer.
-* **The report's own stated root is decisive.** A file whose report names a different root is not
-  that worker's, however often your path appears in it.
-* **Where a directory name has been reused, separate the incarnations by the branch the tree carries
-  NOW** — the earlier one names a branch that is gone and tends to end mid-flight.
-
-**A worktree the MAYOR occupied has no agent**, so the search comes back empty for that reason alone
-— and empty is the reap test's blocking condition, which makes such a tree permanently unreapable.
-**The rule does not bend: for that tree the mayor IS the agent**, and its authorising report is the
-mayor's own knowledge. Identify it by the branch the work was PUBLISHED from — an author's tree is
-on it, while an auditor, reviewer or monitor carries a branch named for what it inspects. **Tip
-revision cannot identify an occupant**, only the work. **And do not promote occupancy into a proxy**:
-a tree at the trunk with nothing of its own is the ordinary state of a worker just created, the most
-dangerous tree to remove rather than the safest. Expect automated processes to hold trees too, at
-commits they did not author and under recycled names.
-
-A transcript path the platform documents as an implementation detail is not a contract, and retention
-sweeps typically DELETE rather than truncate — so whether to hold report text somewhere of your own
-is the operator's call.
-
-**Reaping on the report is correct and still costs something**: a worker can need its tree after
-reporting, when its change hits a conflict. Pushed commits make that survivable. **Do not add a
-second condition to a rule whose strength is that it has one** — but nothing requires reaping the
-moment the report arrives, and deferring until the change merges is free insurance.
+- **Nothing validates that line, so specify its fields somewhere tracked.** A version-ignored file's own
+  header is the only description of it that exists — and here header and rows drifted apart while both
+  carried five fields, so no count disagreed and a reader addressing a field BY NAME got its
+  neighbour's value.
+- **The id buys the TRANSCRIPT, not a live conversation**, and may key several locations. An empty file
+  keyed by the id is a fact about *that location*, never about the id.
+- **With no id, the report is unindexed rather than missing.** Search transcripts for the worktree's
+  path — but **the match is many-to-one**, since the dispatching session and every peer brief name it
+  too. Hit count per file is triage; **the report's own stated root is the decisive test.** Where a
+  directory name was reused, separate incarnations by the branch the tree carries NOW.
+- **A worktree the MAYOR occupied has no agent**, so the search is empty for that reason alone — which
+  is the reap test's blocking condition. **The rule does not bend: for that tree the mayor IS the
+  agent.** Identify it by the branch the work was PUBLISHED from; tip revision identifies the work, not
+  the occupant.
+- **Do not promote occupancy into a proxy.** A tree at the trunk with nothing of its own is the ordinary
+  state of a worker just created — the most dangerous tree to remove, not the safest.
 
 ### Removing
 
-**If your project links or junctions a shared dependency tree into worker worktrees, never remove a
-worktree with the plain command.** It follows the link and deletes *through* it, emptying the shared
-tree — silently, exiting successfully, breaking every local build. **And removal is not the only
-write that follows a link**: an installer a gate runs inside the worktree rewrites the shared target
-the same way, so a tree can be emptied while its worker is still alive and no cleanup has run. Count
-every shared tree a worker's gates could have reinstalled, not only the ones a removal touches.
+**If your project links a shared dependency tree into worker worktrees, never remove a worktree with
+the plain command** — it follows the link and deletes *through* it, silently, exiting successfully. Put
+the safe sequence in a **script**: snapshot every shared tree, unlink each *link* (never a recursive
+delete), verify, remove, re-check, and **fail loudly if the signature moved**.
 
-Put the safe sequence in a **script**, not in prose — prose was tried and the class recurred. It
-should snapshot every shared tree, unlink each *link* under the worktree (the link only, never a
-recursive delete), verify each is gone, remove the worktree, then re-check the snapshot and **fail
-loudly if the signature moved**, naming the recovery command.
+- **Removal is not the only write that follows a link.** An installer a gate runs rewrites the shared
+  target, so a tree can be emptied while its worker is alive and no cleanup has run.
+- **Capture the snapshot at runtime and count both sides the SAME WAY.** Count immediate entries *and*
+  recursive files — a top-level count cannot see files vanishing under surviving directories. And a
+  listing that hides entries turns the comparison into an offset that **CANCELS a real loss of its own
+  size**.
+- **So make the decisive control a clock, not a count** — the newest modification time inside the tree,
+  which a removal moves and a change of listing options cannot.
+- **Sweep with a narrow force flag, never a blanket one.** A disposable-only force refuses any tree
+  holding a modified tracked file, a note or a draft; when that guard was written, four worktrees held
+  uncommitted work a blanket force would have destroyed silently.
+- **A refusal has four modes and they are not interchangeable** — nine worktrees were once read as
+  locked, waited out for two days, and were all simply dirty.
 
-**Capture the snapshot at runtime and count both sides the SAME WAY.** A remembered constant cannot
-detect a delta; a top-level count cannot see files vanishing from under surviving directories, so
-count immediate entries *and* recursive files. And a listing that hides entries does not merely
-undercount — it turns the comparison into an offset, and in one direction that offset **CANCELS a
-real loss of its own size**: two hidden entries make a tree read the same before and after two
-visible ones are destroyed. The other direction is only a false alarm, which is the cheaper half and
-the one you meet first.
+  | mode | meaning | remedy |
+  |---|---|---|
+  | Dirty | modified or untracked files | waiting never clears it |
+  | Held | the sweep stopped on something that is not build output | nothing was deleted |
+  | Locked | clean and intact, a live process holding a handle | genuinely transient; retry |
+  | Partial | a **husk** | the acknowledged-husk path only |
 
-**So make the decisive control a clock rather than a count** — the newest modification time inside
-the tree, which a removal moves and a change of listing options cannot. Note which entry carries it
-before you start, and check whether that entry is one the listing form suppresses.
-
-**Sweep with a narrow force flag, never a blanket one.** A disposable-only force removes a tree only
-when every untracked path is build or gate output, and refuses one holding a modified tracked file,
-a note or a draft. Not hypothetical: when that guard was written, four worktrees held uncommitted
-analysis or source edits a blanket force would have destroyed silently — far worse than a worktree
-that will not reap.
-
-**A refusal to remove has modes that are not interchangeable.** Nine worktrees were once read as
-locked, waited out for two days, and were all simply dirty:
-
-* **Dirty** — modified or untracked files. **Waiting never clears this.**
-* **Held** — the disposable sweep stopped on something that is not build output. Nothing was deleted.
-* **Locked** — clean and intact, a live process holding a handle. Genuinely transient: note and retry.
-* **Partial** — a *husk*. The tool deregistered the worktree and deleted its metadata, then hit the
-  lock and stopped. It no longer appears in the listing, pruning has nothing to clear, and a status
-  check inside it *fails and prints nothing* — which is why a clean/dirty test reads a husk as clean.
-  Retrying the ordinary path is futile; the registered-worktree check refuses a husk forever. **But
-  do not reach for a raw recursive delete, which is the operation the top of this section forbids** —
-  a husk still holds every file the worktree had, links among them. Use the tool's acknowledged-husk
-  path, which disarms the link before deleting anything; a tool offering no such path is one to fix
-  rather than work around. **A partial removal kills a running gate exactly as a complete one does.**
-
-**A husk is identified, never inferred.** "Not listed, no metadata" is equally true of an ordinary
-directory, a mistyped argument and an unrelated project — one tool handed a temp directory created
-seconds earlier unlinked the dependencies inside it and called it a destroyed tree. Refuse an
-unregistered path unless the caller acknowledges it **and** its contents are recognisable as this
-repository's, established from version control's own object database. Never spray that
-acknowledgement across a sweep list.
+- **A husk no longer appears in the listing, pruning has nothing to clear, and a status check inside it
+  fails and prints nothing** — which is why a clean/dirty test reads it as clean. **Do not reach for a
+  raw recursive delete**: a husk still holds every file the worktree had, links among them. **A partial
+  removal kills a running gate exactly as a complete one does.**
+- **A husk is identified, never inferred.** "Not listed, no metadata" is equally true of an ordinary
+  directory, a mistyped argument and an unrelated project — one tool handed a temp directory created
+  seconds earlier unlinked the dependencies inside it and called it a destroyed tree. Require the
+  caller's acknowledgement **and** contents recognisable as this repository's, from version control's
+  own object database.
 
 ### Branches
 
-Delete merged local and remote worker branches — **never one whose change is not verifiably merged**.
-
-**Enumerate the remote set separately: it is not a subset of the local one.** Everything else in this
-loop starts from the worktrees, which is right for reaping and blind here — a branch whose worktree
-and local ref are both gone still exists on the remote, and nothing you are looking at mentions it.
-
-**Where the project merges by REBASE, the two obvious containment tests are both wrong.** A rebase
-replays every commit under a new identity, so a merged branch never becomes an ancestor of the trunk
-and never stops reading as *ahead* of it. Ancestry keeps merged branches forever; the ahead count
-destroys unmerged ones.
-
-**The test is patch-equivalence** — what each commit *does* rather than which object it is. Its two
-answers are not symmetric, and reading them as symmetric is the error to avoid:
-
-* **Contained is proof.** Delete only on it, and nothing is ever destroyed.
-* **Not-contained is only the ABSENCE of proof.** Patch identity is computed over the diff including
-  its CONTEXT lines, so a sibling change landing in neighbouring lines of the same file changes your
-  commit's identity and leaves fully-merged work reading as unmerged.
-
-**So the rule is safe and its reading is not.** A mayor who reads *not contained* as *this branch
-has unmerged work* hunts for work that landed weeks ago, and a branch list read as a backlog is a
-list of phantoms. Cheap triage: look for the lines that commit ADDED at the tip. **But that is
-triage and it is wrong in both directions** — a line search has no notion of path, multiplicity or
-order and cannot see a deletion at all, so a commit whose substance is a removal scans clean having
-been inspected for nothing, while a rename or reformat upstream hides work that is fully present.
-**To CONCLUDE, compare the commit's whole patch against the tip at the paths it touches, deletions
-included.** Ask what the instrument compared, not what it answered: a scan returning EVERYTHING
-reads as corroboration where a scan returning nothing at least reads as silence.
-
-**Containment is not the only question. A branch with unlanded commits and no proposed change may be
-a DELIBERATELY RETAINED RECORD.** A spike is the standard case: its findings are promoted as prose
-and its diff is meant never to land, so *pushed, unlanded, nothing proposed* describes the design.
-Ask the tracker who owns it — and ask three things most defaults get wrong:
-
-* **Include CLOSED items**, because a retention ruling lives on a closed item by definition.
-* **Do not filter TO closed either**, which hides an open item carrying a live release condition.
-  Ask for all statuses.
-* **Search the full export, not the title index.** Such rulings are written in close reasons, which
-  a title search cannot see at any status.
-
-**Every defence above finds a record that EXISTS. The case with no record is a LIVE worker's
-branch** — a dispatch in flight has written its name into no item, so the strongest query above
-returns zero, and zero authorises deletion. **Subtract the live set before reading any zero as an
-orphan**: the branches the worktree listing reports, and the ledger rows whose worker has not
-reported.
-
-**Key destructive operations on identity, never on a name.** Branch names repeat and prefix-match,
-so a search term matches siblings and may rank one first — reading one branch's state as another's.
-Ask for the exact head-ref field and compare for equality yourself.
-
-**But equality over a LISTING still filters a WINDOW, and that failure is silent.** A listing returns
-the most recent N; your test is correct and its answer is only as wide as the listing, and a zero
-over the wrong range reads exactly like a zero over the right one. **Prefer an instrument that takes
-the identity as INPUT** — filtering at the source, before paging, caps how many MATCHES return
-rather than how far back it looked, so it cannot turn a proposed branch into one that reads as never
-proposed. Pass an explicit limit anyway: a reused name can carry several changes, and completeness
-still matters where their states do. **An empty answer is still not a licence to delete** — it
-settles that this query matched nothing, not that you asked the right repository, states, spelling
-or credentials. **Exercise the query in both directions before trusting it.**
-
-Throughout, the asymmetry governs: mistaking a record for residue destroys it, mistaking residue for
-a record costs a branch nobody was using.
-
+Delete merged local and remote worker branches — **never one whose change is not verifiably merged.**
 Then prune stale remote-tracking refs and clear any stray stashes.
 
-**Merge state is the test for a branch, never for a worktree.** Conflating the two is how the reaping
-rule goes wrong. An open change is one more reason to leave a worktree alone; the test is still its
-agent's report.
+- **Enumerate the remote set separately: it is not a subset of the local one.** This loop starts from
+  the worktrees, which is right for reaping and blind here.
+- **Where the project merges by REBASE, both obvious containment tests are wrong.** Ancestry keeps
+  merged branches forever; the ahead count destroys unmerged ones.
+- **The test is patch-equivalence, and its answers are not symmetric.** *Contained* is proof — delete
+  only on it. *Not contained* is the ABSENCE of proof: patch identity covers the diff's CONTEXT lines,
+  so a sibling landing in neighbouring lines leaves fully-merged work reading as unmerged. **A branch
+  list read as a backlog is a list of phantoms.**
+- **A line search is triage and is wrong in both directions** — no notion of path, multiplicity or
+  order, and blind to deletions, so a commit whose substance is a removal scans clean having been
+  inspected for nothing. **To CONCLUDE, compare the whole patch against the tip at the paths it
+  touches.** Ask what the instrument compared, not what it answered.
+- **A branch with unlanded commits and no proposed change may be a DELIBERATELY RETAINED RECORD** — a
+  spike, whose findings are promoted as prose and whose diff is meant never to land. Ask the tracker who
+  owns it: **include CLOSED items** (a retention ruling lives on one by definition), **do not filter TO
+  closed** (that hides an open item with a live release condition), and **search the full export, not
+  the title index**, because such rulings are written in close reasons.
+- **Every defence above finds a record that EXISTS. The case with no record is a LIVE worker's branch**
+  — a dispatch in flight has written its name into no item, so the strongest query returns zero and zero
+  authorises deletion. **Subtract the live set before reading any zero as an orphan.**
+- **Key destructive operations on identity, never on a name** — names repeat and prefix-match.
+- **But equality over a LISTING still filters a WINDOW, silently.** Prefer an instrument that takes the
+  identity as INPUT, filtering before paging, so it caps how many MATCHES return rather than how far
+  back it looked. **An empty answer is still not a licence to delete**: it settles that this query
+  matched nothing, not that you asked the right repository, states, spelling or credentials.
+- **Merge state is the test for a branch, never for a worktree.** Conflating them is how the reaping
+  rule goes wrong.
+
+Throughout, the asymmetry governs: mistaking a record for residue destroys it; mistaking residue for a
+record costs a branch nobody was using.
 
 ### The residue
 
-*"Reap only on the worker's own report"* is correct and it leaves residue: an agent that vanishes will
-never report, and its worktree becomes unreapable.
-
-**Keep the rule. Let the residue accumulate, and clear it on explicit operator authority rather than
-inventing another proxy.** A stale directory is cheap. A destroyed run is not.
+Reap-only-on-report is correct and it leaves residue: an agent that vanishes never reports. **Keep the
+rule. Let the residue accumulate, and clear it on explicit operator authority rather than inventing
+another proxy.** A stale directory is cheap; a destroyed run is not.
 
 ---
 
-## 6. Method reread
+## 5. Method reread
 
-**This loop earns its place, but not by re-reading.** Re-reading unchanged files spends context for
-nothing. Do two things instead:
+**Not by re-reading** — that spends context for nothing. Instead: **check what changed** since the last
+pass, in these documents and in your loop command files; and **check the rules you have been
+*enforcing* against what the tree actually does.** That second is where drift lives.
 
-1. **Check what changed** since the last pass — in these documents and in your loop command files.
-   When a method rule changes, re-read the matching command file. A link checker catches renamed
-   files, not semantic drift.
-2. **Check the rules you have been *enforcing* against what the tree actually does.** That is where
-   the drift lives — twice this found a rule the documents asserted universally that the tree did
-   not support, one of them introduced by a merge the mayor approved.
+**Read a loop's page when you are about to do that loop's work, whatever this loop's cadence says.** A
+destructive step performed hours before its page comes round is a step taken without it, and the reread
+that follows finds nothing wrong because the damage is already done.
 
-Watch specifically for:
+Report one or two lines unless you find real drift; if you find it, fix the document or the command
+file rather than noting it.
 
-* **A measured constant that has gone stale.** The check-count band is the standing example: written
+### Gotchas
+
+- **A measured constant that has gone stale.** The check-count band is the standing example: written
   down, moving, and stale exactly where it has to be right.
-* **Unsatisfiable quantifiers.** *"Every gate prints X"* when a third do not. Workers facing an
-  unsatisfiable rule do not stop — they improvise, and the improvisation varies. **When a rule says
-  *every*, check the quantifier.**
-* **Blocks that have diverged from the command files that paste them.** Two copies of one rule
-  disagree within days.
-* **A hazard recorded without the test that discharges it** — *"beware X"* with nothing saying how
-  to tell X from the legitimate case that looks identical. Whoever wrote it had just performed that
-  test, so it read as part of the observation rather than as something needing words. This document
-  says elsewhere that a remedy without its discriminator is worse than no remedy; that judgement
-  applies to its own prose, and this loop is the only place that checks whether it does.
-
-**Read a loop's page when you are about to do that loop's work, whatever this loop's cadence says.**
-A destructive or unfamiliar step performed hours before its page comes round is a step taken without
-it, and the reread that follows finds nothing wrong because the damage is already done.
-
-Report one or two lines unless you find real drift. If you find drift, fix the document or the
-command file — do not just note it.
-
-**But the repair is the step most likely to need repairing, and it fails in one particular way: a
-correction tends to overshoot into the INVERSE of the claim it replaces.** A wrong sentence is
-usually wrong by asserting too much, and the evidence that exposes it feels like evidence for the
-opposite — so the fix arrives with the original's confidence pointing the other way, reading as
-*more* reliable because it was written in response to being caught.
-
-**The discharging test is one question and it costs nothing: what would you expect to SEE that is
-different if the new claim were false?** If the only answer is *the evidence that refuted the old
-one*, nothing has been established — that evidence rules the old claim out and leaves the
-replacement standing among several survivors, which is the old error re-pointed. Where the honest
-answer is that the observation supports neither side, **say so and let the guidance rest on the
-asymmetric cost of the two errors instead**: that is a real reason to act one way, and it survives
-the next counterexample where a re-pointed claim does not.
-
-**And the fix is bounded in change, not in search.** What this loop finds is mechanical, so a defect
-in one place usually has siblings — [*"Bounded repair" bounds the change, not the
-search*](dispatch-prompt-template.md#name-the-discriminator) binds the mayor's own repairs exactly
-as it binds a worker's.
-
-**Weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
-usually not the repair. Two remedies that worked landed the other way: an item whose OLDEST field
-was rewritten to open with its disposition, after three workers had been dispatched at work that
-should not exist; and a guard that refused an edit the rule had already forbidden in words. Both
-changed the artefact a reader meets rather than the instruction they had read and recited. **And a
-guard is not a rule that cannot fail** — one added in an evening was run the next hour and misread,
-because a check executed carelessly returns the same reassuring answer as no check at all.
-
-**Where the project arms a mayor-side commit guard, the mayor's own repair goes through a
-mayor-occupied worktree.** The guard refuses the mayor checkout for every non-tracker surface, these
-documents included, and that refusal is the guard working. Author the fix in a worktree of your own
-and merge it on the ordinary criterion. Two mechanical gotchas: **the refused commit exits non-zero
-with the files still STAGED**, so read the commit's own exit rather than the output tail — the
-refusal scrolls away under later lines; and those staged files then abort the next update with a
-message that never names the refusal that caused it, so restore them rather than diagnosing the
-update.
+- **An unsatisfiable quantifier** — *"every gate prints X"* when a third do not. Workers facing one do
+  not stop; they improvise, and the improvisation varies.
+- **A block that has diverged from the command file that pastes it.**
+- **A hazard recorded without the test that discharges it** — *"beware X"* with nothing saying how to
+  tell X from the legitimate case that looks identical. Whoever wrote it had just performed that test,
+  so it read as part of the observation. This loop is the only place that checks whether this document
+  obeys its own rule.
+- **A correction tends to overshoot into the INVERSE of the claim it replaces.** The evidence exposing a
+  too-strong sentence feels like evidence for the opposite, so the fix arrives with the original's
+  confidence pointing the other way — reading as *more* reliable for having been written in response to
+  being caught. **The discharging test is one question: what would you expect to SEE that is different
+  if the new claim were false?** If the only answer is *the evidence that refuted the old one*, nothing
+  has been established. Where the observation supports neither side, say so and rest the guidance on the
+  asymmetric cost of the two errors.
+- **The fix is bounded in change, not in search.** What this loop finds is mechanical, so a defect in
+  one place usually has siblings.
+- **Weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
+  usually not the repair: two remedies that worked were an item whose OLDEST field was rewritten to open
+  with its disposition, and a guard that refused an edit the rule had already forbidden in words. **And
+  a guard is not a rule that cannot fail** — one added in an evening was run the next hour and misread.
+- **Where the project arms a mayor-side commit guard, the mayor's own repair goes through a
+  mayor-occupied worktree**, and that refusal is the guard working. Two mechanics: the refused commit
+  **exits non-zero with the files still STAGED**, so read the commit's exit rather than the output tail;
+  and those staged files then abort the next update with a message that never names the refusal.
 
 ---
 
 ## Tracker mechanics
 
-These belong to no single loop and bite in all of them.
-
-**An instrument can be RIGHT and still answer a different question from the one you asked.** The
-rule about an instrument that says *"nothing here"* covers a wrong answer; the remedy for that —
-exercise it against an input it should flag — is inert here, because nothing is malfunctioning and
-the control comes back green. Four in one session, one per loop: a count of running workers read as
-*the machine is quiet*; a count of resident processes read as *the machine is busy*; a marker scan
-finding a banner read as *this item is held*; a note true when written read as *true now*. **Write
-the question the instrument answers, in its own terms, beside the question you are asking.** The gap
-is invisible in the answer and obvious once both sentences are on the page — and this is the harder
-half, because a wrong answer gives you something to be suspicious of and a right one does not.
-
-**A marker scan fails in BOTH directions, so it is a CANDIDATE FILTER and never a verdict.** It
-over-reports items that QUOTE a marker or whose marker has been struck, and under-reports holds
-written in ordinary prose. A second scan built to discriminate fails the same way, because marker
-text typically instructs whoever rules to strike it, so the word *struck* appears inside every live
-marker. Narrow to a handful, then READ each candidate, and **report the number you read, never the
-number you scanned**. Where a project wants this machine-checkable the durable answer is a
-structured field rather than a marker in prose — an operator's decision, but every failure here is a
-consequence of encoding state in text that also discusses state.
-
-**A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked
-when X is later reopened for an unrelated residual. Force the close and **write the reasoning on the
-item**: what the dependency enforced, that it was satisfied, and why the reopen does not re-block
-merged work.
-
-**Items usually close on change-*open*, not change-*merge*** — so "closed" does not mean "on the
-trunk". Check the merge before treating a dependency as discharged.
-
-**Verify closures by reading the status field keyed on the item ID.** Keyed on an internal row
-identifier, a re-import reports phantom losses; searching the whole record matches the word "open"
-inside a title.
-
-**A command's echoed output is not confirmation that it did anything.** This is the gate-behind-a-
-filter rule reaching every command the mayor runs. Trimming output to the last line hides it
-perfectly: where a close carries a long reason, the last line *is* the reason text, so a refusal and
-an acceptance look identical.
-
-**Exit status and mutation are two different questions, and only the first is cheap.** A non-zero
-status is proof the command refused, so **always read it**. A *zero* proves the command reported
-success, not that state changed — an idempotent call legitimately does nothing, and a durable
-operation can acknowledge locally before the postcondition you care about is true. **When you need a
-state change, or a durable one, re-read the target as well.**
-
-**A tracker write can silently revert** — a rollback, a re-import over the top — so the session's
-"closed" count quietly overstates. **Re-check what you closed across the sequence that exports the
-tracker, restores it from version control and publishes it**, reading BOTH sides of that sequence: a
-single check afterwards tells you a close is missing but not which side lost it, and the two have
-different remedies. **Do not infer the mechanism from the coincidence** — a multi-step sequence is
-no evidence about which step moved the state.
-
-**But a status change made by a LIVE worker is that worker speaking, not corruption.** The rule
-above trains you to read an unexpected status as a bad write and supplies no competing reading. A
-worker that un-claims an item is often saying something precise — commonly that part of it is the
-operator's. Its report is the authority and usually lags the status by minutes, so read the report
-before acting on the clock.
-
-**Read the item's notes before re-closing anything.** Where a process audits merged changes, expect
-closed items to reappear, and expect chains: a fix lands, its audit reopens for a second carrier,
-that fix's audit for a third. **The reflex to re-close a "reverted" item destroys a real finding and
-looks like tidiness.**
-
-**A reopen that records no finding is not yet a finding.** A bare status flip — close reason wiped,
-nothing appended — leaves nothing to read and nothing to dispatch, and both reflexes are wrong:
-re-closing destroys a finding still being written, treating it as ready dispatches a worker at work
-nobody has named. Mark it as awaiting its finding, in the same scan-findable words each time, and
-give the writer one full pass. Then re-close, restoring the original reason the flip cleared and
-recording the reopen's emptiness.
-
-**And a wiped closure makes any brief that CITES it unsatisfiable** — a worker sent to read text the
-reopen deleted finds an empty field and reads the absence as its own failure. Restore the text or
-cite where it was preserved, **before** dispatching. Having verified the preservation yourself is no
-protection: verification and briefing are separate acts.
-
-**Checkpoint tracker state on the heartbeat.** Many trackers auto-stage but never commit, so a long
-session's state strands locally.
-
-**A checkpoint is two operations and the harness can kill it between them.** The export contends
-with every worker's tracker writes, so under a full fleet it can outrun a command cap: one kill left
-the commit made and the push not, and the re-run reported *nothing to checkpoint* — true, with the
-remote still behind. **Verify the remote against the local head after every checkpoint**; the
-script's message answers only the commit.
-
-**Long tracker text does not travel as a shell argument.** A batch of notes passed as quoted strings
-can fail to parse before a single note is written, and a quoted heredoc is not a cure. Write the
-text with a tool that is not a shell and drive the tracker from that file, so the transport has no
-quoting to get wrong.
-
-**If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict
-in it by taking one side wholesale — both sides are full exports, so picking one discards every item
-the other recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch
-carries a snapshot from when its worktree was created, so committing it time-travels the tracker.
+- **An instrument can be RIGHT and still answer a different question from the one you asked** — and the
+  usual remedy is inert, because nothing is malfunctioning and the control comes back green. Four in one
+  session: running workers read as *the machine is quiet*; resident processes read as *the machine is
+  busy*; a marker scan finding a banner read as *this item is held*; a note true when written read as
+  *true now*. **Write the question the instrument answers beside the question you are asking.**
+- **A marker scan is a CANDIDATE FILTER, never a verdict.** It over-reports items that QUOTE a marker or
+  whose marker was struck, and under-reports holds in ordinary prose — and a second scan built to
+  discriminate fails the same way, because marker text instructs whoever rules to strike it, so *struck*
+  appears inside every live marker. **Report the number you read, never the number you scanned.**
+- **A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked when
+  X is reopened for an unrelated residual. Force the close and write the reasoning on the item.
+- **Items usually close on change-*open*, not change-*merge***, so "closed" does not mean "on the trunk".
+- **Verify closures by reading the status field keyed on the item ID.** Keyed on an internal row id a
+  re-import reports phantom losses; searching the whole record matches the word "open" inside a title.
+- **A command's echoed output is not confirmation that it did anything.** Trimming to the last line
+  hides this perfectly: where a close carries a long reason, the last line *is* the reason text, so a
+  refusal and an acceptance look identical.
+- **Exit status and mutation are different questions and only the first is cheap.** A non-zero status
+  proves refusal, so always read it; a *zero* proves the command reported success, not that state
+  changed. **When you need a state change, re-read the target.**
+- **A tracker write can silently revert.** Re-check what you closed across the sequence that exports,
+  restores and publishes, reading BOTH sides — a single check afterwards tells you a close is missing
+  but not which side lost it, and the two have different remedies.
+- **But a status change made by a LIVE worker is that worker speaking, not corruption** — often
+  something precise, commonly that part of the item is the operator's. Its report is the authority and
+  usually lags the status by minutes.
+- **Read the item's notes before re-closing anything.** Where a process audits merged changes, expect
+  closed items to reappear, and expect chains. **The reflex to re-close a "reverted" item destroys a
+  real finding and looks like tidiness.**
+- **A reopen that records no finding is not yet a finding.** Re-closing destroys a finding still being
+  written; treating it as ready dispatches a worker at work nobody has named. Mark it as awaiting its
+  finding, give the writer one pass, then re-close — restoring the original reason the flip cleared.
+- **A wiped closure makes any brief that CITES it unsatisfiable** — the worker finds an empty field and
+  reads the absence as its own failure. Restore or re-cite **before** dispatching; verification and
+  briefing are separate acts.
+- **Every note you leave becomes the NEWEST text on that item**, and a newest-first walk lands on it and
+  stops. **The tell is mechanical: a note repeating a figure some later note retracted re-derived
+  instead of re-checking.** Cite the check you made, or say you are summarising and from what.
+- **Check ONCE whether your tracker's update verb appends or REPLACES.** Where it replaces, the walk you
+  are teaching readers to make runs over text you deleted — no error, and the item afterwards looks
+  well-maintained.
+- **Separate *needs a decision* from *needs work under a decision already made***; the second is
+  dispatchable now and tends to sit in the first pile. **And read WHY a hold was set before writing what
+  it costs** — an oversight and a deliberate dormancy put identical numbers behind it, so cost is only
+  cost against a want.
+- **A hold that expires on a DATE while its reason does not is the one hold that removes its own
+  evidence.** The item returns to the ready list carrying an empty blocker column, reading as MORE
+  legitimate than an ordinary item because a reappearance looks like something happened. Nothing
+  happened; a date passed. Write that on the item BEFORE the date arrives.
+- **Checkpoint tracker state on the heartbeat**, and **verify the remote against the local head
+  afterwards** — a checkpoint is two operations and the harness can kill it between them, leaving the
+  commit made, the push not, and the re-run truthfully reporting *nothing to checkpoint*.
+- **Long tracker text does not travel as a shell argument**, and a quoted heredoc is not a cure. Write
+  it with a tool that is not a shell and drive the tracker from that file.
+- **If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict by
+  taking one side wholesale — both are full exports, so picking one discards every item the other
+  recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch carries a
+  snapshot from when its worktree was created, so committing it time-travels the tracker.


### PR DESCRIPTION
Trims `docs/the-mayor-method/` to rules, discriminators and gotchas, and genericises the one block that had drifted project-specific.

## What changed

| page | before | after |
|---|---|---|
| `loops.md` | 136,186 | 85,542 |
| `dispatch-prompt-template.md` | 94,119 | 82,721 |

`README.md` and `bootstrap.md` are untouched — the README is the human-readable door and bootstrap is already a terse prompt.

**The rule applied:** keep the rule, the discriminator, and the stated direction of failure; drop anecdote narration, repeated framing, and meta-commentary about the documents' own rhetoric. Where a passage argued for a point a mayor reaches unaided, the argument goes and the gotcha stays. Nothing that a rule REFUSES was weakened — the three blocks that travel verbatim into a dispatch (common preamble, worktree boundary, gate mechanics) still refuse everything they refused, and each one's enumerated traps are intact.

**Genericising the common preamble.** That block travels verbatim into every dispatch and had accreted one tracker's command spellings and JSON field names, against this page's own opening contract that project-specifics live with the project and this page is the reusable, OS-neutral method. Every trap in it is a property of history walks in general — a plain listing that names no changed field; a snapshot that nests the item's fields under a sub-key, so a walk keyed at the top level reports "no change" without erroring; a walk bounded short of the item's beginning; an omitted empty field whose null hashes constant across every adjacent pair. Those are now stated that way, with the commands as placeholders like every other project-specific value, and a line above the fence saying so.

## Retrospective findings folded in

- **A SKIPPED run reports as a successful one and contributes a zero-length sample.** A hang baseline drawn from a conditional job's recent "successes" collapses toward zero, after which every real run reads as overrunning by orders of magnitude. It fails in the alarming direction — it manufactures a hang — and the remedy it invites is the cancel-and-re-run that costs another wall-clock hour. Discard the zero-length samples before averaging and check the survivors are a plausible sample size. (`loops.md` § When a change is not green.)
- **A figure and the subject it was measured on arrive in a worker's report in the same sentence**, so a compression can pair them wrongly — and re-deriving at the current tip cannot catch it, because the census is correct about the subject you wrote. Trace a refuted figure back to what it WAS true of before dropping it; the thing it was true of is an unfiled finding. (`dispatch-prompt-template.md` § Reviewing what comes back.)

## Quality gates

| gate | exit |
|---|---|
| `scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` | 0 — `docs/the-mayor-method/` is not in `exclude_docs`, and the build names both touched pages |
| `scripts/check_readme_links.py --ci` | 0 |
| `scripts/check_retired_spellings.py` | 0 |
| `scripts/check_provenance_pins.py` | 0 |
| `scripts/check-ai-tracking-ratchet.sh` | 0 |
| `scripts/check-no-hardcoded-paths.sh` | 0 |

Both doc gates were re-run after the rebase onto the final base, not carried over from the pre-rebase tree.

**By hand, because no gate reaches it.** Neither gate validates prose, tables or nav, and neither looks inside a fenced block. After every heading-level splice: all intra-tree link anchors across the four pages re-resolved (0 missing), and the four inbound anchors `CLAUDE.md` cites into `loops.md` (`#1-merge`, `#after-each-merge`, `#reaping`, `#tracker-mechanics`) all still exist. CR count equals CRLF count on every touched file with 0 bare CR, read with Python over the bytes rather than with `grep -c`.

**Revert check.** `git log <merge-base>..origin/main -- docs/the-mayor-method/` is empty, so nothing landed on these paths while this was in flight and no hunk here puts anything back.
