### PR TITLE
feat(xray): own the React root — shell-view becomes a Fresco boundary (rf2-k97c.3)

### DIFF
--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -498,9 +498,14 @@ namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
 ### Adapter resolution
 
-Xray renders pure hiccup, so it can mount only through a host adapter
-whose `:render` slot accepts hiccup render-trees — the **ratom family**
-(stock Reagent, Reagent-slim). The React-hook substrates (UIx, Fresco)
+Since rf2-k97c.3 Xray does **not** mount through the host adapter's
+`:render` at all — its shell is a `re-frame.fresco` boundary painted
+through Xray's **own** React root, so the host's render shape no longer
+decides whether Xray can paint, and the refusal set out below is a
+denylist that has outlived its cause rather than a statement about what
+Xray can render (retiring it is rf2-k97c.4; until that lands the mount
+verbs still refuse on those hosts exactly as described here). The
+React-hook substrates (UIx, Fresco)
 share an **element-shaped** `render` that hands the tree to React
 untouched; a hiccup shell mounted there
 reaches React children as raw CLJS data (fn-as-child console.error

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -48,6 +48,7 @@
   so first mount performs registration and seeding after adapter
   readiness. The operation is idempotent."
   (:require [re-frame.core :as rf]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.substrate.adapter :as rf.substrate.adapter]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.defaults :as defaults]
@@ -376,27 +377,70 @@
       (when-let [shell (shell-node node)]
         (.setAttribute shell "data-rf-xray-mode" mode-name)))))
 
