### PR TITLE
docs(story): narrow the Xray render claim in deps.edn to today's split (rf2-52rj)

### DIFF
--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -86,11 +86,23 @@
          ;; THE STATED REPLACEMENT (this is a re-point, not a silent drop):
          ;; Story supplies the substrate adapter for its embedded Xray
          ;; itself, through the `day8/re-frame2-reagent` coordinate on line
-         ;; 16. Xray renders through `re-frame.substrate.adapter` and the
-         ;; adapter the HOST installs governs the runtime path, so Xray is
-         ;; fully served by Story's stock-Reagent adapter; Xray's src
-         ;; requires neither `reagent2.*` nor the adapter ns. Xray's own
-         ;; deps.edn is deliberately UNTOUCHED, so a standalone
+         ;; 16. Xray's rendering is SPLIT today, so the claim is scoped to
+         ;; the half that runs on the host's adapter:
+         ;;   • THE EMBEDDED PANEL DOOR — `panels/render-panel!` and
+         ;;     `panels/mount-shell!`, the chokepoint behind every
+         ;;     `mount-<panel>!` facade the RHS inspector reaches — still
+         ;;     delegates to `rf.substrate.adapter/render` with a hiccup
+         ;;     tree, so the adapter the HOST installs does govern that
+         ;;     path and Story's stock-Reagent adapter does serve it.
+         ;;   • XRAY'S OWN MOUNT VERBS — `mount/open!`,
+         ;;     `mount/open-overlay!` and `mount/popout!`, the last being
+         ;;     Story's popout escape hatch — paint through
+         ;;     `re-frame.fresco` client roots Xray owns and do not consult
+         ;;     the host adapter at all (rf2-k97c.3 severed that coupling).
+         ;; Neither half disturbs the ground this exclusion stands on,
+         ;; which is PUBLICATION and classpath rather than render path:
+         ;; Xray's src requires neither `reagent2.*` nor the adapter ns.
+         ;; Xray's own deps.edn is deliberately UNTOUCHED, so a standalone
          ;; `day8/re-frame2-xray` consumer still gets reagent-slim by
          ;; default — this narrows Story's edge only.
          day8/re-frame2-xray     {:local/root "../xray"


### PR DESCRIPTION
Closes rf2-52rj. One commit, one file, comments only.

## What was wrong

`tools/story/deps.edn`, in the `day8/re-frame2-xray` `:exclusions` rationale under
"THE STATED REPLACEMENT (this is a re-point, not a silent drop)", claimed without
qualification:

> Xray renders through `re-frame.substrate.adapter` and the adapter the HOST installs
> governs the runtime path, so Xray is fully served by Story's stock-Reagent adapter

Half-stale since rf2-k97c.3. The half that is still true is the half Story's inspector
reaches; the mount verbs went onto Fresco roots Xray owns.

## What it says now

The sentence is replaced by the split it describes:

* **the embedded panel door** — `panels/render-panel!` and `panels/mount-shell!`, the
  chokepoint behind every `mount-<panel>!` facade — still delegates to
  `rf.substrate.adapter/render` with a hiccup tree, so the host's installed adapter does
  govern that path and Story's stock Reagent does serve it;
* **Xray's own mount verbs** — `mount/open!`, `mount/open-overlay!` and `mount/popout!`
  (the last being Story's popout escape hatch) — paint through `re-frame.fresco` client
  roots Xray owns and do not consult the host adapter at all.

## Premise verified at source, not taken from the bead

| file | `adapter/render` sites |
| --- | --- |
| `tools/xray/src/day8/re_frame2_xray/mount.cljs` | 0 |
| `tools/xray/src/day8/re_frame2_xray/panels.cljs` | 2 |

The zero carries a live positive control on the same census over the same file
(`fresco` reads 9 in `mount.cljs`), so it means absence rather than a broken instrument.
Code was separated from comment before counting: `panels.cljs` has six textual hits and
only two are executable — `render-panel!` spans 246-341 and holds the call at 328,
`mount-shell!` starts at 793 and holds the call at 855; the other four are
docstring/comment prose. On the other side, `mount.cljs` owns two `rf.fresco/client-root`
handles (367, 371) and `render-shell!` (373) paints via `rf.fresco/render!` (382);
`open!` (1010), `open-overlay!` (1045) and `popout!` (1641) all reach it.

The surviving clause "Xray's src requires neither `reagent2.*` nor the adapter ns" was
re-checked too: all six hits of `reagent2|re-frame.adapter.reagent|reagent-slim` under
`tools/xray/src` sit in comments, none in a `:require`.

## What deliberately did not change

The `:exclusions` value, the publication/classpath argument above it, the
"THE :exclusions IS LOAD-BEARING — do not drop it (rf2-qvyr)" line, the preceding
embedded-Xray context and the dependency conclusion. The exclusion's ground is
publication and classpath, not render path, and the split does not touch it.

Proved rather than asserted: the parsed EDN data before and after the edit compares
equal (`clojure.edn/read-string` on both, `=` is `true`, no differing top-level keys),
so no coordinate, exclusion or alias moved. The diff is 17 insertions / 5 deletions,
all of them `;;` comment lines.

`tools/xray/` was not opened for edit. This states today's behaviour and settles nothing
about tomorrow's — rf2-l1jm's question, whether the embed door follows the mount verbs
onto an owned root, is untouched.

## Quality gates

`.github/scripts/report-changed-surfaces.sh`, handed the changed PATH (it fails open and
reports every surface false when handed revisions), arms `tools_jvm`, `examples_compile`
and `mcp_conformance`.

| gate | captured exit | evidence it read this change |
| --- | --- | --- |
| `jvm-tools-story` (`clojure -M:test` from `tools/story`) | **0** — 1914 tests, 7047 assertions, 0 failures, 0 errors | run from the worker worktree's `tools/story` (`pwd` printed on the same command line), so it resolved this deps.edn |
| `scripts/check_retired_spellings.py` | **0** | planted fault went **red at exit 1** naming `tools/story/deps.edn` at the line being edited; restore verified by blob hash |
| `scripts/check_jvm_lane_rosters.py` | **0** | reads `deps.edn` presence and aliases |
| `scripts/check-no-hardcoded-paths.sh` | **0** | whole-tree |
| `scripts/check_readme_inventories.py` | **0** | whole-tree |

Every exit code above is the runner's own, captured with the redirect and the `echo` on
one command line in one shell — not a number reported about the run.

**One gate's green is deliberately not claimed as evidence.**
`scripts/check_retired_image_keys.py` does cover this path — `tools/` is in its
`DEFAULT_SOURCE_DIRS` and `.edn` is in its `_CLJ_SUFFIXES` — but it grades a
Clojure-family file through `_clj_code_lines`, i.e. code only. A retired key planted in
the very comment being edited left it **green at exit 0**, so a comment-only change is
structurally invisible to it. It is green; that green says nothing about this diff.

**Honest limit.** No gate in this repository grades this file's PROSE. The change is
comments only, so what CI can discriminate is that the file still parses and resolves and
that Story's JVM suite is unaffected — which `jvm-tools-story` establishes, and which the
EDN-data comparison above strengthens to "no data changed at all". The prose claims were
checked by reading `mount.cljs` and `panels.cljs` at source, as tabulated above.

`examples_compile` and `mcp_conformance` were not run locally — both are heavy sweeps
that a comment-only deps change cannot affect beyond parsing. Relying on CI for those.

Branch base is `f882486af0`; `origin/main` has since advanced by one beads checkpoint
commit only, so the three-dot diff `origin/main...HEAD` introduces this one file and
reverts nothing.
