### PR TITLE
docs(xray): correct the stale render-coupling sentence in shell.cljs's ns docstring (rf2-zaat, site 2)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -150,9 +150,11 @@
 
   ## Pure hiccup
 
-  Per rf2-tijr the view code is pure hiccup. The substrate adapter's
-  render fn (`rf/render`) handles the substrate-specific mount in
-  `mount.cljs`. No per-substrate switches in view code."
+  Per rf2-tijr the view code is pure hiccup. What RENDERS that hiccup
+  changed at the root swap: `mount.cljs` paints it through the
+  `re-frame.fresco` client root Xray owns (`rf.fresco/render!`), not
+  through the installed substrate adapter's `:render` — see the
+  rf2-k97c.3 section above. No per-substrate switches in view code."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.fresco :as rf.fresco]


### PR DESCRIPTION
## What

rf2-zaat **SITE 2 ONLY**. One paragraph of `tools/xray/src/day8/re_frame2_xray/shell.cljs`'s
namespace docstring. Comment-only; no code changed. Diff is 3 lines out, 5 in.

The docstring contradicted itself. Its closing `## Pure hiccup` paragraph said:

> The substrate adapter's render fn (`rf/render`) handles the substrate-specific mount in `mount.cljs`.

while sixty lines above, under `## rf2-k97c.3 — the Dynamic chrome is a FRESCO TREE`, the same
docstring says the shell "no longer paints through the installed adapter's `:render` at all —
`mount.cljs` owns a Fresco root". The reader who reaches the stale half last is the one misled,
which is why this is an edit rather than a note.

## Why the second half is the current one — verified at source, not taken on trust

rf2-k97c.3 (PR #9708) severed that coupling. Over `mount.cljs` at this branch's base:

- `adapter/render` **0** hits, `rf.substrate.adapter/render` **0**, `rf/render` **0**.
- Controls on the same census over the same file, so a zero means absence rather than a broken
  instrument: `current-adapter` **7** hits, `(rf.fresco/render!` **1**.
- The live path is `render-shell!`, which calls `rf.fresco/render!` on a `rf.fresco/client-root`
  handle Xray owns, painting `[rf.fresco/frame-provider {:frame …} [shell/ShellView …]]`.

## What was preserved

The rf2-tijr point the paragraph also makes is kept intact — the view code **is** pure hiccup, and
there are still no per-substrate switches in view code. Both of those sentences survive verbatim.
Only the claim about *who renders it* changed. The docstring was not rewritten at large.

## What is NOT in this PR

Site 1 (`tools/story/deps.edn`'s `:exclusions` rationale) is untouched — `tools/story/` was not
opened — so **rf2-zaat stays open**. Writing its replacement sentence needs a determination nobody
has made: whether Story's embed door stays on `adapter/render` or follows the mount verbs onto the
owned root. That is the open question on rf2-l1jm, now a blocking edge on rf2-zaat. The
`:exclusions` itself is about publication and classpath — two jars both carrying
`re_frame/adapter/reagent.cljs` with nothing but classpath order deciding which adapter an app gets
— and the root swap does not touch any of it.

## Quality gates

| Gate | Captured exit | Result |
| --- | --- | --- |
| `npm run test:cljs`, phase 1 — `compile-node-test.cjs node-test` | `0` | 1985 files, 1984 compiled, 0 warnings |
| `npm run test:cljs`, phase 2 — `node out/node-test.js` | `0` | 11785 tests, 58866 assertions, 0 failures, 0 errors |
| `python scripts/check_retired_spellings.py` | `0` | the one ratchet whose scan surface covers this path |

The compound gate was **split into its two phases** and the second gated on the first's captured
exit, so a failed compile could not have been papered over by a stale artefact — and there was no
prior `implementation/out/node-test.js` in the tree at all, so the run phase could only have
executed this compile's output.

**Which tree the gates read.** The compile printed its config path and that line named this
worker's own worktree. The ratchet prints no root, so it was proved to read *this file* by planting
its retired product name in the very paragraph being edited: the gate went **red at exit 1 naming
that file and line**, then green again after restore. Restore confirmed by blob hash against the
committed object — the default `git hash-object` form matched, which is the correct form here since
`git ls-files --eol` reads `i/lf w/crlf` — corroborated by a clean `git diff --quiet HEAD`.

**No planted fault was manufactured for the CLJS gate**, and the honest reason is that a docstring
edit is invisible to it beyond compilation. What that gate genuinely discriminates here is that the
docstring is still a well-formed string literal and the namespace still compiles and loads, which
the 1984-file compile establishes.

`cd tools/xray && clojure -M:test` was deliberately **not** run: it is a JVM run that cannot load a
`.cljs` test and would have gone green having inspected nothing.

**Relied on CI** for the remaining armed surfaces. The changed-surface classifier reports
`cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and
`story_xray_browser` for this path; only the first was run locally.

Other retired-vocabulary and alias ratchets were run and are green, but their scan surfaces are
markdown, `tools/*/spec` and `:require` forms, so their green says nothing about this diff and is
not claimed as evidence.

The worker worktree guard ran and exited 0 before editing, and the merge base was re-checked after
the work: the only trunk movement since this branch left main is a beads checkpoint touching
`.beads/issues.jsonl` alone, so the gate results still describe the merged tree.
