### PR TITLE
test: state the node-lane skip on two browser-gated DOM suites (rf2-b8zo)

### DIFF
--- a/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
@@ -59,6 +59,15 @@
   the Node lane asserts SILENCE for the same refusal. One file, both sides
   of the boundary, neither able to drift from the other.
 
+  Every browser-gated row below therefore spells its guard as
+  `(if-not (browser?) (is true skip-msg) ...)` rather than as a bare
+  `(when (browser?) ...)` (rf2-b8zo). Under `:node-test` the marker
+  assertion fires and the row reports a STATED skip; a bare `when` left
+  it passing with zero assertions, which reads on the console exactly
+  like a row that ran. Nothing about the coverage moved: the browser
+  lane evaluates the same body it always did. `node-targeted-cljs-stays-quiet`
+  is the one row that runs only OFF a DOM host, so it keeps `when-not`.
+
   The JVM / SSR lane is listener-only by the same rule and needs no
   counterpart here: `#?(:clj …)` in `report-unowned-error!` is `nil`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -102,6 +111,9 @@
   (and (exists? js/document)
        (some? (.-createElement js/document))))
 
+(def ^:private skip-msg
+  "skipped: no DOM (node lane — see ns docstring)")
+
 (defn- capture-console
   "Run `thunk` with `console.error` swapped for a recorder and
   `globalThis.reportError` swapped for a counter. Returns
@@ -139,108 +151,114 @@
 ;; ===========================================================================
 
 (deftest unowned-refusal-reaches-the-dev-console
-  (when (browser?)
-    (register-refusal-handlers!)
-    (testing "a throwing handler — one structured diagnostic, no reportError"
-      (let [{:keys [console report-error]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-        (is (= 1 (count console))
-            (str "exactly one console.error for one refusal; got "
-                 (pr-str (mapv first console))))
-        (let [[prefix summary record ex] (first console)]
-          (is (= "[re-frame2]" prefix) "the stable prefix leads")
-          (is (string? summary)
-              "a READABLE line comes before the record (rf2-6sqv) — without it
-               Chrome renders the CLJS map's interior fields and the reader
-               sees no message at all")
-          (is (re-find #"^:rf\.error/handler-exception\b" summary)
-              (str "the summary names the category first — the greppable "
-                   "discriminator; got " (pr-str summary)))
-          (is (re-find #"kaboom" summary)
-              (str "and carries the exception's OWN message, not a synthesised "
-                   "one; got " (pr-str summary)))
-          (is (map? record) "the structured record still rides as its OWN argument")
-          (is (= :rf.error/handler-exception (:error record)))
-          (is (= :fu75.console/throws (:event-id record)))
-          (is (= [:fu75.console/throws] (:event record)))
-          (is (= :rf/default (:frame record)))
-          (is (identical? ex (:exception record))
-              "the ORIGINAL exception object rides as its own argument")
-          (is (= "kaboom" (ex-message ex))
-              "and it is the handler's exception, not a synthesised one"))
-        (is (zero? report-error)
-            "no reportError — so no window `error` event and no pageerror")))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (register-refusal-handlers!)
+      (testing "a throwing handler — one structured diagnostic, no reportError"
+        (let [{:keys [console report-error]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+          (is (= 1 (count console))
+              (str "exactly one console.error for one refusal; got "
+                   (pr-str (mapv first console))))
+          (let [[prefix summary record ex] (first console)]
+            (is (= "[re-frame2]" prefix) "the stable prefix leads")
+            (is (string? summary)
+                "a READABLE line comes before the record (rf2-6sqv) — without it
+                 Chrome renders the CLJS map's interior fields and the reader
+                 sees no message at all")
+            (is (re-find #"^:rf\.error/handler-exception\b" summary)
+                (str "the summary names the category first — the greppable "
+                     "discriminator; got " (pr-str summary)))
+            (is (re-find #"kaboom" summary)
+                (str "and carries the exception's OWN message, not a synthesised "
+                     "one; got " (pr-str summary)))
+            (is (map? record) "the structured record still rides as its OWN argument")
+            (is (= :rf.error/handler-exception (:error record)))
+            (is (= :fu75.console/throws (:event-id record)))
+            (is (= [:fu75.console/throws] (:event record)))
+            (is (= :rf/default (:frame record)))
+            (is (identical? ex (:exception record))
+                "the ORIGINAL exception object rides as its own argument")
+            (is (= "kaboom" (ex-message ex))
+                "and it is the handler's exception, not a synthesised one"))
+          (is (zero? report-error)
+              "no reportError — so no window `error` event and no pageerror")))
 
-    (testing "the effect-map envelope refusal — same shape"
-      (let [{:keys [console report-error]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/foreign-fx]))]
-        (is (= 1 (count console)))
-        (let [[prefix summary record] (first console)]
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/effect-map-shape\b" summary))
-          (is (= :rf.error/effect-map-shape (:error record))))
-        (is (zero? report-error))))
+      (testing "the effect-map envelope refusal — same shape"
+        (let [{:keys [console report-error]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/foreign-fx]))]
+          (is (= 1 (count console)))
+          (let [[prefix summary record] (first console)]
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/effect-map-shape\b" summary))
+            (is (= :rf.error/effect-map-shape (:error record))))
+          (is (zero? report-error))))
 
-    (testing "an unregistered event id — the typo case. It carries NO
-              exception, so there is no fourth argument; the summary still
-              names the category, which is what a reader greps"
-      (let [{:keys [console report-error]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/nothing-here]))]
-        (is (= 1 (count console)))
-        (let [args (first console)]
-          (is (= 3 (count args))
-              (str "prefix + summary + record — nothing synthesised to stand in "
-                   "for the absent exception; got " (count args) " arguments"))
-          (is (= "[re-frame2]" (first args)))
-          (is (= ":rf.error/no-such-handler" (second args))
-              (str "no exception and no :reason on this category, so the summary "
-                   "is the bare category keyword — never an empty string, never "
-                   "invented prose; got " (pr-str (second args))))
-          (is (= :rf.error/no-such-handler (:error (nth args 2))))
-          (is (nil? (:exception (nth args 2)))))
-        (is (zero? report-error))))))
+      (testing "an unregistered event id — the typo case. It carries NO
+                exception, so there is no fourth argument; the summary still
+                names the category, which is what a reader greps"
+        (let [{:keys [console report-error]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/nothing-here]))]
+          (is (= 1 (count console)))
+          (let [args (first console)]
+            (is (= 3 (count args))
+                (str "prefix + summary + record — nothing synthesised to stand in "
+                     "for the absent exception; got " (count args) " arguments"))
+            (is (= "[re-frame2]" (first args)))
+            (is (= ":rf.error/no-such-handler" (second args))
+                (str "no exception and no :reason on this category, so the summary "
+                     "is the bare category keyword — never an empty string, never "
+                     "invented prose; got " (pr-str (second args))))
+            (is (= :rf.error/no-such-handler (:error (nth args 2))))
+            (is (nil? (:exception (nth args 2)))))
+          (is (zero? report-error)))))))
 
 (deftest unowned-diagnostic-does-not-change-control-flow
-  (when (browser?)
-    (register-refusal-handlers!)
-    (let [outcome (atom nil)]
-      (capture-console
-        (fn []
-          (reset! outcome
-                  (try (rf/dispatch-sync [:fu75.console/throws]) ::returned
-                       (catch :default e e)))))
-      (is (= ::returned @outcome)
-          "the refusal was still CAPTURED — printing it re-raises nothing"))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (register-refusal-handlers!)
+      (let [outcome (atom nil)]
+        (capture-console
+          (fn []
+            (reset! outcome
+                    (try (rf/dispatch-sync [:fu75.console/throws]) ::returned
+                         (catch :default e e)))))
+        (is (= ::returned @outcome)
+            "the refusal was still CAPTURED — printing it re-raises nothing")))))
 
 ;; ===========================================================================
 ;; NON-EVENT UNION RECORD — the second fan-out site follows the same rule
 ;; ===========================================================================
 
 (deftest unowned-union-record-reaches-the-dev-console
-  (when (browser?)
-    (testing "`dispatch-error-record*`'s site — reached here through the
-              genuine frame-teardown report caller, a non-event union record
-              that carries no top-level `:exception`"
-      (let [{:keys [console report-error]}
-            (capture-console
-              (fn []
-                (rf.error-emit/dispatch-frame-teardown-report!
-                  :rf/default
-                  [{:hook :fu75/step :exception (ex-info "teardown" {})
-                    :where :safe-call-hook!}]
-                  1234)))]
-        (is (= 1 (count console)))
-        (let [[prefix summary record] (first console)]
-          (is (= 3 (count (first console))))
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/frame-teardown-failed\b" summary))
-          (is (re-find #"teardown step\(s\) threw" summary)
-              (str "this union record carries no top-level :exception but DOES "
-                   "carry a composed :reason — the summary must fall back to it "
-                   "rather than stopping at the category; got " (pr-str summary)))
-          (is (= :rf.error/frame-teardown-failed (:error record)))
-          (is (= 1 (count (:hook-failures record)))))
-        (is (zero? report-error))))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "`dispatch-error-record*`'s site — reached here through the
+                genuine frame-teardown report caller, a non-event union record
+                that carries no top-level `:exception`"
+        (let [{:keys [console report-error]}
+              (capture-console
+                (fn []
+                  (rf.error-emit/dispatch-frame-teardown-report!
+                    :rf/default
+                    [{:hook :fu75/step :exception (ex-info "teardown" {})
+                      :where :safe-call-hook!}]
+                    1234)))]
+          (is (= 1 (count console)))
+          (let [[prefix summary record] (first console)]
+            (is (= 3 (count (first console))))
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/frame-teardown-failed\b" summary))
+            (is (re-find #"teardown step\(s\) threw" summary)
+                (str "this union record carries no top-level :exception but DOES "
+                     "carry a composed :reason — the summary must fall back to it "
+                     "rather than stopping at the category; got " (pr-str summary)))
+            (is (= :rf.error/frame-teardown-failed (:error record)))
+            (is (= 1 (count (:hook-failures record)))))
+          (is (zero? report-error)))))))
 
 ;; ===========================================================================
 ;; NO-FRAME-CONTEXT — the category the rf2-6sqv measurement was OF
