### PR TITLE
refactor(xray): delete the four Reagent islands (rf2-k97c.3)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -82,6 +82,7 @@
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.local-storage :as ls]
@@ -295,8 +296,10 @@
 
 ;; ---- view ----------------------------------------------------------------
 
-(rf/reg-view frame-switcher-view
-  "L1 chrome-ribbon frame-switcher — the `Frame ▾` dropdown BUTTON per
+(defn frame-switcher-tree
+  "The frame-switcher's WHOLE hiccup, as a pure function of the
+  frame-bound `dispatch` and the two values [[frame-switcher-view]]
+  reads — the `Frame ▾` dropdown BUTTON per
   the Figma design-reference (the `chrome-ribbon` component in
   `design-reference/xray_devtools_reference.cljs`) + spec/018 §3 Frame dropdown. STRICTLY single-select (spec/018
   §1 Non-goals + Round-3 rf2-i74n7): no 'All frames (merged)' option, no
@@ -332,14 +335,18 @@
   documented at ns-top. Other frame-aware features (Cmd-K palette, future
   panels) reach through the same surface.
 
-  `reg-view`-registered (rf2-in6l2) so its rendered React component
-  carries `:contextType frame-context` and the closest enclosing
-  `[rf/frame-provider {:frame :rf/xray}]` flows through React-context
-  — subscribes resolve to `:rf/xray`."
-  [_props]
-  (let [selected-frame  @(rf/subscribe [:rf.xray/current-frame])
-        frames          @(rf/subscribe [:rf.xray/available-frames])
-        active          (or selected-frame (first frames))
+  SPLIT OUT OF [[frame-switcher-view]] BY rf2-k97c.3, for the reason
+  every migrated view in this epic splits: a boundary's body may only run
+  inside a React render window, so `(frame-switcher-view {})` is no
+  longer a callable that answers hiccup. This is `defview`'s OWN
+  documented extract-a-helper spelling, not an invention.
+
+  IT TAKES THE RAW READ VALUES in the order the boundary reads them, so
+  the node lane's door is a reproduction of the READS alone with no
+  second copy of the `(or selected-frame (first frames))` derivation to
+  drift."
+  [dispatch selected-frame frames]
+  (let [active          (or selected-frame (first frames))
         ;; rf2-v8bule — the controlled `<select>`'s value is `(str active)`,
         ;; so it MUST have a matching `<option>` or React warns "value not
         ;; in options" and renders blank. `active` can be a frame that is
@@ -404,10 +411,11 @@
                                     kw  (when (and v (.startsWith v ":"))
                                           (keyword (subs v 1)))]
                                 (when kw
-                                  ;; rf2-nesy9 — dispatch through the
-                                  ;; reg-view-injected frame-aware
-                                  ;; `dispatch` so the frame select lands
-                                  ;; on the surrounding instance frame.
+                                  ;; rf2-nesy9 / rf2-k97c.3 — dispatch
+                                  ;; through the frame-bound dispatcher
+                                  ;; the boundary captured, so the frame
+                                  ;; select lands on the surrounding
+                                  ;; instance frame.
                                   (dispatch [:rf.xray/select-frame kw]))))
                :style       {:position   "absolute"
                              :top        0
@@ -429,6 +437,44 @@
         [:option {:key   (str f)
                   :value (str f)}
          (str (if (= f active) "✓ " "  ") f)])]]))
