### PR TITLE
docs(xray): stop open!'s docstring contradicting itself on who renders (rf2-i0cj)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -1011,8 +1011,8 @@
   "Mount + show the default Xray shell in the app-provided true-inline
   layout host. On first call: register the `:rf/xray` frame, find the
   configured host (`[data-rf-xray-host]` by default), create
-  `#rf-xray-root` inside it, render the shell via the installed
-  substrate adapter, mark visible. On subsequent calls when already
+  `#rf-xray-root` inside it, render the shell through Xray's own
+  React root, mark visible. On subsequent calls when already
   mounted inline: make the container visible (a CSS-only show — the
   <80ms toggle target). When already mounted as the OVERLAY surface:
   realize the requested inline surface — re-parent the shell into the


### PR DESCRIPTION
## What

One docstring clause in `tools/xray/src/day8/re_frame2_xray/mount.cljs`. One file, +2/-2.

`open!`'s docstring said two different things about the same act, eleven lines apart:

* the **STEP LIST** claimed first call would "render the shell via the installed **substrate adapter**";
* the **same docstring's** later paragraph said "WHICH adapter is installed no longer matters (rf2-k97c.4): the shell paints through Xray's own React root, so an element-shaped host (UIx / Fresco) mounts exactly as a ratom-family one does."

So this was not a stale docstring beside two correct siblings — it was one docstring contradicting itself, already citing the bead that settles the question. The later paragraph is the authority, is correct, and is untouched. Only the step-list clause changed.

## The strongest argument for fixing rather than leaving

`open-overlay!` reads "Indifferent to the installed adapter's render shape, **same as `open!`** (rf2-k97c.4)". While `open!` read wrongly, the *correct* sibling inherited the wrong sentence by pointing at it. `popout!` was already right on both halves and served as the worked example.

## Presence is not identity — both halves kept

The obvious over-correction here is a clause reading "the adapter is irrelevant", which would replace one false sentence with another in the file being fixed for false sentences.

`open!`'s body still reads `(when (rf.substrate.adapter/current-adapter) ...)`, so the neighbouring sentence **"If the substrate adapter is absent, returns nil so preload retry can wait" is TRUE and is untouched**. The adapter's PRESENCE still gates the mount; only its IDENTITY stopped selecting the render path. The file already frames it exactly this way in its ns docstring and at the `current-adapter` comment — a PRESENCE check, never `:kind` — so the replacement clause agrees with the file rather than inventing a framing.

## Verified at source, not taken from the bead

* `mount.cljs` carries **ZERO** `adapter/render` call sites (exit 1), against a live positive control on the **same file** (`fresco` reads **9**), so the zero means absence and not a broken instrument.
* The chain: `open!` → `mount-shell-into!` → `render-shell!`, which paints via `rf.fresco/render!` on `xray-root`, a `rf.fresco/client-root` handle Xray owns. `render-shell!`'s own docstring describes the Fresco `render!`/`unmount!` pair.
* `panels.cljs` still holds the **two executable** `adapter/render` sites (of six textual hits — the other four are docstring/comment prose). That file is not this subject.

Line numbers in the bead were re-derived at this branch's base rather than trusted; the step-list clause was at 1014-1015 and the authority paragraph at 1027-1032.

## Deliberately NOT done

No forward pointer to rf2-l1jm's open embed-door question is added. That question is about `panels.cljs`; the mount verbs moved under rf2-k97c.3 and are settled. An open question embedded in a docstring is the next thing to go stale.

The file was not swept for other prose. One clause.

## Quality gates

Reported in a follow-up comment once the run settles; CI is the authority for the armed surfaces.

Armed surfaces, from `.github/scripts/report-changed-surfaces.sh` given the PATH (not assumed): `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`, `story_xray_browser`.

`npm run test:cljs` is the gate that covers a `tools/xray` CLJS change: `implementation/shadow-cljs.edn` lists `"../tools/xray/src"` on the `:node-test` build (verified at source, line 313). `cd tools/xray && clojure -M:test` is deliberately **not** nominated — it is a JVM run that cannot load a `.cljs` test and goes green having inspected nothing.
