### PR TITLE
test(core): state the browser-lane skip on the one mirror-case DOM row (rf2-f8yj)

### DIFF
--- a/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
@@ -66,7 +66,9 @@
   it passing with zero assertions, which reads on the console exactly
   like a row that ran. Nothing about the coverage moved: the browser
   lane evaluates the same body it always did. `node-targeted-cljs-stays-quiet`
-  is the one row that runs only OFF a DOM host, so it keeps `when-not`.
+  is the one row that runs only OFF a DOM host, so its guard and its
+  stated skip are the mirror image: the marker fires under
+  `:browser-test`, where the row's body does not run (rf2-f8yj).
 
   The JVM / SSR lane is listener-only by the same rule and needs no
   counterpart here: `#?(:clj …)` in `report-unowned-error!` is `nil`."
@@ -792,65 +794,67 @@
 ;; ===========================================================================
 
 (deftest node-targeted-cljs-stays-quiet
-  (when-not (browser?)
-    (register-refusal-handlers!)
-    (testing "same refusal, same empty registry, no DOM host: the fallback is
-              a browser-DEVELOPMENT diagnostic, not a generic CLJS print. A
-              Node lane's caller observes the dispatch directly and attaches
-              a listener in one line, exactly as the JVM lane does."
-      (let [{:keys [console report-error]}
-            (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
-        (is (empty? console)
-            (str "no console output off a DOM host; got " (pr-str console)))
-        (is (zero? report-error))))
-
-    (testing "and the record still reaches an attached listener — the
-              always-on axis is unchanged off-browser"
-      (let [seen (atom [])]
-        (rf.error-emit/register-error-listener! :fu75/owner
-                              (fn [record] (swap! seen conj record)))
-        (rf/dispatch-sync [:fu75.console/throws])
-        (is (= [:rf.error/handler-exception] (mapv :error @seen)))))
-
-    ;; rf2-vkn8: the same boundary for PR2's arms. The host rule is a property
-    ;; of the FALLBACK, not of a category, so a new producer must inherit it
-    ;; rather than acquire its own exemption — this is the half that would
-    ;; catch a second printer being added beside the seam.
-    (testing "the machine-data and malformed-schema rollbacks obey the same
-              host boundary: silent off a DOM host, and still delivered to an
-              attached listener"
-      (when (some? (rf.late-bind/get-fn :machines/validate-machine-data!))
-        (register-machine-rollback-app!)
-        (rf/dispatch-sync [vkn8-machine-id [:noop]] {:frame :fu75.machine/frame})
-        (rf.error-emit/clear-error-listeners!)
+  (if (browser?)
+    (is true "skipped: DOM host present (browser lane — see ns docstring)")
+    (do
+      (register-refusal-handlers!)
+      (testing "same refusal, same empty registry, no DOM host: the fallback is
+                a browser-DEVELOPMENT diagnostic, not a generic CLJS print. A
+                Node lane's caller observes the dispatch directly and attaches
+                a listener in one line, exactly as the JVM lane does."
         (let [{:keys [console report-error]}
-              (capture-console
-                #(rf/dispatch-sync [vkn8-machine-id [:break]]
-                                   {:frame :fu75.machine/frame}))]
+              (capture-console #(rf/dispatch-sync [:fu75.console/throws]))]
           (is (empty? console)
               (str "no console output off a DOM host; got " (pr-str console)))
-          (is (zero? report-error)))
-        (let [seen (atom [])]
-          (rf.error-emit/register-error-listener! :fu75/machine-owner
-                                 (fn [r] (swap! seen conj r)))
-          (rf/dispatch-sync [vkn8-machine-id [:break]] {:frame :fu75.machine/frame})
-          (is (= 1 (count (filter #(= :machine-data (:where %)) @seen)))
-              "the always-on axis is unchanged off-browser")
-          (rf.error-emit/unregister-error-listener! :fu75/machine-owner)))
+          (is (zero? report-error))))
 
-      (when (some? (rf.late-bind/get-fn :schemas/validate-app-schema!))
-        (register-malformed-rollback-app!)
-        (rf.error-emit/clear-error-listeners!)
-        (let [{:keys [console report-error]}
-              (capture-console
-                #(rf/dispatch-sync [:fu75.malformed/write]
-                                   {:frame :fu75.malformed/frame}))]
-          (is (empty? console)
-              (str "no console output off a DOM host; got " (pr-str console)))
-          (is (zero? report-error)))
+      (testing "and the record still reaches an attached listener — the
+                always-on axis is unchanged off-browser"
         (let [seen (atom [])]
-          (rf.error-emit/register-error-listener! :fu75/malformed-owner
-                                 (fn [r] (swap! seen conj r)))
-          (rf/dispatch-sync [:fu75.malformed/write] {:frame :fu75.malformed/frame})
-          (is (= 1 (count (filter #(= :rf.error/malformed-schema (:error %)) @seen))))
-          (rf.error-emit/unregister-error-listener! :fu75/malformed-owner))))))
+          (rf.error-emit/register-error-listener! :fu75/owner
+                                (fn [record] (swap! seen conj record)))
+          (rf/dispatch-sync [:fu75.console/throws])
+          (is (= [:rf.error/handler-exception] (mapv :error @seen)))))
+
+      ;; rf2-vkn8: the same boundary for PR2's arms. The host rule is a property
+      ;; of the FALLBACK, not of a category, so a new producer must inherit it
+      ;; rather than acquire its own exemption — this is the half that would
+      ;; catch a second printer being added beside the seam.
+      (testing "the machine-data and malformed-schema rollbacks obey the same
+                host boundary: silent off a DOM host, and still delivered to an
+                attached listener"
+        (when (some? (rf.late-bind/get-fn :machines/validate-machine-data!))
+          (register-machine-rollback-app!)
+          (rf/dispatch-sync [vkn8-machine-id [:noop]] {:frame :fu75.machine/frame})
+          (rf.error-emit/clear-error-listeners!)
+          (let [{:keys [console report-error]}
+                (capture-console
+                  #(rf/dispatch-sync [vkn8-machine-id [:break]]
+                                     {:frame :fu75.machine/frame}))]
+            (is (empty? console)
+                (str "no console output off a DOM host; got " (pr-str console)))
+            (is (zero? report-error)))
+          (let [seen (atom [])]
+            (rf.error-emit/register-error-listener! :fu75/machine-owner
+                                   (fn [r] (swap! seen conj r)))
+            (rf/dispatch-sync [vkn8-machine-id [:break]] {:frame :fu75.machine/frame})
+            (is (= 1 (count (filter #(= :machine-data (:where %)) @seen)))
+                "the always-on axis is unchanged off-browser")
+            (rf.error-emit/unregister-error-listener! :fu75/machine-owner)))
+
+        (when (some? (rf.late-bind/get-fn :schemas/validate-app-schema!))
+          (register-malformed-rollback-app!)
+          (rf.error-emit/clear-error-listeners!)
+          (let [{:keys [console report-error]}
+                (capture-console
+                  #(rf/dispatch-sync [:fu75.malformed/write]
+                                     {:frame :fu75.malformed/frame}))]
+            (is (empty? console)
+                (str "no console output off a DOM host; got " (pr-str console)))
+            (is (zero? report-error)))
+          (let [seen (atom [])]
+            (rf.error-emit/register-error-listener! :fu75/malformed-owner
+                                   (fn [r] (swap! seen conj r)))
+            (rf/dispatch-sync [:fu75.malformed/write] {:frame :fu75.malformed/frame})
+            (is (= 1 (count (filter #(= :rf.error/malformed-schema (:error %)) @seen))))
+            (rf.error-emit/unregister-error-listener! :fu75/malformed-owner)))))))


### PR DESCRIPTION
Closes the last member of the browser-gated-row-without-a-stated-skip class,
tree-wide. One `deftest` row, one file.

`node-targeted-cljs-stays-quiet` is the MIRROR of the class PR #9700 closed in
this same file. It gates on `(when-not (browser?) ...)`, so in the BROWSER lane
the body never runs and the row reported **passing with zero assertions** —
on the console indistinguishable from a row that ran and asserted nothing.
It now states its skip on the browser arm, the same shape the sixteen rows
above it use for the node arm. The body is verbatim, re-indented two columns
under the added `do`.

rf2-b8zo left this row deliberately, because marking it moves the browser-lane
assertion count and that bead's fence forbade it. That fence was rf2-b8zo's
own, and rf2-f8yj is the decision to sweep the class whole.

## The numbers, which are the deliverable

Measured on the final base `f6758e322a`, captured exit codes throughout.

| lane | before | after |
|---|---|---|
| node (`test:cljs`) | 11773 tests / 58800 assertions | 11773 / 58800 |
| browser (`test:browser`) | 1083 tests / 5843 assertions | 1083 / **5844** |

**The test count did not move in either lane, and the browser lane rose by
exactly one assertion — the single marker added.** Reporting changed; coverage
did not. The node lane is untouched, which is the constraint this change had to
respect.

A pre-rebase pair was also captured on the dispatch base `2e5bb4c432`
(node 11780/58816 unmoved, browser 1083/5843 → 5844). The trunk moved eleven
commits under me and `refactor(xray): retire two zero-mount vars (rf2-bcub)`
removed 7 node tests and 16 assertions, so the baseline was re-derived on the
new base rather than reconfirmed — the pre-rebase figure is evidence about a
tree that no longer exists.

## The census — the other half

Structural parse of every `(deftest` block in all tracked `*_dom_cljs_test.cljs`
files. A row is MARKED if its non-executing lane's arm reaches an assertion that
fires there; both landed spellings are matched, `(is true <msg>)` and the
per-namespace `(skip! <why>)` helper.

| | before | after |
|---|---|---|
| files | 206 | 206 |
| deftest rows | 1362 | 1362 |
| rows with no `(browser?)` at all | 780 | 780 |
| **MARKED** | **579** | **580** |
| **UNMARKED** | **3** | **2** |

This reproduces the dispatch census exactly, and the two remaining unmarked rows
are **false positives of the census itself**, correct as they stand and not
touched: the `the-fixture-frames-are-actually-platform-tagged` rows in
`implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs`
and `multi_root_hydration_dom_cljs_test.cljs`. They match only because their
docstrings say they are *"Deliberately NOT gated on `(browser?)`"*; they are
ungated, run in both lanes, and assert for real. **No fourth row exists** — so
zero real unmarked rows remain tree-wide.

An instrument note worth keeping: the first pass of this census read 399 MARKED
/ 183 UNMARKED, because the `(skip!` arm was written `\(skip!\b` — `!` and the
following space are both non-word characters, so `\b` can never match between
them and that arm read zero. The 180-row gap was caught only because the
dispatch carried a number to control against.

## Docstring correction

The ns docstring claimed this row *"keeps `when-not`"*, which this change
falsifies, so it is corrected in the same commit. The correction deliberately
does **not** quote the marker expression: the paragraph above it already does,
and that quotation is the decoy anchor that made a first-occurrence sabotage
plant on PR #9700 patch the prose and come back green.

## Sabotage control

The plant anchor was reconciled against code sites **before** the gate ran, per
that warning. `(is true "skipped: DOM host present` matched **1** line, a code
site; the decoy-bearing node marker `(is true skip-msg)` matched **17** against
16 code sites, the excess being the docstring quotation at line 63. The plant
avoided that spelling entirely.

Flipped to `(is false "SABOTAGE-...")`:

* **browser lane — captured exit 1**, `FAIL in (node-targeted-cljs-stays-quiet)`,
  the sentinel printed on the browser console, counts unchanged at 1083 / 5844,
  so the blast radius was exactly one assertion and no namespace crashed out.
* **node lane — captured exit 0**, 11773 / 58800, sentinel count 0. The marker
  sits on the browser arm only, which is the independent proof that the node
  lane cannot see it.
* The compile reported `3 compiled` both times, so the runtime saw the plant
  rather than serving a stale artefact.

Restored and verified three ways: the committed blob id equals
`git hash-object` in its default form (this file is `i/lf w/crlf`, so the
`--no-filters` form correctly does *not* match), `git diff --quiet HEAD` exit 0,
and a sentinel count of 0.

## Gates, every captured exit

Nominated by path, all re-run on the final base after the rebase.

| gate | exit |
|---|---|
| `test:cljs` compile / run — before | 0 / 0 |
| `test:cljs` compile / run — after | 0 / 0 |
| `test:browser` compile / run — before | 0 / 0 |
| `test:browser` compile / run — after | 0 / 0 |
| `test:browser` — sabotage | **1** (expected red) |
| `test:cljs` — sabotage | 0 (marker is browser-only) |
| `check_test_lane_bijection.py --self-test` | 0 |
| `check_test_lane_bijection.py --verbose` | 0 — 1655 test-defining files, 45 lanes |
| `check_require_alias_dialect.py --self-test` | 0 |
| `check_require_alias_dialect.py --verbose` | 0 — 0 non-canonical, every surface under floor |
| `check_retired_spellings.py --self-test --verbose` | 0 |
| `check_retired_spellings.py --verbose` | 0 |
| `check_ambient_durable_reads.py --self-test --verbose` | 0 |
| `check_ambient_durable_reads.py --verbose` | 0 |
| `check_thrown_error_messages.py --self-test --verbose` | 0 |
| `check_thrown_error_messages.py --verbose` | 0 |
| `check-no-hardcoded-paths.sh` | 0 |
| `lint_kondo.py` | 0 — errors 0 |
| `lint_kondo.py --classify <path>` | 0 — `kondo_surface=true` |

Ratchets were selected by asking which scripts grade this path rather than from
a list. `check_escaped_continuations.py` and `check_flattened_lists.py` grade
markdown only and are not this path's gates. `npm run test:scripts` was not run:
no `.cjs` changed.

One instrument note: `check_thrown_error_messages.py --include-tests --verbose`
exits 1 on this tree, naming five pre-existing sites in other files. That flag is
not the form CI runs; the CI form (`--verbose`) is green, and nothing of mine is
implicated.

## Fence

One row in one file. No new test, no behaviour change, no other file. The
compound-guard hunt, the third file and the machines-viz path named in the
bead's description were withdrawn by the mayor's own census before dispatch and
were not pursued.