@@ -260,132 +278,142 @@
 ;; and it REACHES THE CONSOLE LINE.
 
 (deftest no-frame-context-carries-its-ladder-to-the-console
-  (when (browser?)
-    (let [payload (rf.frame/no-frame-context-payload :subscribe
-                                                  {:where 'rf/subscribe})]
-      (is (string? (:reason payload))
-          "premise: the payload composes the ladder in the first place")
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (let [payload (rf.frame/no-frame-context-payload :subscribe
+                                                    {:where 'rf/subscribe})]
+        (is (string? (:reason payload))
+            "premise: the payload composes the ladder in the first place")
 
-      (testing "the always-on record carries the payload's OWN :reason and
-                :recovery — this category throws nothing, so without them the
-                record holds no message anywhere"
-        (let [seen (atom [])]
-          (rf.error-emit/register-error-listener! :fu75/ladder
-                                 (fn [record] (swap! seen conj record)))
-          (rf.frame/emit-no-frame-context! payload)
-          (rf.error-emit/unregister-error-listener! :fu75/ladder)
-          (let [record (first @seen)]
-            (is (= :rf.error/no-frame-context (:error record)))
-            (is (= (:reason payload) (:reason record))
-                "the composed ladder, verbatim — not a re-derivation")
-            (is (= :supply-frame (:recovery record))
-                "and the machine-readable repair beside it"))))
+        (testing "the always-on record carries the payload's OWN :reason and
+                  :recovery — this category throws nothing, so without them the
+                  record holds no message anywhere"
+          (let [seen (atom [])]
+            (rf.error-emit/register-error-listener! :fu75/ladder
+                                   (fn [record] (swap! seen conj record)))
+            (rf.frame/emit-no-frame-context! payload)
+            (rf.error-emit/unregister-error-listener! :fu75/ladder)
+            (let [record (first @seen)]
+              (is (= :rf.error/no-frame-context (:error record)))
+              (is (= (:reason payload) (:reason record))
+                  "the composed ladder, verbatim — not a re-derivation")
+              (is (= :supply-frame (:recovery record))
+                  "and the machine-readable repair beside it"))))
 
-      (testing "and the console line leads with the category and the ladder,
-                so a reader who opens devtools sees the text FIRST"
-        (rf.error-emit/clear-error-listeners!)
-        (let [{:keys [console report-error]}
-              (capture-console #(rf.frame/emit-no-frame-context! payload))]
-          (is (= 1 (count console)))
-          (let [args (first console)
-                [prefix summary record] args]
-            (is (= 3 (count args))
-                (str "prefix + summary + record; no exception on this "
-                     "category. Got " (count args)))
-            (is (= "[re-frame2]" prefix))
-            (is (re-find #"^:rf\.error/no-frame-context\b" summary))
-            (is (re-find #"no frame context" summary)
-                (str "the ladder itself reaches the line — this is the exact "
-                     "text the rf2-6sqv page load could not show; got "
-                     (pr-str summary)))
-            (is (map? record) "and the record still rides for the inspector"))
-          (is (zero? report-error)))))))
+        (testing "and the console line leads with the category and the ladder,
+                  so a reader who opens devtools sees the text FIRST"
+          (rf.error-emit/clear-error-listeners!)
+          (let [{:keys [console report-error]}
+                (capture-console #(rf.frame/emit-no-frame-context! payload))]
+            (is (= 1 (count console)))
+            (let [args (first console)
+                  [prefix summary record] args]
+              (is (= 3 (count args))
+                  (str "prefix + summary + record; no exception on this "
+                       "category. Got " (count args)))
+              (is (= "[re-frame2]" prefix))
+              (is (re-find #"^:rf\.error/no-frame-context\b" summary))
+              (is (re-find #"no frame context" summary)
+                  (str "the ladder itself reaches the line — this is the exact "
+                       "text the rf2-6sqv page load could not show; got "
+                       (pr-str summary)))
+              (is (map? record) "and the record still rides for the inspector"))
+            (is (zero? report-error))))))))
 
 (deftest bad-frame-provider-arg-carries-its-reason-too
-  (when (browser?)
-    (testing "`emit-bad-frame-provider-arg!` says it MIRRORS
-              `emit-no-frame-context!`, and it has the same shape for the
-              same reason — no exception, a composed :reason on the payload.
-              Pinned so the two cannot drift into one carrying its message
-              and the other not"
-      (rf.error-emit/clear-error-listeners!)
-      (let [payload (rf.frame/bad-frame-provider-arg-payload
-                      "not-a-frame" {:where 'rf/frame-provider})
-            {:keys [console]}
-            (capture-console #(rf.frame/emit-bad-frame-provider-arg! payload))]
-        (is (= 1 (count console)))
-        (let [[_ summary record] (first console)]
-          (is (re-find #"^:rf\.error/bad-frame-provider-arg\b" summary))
-          (is (re-find #"must be a frame id keyword" summary)
-              (str "the payload's own sentence reaches the line; got "
-                   (pr-str summary)))
-          (is (= (:reason payload) (:reason record))
-              "and verbatim onto the record for an off-box shipper"))))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "`emit-bad-frame-provider-arg!` says it MIRRORS
+                `emit-no-frame-context!`, and it has the same shape for the
+                same reason — no exception, a composed :reason on the payload.
+                Pinned so the two cannot drift into one carrying its message
+                and the other not"
+        (rf.error-emit/clear-error-listeners!)
+        (let [payload (rf.frame/bad-frame-provider-arg-payload
+                        "not-a-frame" {:where 'rf/frame-provider})
+              {:keys [console]}
+              (capture-console #(rf.frame/emit-bad-frame-provider-arg! payload))]
+          (is (= 1 (count console)))
+          (let [[_ summary record] (first console)]
+            (is (re-find #"^:rf\.error/bad-frame-provider-arg\b" summary))
+            (is (re-find #"must be a frame id keyword" summary)
+                (str "the payload's own sentence reaches the line; got "
+                     (pr-str summary)))
+            (is (= (:reason payload) (:reason record))
+                "and verbatim onto the record for an off-box shipper")))))))
 
 ;; ===========================================================================
 ;; OWNED — a listener suppresses the fallback, on BOTH fan-out sites
 ;; ===========================================================================
 
 (deftest an-attached-listener-suppresses-the-fallback
-  (when (browser?)
-    (register-refusal-handlers!)
-    (let [seen (atom [])]
-      (rf.error-emit/register-error-listener! :fu75/owner
-                            (fn [record] (swap! seen conj record)))
-      (testing "the listener receives the record exactly once and the console
-                stays silent"
-        (let [{:keys [console report-error]}
-              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-          (is (= [:rf.error/handler-exception] (mapv :error @seen))
-              "the owner got its record")
-          (is (empty? console)
-              (str "and the fallback stayed quiet; got " (pr-str console)))
-          (is (zero? report-error))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (register-refusal-handlers!)
+      (let [seen (atom [])]
+        (rf.error-emit/register-error-listener! :fu75/owner
+                              (fn [record] (swap! seen conj record)))
+        (testing "the listener receives the record exactly once and the console
+                  stays silent"
+          (let [{:keys [console report-error]}
+                (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+            (is (= [:rf.error/handler-exception] (mapv :error @seen))
+                "the owner got its record")
+            (is (empty? console)
+                (str "and the fallback stayed quiet; got " (pr-str console)))
+            (is (zero? report-error))))
 
-      (testing "the union-record site is suppressed by the same ownership"
-        (reset! seen [])
-        (let [{:keys [console]}
-              (capture-console
-                (fn []
-                  (rf.error-emit/dispatch-frame-teardown-report!
-                    :rf/default
-                    [{:hook :fu75/step :where :safe-call-hook!}]
-                    1234)))]
-          (is (= [:rf.error/frame-teardown-failed] (mapv :error @seen)))
-          (is (empty? console)))))))
+        (testing "the union-record site is suppressed by the same ownership"
+          (reset! seen [])
+          (let [{:keys [console]}
+                (capture-console
+                  (fn []
+                    (rf.error-emit/dispatch-frame-teardown-report!
+                      :rf/default
+                      [{:hook :fu75/step :where :safe-call-hook!}]
+                      1234)))]
+            (is (= [:rf.error/frame-teardown-failed] (mapv :error @seen)))
+            (is (empty? console))))))))
 
 (deftest ownership-is-implicit-and-corpus-wide
-  (when (browser?)
-    (register-refusal-handlers!)
-    (testing "a listener that IGNORES the category still owns the stream —
-              ownership is the registration, not the handling"
-      (rf.error-emit/register-error-listener! :fu75/indifferent (fn [_record] nil))
-      (let [{:keys [console]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-        (is (empty? console))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (register-refusal-handlers!)
+      (testing "a listener that IGNORES the category still owns the stream —
+                ownership is the registration, not the handling"
+        (rf.error-emit/register-error-listener! :fu75/indifferent (fn [_record] nil))
+        (let [{:keys [console]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+          (is (empty? console))))
 
-    (testing "and so does one that THROWS — the substrate swallows the
-              listener throw, and the fallback must not read that as
-              nobody-owns-it"
-      (rf.error-emit/clear-error-listeners!)
-      (rf.error-emit/register-error-listener! :fu75/broken
-                            (fn [_record] (throw (ex-info "listener boom" {}))))
-      (let [{:keys [console]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-        (is (empty? console))))))
+      (testing "and so does one that THROWS — the substrate swallows the
+                listener throw, and the fallback must not read that as
+                nobody-owns-it"
+        (rf.error-emit/clear-error-listeners!)
+        (rf.error-emit/register-error-listener! :fu75/broken
+                              (fn [_record] (throw (ex-info "listener boom" {}))))
+        (let [{:keys [console]}
+              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+          (is (empty? console)))))))
 
 (deftest dropping-the-last-listener-resumes-the-fallback
-  (when (browser?)
-    (register-refusal-handlers!)
-    (rf.error-emit/register-error-listener! :fu75/owner (fn [_record] nil))
-    (let [owned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-      (is (empty? (:console owned)) "quiet while owned"))
-    (rf.error-emit/unregister-error-listener! :fu75/owner)
-    (let [unowned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-      (is (= 1 (count (:console unowned)))
-          "the registry is empty again, so the fallback resumes")
-      (is (= "[re-frame2]" (ffirst (:console unowned))))
-      (is (zero? (:report-error unowned))))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (register-refusal-handlers!)
+      (rf.error-emit/register-error-listener! :fu75/owner (fn [_record] nil))
+      (let [owned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (empty? (:console owned)) "quiet while owned"))
+      (rf.error-emit/unregister-error-listener! :fu75/owner)
+      (let [unowned (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
+        (is (= 1 (count (:console unowned)))
+            "the registry is empty again, so the fallback resumes")
+        (is (= "[re-frame2]" (ffirst (:console unowned))))
+        (is (zero? (:report-error unowned)))))))
 
 ;; ===========================================================================
 ;; OWNED BY THE FRAME'S SINK POLICY — the second ownership arm (rf2-kuky.18)
@@ -428,113 +456,123 @@
   nil)
 
 (deftest a-registered-frame-sink-suppresses-the-fallback
-  (when (browser?)
-    (testing "the frame's :errors policy delivered the record to a REGISTERED
-              sink, so the record was routed and the console stays silent —
-              with NO :errors listener anywhere"
-      (let [seen (atom [])]
-        ;; Arm (a) must be provably OUT of the picture, or the silence below
-        ;; could be a leaked listener rather than the sink route.
-        (rf.error-emit/clear-error-listeners!)
-        (rf/register-observability-sink! :fu75.sink/collector
-                                         (fn [r] (swap! seen conj r)))
-        (register-sink-refusal! :fu75.sink/frame [{:sink :fu75.sink/collector}])
-        (let [{:keys [console report-error]}
-              (capture-console
-                #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/frame}))]
-          (is (= 1 (count @seen))
-              (str "premise: the sink genuinely received the record — without "
-                   "this the silence below would be vacuous; got " (count @seen)))
-          (is (= :rf.observe/error (:kind (first @seen))))
-          (is (empty? console)
-              (str "the record was routed, so nothing is unowned; got "
-                   (pr-str console)))
-          (is (zero? report-error)))))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "the frame's :errors policy delivered the record to a REGISTERED
+                sink, so the record was routed and the console stays silent —
+                with NO :errors listener anywhere"
+        (let [seen (atom [])]
+          ;; Arm (a) must be provably OUT of the picture, or the silence below
+          ;; could be a leaked listener rather than the sink route.
+          (rf.error-emit/clear-error-listeners!)
+          (rf/register-observability-sink! :fu75.sink/collector
+                                           (fn [r] (swap! seen conj r)))
+          (register-sink-refusal! :fu75.sink/frame [{:sink :fu75.sink/collector}])
+          (let [{:keys [console report-error]}
+                (capture-console
+                  #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/frame}))]
+            (is (= 1 (count @seen))
+                (str "premise: the sink genuinely received the record — without "
+                     "this the silence below would be vacuous; got " (count @seen)))
+            (is (= :rf.observe/error (:kind (first @seen))))
+            (is (empty? console)
+                (str "the record was routed, so nothing is unowned; got "
+                     (pr-str console)))
+            (is (zero? report-error))))))))
 
 (deftest a-policy-naming-an-UNREGISTERED-sink-still-prints
-  (when (browser?)
-    (testing "declaring a policy is not routing. The named sink was never
-              registered, so `deliver-to-sink!` no-op'd and the record went
-              NOWHERE — fail-visible: the console is the only channel left"
-      (register-sink-refusal! :fu75.sink/orphan [{:sink :fu75.sink/never-wired}])
-      (let [{:keys [console report-error]}
-            (capture-console
-              #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/orphan}))]
-        (is (= 1 (count console))
-            (str "an unwired sink id must not buy silence; got " (pr-str console)))
-        (let [[prefix summary record] (first console)]
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/handler-exception\b" summary))
-          (is (= :fu75.sink/orphan (:frame record))))
-        (is (zero? report-error))))))
-
-(deftest sink-ownership-is-frame-scoped-not-page-wide
-  (when (browser?)
-    (testing "one frame's policy silences ONLY its own records. A sibling
-              frame on the same page that declared nothing keeps its console
-              line — this is the property a corpus-wide listener claim could
-              not express, and the whole reason the key moved"
-      (let [seen (atom [])]
-        (rf/register-observability-sink! :fu75.sink/collector
-                                         (fn [r] (swap! seen conj r)))
-        (register-sink-refusal! :fu75.sink/owned [{:sink :fu75.sink/collector}])
-        (rf/make-frame {:id :fu75.sink/bare :doc "no :observability policy"})
-        (rf/reg-event :fu75.sink/bare-throws
-                      {:frame :fu75.sink/bare}
-                      (fn [_ _] (throw (ex-info "bare kaboom" {}))))
-        (let [owned (capture-console
-                      #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/owned}))
-              bare  (capture-console
-                      #(rf/dispatch-sync [:fu75.sink/bare-throws] {:frame :fu75.sink/bare}))]
-          (is (empty? (:console owned))
-              (str "the frame that routed stays quiet; got "
-                   (pr-str (:console owned))))
-          (is (= 1 (count (:console bare)))
-              (str "the frame that routed NOTHING still prints; got "
-                   (pr-str (:console bare))))
-          (is (= :fu75.sink/bare (:frame (nth (first (:console bare)) 2)))
-              "and the line that printed is the bare frame's own record"))))))
-
-(deftest a-throwing-registered-sink-still-owns-the-record
-  (when (browser?)
-    (testing "the sink was invoked and threw. `deliver-to-sink!` swallows it
-              for sibling isolation, and that swallow must not read as
-              nobody-owns-it — the sink author HAS the record. Same posture
-              as the throwing listener in `ownership-is-implicit-and-corpus-wide`"
-      (let [calls (atom 0)]
-        (rf/register-observability-sink! :fu75.sink/broken
-                                         (fn [_r]
-                                           (swap! calls inc)
-                                           (throw (ex-info "sink boom" {}))))
-        (register-sink-refusal! :fu75.sink/throwing [{:sink :fu75.sink/broken}])
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "declaring a policy is not routing. The named sink was never
+                registered, so `deliver-to-sink!` no-op'd and the record went
+                NOWHERE — fail-visible: the console is the only channel left"
+        (register-sink-refusal! :fu75.sink/orphan [{:sink :fu75.sink/never-wired}])
         (let [{:keys [console report-error]}
               (capture-console
-                #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/throwing}))]
-          (is (= 1 @calls) "premise: the sink really was invoked")
-          (is (empty? console)
-              (str "delivery is ownership, whatever the sink then did; got "
-                   (pr-str console)))
+                #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/orphan}))]
+          (is (= 1 (count console))
+              (str "an unwired sink id must not buy silence; got " (pr-str console)))
+          (let [[prefix summary record] (first console)]
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/handler-exception\b" summary))
+            (is (= :fu75.sink/orphan (:frame record))))
           (is (zero? report-error)))))))
 
+(deftest sink-ownership-is-frame-scoped-not-page-wide
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "one frame's policy silences ONLY its own records. A sibling
+                frame on the same page that declared nothing keeps its console
+                line — this is the property a corpus-wide listener claim could
+                not express, and the whole reason the key moved"
+        (let [seen (atom [])]
+          (rf/register-observability-sink! :fu75.sink/collector
+                                           (fn [r] (swap! seen conj r)))
+          (register-sink-refusal! :fu75.sink/owned [{:sink :fu75.sink/collector}])
+          (rf/make-frame {:id :fu75.sink/bare :doc "no :observability policy"})
+          (rf/reg-event :fu75.sink/bare-throws
+                        {:frame :fu75.sink/bare}
+                        (fn [_ _] (throw (ex-info "bare kaboom" {}))))
+          (let [owned (capture-console
+                        #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/owned}))
+                bare  (capture-console
+                        #(rf/dispatch-sync [:fu75.sink/bare-throws] {:frame :fu75.sink/bare}))]
+            (is (empty? (:console owned))
+                (str "the frame that routed stays quiet; got "
+                     (pr-str (:console owned))))
+            (is (= 1 (count (:console bare)))
+                (str "the frame that routed NOTHING still prints; got "
+                     (pr-str (:console bare))))
+            (is (= :fu75.sink/bare (:frame (nth (first (:console bare)) 2)))
+                "and the line that printed is the bare frame's own record")))))))
+
+(deftest a-throwing-registered-sink-still-owns-the-record
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "the sink was invoked and threw. `deliver-to-sink!` swallows it
+                for sibling isolation, and that swallow must not read as
+                nobody-owns-it — the sink author HAS the record. Same posture
+                as the throwing listener in `ownership-is-implicit-and-corpus-wide`"
+        (let [calls (atom 0)]
+          (rf/register-observability-sink! :fu75.sink/broken
+                                           (fn [_r]
+                                             (swap! calls inc)
+                                             (throw (ex-info "sink boom" {}))))
+          (register-sink-refusal! :fu75.sink/throwing [{:sink :fu75.sink/broken}])
+          (let [{:keys [console report-error]}
+                (capture-console
+                  #(rf/dispatch-sync [:fu75.sink/throws] {:frame :fu75.sink/throwing}))]
+            (is (= 1 @calls) "premise: the sink really was invoked")
+            (is (empty? console)
+                (str "delivery is ownership, whatever the sink then did; got "
+                     (pr-str console)))
+            (is (zero? report-error))))))))
+
 (deftest a-frameless-record-has-no-sink-arm-and-still-prints
-  (when (browser?)
-    (testing "a `:frame nil` record carries no frame-owned policy BY
-              DEFINITION, so arm (b) can never fire for it. With no listener
-              either, the fallback is unchanged — this is the untooled case
-              rf2-fu75 exists for, and the arm added here must not erode it"
-      (rf/register-observability-sink! :fu75.sink/collector (fn [_r] nil))
-      (let [payload (rf.frame/no-frame-context-payload :subscribe
-                                                       {:where 'rf/subscribe})
-            {:keys [console report-error]}
-            (capture-console #(rf.frame/emit-no-frame-context! payload))]
-        (is (= 1 (count console))
-            (str "a frameless record still reaches the console; got "
-                 (pr-str console)))
-        (let [[prefix _summary record] (first console)]
-          (is (= "[re-frame2]" prefix))
-          (is (nil? (:frame record))
-              "premise: this record really is frameless"))
-        (is (zero? report-error))))))
+  (if-not (browser?)
+    (is true skip-msg)
+    (do
+      (testing "a `:frame nil` record carries no frame-owned policy BY
+                DEFINITION, so arm (b) can never fire for it. With no listener
+                either, the fallback is unchanged — this is the untooled case
+                rf2-fu75 exists for, and the arm added here must not erode it"
+        (rf/register-observability-sink! :fu75.sink/collector (fn [_r] nil))
+        (let [payload (rf.frame/no-frame-context-payload :subscribe
+                                                         {:where 'rf/subscribe})
+              {:keys [console report-error]}
+              (capture-console #(rf.frame/emit-no-frame-context! payload))]
+          (is (= 1 (count console))
+              (str "a frameless record still reaches the console; got "
+                   (pr-str console)))
+          (let [[prefix _summary record] (first console)]
+            (is (= "[re-frame2]" prefix))
+            (is (nil? (:frame record))
+                "premise: this record really is frameless"))
+          (is (zero? report-error)))))))
 
 ;; ===========================================================================
 ;; THE APP-DB CANDIDATE REJECTION — rf2-xpd8's whole point (PR1)
@@ -564,58 +602,59 @@
                 (fn [_ _] {:db {:unrelated 1}})))
 
 (deftest unowned-app-db-rollback-reaches-the-dev-console
-  (when (and (browser?)
-             (some? (rf.late-bind/get-fn :schemas/validate-app-schema!)))
-    (register-rollback-app!)
-    (testing "an EMPTY registry — one console.error per FAILING registration,
-              each naming the registered path and what was found there"
-      (let [{:keys [console report-error]}
-            (capture-console
-              #(rf/dispatch-sync [:fu75.rollback/write]
-                                 {:frame :fu75.rollback/frame}))
-            rollback (filterv (fn [args]
-                                (= :rf.error/schema-validation-failure
-                                   (:error (nth args 2 nil))))
-                              console)]
-        (is (= 2 (count rollback))
-            (str "one line per violated registration; got "
-                 (pr-str (mapv second console))))
-        (doseq [[prefix summary record] rollback]
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/schema-validation-failure\b" summary)
-              (str "the summary names the category first; got " (pr-str summary)))
-          (is (re-find #"got nil" summary)
-              (str "and ends with the TYPE of what it found — the half that "
-                   "makes a wall of these lines self-diagnosing; got "
-                   (pr-str summary)))
-          (is (= :app-db (:where record)))
-          (is (true? (:rollback? record)))
-          (is (nil? (:value record))
-              "the offending value stays on the dev trace"))
-        (is (= #{[:articles] [:tags]}
-               (set (map (fn [args] (:registered-path (nth args 2))) rollback)))
-            "each line names a DISTINCT registration, so seventeen of them read
-             as seventeen broken declarations rather than one repeated noise")
-        (is (zero? report-error)
-            "console.error, never reportError — a rejected candidate is a
-             framework verdict, not an unhandled exception")))
-
-    (testing "ANY listener owns the stream and the fallback goes quiet — the
-              rf2-fu75 ownership rule applies unchanged to this category"
-      (rf.error-emit/clear-error-listeners!)
-      (let [seen (atom [])]
-        (rf.error-emit/register-error-listener! :fu75/rollback-owner
-                               (fn [r] (swap! seen conj r)))
-        (let [{:keys [console]}
+  (if-not (browser?)
+    (is true skip-msg)
+    (when (some? (rf.late-bind/get-fn :schemas/validate-app-schema!))
+      (register-rollback-app!)
+      (testing "an EMPTY registry — one console.error per FAILING registration,
+                each naming the registered path and what was found there"
+        (let [{:keys [console report-error]}
               (capture-console
                 #(rf/dispatch-sync [:fu75.rollback/write]
-                                   {:frame :fu75.rollback/frame}))]
-          (is (= 2 (count (filter #(= :rf.error/schema-validation-failure (:error %))
-                                  @seen)))
-              "the owner got both records")
-          (is (empty? console)
-              (str "and nothing printed; got " (pr-str console))))
-        (rf.error-emit/unregister-error-listener! :fu75/rollback-owner)))))
+                                   {:frame :fu75.rollback/frame}))
+              rollback (filterv (fn [args]
+                                  (= :rf.error/schema-validation-failure
+                                     (:error (nth args 2 nil))))
+                                console)]
+          (is (= 2 (count rollback))
+              (str "one line per violated registration; got "
+                   (pr-str (mapv second console))))
+          (doseq [[prefix summary record] rollback]
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/schema-validation-failure\b" summary)
+                (str "the summary names the category first; got " (pr-str summary)))
+            (is (re-find #"got nil" summary)
+                (str "and ends with the TYPE of what it found — the half that "
+                     "makes a wall of these lines self-diagnosing; got "
+                     (pr-str summary)))
+            (is (= :app-db (:where record)))
+            (is (true? (:rollback? record)))
+            (is (nil? (:value record))
+                "the offending value stays on the dev trace"))
+          (is (= #{[:articles] [:tags]}
+                 (set (map (fn [args] (:registered-path (nth args 2))) rollback)))
+              "each line names a DISTINCT registration, so seventeen of them read
+               as seventeen broken declarations rather than one repeated noise")
+          (is (zero? report-error)
+              "console.error, never reportError — a rejected candidate is a
+               framework verdict, not an unhandled exception")))
+
+      (testing "ANY listener owns the stream and the fallback goes quiet — the
+                rf2-fu75 ownership rule applies unchanged to this category"
+        (rf.error-emit/clear-error-listeners!)
+        (let [seen (atom [])]
+          (rf.error-emit/register-error-listener! :fu75/rollback-owner
+                                 (fn [r] (swap! seen conj r)))
+          (let [{:keys [console]}
+                (capture-console
+                  #(rf/dispatch-sync [:fu75.rollback/write]
+                                     {:frame :fu75.rollback/frame}))]
+            (is (= 2 (count (filter #(= :rf.error/schema-validation-failure (:error %))
+                                    @seen)))
+                "the owner got both records")
+            (is (empty? console)
+                (str "and nothing printed; got " (pr-str console))))
+          (rf.error-emit/unregister-error-listener! :fu75/rollback-owner))))))
 
 ;; ===========================================================================
 ;; THE OTHER THREE ROLLBACK ARMS — rf2-vkn8 (PR2)
@@ -650,101 +689,103 @@
   (rf/reg-event :fu75.malformed/write (fn [_ _] {:db {:broken [1]}})))
 
 (deftest unowned-machine-data-rollback-reaches-the-dev-console
-  (when (and (browser?)
-             (some? (rf.late-bind/get-fn :machines/validate-machine-data!)))
-    (register-machine-rollback-app!)
-    ;; Settle the machine with its conforming initial `:data` first, so the
-    ;; line under test comes from the MACROSTEP and not the bootstrap.
-    (rf/dispatch-sync [vkn8-machine-id [:noop]] {:frame :fu75.machine/frame})
+  (if-not (browser?)
+    (is true skip-msg)
+    (when (some? (rf.late-bind/get-fn :machines/validate-machine-data!))
+      (register-machine-rollback-app!)
+      ;; Settle the machine with its conforming initial `:data` first, so the
+      ;; line under test comes from the MACROSTEP and not the bootstrap.
+      (rf/dispatch-sync [vkn8-machine-id [:noop]] {:frame :fu75.machine/frame})
 
-    (testing "an EMPTY registry — one console.error naming the machine whose
-              `:data` broke its schema and the lifecycle phase it broke at"
-      (let [{:keys [console report-error]}
-            (capture-console
-              #(rf/dispatch-sync [vkn8-machine-id [:break]]
-                                 {:frame :fu75.machine/frame}))
-            rollback (filterv (fn [args]
-                                (= :machine-data (:where (nth args 2 nil))))
-                              console)]
-        (is (= 1 (count rollback))
-            (str "one line for the rejected machine transition; got "
-                 (pr-str (mapv second console))))
-        (let [[prefix summary record] (first rollback)]
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/schema-validation-failure\b" summary)
-              (str "the summary names the category first; got " (pr-str summary)))
-          (is (re-find #":macrostep" summary)
-              (str "and the lifecycle phase, which is where the blast radius "
-                   "is read off; got " (pr-str summary)))
-          (is (= vkn8-machine-id (:machine-id record)))
-          (is (= :fu75.machine/frame (:frame record))
-              "the frame threaded by rf2-vkn8 — without it the record could
-               never reach this frame's :observability :errors sink")
-          (is (true? (:rollback? record)))
-          (is (nil? (:value record))
-              "the machine's `:data` stays on the dev trace"))
-        (is (zero? report-error)
-            "console.error, never reportError — a rejected candidate is a
-             framework verdict, not an unhandled exception")))
-
-    (testing "ANY listener owns the stream and the fallback goes quiet"
-      (rf.error-emit/clear-error-listeners!)
-      (let [seen (atom [])]
-        (rf.error-emit/register-error-listener! :fu75/machine-owner
-                               (fn [r] (swap! seen conj r)))
-        (let [{:keys [console]}
+      (testing "an EMPTY registry — one console.error naming the machine whose
+                `:data` broke its schema and the lifecycle phase it broke at"
+        (let [{:keys [console report-error]}
               (capture-console
                 #(rf/dispatch-sync [vkn8-machine-id [:break]]
-                                   {:frame :fu75.machine/frame}))]
-          (is (= 1 (count (filter #(= :machine-data (:where %)) @seen)))
-              "the owner got the record")
-          (is (empty? console)
-              (str "and nothing printed; got " (pr-str console))))
-        (rf.error-emit/unregister-error-listener! :fu75/machine-owner)))))
+                                   {:frame :fu75.machine/frame}))
+              rollback (filterv (fn [args]
+                                  (= :machine-data (:where (nth args 2 nil))))
+                                console)]
+          (is (= 1 (count rollback))
+              (str "one line for the rejected machine transition; got "
+                   (pr-str (mapv second console))))
+          (let [[prefix summary record] (first rollback)]
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/schema-validation-failure\b" summary)
+                (str "the summary names the category first; got " (pr-str summary)))
+            (is (re-find #":macrostep" summary)
+                (str "and the lifecycle phase, which is where the blast radius "
+                     "is read off; got " (pr-str summary)))
+            (is (= vkn8-machine-id (:machine-id record)))
+            (is (= :fu75.machine/frame (:frame record))
+                "the frame threaded by rf2-vkn8 — without it the record could
+                 never reach this frame's :observability :errors sink")
+            (is (true? (:rollback? record)))
+            (is (nil? (:value record))
+                "the machine's `:data` stays on the dev trace"))
+          (is (zero? report-error)
+              "console.error, never reportError — a rejected candidate is a
+               framework verdict, not an unhandled exception")))
+
+      (testing "ANY listener owns the stream and the fallback goes quiet"
+        (rf.error-emit/clear-error-listeners!)
+        (let [seen (atom [])]
+          (rf.error-emit/register-error-listener! :fu75/machine-owner
+                                 (fn [r] (swap! seen conj r)))
+          (let [{:keys [console]}
+                (capture-console
+                  #(rf/dispatch-sync [vkn8-machine-id [:break]]
+                                     {:frame :fu75.machine/frame}))]
+            (is (= 1 (count (filter #(= :machine-data (:where %)) @seen)))
+                "the owner got the record")
+            (is (empty? console)
+                (str "and nothing printed; got " (pr-str console))))
+          (rf.error-emit/unregister-error-listener! :fu75/machine-owner))))))
 
 (deftest unowned-malformed-schema-rollback-reaches-the-dev-console
-  (when (and (browser?)
-             (some? (rf.late-bind/get-fn :schemas/validate-app-schema!)))
-    (register-malformed-rollback-app!)
+  (if-not (browser?)
+    (is true skip-msg)
+    (when (some? (rf.late-bind/get-fn :schemas/validate-app-schema!))
+      (register-malformed-rollback-app!)
 
-    (testing "an EMPTY registry — one console.error naming the registration
-              the developer has to fix"
-      (let [{:keys [console report-error]}
-            (capture-console
-              #(rf/dispatch-sync [:fu75.malformed/write]
-                                 {:frame :fu75.malformed/frame}))
-            rollback (filterv (fn [args]
-                                (= :rf.error/malformed-schema
-                                   (:error (nth args 2 nil))))
-                              console)]
-        (is (= 1 (count rollback))
-            (str "one line for the malformed registration; got "
-                 (pr-str (mapv second console))))
-        (let [[prefix summary record] (first rollback)]
-          (is (= "[re-frame2]" prefix))
-          (is (re-find #"^:rf\.error/malformed-schema\b" summary)
-              (str "the summary names the category first; got " (pr-str summary)))
-          (is (= [:broken] (:registered-path record)))
-          (is (= :fu75.malformed/frame (:frame record)))
-          (is (true? (:rollback? record)))
-          (is (nil? (:schema record))
-              "the malformed registration FORM stays on the dev trace — it
-               `pr-str`s unbounded"))
-        (is (zero? report-error))))
-
-    (testing "ANY listener owns the stream and the fallback goes quiet"
-      (rf.error-emit/clear-error-listeners!)
-      (let [seen (atom [])]
-        (rf.error-emit/register-error-listener! :fu75/malformed-owner
-                               (fn [r] (swap! seen conj r)))
-        (let [{:keys [console]}
+      (testing "an EMPTY registry — one console.error naming the registration
+                the developer has to fix"
+        (let [{:keys [console report-error]}
               (capture-console
                 #(rf/dispatch-sync [:fu75.malformed/write]
-                                   {:frame :fu75.malformed/frame}))]
-          (is (= 1 (count (filter #(= :rf.error/malformed-schema (:error %)) @seen))))
-          (is (empty? console)
-              (str "and nothing printed; got " (pr-str console))))
-        (rf.error-emit/unregister-error-listener! :fu75/malformed-owner)))))
+                                   {:frame :fu75.malformed/frame}))
+              rollback (filterv (fn [args]
+                                  (= :rf.error/malformed-schema
+                                     (:error (nth args 2 nil))))
+                                console)]
+          (is (= 1 (count rollback))
+              (str "one line for the malformed registration; got "
+                   (pr-str (mapv second console))))
+          (let [[prefix summary record] (first rollback)]
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/malformed-schema\b" summary)
+                (str "the summary names the category first; got " (pr-str summary)))
+            (is (= [:broken] (:registered-path record)))
+            (is (= :fu75.malformed/frame (:frame record)))
+            (is (true? (:rollback? record)))
+            (is (nil? (:schema record))
+                "the malformed registration FORM stays on the dev trace — it
+                 `pr-str`s unbounded"))
+          (is (zero? report-error))))
+
+      (testing "ANY listener owns the stream and the fallback goes quiet"
+        (rf.error-emit/clear-error-listeners!)
+        (let [seen (atom [])]
+          (rf.error-emit/register-error-listener! :fu75/malformed-owner
+                                 (fn [r] (swap! seen conj r)))
+          (let [{:keys [console]}
+                (capture-console
+                  #(rf/dispatch-sync [:fu75.malformed/write]
+                                     {:frame :fu75.malformed/frame}))]
+            (is (= 1 (count (filter #(= :rf.error/malformed-schema (:error %)) @seen))))
+            (is (empty? console)
+                (str "and nothing printed; got " (pr-str console))))
+          (rf.error-emit/unregister-error-listener! :fu75/malformed-owner))))))
 
 ;; ===========================================================================
 ;; HOST BOUNDARY — Node-targeted CLJS stays listener-only

--- a/tools/story/test/re_frame/story/xray_preset_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/xray_preset_dom_cljs_test.cljs
@@ -47,6 +47,13 @@
   red. Dropping the guard on the way across is how a browser-only row
   ends up failing in node.
 
+  The guard is spelled `(if-not (browser?) (is true skip-msg) ...)`
+  rather than as a bare `(when (browser?) ...)` (rf2-b8zo): under
+  `:node-test` the marker assertion fires and the row reports a STATED
+  skip, where a bare `when` left it passing with zero assertions — on
+  the console indistinguishable from a row that ran. The browser lane
+  evaluates the same body it always did.
+
   These assertions had never executed anywhere. A failure here is first
   evidence about `keybinding/attach!` / `keybinding/detach!` and the
   bridge that drives them, not a regression introduced by the move."
@@ -63,6 +70,9 @@
   (and (exists? js/document)
        (some? (.-addEventListener js/document))))
 
+(def ^:private skip-msg
+  "skipped: no DOM (node lane — see ns docstring)")
+
 (deftest wire-cross-host-clears-attached-listener
   (testing "rf2-ycrt2 — simulate Xray's preload-time attach! under the
             default-true posture, then drive wire-cross-host!: the slot
@@ -70,28 +80,30 @@
             (runtime). rf2-q7who.1 declared the contract and did not
             close it — the slot flip alone never detaches a listener
             that attach! already installed."
-    (when (browser?)
-      ;; Normalise the sentinel before the precondition asserts on it.
-      ;; `attach!` is a `compare-and-set!` from false, so an already-
-      ;; attached listener would make it a silent no-op and the
-      ;; precondition would pass on somebody else's listener.
-      (xray-keybinding/detach!)
-      (xray-config/set-keybinding-enabled! true)
-      (try
-        (xray-keybinding/attach!)
-        (is (true? (xray-keybinding/attached?))
-            "precondition: preload-style attach! installed the listener")
-        ;; Drive the real bridge. No shims: `disable-keybinding!` and
-        ;; `detach-keybinding!` reach Xray's live config / keybinding
-        ;; namespaces through declared `:require`s (rf2-r8trk). No shell
-        ;; mounts — `wire-cross-host!` never calls `apply-open!`.
-        (rf.story.xray-preset/wire-cross-host!)
-        (is (false? (xray-config/keybinding-attach-enabled?))
-            "wire-cross-host! flipped the slot to false")
-        (is (false? (xray-keybinding/attached?))
-            "wire-cross-host! removed the listener (rf2-ycrt2 runtime gap closed)")
-        (finally
-          ;; Restore the baseline so neighbouring namespaces on this
-          ;; page see the default posture and no stray listener.
-          (xray-config/set-keybinding-enabled! true)
-          (xray-keybinding/detach!))))))
+    (if-not (browser?)
+      (is true skip-msg)
+      (do
+        ;; Normalise the sentinel before the precondition asserts on it.
+        ;; `attach!` is a `compare-and-set!` from false, so an already-
+        ;; attached listener would make it a silent no-op and the
+        ;; precondition would pass on somebody else's listener.
+        (xray-keybinding/detach!)
+        (xray-config/set-keybinding-enabled! true)
+        (try
+          (xray-keybinding/attach!)
+          (is (true? (xray-keybinding/attached?))
+              "precondition: preload-style attach! installed the listener")
+          ;; Drive the real bridge. No shims: `disable-keybinding!` and
+          ;; `detach-keybinding!` reach Xray's live config / keybinding
+          ;; namespaces through declared `:require`s (rf2-r8trk). No shell
+          ;; mounts — `wire-cross-host!` never calls `apply-open!`.
+          (rf.story.xray-preset/wire-cross-host!)
+          (is (false? (xray-config/keybinding-attach-enabled?))
+              "wire-cross-host! flipped the slot to false")
+          (is (false? (xray-keybinding/attached?))
+              "wire-cross-host! removed the listener (rf2-ycrt2 runtime gap closed)")
+          (finally
+            ;; Restore the baseline so neighbouring namespaces on this
+            ;; page see the default posture and no stray listener.
+            (xray-config/set-keybinding-enabled! true)
+            (xray-keybinding/detach!)))))))


### PR DESCRIPTION
Closes rf2-b8zo.

Seventeen `deftest` rows across two `*_dom_cljs_test.cljs` files guarded their
bodies with a bare `(when (browser?) ...)`. Both namespaces load on **both**
shadow targets — `:browser-test`'s `.*-dom-cljs-test$` and `:node-test`'s
broader `cljs-test$` — so in the node lane the guard was false and each row
passed having run **zero assertions**. On the console that is indistinguishable
from a row that ran.

They now use the shape the rest of the tree already uses:

```clojure
(if-not (browser?)
  (is true skip-msg)
  (do ...))
```

`TESTING.md`'s `cljs_browser` classifier row is the statement this rests on: it
names the *stated green skip* as the node-lane shape for DOM rows, and describes
the failure being repaired here — a surface that "passed having executed none of
its DOM assertions, which is worse than an unclassified surface".

## This is a legibility repair, not a coverage repair

These rows **do** execute, in the browser lane, and that lane evaluates the same
body it always did — every body is moved verbatim, only re-indented by two
columns. What changed is what the node lane *reports*. This is deliberately not
the never-executed class that rf2-r51p closed; that census reads 0 tree-wide and
stays there.

The proof is in the node-lane counts below: the **test** count does not move, and
the **assertion** count rises by exactly one per marker added.

## What changed, per file

| file | rows | marked |
|---|---|---|
| `implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs` | 17 | 16 |
| `tools/story/test/re_frame/story/xray_preset_dom_cljs_test.cljs` | 1 | 1 |

In the core file, 13 rows were spelled `(when (browser?)` and **3 more** were
spelled `(when (and (browser?) (some? ...))`. The compound three keep their
non-host conjunct as an inner `when`, so the browser lane is bit-for-bit
unchanged:

```clojure
(if-not (browser?)
  (is true skip-msg)
  (when (some? (rf.late-bind/get-fn :schemas/validate-app-schema!))
    ...))
```

The 17th row, `node-targeted-cljs-stays-quiet`, is the **inverse** case — it runs
only *off* a DOM host — so it keeps `when-not` and is untouched. Marking it would
add an assertion to the browser lane, which this change deliberately does not do.

The message is the tree's existing `skipped: no DOM (node lane — see ns
docstring)` rather than the `no localStorage` variant used by six other files:
neither of these is a localStorage file, so that message would be a lie.

Each file's ns docstring gains a short paragraph stating the shape and why, so
the next reader does not have to re-derive it.

## Quality gates

Every exit code below was captured with the runner's own `echo $?` on the same
command line as the redirect, and is the number quoted.

| gate | captured exit | result |
|---|---|---|
| `npm run test:cljs` (baseline, pre-change) | **0** | 11780 tests / **58799** assertions, 0 failures |
| `npm run test:cljs` (after) | **0** | 11780 tests / **58816** assertions, 0 failures |
| `npm run test:cljs` (after rebase onto final base) | **0** | 11780 tests / 58816 assertions, 0 failures |
| `npm run test:scripts` | **0** | 123/123 pass |
| `python scripts/check_test_lane_bijection.py --self-test` | **0** | pass |
| `python scripts/check_test_lane_bijection.py --verbose` | **0** | 1655 test-defining files, 45 lanes, every file selected |
| `python scripts/check_require_alias_dialect.py --self-test` | **0** | pass |
| `python scripts/check_require_alias_dialect.py --verbose` | **0** | 2886 files, 11356 edges, 0 non-canonical, every surface under floor |
| `python scripts/lint_kondo.py` | **0** | errors 0; 0 findings naming either changed file |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** | pass |

**Node-lane delta: tests +0, assertions +17** — 16 markers in the core file plus
1 in the story file. That is the whole claim of this PR, measured.

### Sabotage control

A sentinel fault was planted at a line this PR edits — one marker per file
flipped to `(is false "SABOTAGE-...")` — and the gate was re-run:

* **captured exit 1**, `2 failures, 0 errors`
* failures named `unowned-refusal-reaches-the-dev-console` (core) **and**
  `wire-cross-host-clears-attached-listener` (story), i.e. one from each file, so
  both halves of the change are genuinely reached by this gate
* test and assertion counts were unchanged at 11780 / 58816, so the plant's blast
  radius was one assertion per file and no namespace was halted

Both files were then restored and verified three ways: `git hash-object` equals
`git rev-parse HEAD:<path>` for each, `git diff --quiet HEAD` exits 0, and the
sentinel count is 0.

One note worth recording, because it nearly inverted this control: the first
plant attempt silently **no-opped**. The new ns-docstring paragraph quotes the
literal `(is true skip-msg)`, so a first-occurrence replacement patched the
*prose* and left the code alone — and that run would have come back green. It was
caught by reading the match count before running the gate (17 and 2, where the
code markers number 16 and 1). The re-plant is anchored to a whole line, which
the mid-line docstring mention cannot match.

### Left to CI

Deliberately not run locally; these are the required checks this PR leans on CI
for:

* **`cljs-browser`** (Playwright `:browser-test`) — the lane where these rows
  actually assert. Skipped locally because **no expression inside any row body
  changed**: bodies are moved verbatim, and in the browser lane
  `(if-not (browser?) _ (do BODY))` and `(when (browser?) BODY)` evaluate
  identically, as do `(when (and (browser?) X) BODY)` and the inner-`when` form.
  The browser-lane assertion count is expected to be unchanged.
* The full JVM tier (`jvm-core` and siblings), `cljs_prod`, `bundle_isolation`,
  the `tools_jvm` lanes, and the mcp-conformance set — all armed by the
  classifier for a change under `implementation/core/**`, none of them reading
  CLJS test-lane guards.
* `lint.yml`'s `splint` and `api-manifest` jobs.
