### PR TITLE
docs(xray): the minimum host contract, the owned root, and the rejected substrate options (rf2-k97c.7, rf2-5rf5)

### DIFF
--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -395,6 +395,17 @@ scaffold wired for Xray promised a panel that could never open. The
 `:uix` variant shipped no Xray pieces at all and its README noted the
 devtools story honestly.
 
+> **The PREMISE of that amendment expired on 2026-09-12 (rf2-k97c).** Xray
+> now paints through a React root it owns rather than through the host
+> adapter's `:render`, and the refusal path was retired with the coupling it
+> guarded — so "the mount verbs refuse cleanly on the element-shaped React
+> substrates" is no longer true of any adapter. The paragraph above is kept
+> as the reasoning the 2026-07-22 ruling was actually made on; it is not a
+> statement about the tree today. Whether the `:uix` scaffold should now ship
+> Xray pieces is a separate product question, unasked and unruled — see the
+> revisit condition under §10's "The acknowledged loss, and the revisit
+> condition" below, whose substrate clause this discharges.
+
 **Alternatives considered (at the time).**
 
 | Option | What it is | Outcome |
@@ -483,9 +494,14 @@ it is recorded rather than hidden behind the word "minimal". Default-on
 Xray is reconsidered only on first-run evidence that auto-opening the
 panel materially improves onboarding, only once Xray has a stable
 published coordinate (`xray-v*`), and only if it can mount on every
-default substrate — today it cannot mount on UIx (rf2-p6f6u), and its
-Reagent-only preload is exactly the asymmetry that would force the
-manifest contract into exception clauses.
+default substrate. **That last clause is DISCHARGED as of 2026-09-12
+(rf2-k97c): Xray mounts on UIx.** It reads *"today it cannot mount on
+UIx (rf2-p6f6u), and its Reagent-only preload is exactly the asymmetry
+that would force the manifest contract into exception clauses"* until
+then; the root swap removed the asymmetry, so a revisit no longer has
+to argue past it. The other two conditions — onboarding evidence, a
+published coordinate — are untouched and still unmet, so the decision
+stands.
 
 ## Retired — clj-new-over-deps-new
 

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -322,14 +322,51 @@ just dispatched" follows the same post-settle-listener shape.
 
 ## State isolation (Option-C frame-provider)
 
-Xray's shell mounts **inside the host's React tree** so embedding is
-zero-config — drop a `mount-shell!` call into Story / your own layout
-and it renders. But Xray's *state* must never bleed into the host's
-app-db, its subs, or its dispatch queue. That isolation is achieved
-by an internal frame-provider wrapper; see
+Embedding is zero-config — drop a `mount-shell!` call into Story / your
+own layout and it renders. Xray's *state* must never bleed into the
+host's app-db, its subs, or its dispatch queue, and that isolation is
+achieved by an internal frame-provider wrapper; see
 [`011-Launch-Modes.md`](./011-Launch-Modes.md) for the in-app overlay
 context and [`007-UX-IA.md`](./007-UX-IA.md) for shell layout. The
 mechanism, locked under rf2-tijr (2026-05-12):