+
+(rf.fresco/defview frame-switcher-view
+  "L1 chrome-ribbon frame-switcher, and a FRESCO BOUNDARY (rf2-k97c.3)
+  rather than an `rf/reg-view`. [[frame-switcher-tree]] carries the
+  shape, the contract and the design reasoning; this is the read set and
+  the dispatcher, and nothing else.
+
+  ## rf2-k97c.3 — the boundary that deleted TWO ISLANDS
+
+  Both shells' L1 ribbons — Dynamic `shell.cljs` and `static/shell.cljs`
+  — are Fresco boundaries, and while this was an `rf/reg-view` each of
+  them had to reach it across an `as-child` REAGENT ISLAND, because a
+  `reg-view` grades `:invalid` as a Fresco head down the same arm a plain
+  `defn` does. Migrating it deletes both of those seams: each ribbon now
+  heads `[frame-switcher-view {}]` directly, the way it heads any other
+  boundary.
+
+  The READS are `rf.fresco/sub`, plain calls the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value. They keep the `reg-view` body's ORDER, which
+  is the order the node lane reproduces.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body and replaces
+  the `dispatch` the `reg-view` body used to inject lexically. It
+  supersedes the `:contextType frame-context` route rf2-in6l2 relied on:
+  a boundary resolves its frame from the same REACT CONTEXT
+  `rf/frame-provider` and `rf.fresco/frame-provider` both write, so the
+  enclosing `[rf/frame-provider {:frame :rf/xray}]` still decides where
+  these reads and writes land.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. Both ribbons mount it with none, so it is destructured away."
+  [_props]
+  (frame-switcher-tree (:dispatch (rf/capture-frame))
+                       (rf.fresco/sub [:rf.xray/current-frame])
+                       (rf.fresco/sub [:rf.xray/available-frames])))
 
 ;; ---- install -------------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1224,8 +1224,8 @@
 
 (defn ribbon-tree
   "The L1 chrome ribbon's WHOLE hiccup, as a pure function of the
-  frame-bound `dispatch`, the six values [[ribbon]] reads, and the
-  `as-child` spelling for the ribbon's two REAGENT ISLANDS.
+  frame-bound `dispatch`, the six values [[ribbon]] reads, and its
+  three already-composed boundary children.
 
   SPLIT OUT OF [[ribbon]] BY rf2-k97c.3, for the reason every migrated
   view in this epic splits: a boundary's body may only run inside a React
@@ -1241,21 +1241,31 @@
   `ribbon-right-icons`, `filter-pills/chrome-add-filter-button` and
   `spine-filters/ribbon-mute-indicator` are all plain fns answering
   hiccup, so they are CALLED rather than headed — Fresco grades a plain
-  function in head position a loud error. [[ribbon-theme-toggle]] IS a
-  boundary, so it stays a head.
+  function in head position a loud error.
 
-  TWO REAGENT ISLANDS, both reached through `as-child` — `identity` for a
-  hiccup caller and the node lane, `substrate/as-element` for the
-  boundary:
+  THREE BOUNDARY CHILDREN — `frame-switcher*`, `mode-pill*` and
+  `theme-toggle*` — ARRIVE ALREADY COMPOSED rather than as heads this fn
+  writes, because a boundary head cannot be walked by a hiccup walker:
+  its body only runs inside a React render window. [[ribbon]] passes the
+  three BOUNDARY-headed vectors and `test-helpers.dynamic-shell-tree`
+  passes each one's already-expanded plain hiccup, so a node-lane row
+  that walks this ribbon walks the real thing. Same shape as
+  [[dynamic-chrome-tree]]'s six layers, and for the same reason.
 
-    * `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`, both
-      still `rf/reg-view`s and both ALSO headed by the STATIC shell's
-      ribbon (`static/shell.cljs`), which islands them the same way.
-      Migrating them is a slice of its own that deletes FOUR islands at
-      once — two here and two there — rather than two now and two later."
+  THE `as-child` PARAMETER IS GONE, and its deletion is the deliverable
+  rather than a tidy-up. `frame-switcher/frame-switcher-view` and
+  `mode-pill/mode-pill` were this ribbon's two REAGENT ISLANDS —
+  `rf/reg-view`s a boundary could only reach across an `as-child` seam —
+  and they are boundaries as of rf2-k97c.3, so the seam has nothing left
+  to carry. The STATIC shell's ribbon (`static/shell.cljs`) islanded the
+  same two widgets the same way, so the one slice deleted FOUR islands —
+  two here and two there — which is why they were deferred rather than
+  migrated piecemeal. [[event-list-tree]]'s L4 seam is untouched and
+  stands for its own recorded reason."
   [dispatch
    {:keys [redacted-count muted-count focus event-bundles show-ungrouped? filters]}
-   as-child
+   frame-switcher*
+   mode-pill*
    theme-toggle*]
   (let [no-filters? (zero? (+ (count (:in filters)) (count (:out filters))))
         {:keys [at-head? at-tail? live?]}
@@ -1354,16 +1364,17 @@
       ;; frame` + `:rf.xray/available-frames` and writes via
       ;; `:rf.xray/select-frame`. The frame is a view SCOPE, not a
       ;; filter (rf2-4vp5j Workstream C).
-      ;; rf2-k97c.3 — REAGENT ISLAND. Still an `rf/reg-view`, which
-      ;; Fresco grades `:invalid` as a head down the same arm a plain
-      ;; `defn` does. See [[ribbon-tree]]'s docstring.
-      (as-child [frame-switcher/frame-switcher-view])
+      ;; rf2-k97c.3 — a FRESCO BOUNDARY now, so it arrives here ALREADY
+      ;; COMPOSED rather than as a head this fn writes. It was this
+      ;; ribbon's first Reagent island until that slice. See
+      ;; [[ribbon-tree]]'s docstring.
+      frame-switcher*
       ;; Dynamic/Static dropdown (rf2-4vp5j) — compact, understated; the
       ;; accent stripe carries the mode signal so the control stays
       ;; quiet. Always rendered (the `:rf.xray/static-mode?` feature
       ;; gate was removed per rf2-8l3uk).
-      ;; rf2-k97c.3 — the second REAGENT ISLAND.
-      (as-child [mode-pill/mode-pill])
+      ;; rf2-k97c.3 — the second boundary, and the second island deleted.
+      mode-pill*
       ;; rf2-ikuwt — mute indicator (🔇 N) renders inline next to the
       ;; REDACTED indicator. Both are silent-by-default surfaces that
       ;; only paint when their count is positive. Click → unmute
@@ -1432,8 +1443,10 @@
   `defview` binds NO name inside the body, so the bare `dispatch` this
   body used to close over would be a LOUD compile error.
 
-  `substrate/as-element` is the `as-child` spelling for the two Reagent islands;
-  [[ribbon-tree]] records which they are and why.
+  ITS THREE COMPONENT CHILDREN ARE BOUNDARY HEADS, not islands
+  (rf2-k97c.3). The frame switcher and the mode pill were `rf/reg-view`s
+  reached across an `as-child` seam until that slice; heading them
+  directly is what deleted it, and [[ribbon-tree]] records why.
 
   The argument is the ordinary one-props-map vector every `defview`
   takes. [[dynamic-chrome]] mounts it with none, so it is destructured
@@ -1459,7 +1472,8 @@
      ;; when ≥1 filter is committed (the events-ribbon's own `[+]`
      ;; takes over). Open when zero filters, closed otherwise.
      :filters         (rf.fresco/sub [:rf.xray/active-filters])}
-    substrate/as-element
+    [frame-switcher/frame-switcher-view {}]
+    [mode-pill/mode-pill {}]
     [ribbon-theme-toggle {}]))
 
 ;; ---- L2 event list -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/mode_pill.cljs
@@ -31,21 +31,29 @@
   attribute + active option carry the mode state, and the
   Dynamic/Static MODE drives motion/pulse rather than accent colour.
 
-  ## Why a single registered view
+  ## Why a single boundary
 
-  `(rf/reg-view mode-pill …)` is the canonical Xray shape: subscribes
-  inside the component body resolve to `:rf/xray` via React-context
-  (Spec 000 §Plain Reagent fns do not pick up the surrounding frame).
-  The `<select>` is native so keyboard + screen-reader navigation work
-  out of the box.
+  `(rf.fresco/defview mode-pill …)` is the canonical Xray shape: the
+  boundary resolves its frame from REACT CONTEXT — the same context
+  `rf/frame-provider` and `rf.fresco/frame-provider` both write — so its
+  read lands on `:rf/xray` without either call site threading anything.
+  A plain `defn` would not (Spec 000 §Plain Reagent fns do not pick up
+  the surrounding frame / Spec 006 §Plain-fn footgun); it is a
+  registered view precisely so the read routes. The `<select>` is native
+  so keyboard + screen-reader navigation work out of the box.
+
+  It was an `rf/reg-view` until rf2-k97c.3, which is why both ribbons
+  used to reach it through an `as-child` Reagent island — see
+  [[mode-pill]].
 
   ## Production posture
 
   Mounted only by `static/shell.cljs` (Static mode) AND by `shell.cljs`'s
   chrome ribbon (Dynamic mode) — see the chrome-left cluster wiring.
-  The component subscribes to `:rf.xray/mode` directly so neither call
+  The component reads `:rf.xray/mode` directly so neither call
   site threads the active mode as a prop."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack]]))
 
@@ -69,9 +77,10 @@
 
 ;; ---- view ---------------------------------------------------------------
 
-(rf/reg-view mode-pill
-  "Chrome-ribbon mode dropdown — a compact single-select `<select>`
-  toggling Dynamic ↔ Static. Shares the frame
+(defn mode-pill-tree
+  "The mode dropdown's WHOLE hiccup, as a pure function of the
+  frame-bound `dispatch` and the resolved `:rf.xray/mode` — a compact
+  single-select `<select>` toggling Dynamic ↔ Static. Shares the frame
   picker's control style (`bg-2`, `border-default`, 4px radius) so the
   two chrome-left selectors read as one stratum. The mode SIGNAL is the
   ribbon's left-edge accent stripe, not this control — the dropdown is
@@ -81,35 +90,67 @@
   `:rf/xray` frame so the slot lands on Xray's app-db (the same
   handler Cmd-Shift-M's `:rf.xray/toggle-mode` ends at).
 
-  The component subscribes to `:rf.xray/mode` — no prop threading at
-  the call site. `reg-view`-registered so the subscribe resolves to
-  `:rf/xray` via React-context."
-  []
-  (let [active-mode @(rf/subscribe [:rf.xray/mode])]
-    [:select {:data-testid (str "rf-xray-mode-pill")
-              :data-active-mode (name active-mode)
-              :aria-label  "Xray mode"
-              :title       "Switch Xray mode — Dynamic / Static (Cmd-Shift-M)"
-              :value       (name active-mode)
-              :on-change   (fn [^js e]
-                             (let [v    (.. e -target -value)
-                                   mode (keyword v)]
-                               (when (not= mode active-mode)
-                                 ;; reg-view-injected frame-aware
-                                 ;; dispatch.
-                                 (dispatch [:rf.xray/set-mode mode]))))
-              :style       {:background    (:bg-2 tokens)
-                            :color         (:text-primary tokens)
-                            :border        (str "1px solid " (:border-default tokens))
-                            :border-radius "4px"
-                            :padding       "2px 6px"
-                            :font-family   sans-stack
-                            :font-size     (:body-tight type-scale)
-                            :line-height   "1.4"
-                            :cursor        "pointer"
-                            :flex-shrink   0}}
-     (for [{:keys [mode label]} modes]
-       [:option {:key         mode
-                 :data-testid (str "rf-xray-mode-pill-" (name mode))
-                 :value       (name mode)}
-        label])]))
+  SPLIT OUT OF [[mode-pill]] BY rf2-k97c.3, for the reason every
+  migrated view in this epic splits: a boundary's body may only run
+  inside a React render window, so `(mode-pill)` is no longer a callable
+  that answers hiccup. This is `defview`'s OWN documented
+  extract-a-helper spelling, not an invention."
+  [dispatch active-mode]
+  [:select {:data-testid (str "rf-xray-mode-pill")
+            :data-active-mode (name active-mode)
+            :aria-label  "Xray mode"
+            :title       "Switch Xray mode — Dynamic / Static (Cmd-Shift-M)"
+            :value       (name active-mode)
+            :on-change   (fn [^js e]
+                           (let [v    (.. e -target -value)
+                                 mode (keyword v)]
+                             (when (not= mode active-mode)
+                               ;; rf2-k97c.3 — the frame-bound dispatcher
+                               ;; [[mode-pill]]'s boundary body captured.
+                               (dispatch [:rf.xray/set-mode mode]))))
+            :style       {:background    (:bg-2 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "4px"
+                          :padding       "2px 6px"
+                          :font-family   sans-stack
+                          :font-size     (:body-tight type-scale)
+                          :line-height   "1.4"
+                          :cursor        "pointer"
+                          :flex-shrink   0}}
+   (for [{:keys [mode label]} modes]
+     [:option {:key         mode
+               :data-testid (str "rf-xray-mode-pill-" (name mode))
+               :value       (name mode)}
+      label])])
+
+(rf.fresco/defview mode-pill
+  "Chrome-ribbon mode dropdown, and a FRESCO BOUNDARY (rf2-k97c.3)
+  rather than an `rf/reg-view`. [[mode-pill-tree]] carries the shape and
+  the design reasoning; this is the read and the dispatcher, and nothing
+  else.
+
+  ## rf2-k97c.3 — the boundary that deleted TWO ISLANDS
+
+  Both shells' L1 ribbons — Dynamic `shell.cljs` and `static/shell.cljs`
+  — are Fresco boundaries, and while this was an `rf/reg-view` each of
+  them had to reach it across an `as-child` REAGENT ISLAND, because a
+  `reg-view` grades `:invalid` as a Fresco head down the same arm a
+  plain `defn` does. Migrating it deletes both of those seams: each
+  ribbon now heads `[mode-pill {}]` directly, the way it heads any other
+  boundary.
+
+  The READ is `rf.fresco/sub`, a plain call the shipped collector
+  records an edge for — no deref, no reaction owned by the installed
+  adapter, and a re-wire that NOTIFIES when the substrate disposes the
+  underlying derived value.
+
+  The DISPATCHER is `(:dispatch (rf/capture-frame))` — core's own door,
+  which answers the boundary's DECLARED frame inside a body and replaces
+  the `dispatch` the `reg-view` body used to inject lexically.
+
+  The argument is the ordinary one-props-map vector every `defview`
+  takes. Both ribbons mount it with none, so it is destructured away."
+  [_props]
+  (mode-pill-tree (:dispatch (rf/capture-frame))
+                  (rf.fresco/sub [:rf.xray/mode])))

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -99,32 +99,30 @@
   [[surface]] because it is what the Dynamic composer mounts (so it is
   where the crossing sits — one bridge for the whole surface) and
   because a boundary is the only legal hiccup head for the three
-  regions under it; [[ribbon]] because it carries a dispatcher and
-  hosts the two Reagent islands below.
+  regions under it; [[ribbon]] because it carries a dispatcher.
 
-  TWO REAGENT ISLANDS REMAIN, both reached through an `as-child`
-  seam — `identity` for a hiccup caller and the node lane,
-  `substrate/as-element` for a boundary:
+  ONE REAGENT ISLAND REMAINS, reached through an `as-child` seam —
+  `identity` for a hiccup caller and the node lane,
+  `substrate/as-element` for a boundary: [[detail-panel]]'s
+  `[(:panel tab)]`, because `panel-registry/reg-l4-tab!`'s `:pre`
+  requires `:panel` to be CALLABLE. All five Static panels are
+  boundaries as of PR #9648, so every one of them registers an
+  `as-component` BRIDGE — a plain fn answering `[:> Component {}]` —
+  rather than the view itself. A bridge is a plain fn, which Fresco
+  grades `:invalid` as a head down the same arm a `reg-view` goes, so
+  the island stands until the registry can take a boundary directly.
 
-    * the L1 ribbon's `frame-switcher/frame-switcher-view` and
-      `mode-pill/mode-pill`, both still `rf/reg-view`s. The Dynamic
-      `shell.cljs` ribbon is a BOUNDARY as of rf2-k97c.3 and islands
-      the same two widgets the same way, so migrating them now deletes
-      FOUR islands in one slice — two here and two there — rather than
-      two now and two later.
-    * [[detail-panel]]'s `[(:panel tab)]`, because
-      `panel-registry/reg-l4-tab!`'s `:pre` requires `:panel` to be
-      CALLABLE. All five Static panels are boundaries as of PR #9648,
-      so every one of them registers an `as-component` BRIDGE — a plain
-      fn answering `[:> Component {}]` — rather than the view itself.
-      A bridge is a plain fn, which Fresco grades `:invalid` as a head
-      down the same arm a `reg-view` goes, so the island stands until
-      the registry can take a boundary directly.
+  It is MIGRATION SCAFFOLDING WITH A DEFINED END: the L4 seam goes when
+  `reg-l4-tab!` stores boundaries directly — the deletion each panel's
+  own bridge comment already promises.
 
-  Both are MIGRATION SCAFFOLDING WITH A DEFINED END: the ribbon seam
-  goes when those two widgets are boundaries, and the L4 seam goes
-  when `reg-l4-tab!` stores boundaries directly — the deletion each
-  panel's own bridge comment already promises.
+  THE L1 RIBBON'S TWO ISLANDS ARE GONE (rf2-k97c.3). The ribbon reached
+  `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` across
+  an `as-child` seam while both were `rf/reg-view`s; both are Fresco
+  boundaries now and [[ribbon]] heads them directly. The Dynamic
+  `shell.cljs` ribbon islanded the same two widgets the same way, so
+  that one slice deleted FOUR islands — two here and two there — which
+  is exactly why they were deferred rather than migrated piecemeal.
 
   ## Mode-signal mechanism (4 stacked signals)
 
@@ -284,8 +282,7 @@
 
 (defn ribbon-tree
   "The Static L1 ribbon's WHOLE chrome, as a pure function of the
-  frame-bound `dispatch` and the `as-child` spelling for the two
-  REAGENT ISLANDS (see the ns docstring).
+  frame-bound `dispatch` and its two already-composed selector nodes.
 
   SPLIT OUT OF [[ribbon]] BY rf2-k97c.3, and the split is `defview`'s
   own documented extract-a-helper spelling rather than an invention: a
@@ -294,15 +291,25 @@
   chrome itself is ordinary data → data and is worth walking in the fast
   node lane.
 
-  `as-child` is `identity` for a hiccup caller (the node lane, and any
-  Reagent caller), which leaves each island a fn-headed hiccup vector
-  exactly as it has always been; the boundary passes
-  `substrate/as-element`, which answers a React element — a legal
-  child anywhere per Fresco's component ABI.
+  `frame-switcher*` and `mode-pill*` ARRIVE ALREADY COMPOSED rather than
+  as heads this fn writes, for the same reason [[surface-tree]]'s three
+  layers do: both are Fresco BOUNDARIES as of rf2-k97c.3, and a boundary
+  head cannot be walked by a hiccup walker because its body only runs
+  inside a React render window. [[ribbon]] passes
+  `[frame-switcher/frame-switcher-view {}]` and `[mode-pill/mode-pill
+  {}]`; `test-helpers.static-shell-tree` passes each one's
+  already-expanded plain hiccup.
+
+  THE `as-child` PARAMETER IS GONE, and its deletion is the deliverable
+  rather than a tidy-up. Those two widgets were the ribbon's two REAGENT
+  ISLANDS — `rf/reg-view`s a boundary could only reach across an
+  `as-child` seam — and they are boundaries now, so the seam has nothing
+  left to carry. The L4 seam in [[detail-panel-tree]] is untouched and
+  stands for its own recorded reason.
 
   PURE: `ribbon-right-icons` is CALLED rather than headed, and answers
   keyword hiccup all the way down."
-  [dispatch as-child]
+  [dispatch frame-switcher* mode-pill*]
   [:div {:data-testid "rf-xray-static-ribbon"
          :style {:display          "flex"
                  :align-items      "center"
@@ -325,12 +332,13 @@
    ;; (Dynamic) and event-independent (Static) lenses.
    [:div {:data-testid "rf-xray-static-ribbon-selectors"
           :style {:display "flex" :align-items "center" :gap "8px"}}
-    ;; rf2-k97c.3 — the two REAGENT ISLANDS. Both are still
-    ;; `rf/reg-view`s, which grade `:invalid` as a Fresco head down the
-    ;; same arm a plain `defn` does, and both are ALSO headed by the
-    ;; Dynamic `shell.cljs` ribbon. See the ns docstring.
-    (as-child [frame-switcher/frame-switcher-view])
-    (as-child [mode-pill/mode-pill])]
+    ;; rf2-k97c.3 — both are FRESCO BOUNDARIES now, so they arrive here
+    ;; ALREADY COMPOSED rather than as heads this fn writes. They were
+    ;; the ribbon's two Reagent islands until this slice; the Dynamic
+    ;; `shell.cljs` ribbon islanded the same two the same way and lost
+    ;; its seam in the same commit. See [[ribbon-tree]]'s docstring.
+    frame-switcher*
+    mode-pill*]
    [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
     (ribbon-right-icons dispatch)]])
 
@@ -360,10 +368,16 @@
   lexically. Same guarantee, one call, and it is the spelling every
   migrated view now uses.
 
+  ITS TWO SELECTORS ARE BOUNDARY HEADS, not islands (rf2-k97c.3). Both
+  were `rf/reg-view`s reached across an `as-child` seam until this
+  slice; heading them directly is what deleted it.
+
   The argument is the ordinary one-props-map vector every `defview`
   takes. [[surface]] mounts it with none, so it is destructured away."
   [_props]
-  (ribbon-tree (:dispatch (rf/capture-frame)) substrate/as-element))
+  (ribbon-tree (:dispatch (rf/capture-frame))
+               [frame-switcher/frame-switcher-view {}]
+               [mode-pill/mode-pill {}]))
 
 ;; ---- L3 tab bar (Static) ------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/reagent_dom_cljs_test.cljs
@@ -25,6 +25,28 @@
   a reagent-slim arm is this file with one `:require` and one `:adapter`
   changed.
 
+  ## THAT DEFECT IS FIXED, AND THE PARAGRAPH ABOVE IS KEPT AS HISTORY
+
+  rf2-7ds8 repaired it (PR #9686): `day8.re-frame2-xray.substrate/as-element`
+  now reads the hiccup->React walk off the INSTALLED adapter rather than
+  naming stock Reagent's statically, so the crossing no longer loses the
+  frame under reagent-slim. rf2-k97c.3 then removed the two crossings this
+  file names outright, by making `frame-switcher/frame-switcher-view` and
+  `mode-pill/mode-pill` boundaries.
+
+  MEASURED 2026-09-12 rather than inferred, by running this file's own six
+  criteria with `re-frame.adapter.reagent-slim/adapter` substituted: all six
+  PASS. They pass at rf2-k97c.3's merge-base too, which is what attributes
+  the repair to rf2-7ds8 and not to the island deletion.
+
+  WHAT THAT MEASUREMENT DOES NOT COVER, so the next reader does not widen
+  it: it is [[mount-xray!]]'s path only — Xray's OWN React root, mounting
+  the Static surface. The PUBLIC `open!` path, the other half of the
+  original three-adapter finding, was NOT re-measured. So the reagent-slim
+  arm this docstring offers is now a ~10-line addition somebody should
+  take; it is deliberately not taken here, because the acceptance harness
+  is its own slice's.
+
   ## NODE LANE
 
   Every row short-circuits and reports the skip; see the UIx arm's

--- a/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/acceptance/substrate_gap_dom_cljs_test.cljs
@@ -54,6 +54,21 @@
   runs on Reagent rather than on the reagent-slim the brief named. Fixing
   it is a production change and slice D is test-only.
 
+  THAT SECOND GAP IS CLOSED. The paragraph above is kept as history.
+  rf2-7ds8 (PR #9686) made `substrate/as-element` read the walk off the
+  INSTALLED adapter instead of naming stock Reagent's statically, and
+  `static.shell-reagent-slim-crossing-dom-cljs-test` is its witness — an
+  error boundary above the crossing, which is the instrument this
+  paragraph correctly judged a naked mount could not supply. rf2-k97c.3
+  then deleted the two crossings it names, making
+  `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`
+  boundaries.
+
+  MEASURED 2026-09-12: the six acceptance criteria run green with
+  reagent-slim installed. Xray's OWN React root only — the public `open!`
+  path was not re-measured, so `unsupported-substrate-diagnostic`'s claim
+  about that path is still unverified rather than known-good.
+
   ## FIXTURE
 
   No `:adapter` in the fixture: each row installs its own with `rf/init!`,

--- a/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
@@ -23,6 +23,8 @@
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-helpers.static-shell-tree
+             :as static-shell-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
@@ -285,7 +287,7 @@
     (dispatch-trace 1 :app/main)
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree    (frame-switcher/frame-switcher-view {})
+      (let [tree    (static-shell-tree/frame-switcher-tree rf/dispatch)
             button  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame")
             label   (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-label")
             picker  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker")
@@ -319,7 +321,7 @@
     (dispatch-trace 2 :app/admin)
     (setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (frame-switcher/frame-switcher-view {})
+      (let [tree   (static-shell-tree/frame-switcher-tree rf/dispatch)
             picker (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker")
             label  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-label")]
         (is (some? picker) "dropdown renders for multi-frame")
@@ -397,7 +399,7 @@
   input invariant)."
   []
   (rf/with-frame :rf/xray
-    (let [tree    (frame-switcher/frame-switcher-view {})
+    (let [tree    (static-shell-tree/frame-switcher-tree rf/dispatch)
           picker  (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker")
           options (filter (fn [n] (and (vector? n) (= :option (first n))))
                           (hiccup-seq tree))]

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -38,7 +38,6 @@
             [day8.re-frame2-xray.test-helpers.dynamic-shell-tree
              :as dynamic-shell-tree]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.test-helpers.static-shell-tree
              :as static-shell-tree]
             [day8.re-frame2-xray.test-support :as xray-test-support]
@@ -270,7 +269,7 @@
     (seed-trace! 2 :app/main)
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree   (frame-switcher/frame-switcher-view nil)
+      (let [tree   (static-shell-tree/frame-switcher-tree rf/dispatch)
             picker (rf.test-helpers/find-by-testid tree "rf-xray-ribbon-frame-picker")]
         (is (some? picker)
             "the <select> picker renders when ≥2 frames are present")

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -348,7 +348,7 @@
             Static options"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (mode-pill/mode-pill)]
+      (let [tree (static-shell-tree/mode-pill-tree rf/dispatch)]
         (is (some? (rf.test-helpers/find-by-testid tree "rf-xray-mode-pill"))
             "the select control is present")
         (is (= :select (first tree)) "the control is a native <select>")
@@ -361,13 +361,13 @@
   (testing "the dropdown's :value + data-active-mode track the live mode"
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [attrs (second (mode-pill/mode-pill))]
+      (let [attrs (second (static-shell-tree/mode-pill-tree rf/dispatch))]
         (is (= "dynamic" (:value attrs)))
         (is (= "dynamic" (:data-active-mode attrs)))))
     ;; flip to Static and re-render
     (frame-dispatch [:rf.xray/set-mode :static])
     (rf/with-frame :rf/xray
-      (let [attrs (second (mode-pill/mode-pill))]
+      (let [attrs (second (static-shell-tree/mode-pill-tree rf/dispatch))]
         (is (= "static" (:value attrs)))
         (is (= "static" (:data-active-mode attrs)))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_fresco_boundary_dom_cljs_test.cljs
@@ -40,19 +40,19 @@
   ## W3'S ZERO IS SCOPED, AND THE SCOPE IS THE POINT
 
   A Fresco boundary emits no `:rf.view/*` op — that is the structural
-  claim, and W3 makes it. But the Static shell's rendered SUB-TREE is
-  not trace-silent, and cannot be in this increment: the L1 ribbon
-  reaches `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill`
-  through an `as-child` REAGENT ISLAND, and both are still `rf/reg-view`s
-  that emit view trace wherever they render.
+  claim, and W3 makes it. The Static shell's rendered SUB-TREE is silent
+  too as of rf2-k97c.3: the L1 ribbon's
+  `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` were
+  `rf/reg-view`s reached through an `as-child` REAGENT ISLAND, and that
+  slice made both of them boundaries, which deleted the seam. This is
+  the commit the paragraph here used to promise.
 
   So W3 asserts on the view-op ids rather than on a bare count: NO op
-  names a view in `day8.re-frame2-xray.static.shell`, and the ids that
-  DO fire are exactly the two documented islands. That second half is
-  what stops the row degrading into \"some ops fired, fine\" — a future
-  change that islands a third widget reddens here and has to say so.
-  The remaining emissions go when those two widgets are boundaries, in
-  the same commit that deletes the ribbon's `as-child` seam.
+  names a view in `day8.re-frame2-xray.static.shell`, AND the id set is
+  EMPTY outright. That second half is what stops the row degrading into
+  \"some ops fired, fine\" — a future change that islands a widget
+  reddens here and has to say so. It stays a SET rather than a
+  `(zero? (count …))` so the failure message names whatever came back.
 
   ## The mount is the SHELL'S mount
 
@@ -128,14 +128,16 @@
   "day8.re-frame2-xray.static.shell")
 
 (def ^:private expected-island-views
-  "The view-ids W3 EXPECTS to fire, and the whole of them: the L1
-  ribbon's two `as-child` Reagent islands. Stated positively so that
-  islanding a third widget cannot slip past a row that only counted
-  zeros in one direction.
+  "The view-ids W3 EXPECTS to fire, and the whole of them: NONE. The L1
+  ribbon's `frame-switcher/frame-switcher-view` and
+  `mode-pill/mode-pill` were the only two, and rf2-k97c.3 made both of
+  them boundaries. Stated as a SET rather than as a count so that
+  islanding a widget cannot slip past a row that only counted zeros in
+  one direction, and so the failure message names whatever did fire.
 
   W3 PINS THE L4 SLOT TO :flows FOR THIS SET TO BE WELL-DEFINED, and
   the reason is measured rather than tidy. Written against the DEFAULT
-  :machines tab the row failed with a third id,
+  :machines tab the row failed with an extra id,
   `panels.machine-canvas/Chart` — the Static Machines panel's own
   Topology island, which `definition-detail` reaches through its
   `as-child` seam once a machine is selected. Whether one IS selected
@@ -144,9 +146,13 @@
   namespace in one page, and a neighbouring suite's `rf/reg-machine`
   is enough. So :machines would make this set depend on load order in
   BOTH directions. The Flows tab is fully migrated with no island at
-  all, which makes the set a statement about THIS shell."
-  #{:day8.re-frame2-xray.frame-switcher/frame-switcher-view
-    :day8.re-frame2-xray.static.mode-pill/mode-pill})
+  all, which makes the set a statement about THIS shell.
+
+  THE L4 `[(:panel tab)]` ISLAND SURVIVES and does not contribute an
+  id: every Static panel registers a plain-fn BRIDGE, which is not a
+  substrate view render and emits nothing. The pin is about the
+  Machines tab's Chart, not about it."
+  #{})
 
 (def ^:private island-free-tab
   "The Static tab W3 mounts. See [[expected-island-views]]."
@@ -351,9 +357,9 @@
           ;; something React drops would leave the chrome above intact and
           ;; only these missing, which is why they are asserted separately.
           (is (some? (testid container "rf-xray-mode-pill"))
-              "the mode-pill ISLAND crossed the `as-child` seam and
-               committed — a `reg-view` reached through
-               `reagent.core/as-element` from inside a Fresco body")
+              "the mode-pill committed — a Fresco BOUNDARY the ribbon
+               heads directly since rf2-k97c.3, where it used to be a
+               `reg-view` reached across an `as-child` seam")
           (is (some? (testid container "rf-xray-static-ribbon-icons"))
               "and the right-icons cluster, which is CALLED rather than
                headed, painted beside it")
@@ -490,12 +496,12 @@
             not a substrate view render, so there is no event to gate.
 
             THE ZERO IS SCOPED, AND THE SCOPE IS ASSERTED. The rendered
-            sub-tree is not silent — the ribbon's two `as-child` Reagent
-            islands are still `reg-view`s and emit wherever they render —
-            so this row states BOTH halves: no id names the shell's own
-            namespace, and the ids that fire are exactly those two
-            islands. A future change that islands a third widget reddens
-            here rather than sliding under a bare count.
+            sub-tree is silent too as of rf2-k97c.3, which made the
+            ribbon's two `as-child` Reagent islands boundaries — so this
+            row states BOTH halves: no id names the shell's own
+            namespace, and NO id fires at all. A future change that
+            islands a widget reddens here rather than sliding under a
+            bare count.
 
             The control is an ordinary `reg-view` in the same root, the
             same frame and the same commit shape."
@@ -529,9 +535,11 @@
                        " — the four chrome regions are boundaries, not "
                        "substrate view renders. Ids seen: " (pr-str ids)))
               (is (= expected-island-views ids)
-                  (str "and the ids that DO fire are exactly the two "
-                       "documented Reagent islands, so the scope of the zero "
-                       "above is pinned rather than assumed. Expected: "
+                  (str "and NO view id fires at all, so the scope of the zero "
+                       "above is pinned rather than assumed. The ribbon's two "
+                       "Reagent islands became boundaries in rf2-k97c.3, so a "
+                       "non-empty set here is a widget that has been islanded "
+                       "again. Expected: "
                        (pr-str expected-island-views)
                        " Got: " (pr-str ids)))
               (finally (teardown! root container))))

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_reagent_slim_crossing_dom_cljs_test.cljs
@@ -15,6 +15,17 @@
       head carries IS honoured — `reagent2.impl.component` reads
       `(:contextType (meta f))` exactly as stock's `fn-to-class` does —
       so the frame keyword genuinely reaches the mounted class.
+
+  rf2-k97c.3 LATER RETIRED THE L1 RIBBON'S OWN TWO ISLANDS —
+  `frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` are
+  Fresco boundaries now and the ribbon heads them directly. W2 below is
+  written against what the ribbon renders rather than against the
+  crossing spelling, so it still stands over the same DOM; what it can
+  no longer claim is that the node it finds arrived through an
+  `as-child` seam. The door itself is unchanged and W1 is untouched —
+  the L2/L3 seam handle and the L4 `[(:panel tab)]` mount still cross
+  through it, which is why this suite is still the one that measures
+  it.
     * But the foreign build renders the subtree with ITS
       in-flight-component slot bound, while `:adapter/current-component`
       routes to the INSTALLED build and answers nil inside it.
@@ -207,16 +218,20 @@
   (some-> container (.querySelector (str "[data-testid=\"" id "\"]"))))
 
 (deftest w2-ribbon-reagent-island-paints-under-reagent-slim
-  (testing "rf2-7ds8 — under reagent-slim the Static L1 ribbon's Reagent
-            island commits to the DOM, which it can only do if the
-            boundary crossed it through the installed build AND the frame
-            resolved beneath it.
+  (testing "rf2-7ds8 — under reagent-slim the Static L1 ribbon commits
+            its frame switcher to the DOM, which it can only do if the
+            frame resolved beneath the ribbon boundary.
 
-            `frame-switcher-view` is a `reg-view` whose body makes an
-            ambient read. Its node therefore exists ONLY when
-            views/current-frame found a component to read a frame off —
-            so the node's presence is the frame-context claim, not merely
-            a paint claim."
+            `frame-switcher-view` READS, so its node exists ONLY when the
+            frame resolver found a frame to read against — the node's
+            presence is the frame-context claim, not merely a paint
+            claim. rf2-k97c.3 made it a BOUNDARY (it was a `reg-view`
+            island crossed through `as-child` when this row was written),
+            so what the row now witnesses is the boundary's own context
+            resolution rather than the crossing's. That is a weaker
+            statement about the DOOR and an equally strong one about the
+            FRAME, which is what the row is for; W1 is the door's
+            durable pin and is untouched."
     (if-not (browser?)
       (is true ":node — the :browser-test runner drives the real React mount")
       (async done
@@ -237,11 +252,11 @@
           (is (nil? (testid container "rf-slim-crossing-fallback"))
               "the error boundary did NOT swap in its fallback")
           (is (some? (testid container "rf-xray-ribbon-frame"))
-              (str "frame-switcher-view — a reg-view island the ribbon "
-                   "crosses through its as-child seam — is committed under "
+              (str "frame-switcher-view — the ribbon's frame switcher, a "
+                   "boundary since rf2-k97c.3 — is committed under "
                    "reagent-slim. This is the node the defect removed"))
           (is (some? (testid container "rf-xray-ribbon-frame-picker"))
-              "the island rendered its frame picker, so its ambient read ran
-               rather than raising")
+              "it rendered its frame picker, so its read ran rather than
+               raising")
           (teardown! root container)
           (done))))))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/dynamic_shell_tree.cljs
@@ -35,14 +35,31 @@
 
   ## `as-child` is `identity` here
 
-  The boundaries pass `reagent.core/as-element` for their islands — the
-  L1 ribbon's `frame-switcher-view` and `mode-pill`, the L2/L3 seam
-  handle, and the L4 `[(:panel tab)]` mount. This lane passes `identity`,
-  so each island stays the fn-headed hiccup vector that
-  `rf.test-helpers/expand-tree` walks precisely as it always has. That
-  crossing's evidence is the browser lane's, not this one's — the node
-  lane's `as-child` is `identity` BY CONSTRUCTION, so wrapping and not
-  wrapping are the same value here.
+  The boundaries pass `substrate/as-element` for their surviving islands
+  — the L2/L3 seam handle and the L4 `[(:panel tab)]` mount. This lane
+  passes `identity`, so each island stays the fn-headed hiccup vector
+  that `rf.test-helpers/expand-tree` walks precisely as it always has.
+  That crossing's evidence is the browser lane's, not this one's — the
+  node lane's `as-child` is `identity` BY CONSTRUCTION, so wrapping and
+  not wrapping are the same value here.
+
+  ## A BOUNDARY CHILD IS PASSED ALREADY EXPANDED, never as a head
+
+  [[ribbon-tree]]'s three component children — the frame switcher, the
+  mode pill and the theme toggle — are boundaries, and `expand-tree`
+  INVOKES any fn-headed vector it meets. A boundary head is a real React
+  function component, so invoking one outside a render window is exactly
+  what `rf.fresco/sub` refuses. This lane therefore hands `shell/
+  ribbon-tree` each child's already-expanded plain hiccup, the same way
+  [[shell-view-tree]] hands it the chrome's — which is also why the L1
+  ribbon has no `as-child` seam left to pass `identity` through.
+
+  `frame-switcher-view` and `mode-pill` were the ribbon's two REAGENT
+  ISLANDS until rf2-k97c.3 deleted four of them at once — these two here
+  and the same two in the Static ribbon. Their doors are
+  `test-helpers.static-shell-tree`'s `frame-switcher-tree` and
+  `mode-pill-tree`: both ribbons mount both widgets, so the read
+  reproduction is single-sourced in the ns this one already requires.
 
   ## Call these INSIDE a frame scope
 
@@ -81,7 +98,8 @@
       :event-bundles   @(rf/subscribe [:rf.xray/filtered-event-bundles])
       :show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
       :filters         @(rf/subscribe [:rf.xray/active-filters])}
-     identity
+     (static-shell-tree/frame-switcher-tree dispatch)
+     (static-shell-tree/mode-pill-tree dispatch)
      (theme-toggle-tree dispatch))))
 
 (defn events-ribbon-tree

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/static_shell_tree.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/static_shell_tree.cljs
@@ -33,11 +33,30 @@
       boundary does, and looks the entry up through
       `panel-registry/tab-by-id`, so what a row walks is what the shell
       actually mounts;
-    * both pass `identity` as `as-child`, so the ribbon's two Reagent
-      islands and the L4 `[(:panel tab)]` mount stay fn-headed hiccup
-      vectors that `rf.test-helpers/expand-tree` walks precisely as it
-      always has. The boundaries pass `reagent.core/as-element` there;
-      that crossing's evidence is the browser lane's, not this one's.
+    * [[detail-panel-tree]] passes `identity` as `as-child`, so the L4
+      `[(:panel tab)]` mount stays the fn-headed hiccup vector that
+      `rf.test-helpers/expand-tree` walks precisely as it always has.
+      The boundary passes `substrate/as-element` there; that crossing's
+      evidence is the browser lane's, not this one's.
+
+  ## THE RIBBON'S TWO SELECTORS ARE PASSED ALREADY EXPANDED
+
+  [[ribbon-tree]]'s frame switcher and mode pill are BOUNDARIES as of
+  rf2-k97c.3 — they were the ribbon's two Reagent islands until that
+  slice deleted four of them at once, these two and the same two in the
+  Dynamic ribbon. `expand-tree` INVOKES any fn-headed vector it meets,
+  and a boundary head is a real React function component, so invoking
+  one outside a render window is exactly what `rf.fresco/sub` refuses.
+  This lane therefore hands `static-shell/ribbon-tree` each selector's
+  already-expanded plain hiccup, and the ribbon has no `as-child` seam
+  left to pass `identity` through.
+
+  [[frame-switcher-tree]] and [[mode-pill-tree]] are the doors onto
+  those two, and they live HERE — rather than in the Dynamic sibling —
+  because BOTH ribbons mount BOTH widgets, and
+  `test-helpers.dynamic-shell-tree` already requires this ns. One
+  reproduction of each read, reachable from both lanes; the reverse
+  dependency would be a cycle.
 
   SINGLE-SOURCED ON PURPOSE. Five suites need this composition
   (`static/shell_cljs_test`, `p3_polish_aria_cljs_test`,
@@ -53,18 +72,41 @@
   `(rf/with-frame :rf/xray …)` — the same requirement the `reg-view`
   bodies had, and the same one every existing caller already satisfies."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.frame-switcher :as frame-switcher]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.static.mode-pill :as mode-pill]
             [day8.re-frame2-xray.static.shell :as static-shell]))
+
+(defn frame-switcher-tree
+  "The L1 frame switcher's hiccup, read the way
+  `frame-switcher/frame-switcher-view` reads it — the same two subs in
+  the same order. Shared by BOTH ribbons; see the ns docstring."
+  ([] (frame-switcher-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (frame-switcher/frame-switcher-tree
+     dispatch
+     @(rf/subscribe [:rf.xray/current-frame])
+     @(rf/subscribe [:rf.xray/available-frames]))))
+
+(defn mode-pill-tree
+  "The L1 mode pill's hiccup, read the way `mode-pill/mode-pill` reads
+  it. Shared by BOTH ribbons; see the ns docstring."
+  ([] (mode-pill-tree (:dispatch (rf/capture-frame))))
+  ([dispatch]
+   (mode-pill/mode-pill-tree dispatch @(rf/subscribe [:rf.xray/mode]))))
 
 (defn ribbon-tree
   "The L1 ribbon's hiccup, composed the way `static-shell/ribbon`
   composes it. `dispatch` defaults to `(:dispatch (rf/capture-frame))`
   — the SAME door the boundary uses, so a handler this lane pulls off
   the tree and fires later carries the frame exactly as the shipped one
-  does. The ribbon reads nothing."
+  does. The ribbon itself reads nothing; its two selectors do, and
+  arrive already expanded."
   ([] (ribbon-tree (:dispatch (rf/capture-frame))))
   ([dispatch]
-   (static-shell/ribbon-tree dispatch identity)))
+   (static-shell/ribbon-tree dispatch
+                             (frame-switcher-tree dispatch)
+                             (mode-pill-tree dispatch))))
 
 (defn tab-bar-tree
   "The L3 tab bar's hiccup, read the way `static-shell/tab-bar` reads


### PR DESCRIPTION
## The four-island deletion (rf2-k97c.3)

`frame-switcher/frame-switcher-view` and `mode-pill/mode-pill` were the last two
`rf/reg-view`s in the two shells' L1 ribbons, and **both ribbons headed both of them
across an `as-child` Reagent island** — four islands for two widgets. That is why the
bead deferred them rather than migrating piecemeal: "Deferring them lets a later slice
delete FOUR islands at once instead of two."

Both are `rf.fresco/defview` boundaries now, each ribbon heads them directly, and **both
ribbons lose their `as-child` parameter outright**. The L4 `[(:panel tab)]` seam and the
L2/L3 seam handle are untouched and stand for their own recorded reasons.

### Shape

Each view splits the way every migrated view in this epic splits — a pure `*-tree` fn of
the read values plus a thin boundary that reads and calls it. Reads keep the `reg-view`
body's order; the dispatcher is `(:dispatch (rf/capture-frame))`.

**Q2 was checked on these two specifically** rather than inherited from the population
statistic, because the taxonomy says a view holding per-instance state is the one shape
that makes this non-mechanical: zero `r/atom`, zero `with-let`, no form-2/form-3, no
`reagent.core` — with `rf/subscribe` (2 and 1) as the live positive control on the same
instrument in the same run. Uniformly presentational. Mechanical.

### The node lane

`expand-tree` invokes any fn-headed vector it meets, and a boundary head is a real React
function component, so the ribbons' selectors are passed **already expanded** — the same
treatment `ribbon-theme-toggle` already has, and `dynamic-chrome-tree`'s six layers before
it. `frame-switcher-tree` and `mode-pill-tree` live in `test-helpers.static-shell-tree`
because both ribbons mount both widgets and the Dynamic helper already requires it; the
reverse dependency would be a cycle.

### Prose the change makes false

Found with a three-pass search (line-oriented, whitespace-collapsed, and
comment-stripped-then-collapsed) over every tracked file. **Two of the sites hit only on
the flattened passes** — `static/shell.cljs` and `dynamic_shell_tree.cljs` — i.e. the
claims span lines and a line-oriented search cannot see them at all.

The one that mattered most: `static/mode_pill.cljs`'s ns docstring recommended
`(rf/reg-view mode-pill …)` as "the canonical Xray shape" — the exact spelling this
removes.

`shell_fresco_boundary_dom_cljs_test`'s **W3** asserted that the only view-trace ids firing
were these two islands, and its own docstring promised that set would empty "in the same
commit that deletes the ribbon's `as-child` seam". It is now `#{}`, so the row states a
strictly stronger claim than it did.

### FINDING 1 re-measured — and the bead's prediction does not hold

The bead predicted this slice would fix reagent-slim's inability to host Xray. **It does
not, because a prior slice already had.**

`reagent_dom_cljs_test`'s docstring says a reagent-slim arm is "this file with one
`:require` and one `:adapter` changed", so that substitution was made and run: **all six
acceptance criteria pass under `reagent-slim`** (1083/5843 → 1089/5906, exactly +6 tests
for 6 new rows, 0 failures).

They also **pass unchanged at this branch's merge-base**, which is what attributes the
repair to **rf2-7ds8 / PR #9686** rather than to the island deletion. The mechanism
FINDING 1 names is already gone at tip: `substrate.cljs` is now the *only* Xray source
requiring `reagent.core`, and it is the routed door.

The probe arm is deliberately **not** committed — the acceptance harness belongs to its own
slice — but both affected docstrings are corrected and now say the arm is a ~10-line
addition for whoever takes it.

**Scope is stated rather than assumed**: this is `mount-xray!`'s path only — Xray's own
React root, Static surface. The public `open!` path, the other half of the original
three-adapter finding, was **not** re-measured.

### Sabotage witness

The decoy-anchor hazard this change is the textbook case for was **measured, not assumed**:
`rf.fresco/defview mode-pill` matches **2** in `mode_pill.cljs` — line 36 is the ns
docstring (PROSE, and it sorts first) and line 127 is the only CODE site. A
first-occurrence plant would have patched prose, moved the blob hash, and come back green.

Planted instead on a unique code line inside the edit (`:data-active-mode (name
active-mode)` → `"dynamic"`, match count 1, verified before the run). Result: **captured
exit 1, 1 failure**, `mode-dropdown-reflects-active-mode` — `expected "static", actual
"dynamic"` — with namespace and assertion counts **identical** to the control
(11773/58800), so the plant did not crash a namespace and silence the rest. Restored and
verified against the committed blob (default `git hash-object` form matched; `--no-filters`
did not, as expected for an `i/lf w/crlf` file), with `git diff --quiet HEAD` as a second
instrument.

### Gates — every exit captured, including the zeros

| gate | exit | result |
|---|---|---|
| `test:cljs` compile | 0 | 1984 files, 0 warnings |
| `test:cljs` run | 0 | 11773 tests / 58800 assertions, 0 failures |
| `test:browser` compile | 0 | — |
| `test:browser` run | 0 | 1083 tests / 5843 assertions, 0 failures |
| `test:xray-feature-gate` | 0 | 16 scenarios, 0 failures, 13 matrix rows |
| Xray JVM (`clojure -M:test`) | 0 | 1280 tests / 6145 assertions, 0 failures |
| Splint | 0 | 2646 files |
| api-manifest `gen --check` | 0 | — |
| api-manifest `api-md-check` / `xray-spec-check` / `story-spec-check` / `skills-check` / `doc-guide-check` | 0 each | — |
| 46 `scripts/check_*.py` ratchets | 0 each | baselined before editing; all 46 green before and after |
| `check-ai-tracking-ratchet.sh`, `check-no-hardcoded-paths.sh` | 0 | — |
| `check-commit-attribution.sh origin/main` | 0 | — |
| `check-beads-pr-boundary.sh origin/main` | 0 | — |

All of the above were **re-run after the rebase** onto `fbe0cb61d1`; the pre-rebase greens
are not what is being reported. Re-running the API-manifest projections was not ceremony —
trunk moved `tools/xray/spec/API.md` while this branch was in flight.

**One pre-existing red, not mine**: `clj-kondo --fail-level error` exits 3 on
`implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs:235` ("Expected:
throwable, received: boolean", from `#(throw false)`). This branch touches **zero** files
under `implementation/`, the line is byte-identical at the merge-base, and it reproduces
when that one file is linted alone. My local clj-kondo is v2025.10.23 where CI pins
v2026.04.15, so this is most likely a version difference rather than a live CI failure. The
four "unused require" warnings on files this PR touches were verified pre-existing by
measurement (usage count 0 at base *and* at tip — the change neither created nor removed
them).

### Fence

`panels.cljs`, `shell.cljs`'s `event-list` at `:2286` and `shell-view` at `:3216` are all
untouched. Nothing here required widening into them.