+;; ---- Xray's OWN React root (rf2-k97c.3) ---------------------------------
+;;
+;; THIS IS THE EPIC'S COUPLING (1), SEVERED. Xray used to paint by calling
+;; the INSTALLED ADAPTER's `:render`, which is why a host whose `:render`
+;; takes React ELEMENTS could not host it at all. It now owns a Fresco
+;; client root and paints through that, so what the host installs stops
+;; being Xray's business.
+;;
+;; TWO HANDLES, NOT ONE, AND THE SECOND IS NOT A CONVENIENCE. `render!`
+;; reads its mount-point on the FIRST call through a handle and updates
+;; that same React root on every later one, so a single handle cannot
+;; serve two roots — and the pop-out's root lives in a DIFFERENT DOCUMENT.
+;; Sharing one handle would silently re-render the inline shell when the
+;; pop-out opened.
+;;
+;; `defonce`, so a shadow-cljs `:after-load` keeps the live root rather
+;; than orphaning it; `client-root` does no DOM work and makes no React
+;; call, so it is safe at namespace load.
+
+;; The handle for the inline / overlay shell's React root.
+(defonce ^:private xray-root (rf.fresco/client-root))
+
+;; The handle for the pop-out window's React root — its OWN, because the
+;; pop-out mounts into another document. See the comment above.
+(defonce ^:private xray-popout-root (rf.fresco/client-root))
+
+(defn- render-shell!
+  "Paint `tree` into `node` through `root-handle` and answer the UNMOUNT
+  THUNK the caller stores, so `switch-surface!`, `close!` and `teardown!`
+  keep the `(unmount)` shape they have always had and need no change.
+
+  Fresco's own door is a pair — `render!` then `unmount!` on the same
+  handle — rather than the adapter's render-answers-an-unmount-fn; this
+  closes over the handle so exactly one call site knows that."
+  [root-handle tree node]
+  (rf.fresco/render! root-handle tree node)
+  (fn unmount-xray-root [] (rf.fresco/unmount! root-handle)))
+
 (defn- mount-shell-into! [node mode]
   (ensure-xray-frame!)
-  ;; rf2-tqlmq — wrap `shell-view` ITSELF in the shell's frame-provider at
-  ;; the mount so the whole shell (not just its panels) renders in the
-  ;; Xray frame. `shell-view` is a `reg-view`, so its `:rf.view/rendered`
-  ;; trace carries the resolved `current-frame-id`; rendered BARE (no
-  ;; enclosing provider — its own provider sits INSIDE its body, around
-  ;; the panels) `current-frame-id` fell through to `:rf/default`, so the
-  ;; shell-view's own
-  ;; render trace leaked into the inspected app frame's epoch `:renders`.
-  ;; With the provider moved out one level, `shell-view`'s render resolves
-  ;; to `default-frame-id` (the trace-disabled `:rf/xray` frame registered
-  ;; by `ensure-xray-frame!` just above) and the existing
-  ;; `:rf.trace/frame-no-emit?` gate (trace.cljc/`tagged-frame-trace-
-  ;; disabled?`, which keys off the render emit's `:frame` tag) suppresses
-  ;; it. Threads the shell's actual frame-id (NOT a `:rf/xray` literal),
-  ;; matching the frame `ensure-xray-frame!` registered.
-  (let [unmount (rf.substrate.adapter/render
-                  [rf/frame-provider {:frame shell/default-frame-id}
-                   [shell/shell-view {:mode mode}]]
-                  node nil)]
+  ;; rf2-tqlmq / rf2-k97c.3 — the OUTER `frame-provider` stays, and after
+  ;; the root swap it is load-bearing for a DIFFERENT reason with the
+  ;; OPPOSITE failure mode. It used to be about a render TRACE: `shell-view`
+  ;; was a `reg-view`, and rendered bare its `:rf.view/rendered` emit
+  ;; resolved `current-frame-id` to `:rf/default` and leaked into the
+  ;; inspected app frame's epoch `:renders`. A Fresco boundary emits no
+  ;; view-render trace at all, so that hazard is now structurally absent.
+  ;; What the provider does NOW is give `shell/ShellView`'s two ambient
+  ;; `rf.fresco/sub` reads their frame — drop it and the shell refuses with
+  ;; `:rf.error/no-frame-context` rather than quietly painting into the
+  ;; wrong frame. Silent contamination became a loud refusal, which is
+  ;; strictly better.
+  ;;
+  ;; `frame-provider` and NOT `frame-root`: `frame-root` is an idempotent
+  ;; ENSURE that would REPLACE the frame, silently dropping the
+  ;; `{:images [(xray-image)]}` seating `ensure-xray-frame!` just made.
+  ;; And the NAMED Var rather than a `:rf/xray` literal, matching the frame
+  ;; `ensure-xray-frame!` registered — `frame_singleton_guard_test` ratchets
+  ;; against an allowlist that is empty and must stay so.
+  (let [unmount (render-shell!
+                  xray-root
+                  [rf.fresco/frame-provider {:frame shell/default-frame-id}
+                   [shell/ShellView {:mode mode}]]
+                  node)]
     (set-mode-attrs! node mode)
     (reset! mount-state
             {:node     node
@@ -1685,18 +1729,33 @@
                   (set! (.-id node) "rf-xray-popout-root")
                   (.setAttribute node "data-rf-xray-mode" "popout")
                   (.appendChild body node)
-                  (let [unmount      (rf.substrate.adapter/render
-                                       ;; rf2-tqlmq — same mount-wrap as
-                                       ;; `mount-shell-into!`: wrap the popout
-                                       ;; shell in the shell's frame-provider so
-                                       ;; its own `:rf.view/rendered` trace
-                                       ;; resolves to the trace-disabled Xray
-                                       ;; frame instead of falling through to
-                                       ;; `:rf/default` and leaking into the
-                                       ;; inspected app frame's epoch `:renders`.
-                                       [rf/frame-provider {:frame shell/default-frame-id}
-                                        [shell/shell-view {:mode :popout}]]
-                                       node nil)
+                  (let [unmount      (render-shell!
+                                       ;; rf2-k97c.3 — the pop-out moves onto
+                                       ;; the owned root in the SAME commit as
+                                       ;; the inline shell. Two lines, in a file
+                                       ;; the swap opens anyway, and leaving it
+                                       ;; behind would have left one surface
+                                       ;; painting through the installed
+                                       ;; adapter's `:render` — i.e. coupling (1)
+                                       ;; only half severed, with the pop-out
+                                       ;; still refusing every element-shaped
+                                       ;; host.
+                                       ;;
+                                       ;; ITS OWN HANDLE. `render!` binds a
+                                       ;; handle to its mount-point on the first
+                                       ;; call, and this node lives in the
+                                       ;; pop-out's document; sharing
+                                       ;; `xray-root` would re-render the INLINE
+                                       ;; shell here instead.
+                                       ;;
+                                       ;; Same provider, same reason as
+                                       ;; `mount-shell-into!`: it is what gives
+                                       ;; `ShellView`'s ambient reads their
+                                       ;; frame.
+                                       xray-popout-root
+                                       [rf.fresco/frame-provider {:frame shell/default-frame-id}
+                                        [shell/ShellView {:mode :popout}]]
+                                       node)
                         overlay-node (install-opener-gone-overlay! doc)
                         watchdog-id  (start-opener-gone-watchdog! win overlay-node)
                         ;; rf2-uong — the reload case the watchdog cannot

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -815,7 +815,38 @@
     of colliding on one app-db (rf2-lffg).
 
   Unlike the per-panel mounts, no outer `frame-provider` is added here:
-  `shell-view` opens its own around `frame-id`."
+  `shell-view` opens its own around `frame-id`. Since rf2-k97c.3 that is
+  true one level HIGHER than it used to be — the bridge wraps the shell
+  BOUNDARY in `[rf.fresco/frame-provider {:frame frame-id}]`, so the
+  embed is positively scoped rather than relying on a provider inside the
+  body — and this fn needs no change for it.
+
+  ## The missing outer provider was MEASURED here, not assumed (rf2-k97c.3)
+
+  The root-swap plan raised this absence as a POSSIBLE third rf2-tqlmq
+  instance — Xray's own activity leaking into the inspected application's
+  epoch record — and said in terms that it was a question rather than a
+  finding, because whether it leaked depends on what frame a Story or
+  custom host has in scope, which nobody had measured.
+
+  IT DOES NOT LEAK, AND THE REASON IS ABOUT REACT RATHER THAN ABOUT XRAY,
+  which is why reading this file was never going to settle it:
+  `rf.substrate.adapter/render` creates its OWN React root at
+  `mount-point`, and REACT CONTEXT DOES NOT CROSS A ROOT BOUNDARY. DOM
+  nesting is not React nesting, so a host's `frame-provider` is not in
+  scope inside the embed however deeply the node is nested, and there is
+  no host frame for the shell to fall through TO.
+
+  Measured rather than argued, in the exact configuration the question
+  was about — a host application painting its own Reagent root under
+  `[rf/frame-provider {:frame app}]` with the embed mounted at a node
+  inside that root's DOM, then a REAL click on the embedded L3 tab bar:
+  the host frame's epoch history is unchanged in COUNT and in CONTENTS,
+  beside a control showing the same ring does move for a genuine
+  application event. The row is `w5-the-embed-door-mounts-and-never-
+  touches-the-host-frames-ring` in
+  `shell_fresco_boundary_dom_cljs_test`, and it keeps biting whichever of
+  the three independent reasons a future change removes."
   ([mount-point]      (mount-shell! mount-point nil))
   ([mount-point opts]
    (let [frame-id (get opts :frame shell/default-frame-id)

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -132,11 +132,14 @@
   inside a boundary body is a LOUD REFUSAL rather than a silent
   fall-through to `:rf/default`, which is the whole point.
 
-  [[shell-view]] is STILL an `rf/reg-view`, deliberately: it is the
-  Reagent root `mount.cljs` renders through the installed adapter's
-  `:render`, and severing that is the parent epic's coupling (1) — a
-  later slice. It reaches the Fresco tree through ONE private
-  `as-component` bridge.
+  [[ShellView]] IS ONE TOO, as of the root swap, and it is the eighth:
+  the shell no longer paints through the installed adapter's `:render`
+  at all — `mount.cljs` owns a Fresco root and heads [[ShellView]] under
+  its own `rf.fresco/frame-provider`. That is the parent epic's coupling
+  (1), severed. [[shell-view]] survives as the public CALLABLE every
+  Reagent caller already holds, and answers the element [[ShellView]]
+  lowers to; the private `as-component` bridge it used to reach the
+  Fresco tree through is gone, because there is no longer a crossing.
 
   Each boundary's body is thin: it reads, and calls a pure `*-tree` fn
   that owns the hiccup. That is `defview`'s own documented
@@ -2988,56 +2991,21 @@
   read swaps the entire surface, so nothing below needs to see it.
 
   The argument is the ordinary one-props-map vector every `defview`
-  takes. [[surface-bridge]] mounts it with none, so it is destructured
-  away."
+  takes. [[ShellView]] heads it with none, so it is destructured away."
   [_props]
   (surface-composer-tree (rf.fresco/sub [:rf.xray/mode])
                          [static-shell/surface {}]
                          [dynamic-chrome {}]))
 
-;; ---- the migration bridge (rf2-k97c.3) -----------------------------------
+;; ---- the migration bridge (rf2-k97c.3) — RETIRED -------------------------
 ;;
-;; Xray's mount path still paints through the INSTALLED ADAPTER's
-;; `:render` (`mount.cljs:396` and the pop-out at `:1688`), so
-;; [[shell-view]] is still an `rf/reg-view` — a Reagent tree — and a
-;; React component is not a legal hiccup head there. Severing that call
-;; is the epic's coupling (1) and is a LATER slice; this bridge is what
-;; keeps the tree green at every step in between.
-;;
-;; `rf.fresco/as-component` is Fresco's own outward door for exactly
-;; this: it answers a real React component for a boundary, which a React
-;; parent (Reagent, UIx or plain JavaScript) mounts UNDER THE FRAME IT IS
-;; ALREADY IN, taking the frame from React context rather than from a
-;; second root. So there is no second root here, no adapter-kind branch,
-;; and no props ABI.
-;;
-;; THE BRIDGE IS PRIVATE, and that is measured rather than defaulted:
-;; [[shell-view]] is the only caller and it lives in this namespace, so no
-;; name has to cross. `surface-composer` itself KEEPS THE NATURAL NAME —
-;; the #9581 spelling the mayor's RULING 1 fixed as the surviving one —
-;; and neither `spec/api-manifest.edn` nor its curated sidecar rows
-;; anything in this namespace, so no hot-zone file moves.
-;;
-;; THIS IS SCAFFOLDING WITH A DEFINED END. When `mount.cljs` owns a
-;; Fresco root, `shell-view` becomes a boundary too, it heads
+;; `surface-composer-component` and `surface-bridge` lived here. Their own
+;; comment named the condition that deletes them — "when `mount.cljs` owns
+;; a Fresco root, `shell-view` becomes a boundary too, it heads
 ;; `surface-composer` directly, `[:>]` goes, and both defs below are
-;; deleted.
-
-(def ^:private surface-composer-component
-  "The React component [[surface-composer]] presents as, for a non-Fresco
-  parent. Declared once at top level beside the view, as
-  `rf.fresco/as-component`'s contract requires — deriving it per render
-  would mint a new component type every time and remount the whole
-  Dynamic surface on each parent render."
-  (rf.fresco/as-component surface-composer))
-
-(defn ^:private surface-bridge
-  "The callable [[shell-view]] mounts. Returns Reagent-shaped hiccup
-  interoping to the React component above; the shell's enclosing
-  `rf/frame-provider` is what puts the instance frame in React context
-  for it."
-  []
-  [:> surface-composer-component {}])
+;; deleted" — and this is that commit. [[ShellView]] heads
+;; `surface-composer` directly below, so nothing crosses out of Fresco and
+;; back in.
 
 ;; ---- shell view ----------------------------------------------------------
 
@@ -3048,28 +3016,40 @@
   opts, the live lens mode and its ONE already-composed surface node.
 
   SPLIT OUT OF [[shell-view]] BY rf2-k97c.3. Genuinely shared between the
-  two lanes rather than reproduced for them: [[shell-view]] passes
-  `[surface-bridge]` (the `as-component` crossing into the Fresco tree)
-  and `test-helpers.dynamic-shell-tree` passes the chrome's
-  already-expanded plain hiccup, so a node-lane row that walks this
-  envelope walks the shipped definitions of the testids, the flex column,
-  the landmark role and every modal mount.
+  two lanes rather than reproduced for them: [[ShellView]] passes
+  `[surface-composer {}]` and `test-helpers.dynamic-shell-tree` passes the
+  chrome's already-expanded plain hiccup, so a node-lane row that walks
+  this envelope walks the shipped definitions of the testids, the flex
+  column, the landmark role and every modal mount.
 
-  EVERYTHING HERE IS STILL REAGENT and stays so until the epic's coupling
-  (1) is severed: the seven modals are `rf/reg-view`s mounted from a
-  `reg-view` tree, which is exactly what they have always been. They are
-  NOT islands — nothing above them is a boundary.
+  ## rf2-k97c.3 — THIS IS A FRESCO TREE NOW, AND THAT IS WHY THE MOUNTS
+  ## BELOW ARE CALLS RATHER THAN HEADS
 
-  `resize-handle/Handle` is the one name here that is no longer a
-  `reg-view`, and it changes nothing at this mount site (rf2-k97c.3).
-  Its file migrated, so `Handle` is now a plain fn answering `[:> …]`
-  over Fresco's `as-component` bridge — which this Reagent tree heads
-  exactly as it always headed the `reg-view`, and which takes the
-  instance frame from the `rf/frame-provider` below through React
-  context. The mode gate stayed on this side of that crossing because
-  `as-component` round-trips prop names but not prop VALUES, and `mode`
-  is a keyword; `Handle` still takes it positionally, so the call below
-  is untouched."
+  [[ShellView]] is a `rf.fresco/defview`, so everything this fn returns is
+  lowered by Fresco's codec. A PLAIN FUNCTION IN HEAD POSITION IS A LOUD
+  ERROR THERE (`:rf.error/fresco-bad-head`, HD-016), and every name below
+  is exactly that: each modal's public `Modal` / `Popup` / `Toast` /
+  `Popover` is the RULING 1 bridge its own file kept — a plain fn
+  answering `[:> …]` over `rf.fresco/as-component` — because a Reagent
+  parent still heads it elsewhere (`panels.cljs`'s `render-panel!`, and
+  each file's own boundary witness suite). So the bridges STAY, and this
+  file stops HEADING them and CALLS them instead: `(palette/Modal)`
+  answers the same `[:> …]` escape, which IS a legal Fresco head form.
+  That is this bead's own ruled call-site rule for a shared plain fn
+  (\"a migrating panel CALLS them — `(mini v 40)` — which is correct on
+  both substrates\"), and it is what Fresco's own refusal message
+  prescribes: *call it, or make it a view*.
+
+  A REG-VIEW CENSUS CANNOT SEE THIS. Slices B1-B6 retired every
+  `rf/reg-view` under these names, which is what the step-0 precondition
+  measures — and replaced each with a plain-fn bridge, which grades
+  `:invalid` down the identical arm. The precondition passing is
+  therefore not evidence that the heads are legal; only the head kind is.
+
+  `resize-handle/Handle` keeps its positional `mode` argument for the
+  reason its own docstring gives — `as-component` round-trips prop names
+  but not prop VALUES, and `mode` is a keyword — so it is called with it,
+  and answers nil outside `:inline` exactly as it did."
   [{:keys [mode modal-positioning lens-mode frame-id]} surface*]
    ;; rf2-uu3lp — the outer `<div>` IS the shell-view's root so the
    ;; source-coord walk has a DOM node to annotate (Spec 006
@@ -3136,7 +3116,7 @@
     ;; Every subscribing child below is wrapped so the instance
     ;; `frame-id` flows through React-context (rf2-lnluk — the provider
     ;; frame is the parameterized instance frame, default `:rf/xray`).
-    [rf/frame-provider {:frame frame-id}
+    [rf.fresco/frame-provider {:frame frame-id}
     ;; Left-edge horizontal resize handle (rf2-x8h9y) — only renders
     ;; in `:inline` (right-rail) mode. Position-absolute pins it to
     ;; the LEFT edge of this flex container; the outer div is
@@ -3145,7 +3125,7 @@
     ;; `:rf.xray/set-panel-width-px`, which clamps + persists +
     ;; pushes `--rf-xray-inline-width` onto the layout host so the
     ;; host's `flex-basis` re-evaluates this paint.
-    [resize-handle/Handle mode]
+    (resize-handle/Handle mode)
     ;; Mode-aware surface (rf2-o5f5f.1). The composer reads
     ;; `:rf.xray/mode` and renders either the Dynamic 4-layer
     ;; chrome or the Static 3-layer surface. Per rf2-8l3uk the
@@ -3165,19 +3145,19 @@
     ;; overlays the chrome. Modal short-circuits to nil when
     ;; `:rf.xray/palette-open?` is false; closed-state cost is one
     ;; subscribe + when-gate.
-    [palette/Modal]
+    (palette/Modal)
     ;; Filter edit popup (rf2-ak4ms) — mounted at shell root so it
     ;; overlays the chrome AND the palette modal (the popup's z-index
     ;; is one above the palette so an edit opened from a palette
     ;; context wins focus). Modal short-circuits to nil when
     ;; `:rf.xray/edit-popup-open?` is false; closed-state cost is
     ;; one subscribe + when-gate.
-    [filters/Modal]
+    (filters/Modal)
     ;; Settings popup (rf2-9poxq) — same mount discipline as the
     ;; palette + edit popup: shell-root mount so subscribes resolve
     ;; through the shell's `:rf/xray` frame-provider, and the modal
     ;; short-circuits to nil when `:rf.xray/settings-open?` is false.
-    [settings-popup/Modal]
+    (settings-popup/Modal)
     ;; Open-in-editor 'pick an editor in Settings' hint toast
     ;; (rf2-4s08ov). Same shell-root mount discipline as the modals so
     ;; its subscribe resolves through the `:rf/xray` frame-provider; the
@@ -3186,7 +3166,7 @@
     ;; Shown when an open-in-editor chip is clicked but no editor is
     ;; effectively configured (host never set `:rf.xray/editor`, no
     ;; operator override) — instead of the silent `vscode:` no-op.
-    [editor-hint/Toast]
+    (editor-hint/Toast)
     ;; Cancellation-cascade popover (rf2-59e7k) — single waterfall view
     ;; of the rf2-wvkn cancellation contract. Opened from the Trace tab
     ;; (right-click a destroy-event row → 'Show cancellation event-bundle')
@@ -3194,7 +3174,7 @@
     ;; mount discipline as the other popovers: shell-root mount so
     ;; subscribes resolve through the `:rf/xray` frame-provider;
     ;; closed-state cost is one subscribe + a when-gate.
-    [cancellation-cascade/Popover]
+    (cancellation-cascade/Popover)
     ;; rf2-nugvv (2026-06-04) — the Share modal (rf2-nqw0v Phase 5) is
     ;; removed. The Machine panel's Share button was its sole UI entry
     ;; point, so the modal, its shell mount, and the share-URL infra
@@ -3204,20 +3184,20 @@
     ;; mount discipline as the other modals: shell-root mount so the
     ;; subscribes resolve through the `:rf/xray` frame-provider;
     ;; closed-state cost is one subscribe + a when-gate.
-    [spine-filters/Modal]
+    (spine-filters/Modal)
     ;; Row context menu (rf2-ikuwt) — small floating popover opened
     ;; by right-click on an L2 event row. Carries 'Mute <event-id>'
     ;; + 'Always hide this event-type…'. Mounted at shell-view root
     ;; so the menu floats above the L2 list's overflow:hidden
     ;; clipping. Closed-state cost is one subscribe + a when-gate.
-    [spine-filters/RowContextMenu]
+    (spine-filters/RowContextMenu)
     ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any
     ;; path-segment in the App-DB Diff breadcrumb is clicked. Same
     ;; mount discipline as the other modals: shell-root mount so the
     ;; popup's subscribes resolve through the shell's `:rf/xray`
     ;; frame-provider; closed-state cost is one subscribe + a when-
     ;; gate.
-    [app-db-segment-inspector/Popup]
+    (app-db-segment-inspector/Popup)
     ;; Data-display popup stack (rf2-l4625) — overlay surface for the
     ;; "open in popup" affordance on per-panel `[ei/edn-inspector]`
     ;; mounts. Reads `:rf.xray.edn-inspector-popup/stack` + `/entries`;
@@ -3225,14 +3205,47 @@
     ;; one subscribe + a when-gate). Mount discipline matches the
     ;; other modal stacks: shell-root mount so the stack's subscribes
     ;; resolve through the shell's `:rf/xray` frame-provider.
-    [edn-inspector-popup/edn-inspector-popup-stack]]])
+    (edn-inspector-popup/edn-inspector-popup-stack)]])
 
-(rf/reg-view shell-view
-  "The full Xray shell — wraps the 4-layer chrome in a frame-provider
-  so descendant `subscribe` / `dispatch` resolve to the isolated
-  frame. Default `:inline` mode renders in normal document flow inside
-  the app-provided right layout host. `:overlay` and `:popout` remain
-  available debug/manual modes.
+(rf.fresco/defview ShellView
+  "The full Xray shell as a FRESCO BOUNDARY — the head `mount.cljs`
+  renders through Xray's OWN React root (rf2-k97c.3, the epic's coupling
+  (1)). Wraps the 4-layer chrome in a frame-provider so descendant reads
+  and dispatches resolve to the isolated frame. Default `:inline` mode
+  renders in normal document flow inside the app-provided right layout
+  host; `:overlay` and `:popout` remain available debug/manual modes.
+
+  ## What replaced the `rf/reg-view`, and what did not
+
+  This was an `rf/reg-view` painted through the INSTALLED ADAPTER's
+  `:render`. It is now a boundary Fresco paints through its own root, so
+  Xray no longer needs the host to own a renderer that accepts hiccup —
+  which is the whole of what made Xray refuse element-shaped adapters.
+  [[shell-view]] below keeps the public NAME as a callable bridge, so
+  every Reagent caller (`panels.cljs`'s `mount-shell!`, the panel-gallery
+  testbed) is untouched.
+
+  ## THE PROVIDER ABOVE THIS HEAD IS PART OF THE CONTRACT
+
+  Both reads below are `rf.fresco/sub`, so they take their frame from
+  REACT CONTEXT rather than from an argument, and they must resolve to
+  the SAME frame as `:frame-id`. Both doors honour that by construction
+  and neither may drop it:
+
+    * `mount.cljs` renders `[rf.fresco/frame-provider {:frame
+      shell/default-frame-id} [ShellView {:mode …}]]`, and passes no
+      `:frame-id`, so the default IS that frame.
+    * [[shell-view]] wraps this head in a provider naming the very
+      `:frame-id` it forwards.
+
+  AN EXPLICITLY-FRAMED `rf/subscribe` IS NOT AN ALTERNATIVE HERE, and the
+  failure is silent. `(rf/subscribe q {:frame frame-id})` is admitted
+  inside a body and answers the right value, but it contributes ZERO
+  collector edges (HD-002 clause (a)'s forbidden class) — so the shell
+  would paint correctly on first render and then NEVER RE-RENDER when
+  `:rf.xray/mode` moved. Nothing errors. Dropping the provider instead is
+  LOUD (`:rf.error/no-frame-context`), which is why the provider is the
+  contract and the ambient read is the mechanism.
 
   ## `:frame-id` opt (rf2-lnluk) — de-singletoned shell frame
 
@@ -3242,31 +3255,9 @@
   side-by-side (the panel-gallery `:variants-grid`, a Story workspace)
   pass DISTINCT `:frame-id`s so each cell's state (focused epoch,
   selected tab, theme) is fully isolated — driving one shell does not
-  move the others.
-
-  The frame-id flows two ways: it parameterizes the wrapping
-  `[frame-provider {:frame frame-id}]` (so every reg-view descendant
-  resolves to it through React-context), AND it backs the few
-  out-of-render subscribes/dispatches `shell-view` itself issues from
-  OUTSIDE its own provider (the modal-positioning + mode reads below).
-  Handlers register GLOBALLY once under `:rf.xray/*`; only the frame-id
-  for app-db isolation threads through (no per-instance registration).
-
-  ## rf2-k97c.3 — this one stays an `rf/reg-view`, and deliberately
-
-  Everything under [[surface-composer]] is a Fresco boundary now, but
-  `shell-view` is the ROOT `mount.cljs` renders through the installed
-  adapter's `:render` (`mount.cljs:396`, and the pop-out at `:1688`).
-  Severing that call is the parent epic's coupling (1) and is a later
-  slice; until then the root must stay a Reagent tree, and it reaches
-  the Fresco tree through the one private `surface-bridge` above.
-
-  The shell-view itself sits OUTSIDE its own frame-provider (it's the
-  mount root) so React-context inside `shell-view`'s body still resolves
-  to the default — hence the two explicit `{:frame frame-id}` reads
-  below. Every reading child is its own component (a `reg-view` for the
-  modals, a boundary for the chrome) so the surrounding Provider reaches
-  them.
+  move the others. Handlers register GLOBALLY once under `:rf.xray/*`;
+  only the frame-id for app-db isolation threads through (no
+  per-instance registration).
 
   ## `:modal-positioning` opt (rf2-om6fa)
 
@@ -3287,16 +3278,24 @@
   open?`) are now also per-instance — pass a distinct `:frame-id` per
   cell and opening Settings in one cell opens Settings in that cell
   only. (Cells that share a frame-id still share state — that's the
-  contract: one frame, one app-db.)"
-  [& [{:keys [mode modal-positioning frame-id]
-       :or   {mode :inline modal-positioning :fixed
-              frame-id default-frame-id}}]]
+  contract: one frame, one app-db.)
+
+  ## The two render-phase side effects, both deliberate
+
+  `global-styles/install!` already ran during render as a `reg-view` and
+  two testbeds rely on it; it is idempotent (`defonce` plus an id-keyed
+  DOM probe). The `dispatch-sync` is safe under a boundary for a reason
+  that is the collector's rather than this view's: `flush!` defers
+  notification to a macrotask while a body is running
+  (`impl/collector.cljs`), so the write cannot re-enter this render. The
+  `when` guard is what makes it quiesce — once the slot matches the prop
+  it short-circuits."
+  [{:keys [mode modal-positioning frame-id]
+    :or   {mode :inline modal-positioning :fixed
+           frame-id default-frame-id}}]
   ;; rf2-5kfxe.1 — wire Inter + JetBrains Mono once on first paint of
   ;; the shell. Idempotent (`defonce` + id-keyed DOM probe inside) so
-  ;; shadow-cljs `:after-load` and repeated mounts are no-ops. Future
-  ;; cluster commits extend this install with `@keyframes` + the
-  ;; reduced-motion seam so all global stylesheet writes converge on
-  ;; one entry point.
+  ;; shadow-cljs `:after-load` and repeated mounts are no-ops.
   (global-styles/install!)
   ;; Idempotent app-db write so every modal can read the positioning
   ;; via the `:rf.xray/modal-positioning` sub. Guarded against
@@ -3306,13 +3305,12 @@
   ;; children mount and read the sub on this same render pass; without
   ;; sync the first paint of a fresh shell would render every modal's
   ;; backdrop at the default `:fixed` before the async router drains.
-  ;; Sub + dispatch route via the instance `frame-id` so the read/write
-  ;; lands on THIS shell's app-db (`shell-view` itself sits OUTSIDE the
-  ;; `frame-provider` in the tree below — the React-context tier
-  ;; doesn't reach this call site, hence the explicit frame arg). Per
-  ;; rf2-lnluk the explicit frame is the instance `frame-id`, not a
-  ;; `:rf/xray` literal — N shells stay isolated.
-  (let [current-positioning @(rf/subscribe [:rf.xray/modal-positioning] {:frame frame-id})]
+  ;; The READ is ambient (the enclosing provider's frame, which is
+  ;; `frame-id` — see the docstring); the WRITE names `frame-id`
+  ;; explicitly because `dispatch-sync` is not a collector read and has
+  ;; no frame of its own. Per rf2-lnluk that is the instance frame-id,
+  ;; never a `:rf/xray` literal — N shells stay isolated.
+  (let [current-positioning (rf.fresco/sub [:rf.xray/modal-positioning])]
     (when (not= current-positioning modal-positioning)
       (rf/dispatch-sync [:rf.xray/set-modal-positioning modal-positioning]
                         {:frame frame-id})))
@@ -3326,9 +3324,55 @@
      ;; pulse dampening in Static). Post rf2-ad7zx.13 the Figma export
      ;; carries a SINGLE accent (GitHub blue) — the mode class no longer
      ;; re-points `--rf-xray-accent`, so the chrome accent is the same
-     ;; blue in both modes. Subscribed via the explicit instance
-     ;; `frame-id` (same shape as the modal-positioning read above —
-     ;; `shell-view` sits outside its own frame-provider; rf2-lnluk
-     ;; threads the instance frame, not a `:rf/xray` literal).
-     :lens-mode         @(rf/subscribe [:rf.xray/mode] {:frame frame-id})}
-    [surface-bridge]))
+     ;; blue in both modes. An AMBIENT collector read, so the shell
+     ;; actually re-renders when the mode moves.
+     :lens-mode         (rf.fresco/sub [:rf.xray/mode])}
+    [surface-composer {}]))
+
+(defn shell-view
+  "The shell's public callable — the name every REAGENT caller already
+  holds, and the one door `panels.cljs`'s `mount-shell!` and
+  `testbeds/panel_gallery` mount through, UNEDITED by rf2-k97c.3.
+
+  Since rf2-k97c.3 it is the migration bridge rather than the view:
+  [[ShellView]] is the boundary, and this answers the React element it
+  lowers to, already scoped to its frame.
+
+  ## Why `rf.fresco/as-element` and not `rf.fresco/as-component`
+
+  `as-component` is the tree's usual outward door and it is the WRONG one
+  here, for a reason its own contract states: a Reagent parent's `[:>]`
+  runs Reagent's `convert-prop-value` first, so NAMES round-trip across
+  that crossing and VALUES do not. Every opt this view takes is a
+  KEYWORD — `:inline`, `:fixed`, `:rf/xray` — and each would arrive as a
+  bare string, which for `:frame-id` means naming a frame that does not
+  exist. `resize-handle/Handle` met the same wall and answered it by
+  deciding in CLJS and crossing with no props; this view cannot, because
+  the opts are what it is parameterised BY.
+
+  `as-element` is Fresco's own explicit hiccup-to-ReactNode conversion,
+  so the props map crosses as a CLJS value by identity
+  (`codec/boundary-element` hands it over as `rfProps`) and the keywords
+  arrive as keywords. It mints nothing — the component type is
+  [[ShellView]]'s own, minted once by `defview` — so the once-at-top-level
+  rule `as-component` carries does not apply and no parent render can
+  remount the shell.
+
+  ## The provider is HERE rather than in the caller
+
+  `mount-shell!` adds no outer provider of its own — its docstring said
+  `shell-view` opens its own around `frame-id`, and that is now literally
+  true one level higher than it used to be. Opening it here means every
+  Reagent embed gets the instance frame for free, including [[ShellView]]'s
+  own two ambient reads, whatever frame the host happens to have in
+  scope. `shell-view-tree` opens a second provider at the same frame one
+  level down; that one is what the node lane walks, and a re-scope to the
+  frame already in scope costs a context read."
+  [& [{:keys [mode modal-positioning frame-id]
+       :or   {mode :inline modal-positioning :fixed
+              frame-id default-frame-id}}]]
+  (rf.fresco/as-element
+    [rf.fresco/frame-provider {:frame frame-id}
+     [ShellView {:mode              mode
+                 :modal-positioning modal-positioning
+                 :frame-id          frame-id}]]))

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -22,7 +22,7 @@
   2. **Lazy-mount affordance.** The mount cost (DOM node + substrate
      render) is paid once on first `open!`. Subsequent `open!`s flip
      the container's CSS display only — no re-render, no new DOM
-     node, no second `rf.substrate.adapter/render` call. This is the
+     node, no second `rf.fresco/render!` call. This is the
      spec/007-UX-IA.md §The default landing view <80ms toggle
      target: re-mounting would discard internal state and miss the
      budget.
@@ -49,6 +49,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.substrate.adapter :as rf.substrate.adapter]
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.trace :as rf.trace]
@@ -208,26 +209,43 @@
 ;; The fixture installs `rf.substrate.plain-atom/adapter` — its `:render` slot
 ;; throws (per substrate/plain_atom.cljc line 39: render is not
 ;; supported on the JVM/headless adapter). Real `open!` calls
-;; `(rf.substrate.adapter/render [shell/shell-view] node nil)`; we
+;; `(rf.fresco/render! [shell/shell-view] node nil)`; we
 ;; intercept that delegation with `with-redefs` so the test never
 ;; spins a React tree. The stub records its arguments + returns a
 ;; sentinel unmount fn so `teardown!` has something to invoke and
 ;; the assertion can verify it was called exactly once.
 
 (defn- mk-render-stub
-  "Build a stub for `rf.substrate.adapter/render`. Returns
-  `{:render-fn ..., :calls (atom []), :unmount-calls (atom 0)}` so
-  tests can assert call counts. The render-fn signature matches the
-  contract: 3 args, returns an unmount fn."
+  "Build a stub for `rf.fresco/render!` — the seam `mount.cljs` paints the
+  shell through since rf2-k97c.3 severed the epic's coupling (1). Returns
+  `{:render-fn ..., :calls (atom []), :unmount-calls (atom 0)}` so tests
+  can assert call counts.
+
+  IT STUBS ONE DOOR AND LETS THE OTHER RUN, which is the whole reason the
+  rows below needed no second binding. Fresco's root API is a PAIR —
+  `render!` then `unmount!` on the SAME handle — where the adapter's
+  `render` answered its own unmount fn. So rather than redefine both, this
+  writes into the handle the live-root map `render!` itself writes
+  (`impl/mount.cljs`'s `mount-client-root!`), and the REAL
+  `rf.fresco/unmount!` then finds a `:unmount!` to call. Every unmount
+  count below is therefore still a claim about `unmount!` having been
+  REACHED, through shipped code, rather than about a second stub.
+
+  The signature is `render!`'s: `[handle tree mount-point]`, answering
+  nil. `:opts` is recorded as nil because `mount.cljs` passes no root
+  options at all — the rows that assert it keep meaning what they meant."
   []
   (let [calls         (atom [])
         unmount-calls (atom 0)
         unmount-fn    (fn unmount-stub []
                         (swap! unmount-calls inc)
                         nil)]
-    {:render-fn     (fn render-stub [tree node opts]
-                      (swap! calls conj {:tree tree :node node :opts opts})
-                      unmount-fn)
+    {:render-fn     (fn render-stub [handle tree node]
+                      (swap! calls conj {:tree tree :node node :opts nil})
+                      (reset! handle {:live?    (fn [] true)
+                                      :update!  (fn [_tree] nil)
+                                      :unmount! unmount-fn})
+                      nil)
      :calls         calls
      :unmount-calls unmount-calls
      :unmount-fn    unmount-fn}))
@@ -271,17 +289,17 @@
 
 (deftest first-open!-creates-dom-node-and-renders
   (testing "first open! creates a fresh <div id=\"rf-xray-root\"> under
-            document.body, delegates to rf.substrate.adapter/render with
+            document.body, delegates to rf.fresco/render! with
             the shell-view tree and the new node, and marks visible"
     (with-stub-document
       (fn [doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (let [result (mount/open!)]
               (is (some? result) "open! returns the mount-state map")
               (is (map? result))
               (is (= 1 (count @calls))
-                  "rf.substrate.adapter/render invoked exactly once")
+                  "rf.fresco/render! invoked exactly once")
               (let [{:keys [tree node opts]} (first @calls)]
                 (is (vector? tree) "render received a hiccup vector")
                 (is (some? node) "render received the mount node")
@@ -306,7 +324,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (let [node (:node @@#'mount/mount-state)]
               (is (= "block" (.-display (.-style node)))
@@ -321,7 +339,7 @@
       (fn [doc]
         (set! (.-querySelector doc) (fn [_selector] nil))
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (let [prior-console (when (exists? js/console) js/console)]
               (set! js/console (js-obj "error" (fn [& _args] nil)))
               (try
@@ -369,7 +387,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render          render-fn
+          (with-redefs [rf.fresco/render!                    render-fn
                         rf.substrate.adapter/current-adapter (fn [] {:kind :rf.adapter/uix})]
             (with-warn-counter*
               (fn [warns]
@@ -385,7 +403,7 @@
                   (is (= 1 @warns) "exactly one console.warn")
                   (is (false? (mount/mounted?)) "nothing mounted")
                   (is (zero? (count @calls))
-                      "rf.substrate.adapter/render never invoked"))))))))))
+                      "rf.fresco/render! never invoked"))))))))))
 
 (deftest open-overlay!-on-react-element-substrate-refuses-cleanly
   (testing "open-overlay! refuses a React-element substrate host the same
@@ -393,7 +411,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render          render-fn
+          (with-redefs [rf.fresco/render!                    render-fn
                         rf.substrate.adapter/current-adapter (fn [] {:kind :rf.adapter/ui})]
             (with-warn-counter*
               (fn [_warns]
@@ -409,7 +427,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render          render-fn
+          (with-redefs [rf.fresco/render!                    render-fn
                         rf.substrate.adapter/current-adapter (fn [] {:kind :rf.adapter/helix})]
             (with-warn-counter*
               (fn [_warns]
@@ -437,7 +455,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render          render-fn
+          (with-redefs [rf.fresco/render!                    render-fn
                         rf.substrate.adapter/current-adapter (fn [] {:kind :rf.adapter/fresco})]
             (with-warn-counter*
               (fn [warns]
@@ -453,7 +471,7 @@
                   (is (= 1 @warns) "exactly one console.warn")
                   (is (false? (mount/mounted?)) "nothing mounted")
                   (is (zero? (count @calls))
-                      "rf.substrate.adapter/render never invoked"))))))))))
+                      "rf.fresco/render! never invoked"))))))))))
 
 (deftest open!-on-ratom-substrate-still-mounts
   (testing "the gate is a denylist of the element-shaped kinds only — a
@@ -462,13 +480,13 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render          render-fn
+          (with-redefs [rf.fresco/render!                    render-fn
                         rf.substrate.adapter/current-adapter (fn [] {:kind :rf.adapter/reagent-slim})]
             (let [result (mount/open!)]
               (is (map? result) "open! returns the mount-state map")
               (is (true? (mount/mounted?)))
               (is (= 1 (count @calls))
-                  "rf.substrate.adapter/render invoked exactly once"))))))))
+                  "rf.fresco/render! invoked exactly once"))))))))
 
 ;; -------------------------------------------------------------------------
 ;; (3) Open — second call (already mounted; no re-render)
@@ -476,14 +494,14 @@
 
 (deftest second-open!-does-not-re-render
   (testing "calling open! when already mounted is a CSS-only show —
-            rf.substrate.adapter/render is NOT invoked again, the
+            rf.fresco/render! is NOT invoked again, the
             existing DOM node is reused, display flips back to block.
             This is the <80ms toggle target the spec calls out:
             re-rendering would discard internal shell state"
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (let [first-state (mount/open!)
                   first-node  (:node first-state)]
               (is (= 1 (count @calls)) "first open! triggered one render")
@@ -512,7 +530,7 @@
     (with-stub-document
       (fn [doc]
         (let [{:keys [render-fn calls unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (let [pre-close @@#'mount/mount-state]
               (is (some? pre-close))
@@ -548,7 +566,7 @@
           (set! (.-display (.-style host)) "flex"))
         (let [host (.-body doc)
               {:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (= "flex" (.-display (.-style host)))
                 "open! preserves the host's pre-Xray inline display")
@@ -569,7 +587,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (is (nil? (mount/close!))
                 "close! returns nil on clean state")
             (is (nil? @@#'mount/mount-state)
@@ -586,7 +604,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (mount/close!)
             (is (false? (mount/visible?)))
@@ -607,7 +625,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/toggle!)
             (is (= 1 (count @calls))
                 "first toggle! triggers a substrate render")
@@ -620,7 +638,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (true? (mount/visible?)))
             (mount/toggle!)
@@ -638,7 +656,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (mount/close!)
             (is (false? (mount/visible?)))
@@ -655,7 +673,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/toggle!)  ;; #1 open
             (is (true? (mount/visible?)))
             (mount/toggle!)  ;; #2 close
@@ -692,7 +710,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (true? (mount/visible?)) "precondition: shell visible")
             (rf/with-frame :rf/xray
@@ -716,7 +734,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (rf/with-frame :rf/xray
               (rf/dispatch-sync [:rf.xray/close-shell]))
@@ -746,7 +764,7 @@
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)
               popout-calls (atom 0)]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         mount/popout! (fn [] (swap! popout-calls inc) nil)]
             ;; install-fx! is called by register-xray-handlers! in the
             ;; fixture, but redefine-after-register means the fx closure
@@ -771,7 +789,7 @@
     (with-stub-document
       (fn [doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (= 1 (.-length (.-children (.-body doc)))))
             (let [pre-node (:node @@#'mount/mount-state)]
@@ -795,7 +813,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (let [first-node (:node @@#'mount/mount-state)]
               (mount/teardown!)
@@ -816,7 +834,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (is (nil? (mount/teardown!)))
             (is (nil? @@#'mount/mount-state))
             (is (= 0 @unmount-calls)
@@ -832,12 +850,16 @@
       (fn [doc]
         ;; Build a stub render that returns a throwing unmount.
         (let [calls (atom [])]
-          (with-redefs [rf.substrate.adapter/render
-                        (fn [tree node opts]
-                          (swap! calls conj [tree node opts])
-                          (fn throwing-unmount []
-                            (throw (ex-info "unmount blew up"
-                                            {:reason :test}))))]
+          (with-redefs [rf.fresco/render!
+                        (fn [handle tree node]
+                          (swap! calls conj [tree node nil])
+                          (reset! handle
+                                  {:live?    (fn [] true)
+                                   :update!  (fn [_tree] nil)
+                                   :unmount! (fn throwing-unmount []
+                                               (throw (ex-info "unmount blew up"
+                                                               {:reason :test})))})
+                          nil)]
             (mount/open!)
             (is (= 1 (count @calls)))
             ;; teardown! must not propagate the unmount exception.
@@ -863,7 +885,7 @@
     (with-stub-document
       (fn [doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             ;; Tear down the fixture's plain-atom install so
             ;; current-adapter returns nil.
             (rf.substrate.adapter/dispose-adapter!)
@@ -890,7 +912,7 @@
         (config/set-auto-open! false)
         (let [{:keys [render-fn calls]} (mk-render-stub)
               console-calls (atom [])]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (let [prior-console (when (exists? js/console) js/console)]
               (set! js/console (js-obj "error" (fn [& args]
                                                   (swap! console-calls conj args)
@@ -923,7 +945,7 @@
     (with-stub-document
       (fn [doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (rf.substrate.adapter/dispose-adapter!)
             (is (nil? (mount/toggle!))
                 "toggle! returns nil rather than throwing")
@@ -941,7 +963,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (rf.substrate.adapter/dispose-adapter!)
             (is (nil? (mount/open!)) "first open! is a no-op")
             ;; Re-install — same plain-atom adapter the fixture had.
@@ -964,7 +986,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (true? (mount/visible?)))
             ;; Forcibly mutate the singleton's :visible? slot — visible?
@@ -980,7 +1002,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (is (false? (mount/mounted?)) "clean baseline")
             (mount/open!)
             (is (true? (mount/mounted?)) "mounted? true after open!")
@@ -1013,7 +1035,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (is (nil? (rf.frame/frame :rf/xray))
                 ":rf/xray is absent on the clean baseline")
             (mount/open!)
@@ -1029,7 +1051,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             ;; Push two events into the trace-bus atom BEFORE the
             ;; first open!. The frame doesn't exist yet, so the
             ;; `mirror-into-xray!` guard skips the dispatch — atom
@@ -1099,7 +1121,7 @@
                              :trigger-event [:cart/add-item]
                              :event-id     :cart/add-item
                              :trace-events []}]]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         ;; Stub `rf/epoch-history` so the `:rf.xray/
                         ;; set-target-frame` event handler's
                         ;; `(rf/epoch-history target)` read returns the
@@ -1142,7 +1164,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         rf/epoch-history (fn [_] [])]
             (mount/open!)
             (rf/with-frame :rf/xray
@@ -1165,7 +1187,7 @@
                              :db-before {} :db-after {:k 1}
                              :trigger-event [:cart/add] :event-id :cart/add
                              :trace-events []}]]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         rf/epoch-history (fn [frame-id]
                                            (case frame-id
                                              :cart-frame cart-records
@@ -1196,7 +1218,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (let [first-frame (rf.frame/frame :rf/xray)
                   first-db    (rf.frame/app-db-container :rf/xray)]
@@ -1232,7 +1254,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         rf/epoch-history (fn [frame-id]
                                            (case frame-id
                                              :cart-frame [{:epoch-id :e-cart :frame :cart-frame
@@ -1285,7 +1307,7 @@
     (with-stub-document
       (fn [_doc]
         (let [{:keys [render-fn]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn
+          (with-redefs [rf.fresco/render!           render-fn
                         rf/epoch-history (fn [_] [])]
             (mount/open!)
             (rf/with-frame :rf/xray
@@ -1521,7 +1543,7 @@
       (fn [_doc]
         (let [{:keys [render-fn unmount-calls]} (mk-render-stub)
               {:keys [window closed?]}          (mk-stub-popout-window)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (seed-popout-state! {:window     window
                                  :unmount-fn (fn []
@@ -1549,7 +1571,7 @@
         (let [{:keys [render-fn]} (mk-render-stub)
               cycle! (fn []
                        (let [{:keys [window]} (mk-stub-popout-window)]
-                         (with-redefs [rf.substrate.adapter/render render-fn]
+                         (with-redefs [rf.fresco/render!           render-fn]
                            (mount/open!)
                            (seed-popout-state! {:window window})
                            (mount/teardown!))))]
@@ -2211,12 +2233,31 @@
             (set! js/document prior)
             (js-delete js/goog.global "document")))))))
 
+(defn- shell-props-in
+  "The props map the `shell/ShellView` boundary head carries in a recorded
+  mount tree, found by WALKING FOR THE HEAD rather than indexing to it, so
+  a re-shaped tree answers nil instead of a plausible wrong value."
+  [tree]
+  (letfn [(walk [node]
+            (when (vector? node)
+              (if (identical? (first node) shell/ShellView)
+                (second node)
+                (some walk (rest node)))))]
+    (walk tree)))
+
 (defn- shell-view-mode-of
-  "Pull the `:mode` prop shell-view was rendered with from a recorded
-  render call. The render tree is `[frame-provider {:frame ...}
-  [shell-view {:mode mode}]]`."
+  "Pull the `:mode` prop the shell boundary was rendered with from a
+  recorded render call.
+
+  FINDS THE HEAD RATHER THAN INDEXING TO IT (rf2-k97c.3, C4). This read
+  `(get-in (:tree call) [2 1])` until the root swap — a positional index
+  into a tree whose shape the swap changes, which silently depended on the
+  provider wrap while asserting nothing about it. It now walks for
+  `shell/ShellView` and takes the props map beside it, so it answers nil
+  rather than a plausible wrong value if the tree is ever re-shaped again,
+  and `ei-shell-scope` below is what asserts the wrap."
   [call]
-  (:mode (get-in (:tree call) [2 1])))
+  (:mode (shell-props-in (:tree call))))
 
 ;; ---- (1) inline → overlay realizes the overlay surface ------------------
 
@@ -2229,7 +2270,7 @@
     (with-two-owner-document
       (fn [{:keys [body host]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (is (= 1 (count @calls)) "first open! rendered once")
             (let [inline-node (:node @@#'mount/mount-state)]
@@ -2274,7 +2315,7 @@
     (with-two-owner-document
       (fn [{:keys [body host]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open-overlay!)
             (is (= 1 (count @calls)) "first open-overlay! rendered once")
             (let [overlay-node (:node @@#'mount/mount-state)]
@@ -2311,7 +2352,7 @@
     (with-two-owner-document
       (fn [{:keys [body]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open-overlay!)
             (let [first-node (:node @@#'mount/mount-state)]
               (mount/open-overlay!)
@@ -2332,7 +2373,7 @@
     (with-two-owner-document
       (fn [{:keys [body host]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (let [first-node (:node @@#'mount/mount-state)]
               (mount/open!)
@@ -2358,7 +2399,7 @@
       (fn [{:keys [body host]}]
         (let [{:keys [render-fn]} (mk-render-stub)
               prior-window        (when (exists? js/window) js/window)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             ;; Install the same browser API exports install.cljs wires,
             ;; pointing at the REAL mount fns so the bridge exercises the
             ;; production late-bind path.
@@ -2404,7 +2445,7 @@
     (with-two-owner-document
       (fn [{:keys [body]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)
             (mount/open-overlay!)               ; render #2 — realize overlay
             (let [overlay-node (:node @@#'mount/mount-state)]
@@ -2431,7 +2472,7 @@
     (with-two-owner-document
       (fn [{:keys [host body]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open-overlay!)
             (mount/open!)                       ; render #2 — realize inline
             (let [inline-node (:node @@#'mount/mount-state)]
@@ -2516,7 +2557,7 @@
         (let [{:keys [render-fn calls]} (mk-render-stub)
               prior-console (when (exists? js/console) js/console)]
           (set! js/console (js-obj "error" (fn [& _args] nil)))
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (try
               (mount/open-overlay!)
               (is (= 1 (count @calls)) "overlay mount rendered once")
@@ -2562,7 +2603,7 @@
     (with-two-owner-document
       (fn [{:keys [body host]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)                           ; render #1 — inline
             (mount/open-overlay!)                   ; render #2 — realize overlay
             (is (= 2 (count @calls)))
@@ -2609,7 +2650,7 @@
         (let [{:keys [render-fn calls]} (mk-render-stub)
               prior-console (when (exists? js/console) js/console)]
           (set! js/console (js-obj "error" (fn [& _args] nil)))
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (try
               (mount/open-overlay!)
               (let [overlay-node (:node @@#'mount/mount-state)
@@ -2655,7 +2696,7 @@
         (let [{:keys [render-fn calls]} (mk-render-stub)
               prior-console (when (exists? js/console) js/console)]
           (set! js/console (js-obj "error" (fn [& _args] nil)))
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (try
               (mount/open-overlay!)
               (mount/close!)                                ; hidden overlay
@@ -2688,7 +2729,7 @@
     (with-two-owner-document
       (fn [{:keys [host]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (is (nil? @@#'mount/mount-state) "cold start")
             (mount/toggle!)
             (is (= 1 (count @calls)))
@@ -2705,7 +2746,7 @@
     (with-two-owner-document
       (fn [{:keys [host body]}]
         (let [{:keys [render-fn calls]} (mk-render-stub)]
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render!           render-fn]
             (mount/open!)                           ; inline
             (let [inline-node (:node @@#'mount/mount-state)]
               (is (= :inline (:mode (mount/status))))
@@ -2723,76 +2764,76 @@
               (is (= 1 (deep-count-by-id body "rf-xray-root"))))))))))
 
 ;; =========================================================================
-;; EVIDENCE INTEGRITY — Xray's OWN renders must never appear in the
-;; INSPECTED application frame's epoch `:renders` (rf2-k97c.5; the
+;; EVIDENCE INTEGRITY — Xray's OWN activity must never appear in the
+;; INSPECTED application frame's epoch record (rf2-k97c.5; the
 ;; already-realised defect is rf2-tqlmq)
 ;; =========================================================================
 ;;
-;; THE DEFECT. `shell-view` is a `reg-view`, so its `:rf.view/rendered`
-;; trace carries the resolved current-frame. `mount-shell-into!` once
-;; rendered it BARE — the shell's own `[frame-provider {:frame :rf/xray}]`
-;; sat INSIDE its body, around the panels — so `shell-view`'s OWN render
-;; resolved by fall-through to the host page's frame and back-filled into
-;; the INSPECTED app's epoch `:renders` (observed live: `["shell-view" 27]`
-;; in a `:rf/default` boot epoch). A debugger reporting its own activity as
-;; the application's is the worst failure this tool has.
+;; THE ORIGINAL DEFECT. `shell-view` was a `reg-view`, so its
+;; `:rf.view/rendered` trace carried the resolved current-frame.
+;; `mount-shell-into!` once rendered it BARE — the shell's own
+;; `[frame-provider {:frame :rf/xray}]` sat INSIDE its body, around the
+;; panels — so `shell-view`'s OWN render resolved by fall-through to the
+;; host page's frame and back-filled into the INSPECTED app's epoch
+;; `:renders` (observed live: `["shell-view" 27]` in a `:rf/default` boot
+;; epoch). A debugger reporting its own activity as the application's is
+;; the worst failure this tool has.
 ;;
-;; THE FIX (mount.cljs `mount-shell-into!`) moves the provider OUT one
-;; level, so the mount-site tree is
-;;   [rf/frame-provider {:frame shell/default-frame-id} [shell/shell-view …]]
-;; and `shell-view`'s own render resolves to the trace-disabled `:rf/xray`
-;; frame, where the `:rf.trace/frame-no-emit?` gate suppresses the emit.
+;; THE FIX moved the provider OUT one level, and rf2-k97c.3's root swap
+;; keeps it there while changing what it is FOR. The mount-site tree is now
+;;   [rf.fresco/frame-provider {:frame shell/default-frame-id}
+;;    [shell/ShellView …]]
 ;;
-;; WHAT WAS ALREADY PINNED, AND WHAT WAS NOT. The epoch suite's inv-7
-;; (implementation/epoch/test/re_frame/epoch_attribution_test.clj) pins the
-;; EMIT-SIDE GATE: a render already TAGGED with a trace-disabled frame does
-;; not reach the app's epoch. It hand-builds that tag, so it stays green if
-;; the provider moves back inside the shell body — the tag is exactly what
-;; that regression changes. Nothing pinned the MOUNT SITE. This test does,
-;; and it asserts on the epoch record's CONTENTS.
+;; ## THIS PIN WAS RE-AIMED BY rf2-k97c.3, AND BOTH HALVES MOVED
+;;
+;; HALF ONE, THE STRUCTURAL HALF, SURVIVES WITH A NEW KEY. `ei-shell-scope`
+;; walked for `rf/frame-provider` and `shell/shell-view`; both names are
+;; gone from the mount tree, so the walker had to be re-keyed on
+;; `rf.fresco/frame-provider` and the `shell/ShellView` boundary. Its
+;; `:found?` instrument control is what makes that safe to change — a
+;; walker re-keyed onto a name the tree does not carry reports a clean nil
+;; scope, which reads as a PASSING test, and `:found?` is the only thing
+;; that separates those two.
+;;
+;; HALF TWO, THE RENDER-EMIT HALF, WAS REPLACED OUTRIGHT, because its
+;; SUBJECT CEASED TO EXIST. It used to synthesise a `:rf.view/rendered`
+;; through `rf.trace/emit!` and assert the gate suppressed it. A Fresco
+;; boundary emits NO view-render trace at all — measured with a live
+;; control, `rf.view/rendered` reads 108 hits across `implementation/` and
+;; ZERO in `implementation/fresco/src` — so after the swap that half
+;; asserted about an emit NOBODY MAKES. It would have stayed green for ever
+;; and said nothing, which is exactly the hollow-assertion shape this epic
+;; keeps meeting. Note this is the hazard class getting STRICTLY BETTER
+;; rather than merely moving: Xray's renders can no longer reach any
+;; frame's epoch `:renders` structurally, instead of being suppressed by a
+;; gate that could regress.
+;;
+;; What replaces it is a REAL INTERACTION on the EVENT axis, which is where
+;; the guarantee still needs pinning: drive one Xray chrome event and
+;; assert the inspected app frame's epoch history is unchanged in COUNT AND
+;; CONTENTS. An Xray dispatch that leaked into the app's ring would add a
+;; record; one that mutated an existing record would change the contents
+;; while leaving the count alone, so both are asserted.
 ;;
 ;; HOW IT DRIVES THE REAL MACHINERY. Node-test has no jsdom, so there is no
-;; React commit to observe; the suite's `mk-render-stub` captures the hiccup
-;; `mount-shell-into!` hands to the substrate. This test reads the frame
-;; scope out of THAT REAL TREE (modelling `re-frame.views.provider/
-;; current-frame` tier 2 — closest enclosing frame boundary), then emits the
-;; shell's `:rf.view/rendered` through the REAL `re-frame.trace/emit!` under
-;; the frame the tree resolves to, and reads the app frame's epoch back
-;; through the REAL `rf/epoch-history`. Only the React commit is modelled;
-;; the gate, the back-fill and the epoch projection are the shipping code.
-
-(defn- ei-emit-render!
-  "Emit a `:rf.view/rendered` at React-COMMIT timing — post-settle (empty
-  buffer), tags carrying the render-key and the `:frame` the view resolved
-  to. Mirrors the POST-render emit the `:renders` projection sources from."
-  [frame-id view-id]
-  (rf.trace/emit! :rf.view :rf.view/rendered
-                  {:rf.view/render-key [view-id 0]
-                   :frame              frame-id}))
-
-(defn- ei-epoch-by-id
-  "Re-read the frame's ring (back-fills mutate in place) and pull the record
-  matching `record`'s `:epoch-id`."
-  [frame-id record]
-  (some #(when (= (:epoch-id record) (:epoch-id %)) %)
-        (rf/epoch-history frame-id)))
-
-(defn- ei-rendered-view-ids
-  "The view-ids present in an epoch record's `:renders` projection."
-  [record]
-  (->> (:renders record) (map (comp first :render-key)) set))
+;; React commit to observe; the suite's `mk-render-stub` captures the
+;; hiccup `mount-shell-into!` hands to `rf.fresco/render!`. This test reads
+;; the frame scope out of THAT REAL TREE, and reads the app frame's epoch
+;; ring back through the REAL `rf/epoch-history`. Only the React commit is
+;; modelled; the frame seating, the dispatch, the ring and the epoch
+;; projection are the shipping code.
 
 (defn- ei-shell-scope
-  "Resolve, from the hiccup tree `mount-shell-into!` handed to the
-  substrate's `render`, the frame `shell-view`'s OWN render trace would
-  carry.
+  "Resolve, from the hiccup tree `mount-shell-into!` handed to
+  `rf.fresco/render!`, the frame the shell boundary renders under.
 
-  Models `re-frame.views.provider/current-frame` tier 2: descend the tree
-  tracking the scope each `rf/frame-provider` boundary establishes, and
-  report the scope in force at the `shell/shell-view` head. A nil scope is
-  the rf2-tqlmq fall-through — no enclosing provider, so the shell resolves
-  to whatever frame the HOST PAGE established, i.e. the inspected
-  application's.
+  Descends the tree tracking the scope each `rf.fresco/frame-provider`
+  establishes, and reports the scope in force at the `shell/ShellView`
+  head. A nil scope is the rf2-tqlmq fall-through — no enclosing provider.
+  Since the root swap that case is no longer a silent contamination but a
+  LOUD refusal (`ShellView`'s two ambient `rf.fresco/sub` reads have no
+  frame to resolve against), which is strictly better; the pin stays
+  because a loud failure at every user's first paint is still a failure.
 
   Returns `{:found? bool :scope frame-or-nil}`. `:found?` is the instrument
   control: a walker that matched nothing would otherwise report a clean nil
@@ -2802,11 +2843,11 @@
             (when (vector? node)
               (let [head (first node)]
                 (cond
-                  (identical? head rf/frame-provider)
+                  (identical? head rf.fresco/frame-provider)
                   (let [scope' (:frame (second node))]
                     (some #(walk % scope') (drop 2 node)))
 
-                  (identical? head shell/shell-view)
+                  (identical? head shell/ShellView)
                   {:found? true :scope scope}
 
                   :else
@@ -2814,12 +2855,11 @@
     (or (walk tree nil) {:found? false :scope nil})))
 
 (deftest xray-shell-render-never-lands-in-inspected-app-epoch
-  (testing "rf2-k97c.5 (defect rf2-tqlmq) — mount Xray against an
-            application frame, drive ONE application event, and the app
-            frame's epoch record must carry ZERO renders attributable to
-            Xray's own shell. The mount-site frame-provider wrap is what
-            makes the shell's render resolve to the trace-disabled
-            :rf/xray frame; the frame-no-emit gate then suppresses it."
+  (testing "rf2-k97c.5, re-aimed by rf2-k97c.3 — mount Xray against an
+            application frame and the shell must be scoped to its OWN
+            frame in the mount tree; then drive a real Xray chrome event
+            and the application frame's epoch history must be byte-identical
+            to what it was, in count AND contents."
     (with-stub-document
       (fn [_doc]
         (let [app :test/inspected-app
@@ -2833,7 +2873,7 @@
 
           ;; Mount Xray. `open!` runs `ensure-xray-frame!`, registering the
           ;; shell frame with `:rf.trace/frame-no-emit? true`.
-          (with-redefs [rf.substrate.adapter/render render-fn]
+          (with-redefs [rf.fresco/render! render-fn]
             (mount/open!))
 
           (is (= 1 (count @calls))
@@ -2845,53 +2885,73 @@
               "precondition: the INSPECTED app frame is NOT trace-disabled —
                its own renders are still recorded")
 
-          ;; ONE application event on the app frame, producing the epoch
-          ;; whose evidence must stay clean.
+          ;; ---- HALF ONE: the structural claim, re-keyed --------------
+          (let [{:keys [found? scope]} (ei-shell-scope (:tree (first @calls)))]
+            (is (true? found?)
+                "instrument control: the walker LOCATED the ShellView
+                 boundary in the mount tree — the assertion below means a
+                 real scope, not a walker that matched nothing")
+            (is (= shell/default-frame-id scope)
+                "the mount site wraps the shell boundary in the shell's own
+                 frame-provider, so its reads resolve to the Xray frame —
+                 NOT by fall-through to the inspected app (rf2-tqlmq)"))
+
+          ;; rf2-k97c.3 — and the tree is ROOTED at that provider rather
+          ;; than merely carrying one somewhere inside it. This is the row
+          ;; the root-swap plan named as missing: the provider is what gives
+          ;; `ShellView`'s two ambient reads their frame, so a tree that
+          ;; carried it one level too deep would leave the boundary itself
+          ;; outside its own scope.
+          (let [tree (:tree (first @calls))]
+            (is (identical? rf.fresco/frame-provider (first tree))
+                "the tree handed to `render!` is ROOTED at
+                 `rf.fresco/frame-provider`")
+            (is (= {:frame shell/default-frame-id} (second tree))
+                (str "and that provider NAMES `shell/default-frame-id` — the
+                      frame `ensure-xray-frame!` seated, by its Var and not
+                      by a `:rf/xray` literal. Got: "
+                     (pr-str (second tree))))
+            (is (identical? shell/ShellView (first (nth tree 2)))
+                "and the boundary sits directly inside it"))
+
+          ;; ---- HALF TWO: the EVENT axis, by real interaction ----------
+          ;; One application event first, so the ring under inspection is a
+          ;; real one with a record in it rather than an empty ring in which
+          ;; `unchanged` would be vacuous.
           (rf/dispatch-sync [:app/inc] {:frame app})
 
-          (let [epoch (last (rf/epoch-history app))]
-            (is (some? epoch)
+          (let [before (vec (rf/epoch-history app))]
+            (is (seq before)
                 "instrument control: the app frame recorded an epoch for its
-                 event — a later empty :renders means suppression, not an
-                 absent epoch")
-            (is (= :app/inc (:event-id epoch))
-                "the epoch under inspection is the application's own event")
+                 own event — `unchanged` below is a claim about a NON-EMPTY
+                 ring, not about an absent one")
+            (is (= :app/inc (:event-id (last before)))
+                "and the record under inspection is the application's own
+                 event")
 
-            (let [{:keys [found? scope]} (ei-shell-scope (:tree (first @calls)))
-                  ;; nil scope = the rf2-tqlmq fall-through: no enclosing
-                  ;; provider, so the shell renders in the host page's frame.
-                  shell-frame (or scope app)]
-              (is (true? found?)
-                  "instrument control: the walker LOCATED shell-view in the
-                   mount tree — the assertions below mean absence, not a
-                   walker that matched nothing")
-              (is (= shell/default-frame-id scope)
-                  "the mount site wraps shell-view in the shell's own
-                   frame-provider, so its render resolves to the
-                   trace-disabled Xray frame — NOT by fall-through to the
-                   inspected app (rf2-tqlmq)")
+            ;; THE ACT: a real Xray chrome interaction, through the shipped
+            ;; handler, into the shell's own frame — the same door a tab
+            ;; click takes. Nothing about this dispatch names the app.
+            (rf/dispatch-sync [:rf.xray/select-tab :trace]
+                              {:frame shell/default-frame-id})
 
-              ;; Replay the shell's own render at React-commit timing,
-              ;; through the real trace machinery, under the frame the real
-              ;; mount tree resolves to.
-              (ei-emit-render! shell-frame :shell-view)
+            (let [after (vec (rf/epoch-history app))]
+              (is (= (count before) (count after))
+                  (str "an Xray chrome interaction adds NO epoch record to "
+                       "the inspected app's ring. Was " (count before)
+                       ", now " (count after)))
+              (is (= before after)
+                  "and leaves every existing record byte-identical — the
+                   observer does not appear on the observed tape, in count
+                   OR in contents"))
 
-              (let [after (ei-epoch-by-id app epoch)]
-                (is (not (contains? (ei-rendered-view-ids after) :shell-view))
-                    "Xray's own shell-view render did NOT land in the
-                     inspected app frame's epoch :renders")
-                (is (empty? (ei-rendered-view-ids after))
-                    "ZERO renders attributable to Xray in the inspected app
-                     frame's epoch record — the observer does not appear on
-                     the observed tape"))
-
-              ;; POSITIVE CONTROL — the same emit path, tagged with the APP
-              ;; frame, DOES back-fill into this very epoch. Without this the
-              ;; zero above could be a dead instrument rather than the gate.
-              (ei-emit-render! app :app/counter-view)
-              (let [after (ei-epoch-by-id app epoch)]
-                (is (contains? (ei-rendered-view-ids after) :app/counter-view)
-                    "control: a genuine APP-frame render DOES back-fill into
-                     the same epoch — so the emptiness above is the
-                     frame-no-emit gate suppressing Xray, not a broken
-                     read")))))))))
+            ;; POSITIVE CONTROL — the ring is LIVE. Without this, `unchanged`
+            ;; above would also be satisfied by a ring that had stopped
+            ;; recording anything at all, which is a dead instrument rather
+            ;; than a clean one.
+            (rf/dispatch-sync [:app/inc] {:frame app})
+            (let [after-app (vec (rf/epoch-history app))]
+              (is (not= before after-app)
+                  "control: a genuine APPLICATION event DOES move the same
+                   ring — so the equality above is Xray being absent, not
+                   the instrument being deaf"))))))))

--- a/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_fresco_boundary_dom_cljs_test.cljs
@@ -14,16 +14,18 @@
   `static/shell_fresco_boundary_dom_cljs_test`, which asks the same two
   questions of the Static surface.
 
-  ## The mount is the PRODUCTION mount
+  ## The mount is the PRODUCTION mount, and since rf2-k97c.3 that means
+  ## XRAY'S OWN ROOT
 
-  `mount.cljs` renders `[rf/frame-provider {:frame …} [shell/shell-view
-  {…}]]` through the installed adapter's `:render`. `shell-view` is still
-  an `rf/reg-view` — severing that call is the parent epic's coupling (1)
-  and a later slice — and it reaches the Fresco tree through ONE private
-  `as-component` bridge. So mounting that same two-level form into a
-  Reagent root IS the shipped path, crossing included, and nothing here
-  reproduces it. [[mount-shell!]] records why the outer provider is not
-  decoration.
+  `mount.cljs` no longer calls the installed adapter's `:render` at all.
+  It owns a Fresco client root and renders `[rf.fresco/frame-provider
+  {:frame …} [shell/ShellView {…}]]` through it, which is the epic's
+  coupling (1) severed — and it is exactly the two-level form
+  [[mount-shell!]] builds below, so these rows drive the shipped path
+  rather than a reproduction of it. The private `as-component` bridge the
+  shell used to reach the Fresco tree through is gone: there is no longer
+  a crossing to bridge. [[mount-shell!]] records why the outer provider is
+  not decoration, and why the re-point is itself this PR's evidence.
 
   Nothing below ever calls a view a second time. Every assertion after
   the mount reads `container.querySelector…` — the DOM React committed
@@ -56,14 +58,16 @@
   reports the skip rather than passing silently."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
-            [reagent.dom.client :as rdc]
-            ["react-dom" :as react-dom]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
+            [reagent.dom.client :as rdc]
+            ["react-dom" :as react-dom]
+            [re-frame.fresco :as rf.fresco]
             [re-frame.fresco.impl.collector :as rf.fresco.impl.collector]
             [re-frame.fresco.test.runtime :as rf.fresco.test.runtime]
             [re-frame.test-support :as rf.test-support]
+            [day8.re-frame2-xray.panels :as panels]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.shell :as shell]
             [day8.re-frame2-xray.test-support :as xray-test-support]))
@@ -80,6 +84,17 @@
   "A second live frame W2 dispatches into as its DEAF LEVER — the
   negative control. A write here must move nothing in the shell above."
   ::other)
+
+(def ^:private embed-app-frame
+  "W5's INSPECTED APPLICATION frame — the one a Story host owns and paints
+  its own tree under. Its epoch ring is what must stay untouched."
+  ::embed-app)
+
+(def ^:private embed-xray-frame
+  "W5's embed frame — the `:frame` opt `panels/mount-shell!` forwards as
+  the shell's own `:frame-id`. Distinct from [[shell-frame]] so W5 cannot
+  ride a frame another row seated."
+  ::embed-xray)
 
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
@@ -160,42 +175,61 @@
   nil)
 
 (defn- mount-shell!
-  "Mount the shell the way `mount.cljs` mounts it — the OUTER
-  `frame-provider` included:
+  "Mount the shell the way `mount.cljs` mounts it SINCE THE ROOT SWAP —
+  through XRAY'S OWN Fresco root, with the OUTER `frame-provider`
+  included:
 
-      [rf/frame-provider {:frame …} [shell/shell-view {…}]]
+      (h/render! handle [h/frame-provider {:frame …} [shell/ShellView {…}]]
+                 container)
 
-  THAT WRAPPER IS LOAD-BEARING AND THIS ROW MEASURED IT. `shell-view` is
-  itself an `rf/reg-view`, and a `reg-view`'s frame-aware wrapper takes
-  its scope from React context; at a bare root there is none, so the
-  first frame-scoped call in its body refuses with
-  `:rf.error/no-frame-context` and NOTHING commits. `mount.cljs:396`
-  carries the provider for its own documented reason (rf2-uu3lp — so the
-  shell's render trace resolves to the trace-disabled `:rf/xray` frame
-  rather than leaking into the inspected app's epoch), and a suite that
-  drops it is not mounting what production mounts.
+  ## THIS RE-POINT IS THE PR'S EVIDENCE, NOT A PORT OF IT
+
+  It used to read `(rdc/create-root …)` and `(rdc/render root [rf/frame-
+  provider … [shell/shell-view …]])` — a REAGENT root rendering a
+  `reg-view`, which is what `mount.cljs` did by calling the installed
+  adapter's `:render`. Under the old door that call was the only one that
+  worked and this one could not: `shell/ShellView` did not exist, and a
+  boundary head is not a legal Reagent hiccup head. Under the new door it
+  is the other way round. So the same four rows below, unchanged in what
+  they assert, are RED against trunk and GREEN here — which is the epic's
+  coupling (1) being severed, measured rather than described.
+
+  THE WRAPPER IS STILL LOAD-BEARING, for a NEW reason with the OPPOSITE
+  failure mode. It used to be about a `reg-view`'s render trace; a Fresco
+  boundary emits none. What it does now is give `ShellView`'s two ambient
+  `rf.fresco/sub` reads their frame — drop it and the shell refuses with
+  `:rf.error/no-frame-context` and nothing commits. That is sabotage plant
+  1, and it is the direct control on the epic's coupling (2).
 
   The provider frame and the shell's `:frame-id` are the same value here,
   as they are in production.
 
-  Committed synchronously — React 19's `root.render` is otherwise async
-  and the first assertion would read an empty container."
+  NO `flushSync` OF OUR OWN: `h/render!` renders inside one already
+  (`impl/mount.cljs`'s `root!`), and nesting `flushSync` is a React
+  warning. The commit is synchronous either way, so the first assertion
+  reads a populated container."
   [frame]
   (let [container (.createElement js/document "div")
-        root      (rdc/create-root container)]
+        handle    (rf.fresco/client-root)]
     (.appendChild (.-body js/document) container)
-    (react-dom/flushSync
-      (fn []
-        (rdc/render root [rf/frame-provider {:frame frame}
-                          [shell/shell-view {:frame-id frame}]])))
-    {:container container :root root}))
+    (rf.fresco/render! handle
+                       [rf.fresco/frame-provider {:frame frame}
+                        [shell/ShellView {:frame-id frame}]]
+                       container)
+    {:container container :root handle}))
 
 (defn- teardown!
-  "Unmount inside `flushSync` so React's cleanup effects — which is where
-  the collector releases a boundary's reads — have RUN by the time the
-  next line reads anything. A bare `.unmount` schedules them."
+  "Release the root through Fresco's own door, so React's cleanup effects
+  — which is where the collector releases a boundary's reads — have RUN by
+  the time the next line reads anything.
+
+  `h/unmount!` unmounts inside `flushSync` itself, so no bare `.unmount`
+  and no wrapper of ours. And it is `unmount!` rather than `release!`
+  DELIBERATELY: `release!` ends with `reset-runtime!`, which empties the
+  collector's tables, so W4's residue assertions would read ZERO whatever
+  the teardown did and could never turn red."
   [root container]
-  (react-dom/flushSync (fn [] (.unmount root)))
+  (rf.fresco/unmount! root)
   (.remove container))
 
 ;; ---- the diagnostic ------------------------------------------------------
@@ -754,4 +788,164 @@
                        ;; hold a mounted root, and a live root leaks into the
                        ;; next namespace's baseline.
                        (unmount!)
+                       (done)))))))))
+
+;; ===========================================================================
+;; W5 — the EMBED door (`panels/mount-shell!`), and the C5 measurement the
+;;      root-swap plan owed
+;; ===========================================================================
+;;
+;; TWO QUESTIONS IN ONE ROW, because they share a mount.
+;;
+;; (1) THE EMBED DOOR STILL WORKS. `panels/mount-shell!` is the entry a Story
+;;     or a custom dev surface uses, and it mounts `[shell/shell-view {…}]`
+;;     from a REAGENT tree through the installed adapter's `:render`. After
+;;     the root swap `shell-view` is no longer a `reg-view` — it is the public
+;;     callable bridge, answering the React element `ShellView` lowers to via
+;;     `rf.fresco/as-element`. Nothing in the node lane can see whether that
+;;     crossing actually commits: `panels_mount_cljs_test` stubs the adapter
+;;     and captures the hiccup `[shell/shell-view {…}]` BEFORE the bridge is
+;;     ever called, so its rows stay green whatever the bridge returns. This
+;;     row calls it for real.
+;;
+;;     AND `as-element` RATHER THAN `as-component` IS WHAT THIS ROW GRADES.
+;;     Every opt is a KEYWORD, and a Reagent `[:>]` crossing converts
+;;     values — `:frame-id ::shell` would arrive as the STRING
+;;     "day8.re-frame2-xray.shell-fresco-boundary-dom-cljs-test/shell",
+;;     naming a frame that does not exist. The frame assertions below are
+;;     what separate a bridge that carried its opts from one that flattened
+;;     them.
+;;
+;; (2) C5'S OPEN QUESTION, ANSWERED BY MEASUREMENT. The root-swap plan raised
+;;     `mount-shell!`'s missing outer `frame-provider` as a POSSIBLE third
+;;     rf2-tqlmq instance and said so explicitly as a question rather than a
+;;     finding — "whether it leaks depends on what frame a Story or custom
+;;     host has in scope, which was not measured". This measures it, in the
+;;     configuration the question was about: an application that owns a live
+;;     frame, its own Reagent root painting under `[rf/frame-provider {:frame
+;;     app}]`, and the Xray embed mounted at a node INSIDE that root's DOM.
+;;
+;;     THE ANSWER TURNS ON A FACT ABOUT REACT RATHER THAN ABOUT XRAY, which
+;;     is why reading the source was never going to settle it: `mount-shell!`
+;;     goes through `rf.substrate.adapter/render`, which creates its OWN
+;;     React root at the node it is given, and REACT CONTEXT DOES NOT CROSS A
+;;     ROOT BOUNDARY. DOM nesting is not React nesting. So the host's
+;;     `frame-provider` is not in scope inside the embed however deeply the
+;;     node is nested, and there is no host frame to fall through TO — which
+;;     is what the plan's "depends what the host has in scope" was worried
+;;     about.
+;;
+;;     Since rf2-k97c.3 the point is doubly moot and in the better direction:
+;;     the bridge opens its OWN provider around `frame-id`, so the embed is
+;;     positively scoped rather than merely unexposed, and a Fresco boundary
+;;     emits no view-render trace for a ring to collect in the first place.
+;;     The row asserts the outcome — the app's epoch ring is untouched in
+;;     COUNT and CONTENTS across a real Xray interaction — so it keeps biting
+;;     whichever of those three reasons a future change removes.
+
+(defn- mount-embed!
+  "The Story-host shape: an application Reagent root painting under its own
+  `[rf/frame-provider {:frame app-frame}]`, with the Xray embed mounted
+  through `panels/mount-shell!` at a node INSIDE that root's DOM."
+  [app-frame xray-frame]
+  (let [app-container (.createElement js/document "div")
+        app-root      (rdc/create-root app-container)
+        embed-node    (.createElement js/document "div")]
+    (.appendChild (.-body js/document) app-container)
+    (react-dom/flushSync
+      (fn []
+        (rdc/render app-root
+                    [rf/frame-provider {:frame app-frame}
+                     [:div {:data-testid "host-app-surface"} "host app"]])))
+    ;; The embed node is a DOM child of the host's painted tree, which is
+    ;; exactly the nesting a Story cell has — and exactly the nesting that
+    ;; does NOT make it a React descendant.
+    (.appendChild app-container embed-node)
+    {:app-container app-container
+     :app-root      app-root
+     :embed-node    embed-node
+     ;; `mount-shell!` answers the adapter's own unmount fn; there is no
+     ;; `panels/unmount-shell!` facade.
+     :unmount       (panels/mount-shell! embed-node {:frame xray-frame
+                                                     :mode  :inline})}))
+
+(deftest w5-the-embed-door-mounts-and-never-touches-the-host-frames-ring
+  (testing "rf2-k97c.3 — `panels/mount-shell!` still paints the shell after
+            the root swap, carries its KEYWORD opts across the bridge
+            intact, and a real Xray chrome interaction leaves the inspected
+            application frame's epoch history unchanged in count AND
+            contents. The C5 measurement, taken rather than assumed."
+    (if-not (browser?)
+      (is true "skipped: no DOM (node lane)")
+      (async done
+        (setup!)
+        (rf/make-frame {:id embed-app-frame})
+        (rf/reg-event :w5/app-inc (fn [{:keys [db]} _]
+                                    {:db (update db :n (fnil inc 0))}))
+        ;; One real application event FIRST, so the ring under inspection is
+        ;; non-empty and `unchanged` below is a claim about real records.
+        (rf/dispatch-sync [:w5/app-inc] {:frame embed-app-frame})
+        (let [{:keys [app-container embed-node unmount]}
+              (mount-embed! embed-app-frame embed-xray-frame)
+              tab-testid (fn [] (some-> (detail-panel-node embed-node)
+                                        (.getAttribute "data-testid")))
+              !before    (atom nil)]
+          (-> (poll-until tab-testid)
+              (.then
+                (fn [_]
+                  (is (some? (testid embed-node "rf-xray-shell"))
+                      (str "the EMBED door commits the shell envelope — the "
+                           "`shell-view` bridge crossed into Xray's own "
+                           "Fresco tree from a Reagent parent"
+                           (uncaught-note)))
+                  (is (some? (testid embed-node "rf-xray-tab-bar"))
+                      "and the migrated L3 tab bar with it")
+                  ;; THE KEYWORD-CROSSING CLAIM. If the opts had gone through
+                  ;; a Reagent `[:>]` conversion, `:frame-id` would be a
+                  ;; string and this frame would hold nothing.
+                  (is (= :epoch (selected-tab-in embed-xray-frame))
+                      (str "the embed's own frame — named by the KEYWORD the "
+                           "bridge carried — holds the shell's state. Got: "
+                           (pr-str (selected-tab-in embed-xray-frame))))
+                  (reset! !before (vec (rf/epoch-history embed-app-frame)))
+                  (is (seq @!before)
+                      "instrument control: the host app's ring is NON-EMPTY,
+                       so `unchanged` below is a claim about real records")
+                  ;; THE ACT: a real click on the embedded chrome.
+                  (if (click! (tab-node embed-node clicked-tab)
+                              (str "the embedded L3 " (name clicked-tab)
+                                   " tab button"))
+                    (poll-until #(= (panel-testid-for clicked-tab) (tab-testid)))
+                    (js/Promise.resolve nil))))
+              (.then
+                (fn [_]
+                  (is (= (panel-testid-for clicked-tab) (tab-testid))
+                      (str "NON-VACUITY: the embedded chrome actually "
+                           "RESPONDED to the click, so the untouched ring "
+                           "below is about a live shell rather than a dead "
+                           "one. Got: " (pr-str (tab-testid))))
+                  (is (= clicked-tab (selected-tab-in embed-xray-frame))
+                      "and the write landed in the embed's OWN frame")
+                  (let [after (vec (rf/epoch-history embed-app-frame))]
+                    (is (= (count @!before) (count after))
+                        (str "C5 MEASURED: the embed adds NO epoch record to "
+                             "the host application's ring. Was "
+                             (count @!before) ", now " (count after)))
+                    (is (= @!before after)
+                        "and leaves every existing record byte-identical —
+                         the missing outer provider `mount-shell!` never had
+                         is not a leak, and cannot become one"))
+                  ;; The ring is LIVE, not merely quiet.
+                  (rf/dispatch-sync [:w5/app-inc] {:frame embed-app-frame})
+                  (is (not= @!before (vec (rf/epoch-history embed-app-frame)))
+                      "control: a genuine APPLICATION event DOES move the
+                       same ring — the equality above is Xray being absent,
+                       not the instrument being deaf")))
+              (.catch (fn [e]
+                        (is false (str "W5 never settled: " (.-message e)
+                                       (uncaught-note)))
+                        nil))
+              (.then (fn [_]
+                       (when unmount (unmount))
+                       (.remove app-container)
                        (done)))))))))


### PR DESCRIPTION
## The root swap (rf2-k97c.3)

Xray stops painting through the installed adapter's `:render` and paints through **its own Fresco client root**. That is the epic's coupling (1), severed; coupling (2) rides along, because the frame is now spelled in the tree.

`shell-view` was an `rf/reg-view`. It is now `ShellView`, a `rf.fresco/defview` boundary, with the public name `shell-view` kept as the callable bridge every Reagent caller already holds — so `panels.cljs`'s `mount-shell!` and `testbeds/panel_gallery` are untouched.

**Do not close rf2-k97c.3.** The denylist and `refuse-unsupported-substrate!` stay — retiring them is rf2-k97c.4, which unblocks the moment this merges.

## A premise in the plan that did not hold, and it is the headline

The ROOT-SWAP PLAN said `shell-view-tree` needed **one** edit. It needed **eleven**.

Slices B1–B6 retired every `rf/reg-view` under the modal and handle names — which is exactly what the step-0 precondition measures, and it passes — and replaced each with a plain-fn bridge answering `[:> …]`. A plain fn in head position inside a Fresco tree is `:rf.error/fresco-bad-head` (HD-016), which grades `:invalid` down the identical arm a `reg-view` head did. **A reg-view census cannot see that by construction**, so the precondition passing was never evidence that the heads were legal; only the head kind is.

The bridges **stay** — Reagent parents still head them from `panels.cljs`'s `render-panel!` and from each file's own shipped boundary witness suite, so collapsing them is a later cleanup, not this PR. `shell.cljs` stops *heading* them and *calls* them instead, which is this bead's own ruled call-site rule for a shared plain fn ("a migrating panel CALLS them — `(mini v 40)`") and precisely what Fresco's refusal message prescribes: *call it, or make it a view*. Sabotage plant 2 below reverts one of the eleven and takes the whole shell down, so this is measured rather than argued.

## The C5 measurement, which was owed either way

`mount-shell!`'s missing outer `frame-provider` **does not leak**, and the reason is about React rather than about Xray: the embed goes through `rf.substrate.adapter/render`, which creates its **own** React root, and **React context does not cross a root boundary**. DOM nesting is not React nesting, so a Story host's frame is never in scope inside the embed and there is no host frame to fall through to.

Measured in the configuration the question was about — a host app painting its own Reagent root under `[rf/frame-provider {:frame app}]`, the embed mounted at a node inside that root's DOM, then a **real click** on the embedded L3 tab bar — the host frame's epoch history is unchanged in **count and contents**, beside a control showing the same ring does move for a genuine application event. That is the new `w5-…` row. Since this PR the bridge also opens its own provider around `frame-id`, so the embed is positively scoped rather than merely unexposed.

## The witness re-point IS the evidence

`shell_fresco_boundary_dom_cljs_test`'s `mount-shell!` moves from `rdc/create-root` + a `reg-view` to `rf.fresco/client-root` + `render!` heading the boundary. Under the old door that call could not work (`shell/ShellView` did not exist, and a boundary is not a legal Reagent head); under the new one the previous call cannot. **The same four rows, unchanged in what they assert, are red on trunk and green here.** W5 is added.

The `rf2-k97c.5` pin is re-aimed, **both halves** (operator answer 3): the walker keys on `rf.fresco/frame-provider` and the boundary, keeping its `:found?` instrument control; and the render-emit half is **replaced by a real interaction**, because a Fresco boundary emits no view-render trace at all, so that half had come to assert about an emit nobody makes. The new missing row asserts the tree handed to `render!` is **rooted at** `rf.fresco/frame-provider` naming `shell/default-frame-id`. `shell-view-mode-of` stops indexing `[2 1]` into a tree whose shape this commit changes (C4's debt).

## Four sabotage plants — every green was made to bite

Each anchored to a single line with the **match count read before the run**, each restored with `git checkout HEAD --` and verified against the committed blob id. Namespace totals compared either side of every plant: the browser lane ran **1084 tests in every run**, control and all three plants, so nothing truncated silently.

| # | Plant | Result |
|---|---|---|
| 1 | Witness `mount-shell!`: drop the outer provider | **W1–W4 red** (23 assertions), 28 × `:rf.error/no-frame-context`; **W5 stays green**. The direct control on coupling (2) |
| 2 | `shell-view-tree`: one bridge back to a HEAD instead of a call | **All five rows red** (28 assertions) — the head/call finding, measured |
| 3 | `mount.cljs`: drop the outer provider | **Only** the re-aimed `.5` pin row red (3 failures, 1 error) |
| 4 | `shell-view` bridge: drop its provider | **W5 alone red** (5 assertions) — the exact mirror of plant 1 |

Plants 1 and 4 discriminate the two doors independently.

## Gates — every number read from that run's own captured exit file

Re-run on the final base after the rebase. Never piped, never a harness summary.

| Gate | Exit | Result |
|---|---|---|
| `compile-node-test.cjs node-test` | 0 | 1984 files, 0 warnings |
| `node out/node-test.js` | 0 | 11774 tests / 58806 assertions, 0 failures, 0 errors |
| `shadow-cljs compile browser-test` | 0 | 5 infer-warnings, all pre-existing in `implementation/fresco/test/` |
| `serve-and-run-browser-tests.cjs` | 0 | 1084 tests / 5853 assertions, 0 failures, 0 errors |
| `serve-and-run-xray-feature-gate.cjs` | 0 | 16 scenarios, 13 matrix rows, 0 failures |
| `tools/xray` `clojure -M:test` | 0 | 1280 tests / 6145 assertions, 0 failures |
| `clojure -M:splint --fail-on-errors` | 0 | 2646 files, style warnings only |
| every `scripts/check_*.py` | 0 | 46 of 46, 0 red |
| `check_doc_slugs.py` | 0 | the gate for the `008` edit, nominated **by path** |
| `api-manifest.gen --check` | 0 | in sync, 471 public vars — no hot-zone file moves |
| `api-manifest.api-md-check` / `.xray-spec-check` | 0 / 0 | projections in sync |

`cd tools/xray && clojure -M:test` is **not** nominated as the coverage gate for this change: it is a JVM run that cannot load a `.cljs` test and goes green having inspected nothing. `npm run test:cljs` is what covers it, because `shadow-cljs.edn`'s `:node-test` build lists `../tools/xray/src` and `../tools/xray/test`.

The docs gate for `tools/xray/spec/008-Embedding-Contract.md` is `check_doc_slugs.py` (its roots include `tools/*/spec`), **not** `mkdocs build --strict`: `mkdocs_hooks.py` stages `spec/` and `migration/`, and `tools/` is neither.

## Scope held

One sentence corrected in `008-Embedding-Contract.md` — the one that goes false on landing. The full prose sweep is rf2-k97c.7's and is not here. The denylist stays. rf2-k97c.3 is not closed.

## Follow-up worth a bead, not done here

The eleven `*-bridge` / `*-component` pairs in the satellite files can collapse once no Reagent parent heads them — their own comments name that condition. They cannot collapse yet: `panels.cljs`'s `render-panel!` and each file's shipped boundary witness suite still mount them from Reagent trees.