+
+### Three separate things, and reading them as one is the trap (rf2-5rf5)
+
+**This section opened with "Xray's shell mounts inside the host's React
+tree" and built the isolation story on it. That premise was false, and it
+was false BEFORE the root swap** — `render-panel!`'s `adapter/render` made
+its own React root as far back as rf2-tijr. The root swap did not falsify
+the sentence; it made an already-misleading sentence conspicuous. Read the
+correction as a correction of the embedding contract, not as behaviour
+rf2-k97c.3 introduced.
+
+Three things a reader is apt to collapse into one:
+
+| | What it means | Who decides |
+|---|---|---|
+| **DOM placement** | Where the shell's node sits in the host's document — inside the host's layout host, or in a second window. | The host, via the mount-point / layout host. |
+| **React-root ownership** | Which React root renders the shell's tree. **Never the host's.** `open!` / `open-overlay!` / `popout!` paint through a `re-frame.fresco` client root Xray owns; `panels/mount-shell!` and the per-panel `mount-<panel>!` facades call `rf.substrate.adapter/render`, which creates its OWN root at the supplied mount-point. | Xray, always. |
+| **Frame selection** | Which frame descendant reads and dispatches resolve to. | Xray, explicitly — see §Own frame vs target frame. |
+
+**DOM containment is not React containment.** React context does not cross
+a root boundary, so a host's `[rf/frame-provider …]` is NOT in scope inside
+the embed however deeply its node is nested — and there is no host frame for
+the shell to fall through to. That is a property of React rather than of
+Xray, which is why reading the mount code alone never settles it. It is
+measured, not argued: `shell_fresco_boundary_dom_cljs_test`'s row
+`w5-the-embed-door-mounts-and-never-touches-the-host-frames-ring` mounts the
+embed at a node inside a host Reagent root that is itself under
+`[rf/frame-provider {:frame app}]`, drives a real click on the embedded L3
+tab bar, and asserts the host frame's epoch history is unchanged in COUNT and
+in CONTENTS — beside a control showing the same ring does move for a genuine
+application event.
+
+So isolation does not rest on the frame-provider wrapper alone. The wrapper
+is what makes the shell's reads and dispatches land in a NAMED frame; the
+root boundary is what makes the host's frame unreachable in the first place.
+Both hold independently, and the corollary is the rule in
+§A tool-owned root must establish frame context deliberately: a root that
+inherits nothing must SAY what frame it is in.
 
 ### Frame-provider wraps the shell
 
@@ -496,7 +533,12 @@ contract.
 The convention is enforced by code review and by the registry
 namespace docstring (see `tools/xray/src/day8/re_frame2_xray/registry.cljs`).
 
-### Adapter resolution
+### Adapter resolution in the mount verbs
+
+**Scoped to the mount verbs, and the heading says so deliberately.** It read
+plain "Adapter resolution" until rf2-k97c.7, which invited it as a statement
+about adapter resolution in Xray generally — it is not. What an adapter must
+supply for Xray to work at all is §The minimum host contract below.
 
 Since rf2-k97c.3 Xray does **not** mount through the host adapter's
 `:render` at all — its shell is a `re-frame.fresco` boundary painted
@@ -545,6 +587,169 @@ spelling — the keyword was literally the `:kind` of that same map).
 These escape-hatch sites are bounded — roughly five
 of them across the codebase — and each lives next to the component
 that needs it, not in a central shim layer.
