### PR TITLE
fix(story): execute check assertions; reject unknown checks at compile time (rf2-b2mt, rf2-jjhy)

### DIFF
--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -407,15 +407,17 @@
 
 (defn- reject-unknown-assertions!
   "FAIL plan construction when any authored assertion atom — terminal
-  `:assertions` OR an in-script `[:assert …]` checkpoint — names an id
+  `:assertions`, a resolved check body's atom, OR an in-script `[:assert …]`
+  checkpoint in any named play — names an id
   that is not in the recognised P1 vocabulary
   (`rf.story.assertions/known-assertion-ids`, spec/017 §Assertions).
   Catching it at compile time surfaces the typo before any run, the same
   way the other `:rf.error/story-*` plan errors do — never letting an
   unknown id record a vacuous `:rf.assert/unknown` pseudo-record at run
-  time. `script-assertions` are the atoms pulled from `[:assert …]`
-  checkpoints (post-fold); `terminal-assertions` are the child's own
-  `:assertions` atoms."
+  time. `script-assertions` are the atoms pulled from the `[:assert …]`
+  checkpoints of EVERY named play (post-fold); `terminal-assertions` are
+  the child's own `:assertions` atoms plus every resolved check body's
+  atoms (rf2-jjhy)."
   [id script-assertions terminal-assertions]
   (let [offenders (into []
                         (comp (remove nil?)
@@ -452,10 +454,10 @@
     boolean, never silently coerced or ignored.
 
   A present, boolean `:require-cause?` on `:rf.assert/no-cascade-rerender`
-  is the sole legal use and passes. `script-assertions` are the atoms pulled
-  from `[:assert …]` checkpoints (post-fold); `terminal-assertions` are the
-  child's own `:assertions` atoms — the SAME two sources
-  `reject-unknown-assertions!` walks."
+  is the sole legal use and passes. `script-assertions` and
+  `terminal-assertions` are the SAME two sources `reject-unknown-assertions!`
+  walks: every named play's checkpoints (post-fold), and the child's own
+  `:assertions` plus every resolved check body's atoms."
   [id script-assertions terminal-assertions]
   (let [offenders
         (into []
@@ -1185,7 +1187,10 @@
   check packs). Defaults to the Story side-table `:check` kind. An
   unregistered check id maps to an empty atom vector (it groups nothing —
   the run-level aggregation still sees any ungrouped records), so a missing
-  check never throws at result-assembly time."
+  check never throws at result-assembly time. Plan construction already
+  FAILS on an unregistered id (`:rf.error/story-check-unknown`), so this
+  tolerance only covers a hand-built plan or a check unregistered after
+  compile."
   ([check-ids] (expand-checks check-ids nil))
   ([check-ids check-lookup]
    (let [lookup (coerce-kind-lookup :check-lookup check-lookup default-check-lookup)]
@@ -1308,6 +1313,23 @@
                          (into composed-checks)
                          distinct
                          vec)
+        ;; Every :checks id — inherited, own or composed — MUST resolve to a
+        ;; registered check, exactly as a `:compose` id must (rf2-jjhy). An
+        ;; unresolved id used to expand to an empty atom vector, and a check
+        ;; over no atoms aggregates `:pass` forever. The resolved bodies'
+        ;; atoms feed the assertion-id guards below; the runtime dispatches
+        ;; them after the script, beside the terminal `:assertions`.
+        check-atoms  (into []
+                           (mapcat (fn [cid]
+                                     (if-let [chk (chk-lookup cid)]
+                                       (:assertions chk)
+                                       (fail! :rf.error/story-check-unknown
+                                              (str "re-frame2-story: :checks on " id
+                                                   " references unregistered check " cid
+                                                   ". Register it with reg-check, or fix"
+                                                   " the spelling of the id.")
+                                              {:variant/id id :check/id cid}))))
+                           checks)
         ;; setup APPENDS: inherited (root→parent), THEN composed fragments
         ;; (declared order), THEN the variant's own setup — variant-owned
         ;; values land last (§Merge rules + §Total resolution order). Each
@@ -1397,21 +1419,23 @@
         scripts*     (mapv (fn [p]
                              (update p :script substitute-args arg-map subs!))
                            scripts)
-        ;; Every authored assertion atom (terminal
-        ;; `:assertions` AND an in-script `[:assert …]` checkpoint, incl.
-        ;; the folded `:assert-db` / `:assert-dom` steps) MUST name a
-        ;; recognised :rf.assert/* id. An unknown id FAILS plan
-        ;; construction here, before any run (spec/017 §Assertions). The
-        ;; script is already folded (`normalize-scripts`), so one walk over
-        ;; the `[:assert …]` checkpoints covers every in-script position.
-        _            (reject-unknown-assertions!
-                       id (script-assertion-atoms script*) assertions)
+        ;; Every authored assertion atom (terminal `:assertions`, a resolved
+        ;; check body's atoms, AND an in-script `[:assert …]` checkpoint in
+        ;; ANY named play, incl. the folded `:assert-db` / `:assert-dom`
+        ;; steps) MUST name a recognised :rf.assert/* id. An unknown id FAILS
+        ;; plan construction here, before any run (spec/017 §Assertions). The
+        ;; plays are already folded (`normalize-scripts`), so one walk over
+        ;; their `[:assert …]` checkpoints covers every in-script position.
+        ;; The walk reads `scripts*` — every play the runner can drive — not
+        ;; the primary play alone (rf2-jjhy).
+        play-atoms   (into [] (mapcat (comp script-assertion-atoms :script)) scripts*)
+        expect-atoms (into assertions check-atoms)
+        _            (reject-unknown-assertions! id play-atoms expect-atoms)
         ;; A causal assertion's `:require-cause?` opt is a strict
         ;; `:rf.assert/no-cascade-rerender` boolean (rf2-x76af2.17): reject
         ;; the key on `:rf.assert/caused` and reject a non-boolean value on
         ;; either id, at compile time, before any run.
-        _            (reject-malformed-causal-opts!
-                       id (script-assertion-atoms script*) assertions)
+        _            (reject-malformed-causal-opts! id play-atoms expect-atoms)
         ;; ---- view-state subscription overrides ----
         ;; `:sub-overrides` composes like `:network`: composed-fragment
         ;; override maps merge in declared order (a later fragment wins a

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -1001,8 +1001,14 @@
   verdict lands on `:rf.story/assertions` via the ONE recording path —
   `record-result-map` / `rf.story.result/run-result` already folds that accumulator
   into the unified `:pass` / `:fail`. The terminal atoms are the plan's
-  `[:expect :assertions]` (the SAME slot `plan-assertion-atoms` reads), so a
-  REGISTERED variant and an INLINE plan both route here.
+  `[:expect :assertions]` PLUS every expanded check's atoms (`plan-checks` —
+  the SAME two slots `plan-assertion-atoms` reads), so a REGISTERED variant
+  and an INLINE plan both route here. A check is a terminal expectation too,
+  and this is the only dispatcher its atoms reach: without them every check
+  grouped an empty record set and aggregated `:pass` (rf2-b2mt). The union
+  is `distinct`, so an atom a check shares with `:assertions` (or with
+  another check) dispatches — and records — once; `rf.story.result/check-record`
+  groups by atom match, so that one record serves every check naming it.
 
   The tape-evaluated kinds (`:rf.assert/schema-error`, the causal / cascade
   family, the browser-tier oracle family) are NOT double-processed: they
@@ -1016,7 +1022,8 @@
   [variant-id plan]
   (try
     (rf.story.play.runner-events/run-terminal-assertions!
-      variant-id (get-in plan [:expect :assertions]))
+      variant-id (vec (distinct (concat (get-in plan [:expect :assertions])
+                                        (mapcat val (plan-checks plan))))))
     (catch #?(:clj Throwable :cljs :default) _ nil))
   nil)
 

--- a/tools/story/test/re_frame/story/compose_test.cljc
+++ b/tools/story/test/re_frame/story/compose_test.cljc
@@ -198,7 +198,8 @@
 (deftest compose-mixes-fragments-and-checks-in-declared-order
   (testing "a :compose list interleaving fragments + checks resolves each kind"
     (let [fragments {:fragment/seed {:setup [[:dispatch [:seed]]]}}
-          checks    {:check/clean {:assertions [[:rf.assert/no-warnings]]}}
+          checks    {:check/clean {:assertions [[:rf.assert/no-warnings]]}
+                     :check/own   {:assertions [[:rf.assert/no-warnings]]}}
           variants  {:story.x/v {:compose [:fragment/seed :check/clean]
                                  :checks  [:check/own]}}
           p (compose-plan :story.x/v
@@ -255,7 +256,10 @@
     (let [variants {:story.k/parent {:checks [:check/no-runtime-errors]}
                     :story.k/child  {:extends :story.k/parent
                                      :checks  [:check/extra]}}
-          p (compose-plan :story.k/child {:variants variants})]
+          ;; Every :checks id must resolve (rf2-jjhy).
+          checks   {:check/no-runtime-errors {:assertions [[:rf.assert/no-warnings]]}
+                    :check/extra             {:assertions [[:rf.assert/no-warnings]]}}
+          p (compose-plan :story.k/child {:variants variants :checks checks})]
       (is (= [:check/no-runtime-errors :check/extra]
              (get-in p [:expect :checks]))))))
 

--- a/tools/story/test/re_frame/story/inline_plan_test.clj
+++ b/tools/story/test/re_frame/story/inline_plan_test.clj
@@ -190,8 +190,10 @@
   (testing "an inline plan composing a registered check resolves the check id
             into the plan + groups its records under the check id, exactly the
             way a registered variant does (§B6 — registered check). The check's
-            atom is ALSO an in-script checkpoint so it actually records, proving
-            the registered check resolved and ran."
+            atom appears NOWHERE else in the plan, so the one record it groups
+            can only come from the check's own atoms being dispatched after the
+            script (rf2-b2mt — this test used to duplicate the atom as an
+            in-script checkpoint to make it record at all)."
     (rf.story/reg-check :check.inline/status-loaded
       {:assertions [[:rf.assert/path-equals [:status] :loaded]]})
     ;; The compiled plan carries the composed check id under [:expect :checks].
@@ -200,13 +202,14 @@
       (is (= [:check.inline/status-loaded] (get-in plan [:expect :checks]))
           "the registered check id resolves into the inline plan's :expect"))
     (let [result (run-target {:compose [:check.inline/status-loaded]
-                              :script  [[:dispatch [:inline/set-status :loaded]]
-                                        [:assert [:rf.assert/path-equals [:status] :loaded]]]})]
+                              :script  [[:dispatch [:inline/set-status :loaded]]]})]
       (is (= :pass (:status result)))
       (let [check (first (filter #(= :check.inline/status-loaded (:check %))
                                  (:checks result)))]
         (is (some? check) "the run-result groups records under the check id")
         (is (= :pass (:status check)) "the composed check aggregates :pass")
+        (is (= 1 (count (:assertions check)))
+            "the check's atom was dispatched — not a :pass over an empty group")
         (is (every? :passed? (:assertions check))
             "the registered check's assertion ran + passed")))))
 
@@ -219,6 +222,107 @@
                               :script  [[:assert [:rf.assert/path-equals [:status] :seeded]]]})]
       (is (= :pass (:status result)) "the fragment setup seeded the app-db")
       (is (= :seeded (:status (:app-db result)))))))
+
+;; ===========================================================================
+;; A check's assertions EXECUTE, so a check can FAIL (rf2-b2mt)
+;;
+;; The terminal dispatcher used to run `[:expect :assertions]` only, so a
+;; check's atoms never reached a handler: every check grouped an empty record
+;; set, and `aggregate-status` over `[]` is `:pass`. The failing check below
+;; read `:pass` with ZERO records while its terminal-`:assertions` twin read
+;; `:fail`. A passing check is pinned WITH its record count, so a real pass
+;; stays distinguishable from a vacuous one.
+;; ===========================================================================
+
+(def ^:private never-true [:rf.assert/path-equals [:nope] :never-true])
+(def ^:private loaded?    [:rf.assert/path-equals [:status] :loaded])
+
+(defn- check-rec [result check-id]
+  (first (filter #(= check-id (:check %)) (:checks result))))
+
+(deftest a-failing-check-fails-the-run
+  (rf.story/reg-check :check.probe/must-fail {:assertions [never-true]})
+  (testing "inline plan: a check whose atom is false FAILS the check and the
+            run, over the one record it grouped (was :pass over zero)"
+    (let [result (run-target {:setup  [[:dispatch [:inline/set-status :loaded]]]
+                              :checks [:check.probe/must-fail]})
+          check  (check-rec result :check.probe/must-fail)]
+      (is (= :fail (:status result)))
+      (is (= :fail (:status check)))
+      (is (= [false] (mapv :passed? (:assertions check))))))
+  (testing "registered variant: the same check named in :checks fails too"
+    (rf.story/reg-variant :story.probe/must-fail
+      {:setup  [[:dispatch [:inline/set-status :loaded]]]
+       :checks [:check.probe/must-fail]})
+    (let [result (run-target :story.probe/must-fail)]
+      (is (= :fail (:status result)))
+      (is (= :fail (:status (check-rec result :check.probe/must-fail))))))
+  (testing "CONTROL: the same atom as a terminal :assertions entry fails"
+    (let [result (run-target {:setup      [[:dispatch [:inline/set-status :loaded]]]
+                              :assertions [never-true]})]
+      (is (= :fail (:status result)))
+      (is (= 1 (count (:assertions result)))))))
+
+(deftest a-passing-check-passes-over-a-real-record
+  (rf.story/reg-check :check.probe/must-pass {:assertions [loaded?]})
+  (testing "a check whose atom holds passes WITH the record it grouped"
+    (let [result (run-target {:setup  [[:dispatch [:inline/set-status :loaded]]]
+                              :checks [:check.probe/must-pass]})
+          check  (check-rec result :check.probe/must-pass)]
+      (is (= :pass (:status result)))
+      (is (= :pass (:status check)))
+      (is (= [true] (mapv :passed? (:assertions check))))))
+  (testing "an atom a check shares with :assertions dispatches ONCE, and the
+            one record serves both the run and the check"
+    (let [result (run-target {:setup      [[:dispatch [:inline/set-status :loaded]]]
+                              :checks     [:check.probe/must-pass]
+                              :assertions [loaded?]})]
+      (is (= :pass (:status result)))
+      (is (= 1 (count (:assertions result))))
+      (is (= 1 (count (:assertions (check-rec result :check.probe/must-pass))))))))
+
+;; ===========================================================================
+;; Compile-time guards cover EVERY check id, check body and named play (rf2-jjhy)
+;; ===========================================================================
+
+(deftest unknown-check-id-fails-plan-construction
+  (testing "a :checks id naming no registered check FAILS plan construction
+            (the :checks twin of :compose's story-compose-unknown) — it used to
+            compile and pass forever over an empty group"
+    (let [result (run-target {:setup  [[:dispatch [:inline/set-status :loaded]]]
+                              :checks [:check/no-runtime-erors]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-check-unknown
+             (:assertion (first (:assertions result)))))
+      (is (empty? (rf.story/variant-frames)) "no frame lingers")))
+  (testing "an INHERITED unknown check id fails the child's plan, naming the id"
+    (rf.story/reg-variant :story.probe/parent {:checks [:check/never-registered]})
+    (rf.story/reg-variant :story.probe/child  {:extends :story.probe/parent})
+    (let [ex (try (rf.story/variant-plan :story.probe/child) nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/story-check-unknown (:rf.error/id (ex-data ex))))
+      (is (= :check/never-registered (:check/id (ex-data ex)))))))
+
+(deftest assertion-guards-cover-every-play-and-check-body
+  (testing "a typo'd assertion id in a SECOND named play fails (the guard used
+            to read the primary play only)"
+    (let [result (run-target {:plays [{:name "first"  :script [[:dispatch [:inline/set-status :loaded]]]}
+                                      {:name "second" :script [[:assert [:rf.assert/typo]]]}]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-unknown-assertion
+             (:assertion (first (:assertions result)))))))
+  (testing "a typo'd assertion id inside a registered check body fails"
+    (rf.story/reg-check :check.probe/typo {:assertions [[:rf.assert/typo]]})
+    (let [result (run-target {:checks [:check.probe/typo]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-unknown-assertion
+             (:assertion (first (:assertions result)))))))
+  (testing "a malformed causal opt in a SECOND named play fails too"
+    (let [result (run-target {:plays [{:name "first"  :script [[:dispatch [:inline/set-status :loaded]]]}
+                                      {:name "second" :script [[:assert [:rf.assert/caused {:event :e :require-cause? false}]]]}]})]
+      (is (= :error (:status result)))
+      (is (= :rf.error/story-bad-assertion-opt
+             (:assertion (first (:assertions result))))))))
 
 ;; ===========================================================================
 ;; Inline plan CANNOT reference a missing fragment — fails cleanly

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -323,7 +323,10 @@
     (let [m {:story.k/parent {:checks [:check/no-runtime-errors]}
              :story.k/child  {:extends :story.k/parent
                               :checks  [:check/extra]}}
-          p (plan-of :story.k/child m)]
+          ;; Every :checks id must resolve (rf2-jjhy), so thread the bodies.
+          checks {:check/no-runtime-errors {:assertions [[:rf.assert/no-warnings]]}
+                  :check/extra             {:assertions [[:rf.assert/no-warnings]]}}
+          p (rf.story.plan/variant-plan :story.k/child {:lookup m :check-lookup checks})]
       (is (= [:check/no-runtime-errors :check/extra]
              (get-in p [:expect :checks]))))))
 

--- a/tools/story/test/re_frame/story_authoring_surface_test.clj
+++ b/tools/story/test/re_frame/story_authoring_surface_test.clj
@@ -324,6 +324,9 @@
             :lookup arg): setup APPENDS, checks INHERIT, decorators INHERIT"
     (rf.story/reg-decorator :s84-parent-deco
       {:kind :hiccup :wrap (fn [body _] [:div.s84 body])})
+    ;; Every :checks id must resolve to a registered check (rf2-jjhy).
+    (rf.story/reg-check :check/no-runtime-errors {:assertions [[:rf.assert/no-warnings]]})
+    (rf.story/reg-check :check/extra {:assertions [[:rf.assert/no-warnings]]})
     (rf.story/reg-variant :story.s84/parent
       {:setup      [[:dispatch [:s84/p1]] [:dispatch [:s84/p2]]]
        :checks     [:check/no-runtime-errors]


### PR DESCRIPTION
## Summary

This PR closes a Story vacuous-pass defect from both ends of the pipeline: a check could report `:pass` having asserted nothing. The two beads land as one PR, per their relates-to edge.

- **rf2-b2mt (runtime):** a `reg-check`'s assertion atoms never reached a handler. The only terminal dispatcher, `settle-terminal-assertions!`, ran `[:expect :assertions]` alone. Every check therefore grouped an empty record set, and `aggregate-status` over `[]` is `:pass`. The dispatcher now runs the `distinct` union of the terminal assertions and every expanded check's atoms. An atom shared by a check and `:assertions`, or by two checks, dispatches and records once; `check-record` groups by atom match, so that one record serves each of them.
- **rf2-jjhy (compiler):** the compiler could manufacture the same empty group in three ways. An unregistered `:checks` id expanded to `[]` and compiled. Both assertion-id guards (`reject-unknown-assertions!`, `reject-malformed-causal-opts!`) read only the primary play. No guard read a check body. `compile-body` now resolves every `:checks` id (own, inherited or composed) through the check lookup and fails with `:rf.error/story-check-unknown`, the `:checks` twin of `:rf.error/story-compose-unknown`. Both guards now walk every named play and every resolved check body.

## Evidence: before and after

The same JVM probe (`clojure -M -i <probe>` from `tools/story`, plain-atom adapter) ran on trunk and then on this branch:

| probe | before | after |
|---|---|---|
| D1 failing check in `:checks` | `:pass`, 0 records, check `:pass` over 0 | `:fail`, 1 record, check `:fail` over 1 |
| D2 CONTROL: same atom in `:assertions` | `:fail`, 1 record | `:fail`, 1 record |
| D3 passing check in `:checks` | `:pass`, 0 records, check `:pass` over 0 | `:pass`, 1 record, check `:pass` over 1 |
| D4 unknown `:checks` id | `:pass` | `:error` `:rf.error/story-check-unknown` |
| D5 typo'd assertion id in a SECOND play | `:pass` | `:error` `:rf.error/story-unknown-assertion` |
| D6 CONTROL: same typo in the first play | `:error` `:rf.error/story-unknown-assertion` | unchanged |
| D7 typo'd assertion id inside a check body | `:pass`, check `:pass` over 0 | `:error` `:rf.error/story-unknown-assertion` |

D1 is the headline: a check that asserts something false used to pass with zero assertions, and now it fails. D3 is its twin: a check with a real assertion still passes, now over one real record instead of zero.

## Tests

- In `inline_plan_test.clj`, the registered-check test no longer duplicates the check's atom as an in-script checkpoint. That duplication was the workaround that made it record at all. The test now pins execution with a record count of 1.
- New JVM tests, in the same file:
  - a failing check fails the run, inline and registered, with a terminal-`:assertions` control;
  - a passing check passes over one real record;
  - a shared atom dispatches once;
  - unknown `:checks` ids fail, own and inherited;
  - typo'd ids fail in a second play and inside a check body;
  - a malformed causal opt fails in a second play.
- Four existing deftests across three files (`plan_test.cljc`, `compose_test.cljc`, `story_authoring_surface_test.clj`) named checks that were never registered. They now thread or register the check bodies, and that is the only change to them.

## Quality gates

- **jvm-tools-story** (`clojure -M:test` from `tools/story`, the gate both beads name):

  | run | tests | assertions | failures | errors | exit |
  |---|---|---|---|---|---|
  | trunk baseline | 1914 | 7047 | 0 | 0 | 0 |
  | this branch, pre-rebase | 1918 | 7072 | 0 | 0 | 0 |
  | this branch, rebased onto current `main` | 1918 | 7072 | 0 | 0 | 0 |

  The branch adds exactly 4 tests and 25 assertions, the count the new and changed tests carry.
- **Planted faults**, placed in the changed lines and each restored with the restore verified by blob hash against HEAD:
  - **Plant A (b2mt):** one line, dropping the check atoms from the dispatch. Result: exit 1, still 1918/7072 (no namespace crashed), 7 failures, all of them in the b2mt tests.
  - **Plant B (jjhy):** three single-line faults, each anchor matching exactly once:
    - an unknown check resolves to `{}`;
    - the guards walk the first play only;
    - check-body atoms are dropped from the guards.

    Result: exit 1, still 1918/7072, 10 failures, each attributable to exactly one plant.
- **clj-kondo** (`python scripts/lint_kondo.py`, CI's pinned 2026.04.15 gate run locally, `--lint tools/story` included): 0 errors at `--fail-level error`, exit 0.
- **Thrown-error message gate** (`scripts/check_thrown_error_messages.py`): exit 0. By its own output it scans `implementation/` only, so it does not grade this path. The new throw goes through `plan.cljc`'s existing `fail!` helper, the same one `story-compose-unknown` uses.
- **CLJS lane** (`npm run test:cljs`): not run locally; relying on CI. The changed code is portable `.cljc` with no reader conditionals added, and no CLJS test compiles a plan naming `:checks`.

## Notes for sequencing

- **rf2-exlh** (a separate worker) renames `plan_test.cljc` and `compose_test.cljc` to `*_cljs_test.cljc`. This PR touches three small deftest hunks in those two files, so whichever lands second rebases over a rename plus a small hunk.
- **rf2-z8ta** (P3, filed): `tools/story/spec/017-Testing-Story.md` does not yet name `:rf.error/story-check-unknown`, or say that a check's atoms run as terminal expectations. That file is outside this PR's file fence.
- **rf2-fzbj.3** (held surface review naming `plan.cljc` / `runtime.cljc`): its three findings are about loaders, hot-reload cleanup and effective args, and none of them is this defect.
- **Residual, deliberately unchanged:** `result/check-record` still aggregates `:pass` over an empty group. An empty group is now reachable only when a check's atoms never dispatch at all, which is a loader-incomplete run. There the terminal `:assertions` are skipped too, so it is a pre-existing class and not specific to checks.