+
+## The owned root
+
+Xray owns the React root its shell paints into. That is the architecture,
+not an implementation detail of one mount verb, and it is what the rest of
+this section is about.
+
+`mount.cljs` holds two `re-frame.fresco` client-root handles as
+`defonce`s — one for the inline / overlay shell, one for the pop-out. Two
+and not one because `render!` binds its mount-point on the FIRST call
+through a handle and updates that same React root on every later one, so a
+single handle cannot serve two roots, and the pop-out's root lives in a
+different DOCUMENT. `render-shell!` is the one call site that knows Fresco's
+door is a `render!` / `unmount!` PAIR on a handle rather than the adapter
+contract's render-answers-an-unmount-fn; it closes over the handle and
+answers the unmount thunk, so `switch-surface!`, `close!` and `teardown!`
+keep the shape they have always had.
+
+What the ownership buys, in one sentence each:
+
+- **The host's render shape stops being Xray's business.** The mount verbs
+  read `current-adapter` to learn whether a host has booted at all and never
+  branch on its `:kind` — see §Adapter resolution in the mount verbs.
+- **Xray's own painting cannot be mistaken for the application's.** A
+  Fresco boundary emits no view-render trace, so the leak rf2-tqlmq fixed
+  (Xray's shell-render resolving to `:rf/default` and landing in the
+  inspected frame's epoch `:renders`) is now structurally absent rather than
+  guarded against.
+- **Isolation no longer rests on one wrapper.** Per §Three separate things,
+  the root boundary makes the host's frame unreachable and the frame-provider
+  names the frame the shell uses; neither substitutes for the other.
+
+### A tool-owned root must establish frame context deliberately
+
+**This is the rule most likely to be missed, because missing it does not show
+up in a first-paint smoke test.** A root that renders nothing of the host's
+inherits none of the host's React context — which is exactly the isolation
+above, read from the other side. So the tool must SAY what frame it is in.
+Nothing ambient will supply one, and nothing will notice that nothing did.
+
+Concretely: `mount.cljs` renders
+`[rf.fresco/frame-provider {:frame shell/default-frame-id} [ShellView …]]`
+and passes no `:frame-id`, so `ShellView`'s default IS that frame; the
+public `shell-view` callable wraps the same head in a provider naming the
+very `:frame-id` it forwards. Both doors honour the rule by construction and
+neither may drop it.
+
+Three traps sit around it, and each is recorded because the obvious
+alternative is worse:
+
+- **`frame-provider`, never `frame-root`.** `frame-root` is an idempotent
+  ENSURE that would REPLACE the frame, silently discarding the seating
+  `ensure-xray-frame!` has just done. Scope, not creation — the frame is
+  ensured above the provider.
+- **An explicitly-framed `rf/subscribe` is not an alternative, and it fails
+  SILENTLY.** `(rf/subscribe q {:frame frame-id})` is admitted inside a
+  boundary body and answers the right value, but contributes zero collector
+  edges — so the shell paints correctly on first render and then never
+  re-renders when its slot moves. Nothing errors. Dropping the provider
+  instead is LOUD (`:rf.error/no-frame-context`), which is why the provider
+  is the contract and the ambient read is the mechanism.
+- **Out-of-render dispatches capture the frame; they never name it.** Click
+  handlers, raw window listeners and async continuations resolve through a
+  captured frame-bound op (`rf/capture-frame`, or a render-time
+  `rf/current-frame-id` capture threaded as a `{:frame frame}` opt) — never a
+  `:rf/xray` literal and never a bare global `rf/dispatch`. See
+  §Parameterized shell frame-id; a guard rejects regressions and its
+  `pending-migration` allowlist is empty.
+
+`shell-view-mode-of` is an EXAMPLE OF THIS SHAPE rather than an outstanding
+debt: the root swap re-derived its positional `[2 1]` index into a walk for
+the `shell/ShellView` head, and the only surviving `[2 1]` under `tools/xray`
+is inside the docstring explaining what it used to be.
+
+## The minimum host contract
+
+**What a host adapter must supply for Xray to work on it.** Stated as a
+contract rather than as an extension framework: a future browser adapter
+that supplies the surface below should get Xray with no Xray-side work, and
+Xray commits to asking for nothing more.
+
+Xray asks for the **reactive-container half** of the
+[`spec/006-ReactiveSubstrate.md`](../../../spec/006-ReactiveSubstrate.md)
+§The adapter API contract — and nothing from the render-side half:
+
+| Required of the adapter | Why Xray needs it |
+|---|---|
+| `make-state-container` | Xray's shell frame holds its chrome state in one. |
+| `read-container` | Every read of the shell frame and of the inspected frame. |
+| `replace-container!` | Every `:rf.xray/*` write. |
+| `make-derived-value` | The projections every subscription is layered over. |
+| `dispose-adapter!` | Teardown, so `teardown!` leaves nothing stranded. |
+| A listener surface — `subscribe-container`, or the inline-invalidation fallback spec/006 defines for an adapter that omits it | Xray is a LIVE instrument: it must learn that the inspected frame moved. This is the half of the contract that cannot be faked by polling. |
+
+Plus the two public activation ops in `re-frame.interop`, which Xray reaches
+through the shipped Fresco collector rather than open-coding:
+`activate-derived-value!` and `add-on-dispose!`. **A watch alone is not
+enough on the ratom family** — a `Reaction` captures its sources only through
+deref-capture, so a plain deref taken outside a render leaves it watchable,
+watched, and notifying nobody. On the React-hook spine `activate-derived-value!`
+no-ops, those derived values being push from construction. One code path
+therefore serves both families, which is the whole reason the contract can be
+stated once.
+
+**What Xray does NOT require, and will not start requiring:**
+
+- **`:render`.** The mount verbs own their root. This is the coupling that
+  made Xray refuse element-shaped adapters, and it is severed.
+- **`:make-reaction`.** A ratom-family late-bind hook. Xray observes through
+  the two activation ops above, which are defined on both families.
+- **`:adapter/as-element`.** PREFERRED where it answers — `substrate.cljs`
+  reads the installed build's hiccup→element walk so a surviving `reg-view`
+  island is rendered by the same build whose in-flight component the frame
+  resolver consults — but it is published by the ratom family alone and is
+  ROUTED, so it answers `nil` under any other adapter. Fresco's codec passes
+  an already-built React element through untouched, which is the documented
+  fallback and a REAL path rather than a defensive flourish.
+- **Any view-side hook.** Nothing about how the host binds views to state
+  reaches Xray.
+
+**The evidence, and its bound.** `acceptance/uix_dom_cljs_test` runs the
+epic's six behavioural criteria with the **UIx** adapter installed as the
+inspected application's substrate — an element-shaped `:render` Xray cannot
+use, never called to paint anything — and
+`acceptance/substrate_gap_dom_cljs_test` drives the public `open!` verb on
+that same adapter. Six green rows on a host whose render shape is unusable is
+what "indifferent to the installed adapter" means in a form a row can witness.
+
+**ONE HONEST EXCEPTION, and it is a door rather than the contract.** The
+internal-but-stable per-panel surface — `panels/mount-shell!` and the
+`mount-<panel>!` facades enumerated in
+[`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract — still delegates
+to `rf.substrate.adapter/render` with a HICCUP tree, so a host reaching for
+*that* door needs a `:render` that accepts hiccup, i.e. the ratom family.
+The mount verbs (`open!`, `open-overlay!`, `popout!`, and the preload
+auto-open) do not, and they are the host-facing contract. A host on an
+element-shaped adapter uses the mount verbs.
+
+## Rejected substrate options (recorded so they are not re-proposed)
+
+The epic rf2-k97c weighed three alternatives to the owned root and did not
+take any of them. They are recorded here with their reasons because each is a
+natural thing to propose again.
+
+**(a) Make the spine's `:render` accept hiccup.** REJECTED — wrong layer. It
+solves a TOOL's problem inside the CORE, adds a hiccup converter to every
+application's dependency graph whether or not that application ever loads a
+tool, and weakens a deliberate app-author error: the core's `make-render`
+raises `:rf.error/hiccup-on-element-render-slot` precisely so an application
+author who hands hiccup to an element-shaped render slot is told so.
+
+**(b) Relax spec/006's single-adapter ruling** so Xray could install a second
+adapter for itself. REJECTED — unnecessary for either candidate design, and
+the cost is badly shaped: it would make container, subscription and disposal
+ownership a FRAMEWORK-WIDE problem in order to avoid a TOOL-LOCAL change.
+Multiple React roots in one page are ordinary and require no second adapter
+installation, which is what the owned root demonstrates.
+
+**(c) A separately booted debugger realm** — an iframe or second window plus a
+transport. NOT REJECTED, and the distinction matters: it is a real design with
+genuinely stronger isolation than this problem needs. It is kept as FUTURE
+WORK rather than refused, and the pop-out's own document is the nearest thing
+in the tree today.
 
 ## What this doesn't do
 

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -609,7 +609,8 @@ host installed MUST NOT affect the mount** — the shell paints through
 Xray's own React root, so an element-shaped substrate (UIx / Fresco)
 mounts exactly as a ratom-family one does, per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Adapter
-resolution.
+resolution in the mount verbs. What an adapter MUST supply for Xray to
+work at all is that page's §The minimum host contract.
 
 **This paragraph specified the opposite until rf2-k97c.4.** A React-element
 substrate — a host whose `:render` could not take the hiccup shell — MUST
@@ -654,12 +655,26 @@ user presses `Ctrl+Shift+C` mid-load, the handlers required by the
 shell render are already in the registry when the mount fires.
 
 Within the mount phase the order MUST be **find-layout-host →
-create-mount-node-in-host → substrate-render → mark-visible**. The
-substrate adapter's `:render` slot is the canonical mount path
-(per [`spec/006-ReactiveSubstrate.md`](../../../spec/006-ReactiveSubstrate.md)
-§Render contract) — Xray MUST NOT bypass the adapter and call
-React directly. The render call returns an unmount fn which the
-mount machinery MUST retain for `teardown!`.
+create-mount-node-in-host → render-through-Xray's-own-root →
+mark-visible**. The mount MUST paint through the `re-frame.fresco`
+client root Xray owns, per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §The owned
+root, and MUST NOT go through the host adapter's `:render` slot. The
+mount machinery MUST retain an unmount thunk for `teardown!`; Fresco's
+door is a `render!` / `unmount!` pair on a handle rather than the
+adapter contract's render-answers-an-unmount-fn, so exactly one call
+site closes over the handle and synthesises that thunk.
+
+**This paragraph specified the opposite until rf2-k97c.3.** It read *"The
+substrate adapter's `:render` slot is the canonical mount path — Xray MUST
+NOT bypass the adapter and call React directly"*, and the render call's
+own return value was the unmount fn. That was the epic's coupling (1): it
+is what made Xray's mountability depend on the host's render shape, and
+retiring it is what lets an element-shaped host (UIx, Fresco) run Xray at
+all. The adapter's `:render` remains the canonical mount path for
+APPLICATION code — spec/006 §Render contract is unchanged — and for Xray's
+internal-but-stable per-panel mount surface, which still delegates to it
+(008 §The minimum host contract records that exception).
 
 **Subsequent toggles.** Once mounted, the shell's container stays
 in the DOM for the rest of the page's lifetime. Close MUST be a
@@ -707,9 +722,11 @@ Xray is closed or absent.
 **Unmount semantics.** Production sessions never tear the shell
 down — the shell lives for the page's lifetime once mounted, and
 `Ctrl+Shift+C` close is a CSS hide, not an unmount. The
-`teardown!` operation is **test-only**: it MUST invoke the
-substrate adapter's unmount fn (returned by `:render` at mount
-time), MUST remove the mount-node from its layout host, and MUST
+`teardown!` operation is **test-only**: it MUST invoke the retained
+unmount thunk (the one `render-shell!` closes over Xray's own root
+handle to produce — it was the substrate adapter's unmount fn,
+returned by `:render`, until rf2-k97c.3), MUST remove the mount-node
+from its layout host, and MUST
 reset the mount-state singleton to `nil` so the next test starts
 from a clean slate. The unmount fn MUST be invoked inside a
 swallow-errors guard — substrate adapters MAY throw on a
@@ -721,7 +738,9 @@ singletons, not just the in-app shell:
 
 - `mount-state` — the in-app shell (above).
 - `popout-state` — the optional second-window shell. `teardown!`
-  MUST invoke the popout's substrate unmount, attempt to close the
+  MUST invoke the pop-out's own unmount thunk — the pop-out holds a
+  SECOND root handle, because its root lives in another document and
+  one handle cannot serve two roots — attempt to close the
   popout window (silently tolerating "already closed"), and reset
   the singleton to `nil`. A leaked `popout-state` would short-
   circuit the next `popout!` and return a stale state map whose


### PR DESCRIPTION
Closes rf2-k97c.7 and rf2-5rf5 — **I took both**, in one commit, because
rf2-5rf5's subject is `008-Embedding-Contract.md:325`, the same file .7's item 2
rewrites and its item 3 sweeps. Two workers editing that file in sequence is one
edit done twice.

Last child of the rf2-k97c epic (.3 #9708, .4 #9709, .6 #9711 merged today).
Docs only — no production change is requested or made.

## The four items

**1. The minimum host contract — NEW, and the substance of the bead.**
`008` gains a `## The minimum host contract` section stating what an adapter
must supply for Xray to work on it: spec/006's **reactive-container half**
(`make-state-container`, `read-container`, `replace-container!`,
`make-derived-value`, `dispose-adapter!`) plus a **listener surface**
(`subscribe-container`, or the inline-invalidation fallback spec/006 defines for
an adapter that omits it), plus the two public `re-frame.interop` activation ops
`activate-derived-value!` and `add-on-dispose!`. Explicitly **NOT** `:render`,
**NOT** `:make-reaction`, **NOT** `:adapter/as-element` (preferred where it
answers, with Fresco's element pass-through as the documented fallback), **NOT**
any view-side hook. Written as a contract, not an extension framework.

**One honest exception is recorded rather than smoothed over**, and finding it
is why the section is not shorter: `panels/mount-shell!` and the per-panel
`mount-<panel>!` facades still delegate to `rf.substrate.adapter/render` with a
HICCUP tree (`render-panel!` builds `[rf/frame-provider … [panel-view …]]`), so
that door is still ratom-family. The host-facing mount verbs are not, and they
are what the contract is about. Stating the contract flat would have overreached.

**2. The owned root — was PART-DONE; this is the positive half.** #9709 had
already corrected the refusal paragraphs. Added: `## The owned root` (two
`defonce` Fresco client-root handles, why two — `render!` binds its mount-point
on first call and the pop-out's root is in another document — and what the
ownership buys), and `### A tool-owned root must establish frame context
deliberately`, which is the epic's coupling (2) and the thing a later reader is
most likely to miss because it does not show up in a first-paint smoke test. Its
three traps are recorded with the reason each obvious alternative is worse
(`frame-provider` not `frame-root`; the explicitly-framed `rf/subscribe` that
paints once and then silently never re-renders; capture-not-name for
out-of-render dispatches). `shell-view-mode-of` is written up as an **example of
the new shape**, not an outstanding debt.

**3. The prose sweep — re-derived at my tip; DELTA below, no count taken from
the bead.**

**4. The rejected options — NEW.** `## Rejected substrate options`, all three
with reasons: (a) hiccup-accepting `:render` (wrong layer), (b) relaxing
spec/006's single-adapter ruling (framework-wide cost to avoid a tool-local
change), (c) a separately booted debugger realm — recorded as **kept as future
work rather than refused**, which is the distinction the bead asked for.

## rf2-5rf5

`008`'s §State isolation opened *"Xray's shell mounts **inside the host's React
tree** so embedding is zero-config"* and built the isolation story on it.
Replaced with a three-way split — **DOM placement / React-root ownership / frame
selection** — and the measured reason: React context does not cross a root
boundary, so a host's `frame-provider` is not in scope inside the embed however
deeply its node is nested. Cited to the row that measures it
(`shell_fresco_boundary_dom_cljs_test`'s
`w5-the-embed-door-mounts-and-never-touches-the-host-frames-ring`).

**The nuance the bead insisted on survives, and is stated in bold on the page:
the mismatch PREDATES the root swap.** `render-panel!`'s `adapter/render` made
its own root as far back as rf2-tijr, so this is written as a correction of the
embedding contract, not as behaviour rf2-k97c.3 introduced. Own-frame versus
target-frame semantics are untouched.

## Item 3 — the sweep, as a delta

Re-derived at my tip with a **three-pass** census (line-oriented, whitespace-
collapsed, comment-markers-stripped-then-collapsed) over 4328 tracked files,
because these spec pages are hard-wrapped and the line-oriented pass alone
misses wrapped phrases — it missed 011's own `§Adapter resolution` citation,
which only the flattened pass found. Positive control on every pattern; no
pattern returned a bare zero. `grep -iF` was not used (it aborts on this box,
exit 134, silent on stdout).

**Corrected (3 files):**

- `011-Launch-Modes.md` — **the sweep's most serious find, and nobody had
  flagged it.** The mount-phase paragraph was still NORMATIVE in the retired
  direction: *"The substrate adapter's `:render` slot is the canonical mount
  path — Xray MUST NOT bypass the adapter and call React directly."* That is
  precisely what the ruled design does. Corrected, with the superseded text kept
  on the page in this file's own house style (the same shape #9709 used for the
  preload paragraph). `teardown!`'s "substrate adapter's unmount fn" and the
  pop-out's unmount are corrected with it.
- `008` — §State isolation (above) and the heading rename (below).
- `tools/template/spec/DESIGN-RATIONALE.md` — §10's revisit condition read
  *"only if it can mount on every default substrate — today it cannot mount on
  UIx"*. That is item 3's literal subject, live and present-tense; the clause is
  marked discharged and the other two conditions left untouched, so the decision
  stands. §9's amendment rests on the same expired premise and is annotated as
  dated reasoning rather than rewritten.

**Deliberately NOT corrected, with reasons:**

- `spec/Spec-Schemas.md` — **already correct.** Past tense, and it names
  rf2-k97c.4 as having retired the set. No edit. (It is also a hot-zone file.)
- `docs/design/fresco/reactive-substrate-adapter-costing.md` and
  `docs/design/retirement/freehand-and-ui.md` /
  `docs/design/retirement/donor-surfaces.md` — dated design records. The costing
  page carries an **explicit editorial policy against folding corrections back
  into its prose** ("a prediction is only worth keeping if what happened next is
  beside it"); the retirement pages are dated censuses ("re-taken at
  `85a70687e4` on 2026-08-15"). Editing them would falsify a record rather than
  fix a claim.
- `skills/` — swept, nothing stale found. The one hit
  (`re-frame2-pair/references/screen-reads.md`) is about
  `:evidence-tier-unavailable`, an unrelated surface.

## The two routed findings

**`008`'s "Adapter resolution" heading read wider than its content — RENAMED**
to `### Adapter resolution in the mount verbs`, with a sentence saying the scope
is deliberate and pointing at §The minimum host contract for the general
question. **I checked citations before renaming, as the bead asked.** The
heading has exactly **one** citation in the tree — 011's, in prose, wrapped
across a line break — and **no `#adapter-resolution` anchor link anywhere**, so
the docs gate had nothing to catch. That one prose citation is updated.
(Control: a real heading citation, "Mountable panel contract", reads 9 files, so
the instrument was live.)

**`tools/story/deps.edn`'s exclusion rationale — MY JUDGEMENT: it wants its own
bead, and I did not touch it.** Filed as **rf2-zaat**, cross-referenced from
rf2-k97c.7's close reason. Three reasons, and the first is the one that decides
it:

1. **Its CONCLUSION is unaffected.** The load-bearing sentence — "THE
   `:exclusions` IS LOAD-BEARING — do not drop it" — and the whole jar-collision
   argument behind it are about PUBLICATION and classpath, which the root swap
   does not touch. Only one supporting sentence ("Xray renders through
   `re-frame.substrate.adapter` and the adapter the HOST installs governs the
   runtime path") went imprecise. Nothing is currently misleading anyone into a
   wrong action, so it is genuinely "half-stale" as the routing note said.
2. **Writing the replacement sentence needs a determination I should not make
   unilaterally** — whether Story's embed door, which still goes through
   `adapter/render`, stays there or follows the mount verbs onto the owned root.
   That is an architecture question, not a prose fix.
3. `deps.edn` is a dependency manifest; editing another tool's would widen this
   docs PR's gate surface, which the fence explicitly forbids.

I also found `tools/xray/src/day8/re_frame2_xray/shell.cljs`'s closing
"## Pure hiccup" docstring paragraph still says *"The substrate adapter's render
fn (`rf/render`) handles the substrate-specific mount in `mount.cljs`"* — which
the same docstring contradicts 60 lines above. Same class, same reason for not
taking it here (it is `src`, and would arm the CLJS gates on a docs PR); it is
on rf2-zaat too.

## Quality gates

Both nominated gates **proven live by a planted fault on a line I had edited**,
then restored and verified by blob hash against the committed object — the point
being that the gates print nothing on success, so a bare exit 0 discriminates
nothing.

| Gate | Clean | Sabotage | Restore verified |
|---|---|---|---|
| `scripts/check_doc_slugs.py` (roots include `tools/*/spec`; nominated BY PATH) | captured exit **0** | captured exit **1**, naming `008-Embedding-Contract.md:672` | blob `5e307f8866707f0545100693464d42af3317d1eb`, default form, matches `HEAD:` exactly |
| `scripts/check_retired_spellings.py` rule (f), the arm that does read `.md` | captured exit **0** | captured exit **1**, naming `008-Embedding-Contract.md:730` | same blob, re-verified |

A first sabotage attempt on `check_retired_spellings.py` using a retired
COEFFECT key came back **green**, and that is reported rather than buried: the
gate never opens `.md` for that rule. Rule (f) — the product-name rule, which
scans all suffixes — is the arm that grades my paths, and it is the one shown
red above. A green sabotage run was treated as a reason to stop and find out
why, not to proceed.

**30 further ratchets run, all captured exit 0** (`check_flattened_lists`,
`check_skill_xray_tab_inventory_drift`, `check-no-hardcoded-paths`,
`check-ai-tracking-ratchet`, `check_readme_links.py --ci`, and the rest of the
candidate set derived by grepping for scripts that read `tools/*/spec` or
markdown). No floor was moved.

**`mkdocs build --strict` is NOT the gate here and was not run**: `docs_dir` is
`docs`, and `mkdocs_hooks.py` stages `spec/` and `migration/` into it but **not
`tools/`**. Nominating it would have returned a green that inspected nothing.

**Fence caveat, checked by hand as required.** Neither link gate looks inside a
fenced code block. Measured on my own added lines: **8 link-or-heading lines
added to `008`, 1 to `011`, 0 to the template page — and ZERO of them inside a
fence**, so the caveat does not bite this diff. Table column counts verified by
hand: the three-things table is 3/3/3/3/3, the host-contract table 2/2/2/2/2/2/2.

**No CLJS touched**, so `npm run test:cljs` is not applicable. The classifier
arms `cljs_node_test` and `tools_jvm` off `tools/xray/spec/**`, and
`adapter_diagnostic` and `template_expensive` off `tools/template/spec/**`;
those are conservative over-arming on a markdown-only diff and I am **relying on
CI** for them. (I first ran the classifier with REVISIONS where it wants PATHS
and got every surface `false` — the exact fail-open this project catalogues.
Re-run with paths, against a control that arms far more.)

**Merge-base check.** `git diff origin/main...HEAD` read for accidental reverts:
20 deleted lines, every one the stale text corrected above. `origin/main` moved
during the work but only by three `.beads` checkpoint commits touching no file
of mine, so no rebase was needed and the gate results stand on the final base.

## Hot zone

`spec/API.md` and the two `api-manifest*.edn` sidecars are **untouched** —
verified, not assumed: this diff is three markdown files under `tools/*/spec`.
No public name changed.

Per CLAUDE.md Git Conventions I have declined the AI-attribution trailers on
both the commit and this body, notwithstanding the harness reminder that asks
for them; CLAUDE.md outranks it.
