### PR TITLE
fix(story): step-debugger and scrubber read the compiled plan (rf2-499z)

### DIFF
--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -64,11 +64,13 @@
             ;; The canonical RAW trace-event frame reader
             ;; (`re-frame.trace/frame-of`) reads the frame off a trace event.
             [re-frame.trace            :as rf.trace]
+            [re-frame.story.args       :as rf.story.args]
             [re-frame.story.assertions :as rf.story.assertions]
             [re-frame.story.async      :as rf.story.async]
             [re-frame.story.config     :as rf.story.config]
             [re-frame.story.error      :as rf.story.error]
             [re-frame.story.late-bind  :as rf.story.late-bind]
+            [re-frame.story.plan       :as rf.story.plan]
             [re-frame.story.play.runner :as rf.story.play.runner]
             [re-frame.story.registrar  :as rf.story.registrar]))
 
@@ -240,29 +242,72 @@
   [frame-id]
   (rf.story.assertions/read-assertions frame-id))
 
+;; ---------------------------------------------------------------------------
+;; The stepped program — read from the COMPILED plan (rf2-499z)
+;;
+;; The step-debugger (`variant-play-steps`) and the scrubber
+;; (`variant-play-events`) both show the program the auto-run path
+;; EXECUTED, so they read it where the runtime reads it: the compiled
+;; plan's `[:world :scripts]`, never the raw `:script` slot. The compiler
+;; is what substitutes `[:arg key]` placeholders, prepends `:compose`d
+;; fragments' scripts and lowers `:plays` into named scripts. A raw read
+;; saw none of that: an `[:arg]` script stepped its placeholder verbatim,
+;; a composed variant stepped without its fragments, and a `:plays`
+;; variant stepped nothing at all.
+;; ---------------------------------------------------------------------------
+
+(defn- stepped-program
+  "The folded, arg-substituted step vector for `variant-id`: the scripts of
+  the compiled plan's AUTO-RUNNABLE plays, concatenated in order — the
+  exact program `runtime/run-phase-4!` executes
+  (`rf.story.play.runner/auto-runnable-plays` over `[:world :scripts]`).
+  A variant that auto-runs nothing yields its PRIMARY compiled play
+  instead, so a script the author opted out of auto-running can still be
+  stepped by hand.
+
+  `opts` is the `run-variant` opts map (`:active-modes` /
+  `:cell-overrides`), folded into the compile through
+  `rf.story.args/run-arg-layers` exactly as `runtime/prepare-context`
+  folds it — pass the SAME opts the run or the preparation received. An
+  unregistered variant yields `[]`; a plan-construction failure throws,
+  as the runtime would for the same variant."
+  [variant-id opts]
+  (if-not (rf.story.registrar/handler-meta :variant variant-id)
+    []
+    (let [plan  (rf.story.plan/variant-plan
+                  variant-id
+                  {:run-args (rf.story.args/run-arg-layers variant-id opts)})
+          plays (get-in plan [:world :scripts] [])
+          auto  (rf.story.play.runner/auto-runnable-plays plays)]
+      (vec (if (seq auto)
+             (mapcat :script auto)
+             (:script (first plays)))))))
+
 (defn variant-play-events
-  "Resolve a flat event-vector list for `variant-id`'s phase-4 play.
+  "The flat event-vector list of `variant-id`'s stepped program (see
+  `stepped-program`): one per `:dispatch` / `:dispatch-sync` step. Other
+  step types have no event-vector representation and are skipped. The
+  scrubber matches these against the run's `:epoch-tape`, so `opts`
+  should be the opts that run received.
 
-  Derives a flat event-vector list from the variant's `:script`
-  body by extracting events from the `:dispatch` / `:dispatch-sync`
-  steps. Other step types (`:wait`,
-  `:click`, `:type`, `:assert-db`, `:assert-dom`) have no event-vector
-  representation and are skipped here — the rich-DSL runner
-  (`re-frame.story.play.runner-events`) is the canonical executor.
-
-  This shape stays around for the play-stepper UI which advances ONE
-  event at a time."
-  [variant-id]
-  (let [body   (rf.story.registrar/handler-meta :variant variant-id)
-        spec   (rf.story.play.runner/parse-spec (:script body))
-        script (:script spec)]
-    (->> (or script [])
-         (keep (fn [step]
-                 (when (and (vector? step)
-                            (#{:dispatch :dispatch-sync} (first step))
-                            (vector? (second step)))
-                   (second step))))
-         vec)))
+  A plan-construction failure yields `[]` rather than throwing. An
+  `[:arg]` that only an active mode or cell override supplies cannot
+  compile without those opts, and the scrubber's contract is to degrade to
+  'no epoch buffer', never to lose the run result it is attached to."
+  ([variant-id] (variant-play-events variant-id nil))
+  ([variant-id opts]
+   (let [steps (try (stepped-program variant-id opts)
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+                      (if (= 'rf.story/variant-plan (:where (ex-data e)))
+                        []
+                        (throw e))))]
+     (into []
+           (keep (fn [step]
+                   (when (and (vector? step)
+                              (#{:dispatch :dispatch-sync} (first step))
+                              (vector? (second step)))
+                     (second step))))
+           steps))))
 
 (defn execute-play!
   "Run the play sequence against `variant-id`'s frame. Drives the
@@ -316,9 +361,9 @@
 ;; ---------------------------------------------------------------------------
 ;; UI play-stepper hook
 ;;
-;; The stepper walks the FULL coerced `:script` (every step type —
-;; `:dispatch` / `:dispatch-sync` / `:wait` / `:click` / `:type` /
-;; `:assert-db` / `:assert-dom`), driving each step through the SAME
+;; The stepper walks the FULL compiled program (`stepped-program`, every
+;; step type — `:dispatch` / `:dispatch-sync` / `:wait` / `:click` /
+;; `:type` / `:assert-db` / `:assert-dom`), driving each step through the SAME
 ;; rich-DSL executor the canvas auto-run path uses
 ;; (`runner-events/run-step!`, fetched via the `:run-play-step` late-bind
 ;; hook to avoid the play ↔ runner-events cycle). The slot holds STEPS,
@@ -338,22 +383,19 @@
   (atom {}))
 
 (defn variant-play-steps
-  "Resolve the FULL coerced `:script` step vector for `variant-id`'s
-  default play. Unlike `variant-play-events` (which drops every
-  non-dispatch step) this returns EVERY step the rich-DSL runner
-  recognises, in order, so the step-debugger walks the same sequence the
-  auto-run path executes.
+  "The FULL step vector the step-debugger walks for `variant-id`. Unlike
+  `variant-play-events` (which drops every non-dispatch step) this returns
+  EVERY step the rich-DSL runner recognises, in order.
 
-  Pure data → data; works on JVM + CLJS.
+  Read from the COMPILED plan (`stepped-program`), so it is the program
+  the auto-run path executes: folded (a shipping `:assert-db` /
+  `:assert-dom` step is already the canonical `[:assert …]` checkpoint),
+  `[:arg]`-substituted, `:compose`d fragments prepended, `:plays` lowered.
+  `opts` is the `run-variant` opts map the frame was prepared with.
 
-  The script is FOLDED (`rf.story.assertions/fold-script`) so the
-  stepper walks the SAME canonical `[:assert …]` checkpoints the auto-run
-  path drives: a shipping `:assert-db` / `:assert-dom` step is rewritten to
-  the one assertion atom before the stepper executes it."
-  [variant-id]
-  (let [body (rf.story.registrar/handler-meta :variant variant-id)
-        spec (rf.story.play.runner/parse-spec (:script body))]
-    (rf.story.assertions/fold-script (vec (:script spec)))))
+  Pure aside from the registrar reads; works on JVM + CLJS."
+  ([variant-id] (variant-play-steps variant-id nil))
+  ([variant-id opts] (stepped-program variant-id opts)))
 
 (defn play-stepper-active?
   [frame-id]
@@ -363,23 +405,26 @@
   "Initialise a step-by-step play run for `frame-id`. The UI's
   play-stepper widget calls `step-once!` to advance one step.
 
-  Seeds the FULL coerced script (every step type)."
-  [frame-id]
-  (when rf.story.config/enabled?
-    (swap! pending-exceptions assoc frame-id [])
-    (install-trace-listener! frame-id)
-    ;; Reset the per-dispatch-step settle boundaries at the START
-    ;; of a fresh stepping session (the stepper analogue of `run!`'s reset),
-    ;; so `step-once!`'s per-step appends window onto THIS session's epoch tape
-    ;; rather than accumulating onto a previous run's boundaries. Fetched via
-    ;; the late-bind seam because `play` cannot `:require` `runner-events`.
-    (when-let [clear! (rf.story.late-bind/get-fn :clear-step-boundaries)]
-      (clear! frame-id))
-    (swap! stepper-state assoc frame-id
-           {:remaining (variant-play-steps frame-id)
-            :ran       []
-            :results   []})
-    nil))
+  Seeds the FULL compiled program (every step type, `variant-play-steps`).
+  `opts` is the `run-variant` opts map the frame was PREPARED with, so the
+  seeded steps substitute the same args the prepared frame saw."
+  ([frame-id] (begin-stepper! frame-id nil))
+  ([frame-id opts]
+   (when rf.story.config/enabled?
+     (swap! pending-exceptions assoc frame-id [])
+     (install-trace-listener! frame-id)
+     ;; Reset the per-dispatch-step settle boundaries at the START
+     ;; of a fresh stepping session (the stepper analogue of `run!`'s reset),
+     ;; so `step-once!`'s per-step appends window onto THIS session's epoch tape
+     ;; rather than accumulating onto a previous run's boundaries. Fetched via
+     ;; the late-bind seam because `play` cannot `:require` `runner-events`.
+     (when-let [clear! (rf.story.late-bind/get-fn :clear-step-boundaries)]
+       (clear! frame-id))
+     (swap! stepper-state assoc frame-id
+            {:remaining (variant-play-steps frame-id opts)
+             :ran       []
+             :results   []})
+     nil)))
 
 (defn step-once!
   "Advance the play stepper for `frame-id` by one step. Executes the

--- a/tools/story/test/re_frame/story/stepper_compiled_plan_test.clj
+++ b/tools/story/test/re_frame/story/stepper_compiled_plan_test.clj
@@ -1,0 +1,272 @@
+(ns re-frame.story.stepper-compiled-plan-test
+  "rf2-499z — the step-debugger and the scrubber read the COMPILED plan,
+  the program the auto-run path executes, not the raw `:script` slot.
+
+  Execution walks the compiled plan's `[:world :scripts]`; the stepper
+  (`play/variant-play-steps`) and the scrubber (`play/variant-play-events`)
+  used to walk the registered body's `:script` as authored. Anything the
+  compiler rewrites therefore stepped differently from how it ran: an
+  `[:arg key]` placeholder reached the dispatched event verbatim, a
+  `:compose`d fragment's script was missing, and a `:plays` variant (no
+  `:script` slot at all) showed no steps.
+
+  Every witness below is a variant whose raw `:script` and compiled plan
+  DIFFER, and each first asserts that divergence through `raw-steps` /
+  `raw-events` — the pre-fix readers reproduced verbatim — so a witness
+  that stopped diverging fails its precondition instead of passing
+  vacuously. The comparison target is BEHAVIOURAL: what `run-variant`
+  actually did (its final app-db, its epoch tape), never a re-derivation
+  of the plan expression the reader itself uses. The plain-`:script`
+  case is the CONTROL, where both readers agree trivially.
+
+  JVM-only (`.clj`): `run-variant` / `prepare-variant` settle
+  synchronously here, so a stepped session and an auto-run can be driven
+  back to back against one frame."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.assertions :as rf.story.assertions]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.play.runner :as rf.story.play.runner]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]))
+
+(defn- reset-all! [test-fn]
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  ;; Requiring `re-frame.epoch` installs the epoch artefact's late-bind
+  ;; hooks, so a run records a real `:epoch-tape` for the scrubber witness.
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.play/stepper-state {})
+  (reset! rf.story.play.runner-events/run-state {})
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story.runtime/reset-run-owner!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf/reg-event :ps/set-value (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)}))
+  (rf/reg-event :ps/inc       (fn [{:keys [db]} _] {:db (update db :count (fnil inc 0))}))
+  (rf/reg-event :ps/log       (fn [{:keys [db]} [_ x]] {:db (update db :log (fnil conj []) x)}))
+  (test-fn))
+
+(use-fixtures :each reset-all!)
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- raw-steps
+  "The PRE-FIX stepper reader, reproduced verbatim: the registered body's
+  raw `:script` slot, parsed and folded. The 'before' half of every
+  witness."
+  [vid]
+  (let [body (rf.story.registrar/handler-meta :variant vid)]
+    (rf.story.assertions/fold-script
+      (vec (:script (rf.story.play.runner/parse-spec (:script body)))))))
+
+(defn- raw-events
+  "The PRE-FIX scrubber reader: the dispatch events of the raw slot."
+  [vid]
+  (into []
+        (keep (fn [s] (when (and (vector? s)
+                                 (#{:dispatch :dispatch-sync} (first s))
+                                 (vector? (second s)))
+                        (second s))))
+        (raw-steps vid)))
+
+(defn- auto-run
+  "What the auto-run path DID: the unified result of a full run."
+  ([vid] (auto-run vid nil))
+  ([vid opts]
+   (rf.story.async/deref-blocking (rf.story.runtime/run-variant vid opts) 5000)))
+
+(defn- step-through!
+  "What the step-debugger DOES: Start (prepare phases 0-2 with `opts`,
+  prime the substrate with the same `opts`), then Step until exhausted.
+  Returns the steps it ran, in order, and the final app-db."
+  ([vid] (step-through! vid nil))
+  ([vid opts]
+   (rf.story.async/deref-blocking (rf.story.runtime/prepare-variant vid opts) 5000)
+   (rf.story.play/begin-stepper! vid opts)
+   (loop [n 0]
+     (when (and (< n 100) (rf.story.play/step-once! vid))
+       (recur (inc n))))
+   {:steps  (:ran (get @rf.story.play/stepper-state vid))
+    :app-db (rf/app-db-value vid)}))
+
+;; ---- witnesses: raw and compiled DIFFER ----------------------------------
+
+(deftest arg-placeholder-steps-the-substituted-value
+  (testing "an `[:arg key]` in the script is stepped as the SUBSTITUTED
+            event the auto-run dispatched, never as the placeholder"
+    (let [vid :story.stepper-plan/arg]
+      (rf.story/reg-variant vid
+        {:args   {:value 7}
+         :script [[:dispatch-sync [:ps/set-value [:arg :value]]]]})
+      (is (= [[:dispatch-sync [:ps/set-value [:arg :value]]]] (raw-steps vid))
+          "PRECONDITION — the raw slot carries the placeholder, so this
+           witness really does diverge")
+      (let [ran     (auto-run vid)
+            stepped (step-through! vid)]
+        (is (= 7 (get-in ran [:app-db :value]))
+            "the auto-run dispatched the substituted value")
+        (is (= [[:dispatch-sync [:ps/set-value 7]]] (:steps stepped))
+            "the stepper walked the substituted event")
+        (is (= 7 (get-in stepped [:app-db :value]))
+            "stepping dispatched the substituted value, so the placeholder
+             never reached the handler")))))
+
+(deftest plays-variant-steps-its-auto-run-plays
+  (testing "a `:plays` variant has no `:script` slot, so the raw reader saw
+            no steps at all; the stepper now walks every AUTO-RUNNABLE play
+            in order, and not a play that does not auto-run"
+    (let [vid :story.stepper-plan/plays]
+      (rf.story/reg-variant vid
+        {:plays [{:name   "first"
+                  :script [[:dispatch-sync [:ps/log :first]]]}
+                 {:name      "second"
+                  :auto-run? true
+                  :script    [[:dispatch-sync [:ps/log :second-a]]
+                              [:dispatch-sync [:ps/log :second-b]]]}
+                 {:name   "manual"
+                  :script [[:dispatch-sync [:ps/log :manual]]]}]})
+      (is (= [] (raw-steps vid))
+          "PRECONDITION — the raw reader saw nothing: 'no steps'")
+      (let [ran     (auto-run vid)
+            stepped (step-through! vid)]
+        (is (= [:first :second-a :second-b] (get-in ran [:app-db :log]))
+            "the auto-run ran the two auto-runnable plays, not the manual one")
+        (is (= 3 (count (:steps stepped)))
+            "the stepper walked three steps")
+        (is (= (get-in ran [:app-db :log]) (get-in stepped [:app-db :log]))
+            "and they are the steps the auto-run executed, in its order")))))
+
+(deftest composed-fragment-script-is-stepped-first
+  (testing "a `:compose`d fragment's script runs BEFORE the variant's own;
+            the raw reader missed it, the stepper now walks it"
+    (let [vid :story.stepper-plan/composed]
+      (rf.story/reg-fragment :fragment.stepper-plan/opener
+        {:script [[:dispatch-sync [:ps/log :fragment]]]})
+      (rf.story/reg-variant vid
+        {:compose [:fragment.stepper-plan/opener]
+         :script  [[:dispatch-sync [:ps/log :own]]]})
+      (is (= [[:dispatch-sync [:ps/log :own]]] (raw-steps vid))
+          "PRECONDITION — the raw reader saw only the variant's own step")
+      (let [ran     (auto-run vid)
+            stepped (step-through! vid)]
+        (is (= [:fragment :own] (get-in ran [:app-db :log]))
+            "the auto-run ran the fragment's script first")
+        (is (= [[:dispatch-sync [:ps/log :fragment]]
+                [:dispatch-sync [:ps/log :own]]]
+               (:steps stepped))
+            "the stepper walked the fragment's step, then the variant's")
+        (is (= (get-in ran [:app-db :log]) (get-in stepped [:app-db :log]))
+            "so the stepped run and the auto-run agree")))))
+
+(deftest scrubber-events-align-with-the-run-tape
+  (testing "the scrubber aligns its play events against the run's OWN epoch
+            tape by trigger-event identity; the raw placeholder matched no
+            tape record, so the scrubber had no epochs to offer"
+    (let [vid :story.stepper-plan/scrub]
+      (rf.story/reg-variant vid
+        {:args   {:value 7}
+         :script [[:dispatch-sync [:ps/set-value [:arg :value]]]
+                  [:dispatch-sync [:ps/inc]]]})
+      (let [tape (:epoch-tape (auto-run vid))
+            ids  (rf.story.ui.test-mode.pure/epoch-id-slice
+                   tape (rf.story.play/variant-play-events vid))]
+        (is (seq tape) "PRECONDITION — the run recorded an epoch tape")
+        (is (= [] (rf.story.ui.test-mode.pure/epoch-id-slice tape (raw-events vid)))
+            "PRECONDITION — the raw events matched no record: the scrubber
+             was empty for this variant")
+        (is (= [[:ps/set-value 7] [:ps/inc]] (rf.story.play/variant-play-events vid))
+            "the scrubber's events are the substituted ones")
+        (is (= [[:ps/set-value 7] [:ps/inc]]
+               (mapv (fn [id] (:trigger-event (first (filter #(= id (:epoch-id %)) tape))))
+                     ids))
+            "each event resolves to the epoch that event actually committed")))))
+
+;; ---- the control: raw and compiled COINCIDE ------------------------------
+
+(deftest plain-script-control-both-readers-agree
+  (testing "CONTROL — a plain `:script` with no `[:arg]`, `:compose` or
+            `:plays`: raw and compiled coincide, so the new readers agree
+            with the old ones (bare-vector coercion and `:assert-db`
+            folding included)"
+    (let [vid :story.stepper-plan/plain]
+      (rf.story/reg-variant vid
+        {:script [[:dispatch-sync [:ps/inc]]
+                  [:ps/inc]
+                  [:assert-db [:count] 2]]})
+      (is (= (raw-steps vid) (rf.story.play/variant-play-steps vid)))
+      (is (= (raw-events vid) (rf.story.play/variant-play-events vid)))
+      (is (= 2 (get-in (auto-run vid) [:app-db :count])))
+      (is (= 2 (get-in (step-through! vid) [:app-db :count]))))))
+
+;; ---- run opts, the no-auto-run fallback, and the edges -------------------
+
+(deftest run-opts-thread-into-the-stepped-program
+  (testing "the stepped program substitutes the SAME arg layers the run
+            used: a cell override reaches the steps through `opts`, exactly
+            as `run-variant` threads it into its own compile"
+    (let [vid  :story.stepper-plan/opts
+          opts {:cell-overrides {:value "override"}}]
+      (rf.story/reg-variant vid
+        {:args   {:value "static"}
+         :script [[:dispatch-sync [:ps/set-value [:arg :value]]]]})
+      (is (= [[:ps/set-value "static"]] (rf.story.play/variant-play-events vid)))
+      (is (= [[:ps/set-value "override"]] (rf.story.play/variant-play-events vid opts)))
+      (is (= "override" (get-in (auto-run vid opts) [:app-db :value])))
+      (is (= "override" (get-in (step-through! vid opts) [:app-db :value]))))))
+
+(deftest mode-only-arg-degrades-the-scrubber-instead-of-throwing
+  (testing "an `[:arg]` that only an active mode supplies cannot compile
+            without that mode. The scrubber's reader yields [] (its 'no
+            epoch buffer' degrade) rather than throwing out of the handler
+            that stores the run result, and resolves once given the opts"
+    (let [vid  :story.stepper-plan/mode-only
+          mode :Mode.stepper-plan/seven]
+      (rf.story/reg-mode mode {:args {:value 7}})
+      (rf.story/reg-variant vid
+        {:script [[:dispatch-sync [:ps/set-value [:arg :value]]]]})
+      (is (thrown? clojure.lang.ExceptionInfo (rf.story.play/variant-play-steps vid))
+          "PRECONDITION — without the mode the plan really does refuse")
+      (is (= [] (rf.story.play/variant-play-events vid)))
+      (is (= [[:ps/set-value 7]]
+             (rf.story.play/variant-play-events vid {:active-modes [mode]}))))))
+
+(deftest opted-out-script-is-still-steppable
+  (testing "a script with `:auto-run? false` auto-runs nothing, so the
+            stepper falls back to the primary compiled play and the author
+            can still step it by hand — substituted like every other read"
+    (let [vid :story.stepper-plan/manual]
+      (rf.story/reg-variant vid
+        {:args   {:value 3}
+         :script {:auto-run? false
+                  :script    [[:dispatch-sync [:ps/set-value [:arg :value]]]]}})
+      (is (nil? (get-in (auto-run vid) [:app-db :value]))
+          "nothing auto-ran")
+      (is (= [[:dispatch-sync [:ps/set-value 3]]] (:steps (step-through! vid)))
+          "the stepper walked the primary play, substituted"))))
+
+(deftest unregistered-variant-has-no-steps
+  (testing "an unregistered id keeps the pre-fix contract — no steps and
+            no throw — so `begin-stepper!` on a bare frame seeds an empty
+            cursor"
+    (is (= [] (rf.story.play/variant-play-steps :story.stepper-plan/never)))
+    (is (= [] (rf.story.play/variant-play-events :story.stepper-plan/never)))))


### PR DESCRIPTION
Fixes rf2-499z.

## The defect

Two readers of one play disagreed. The runtime executes the COMPILED plan's `[:world :scripts]` (`runtime/run-phase-4!` over `auto-runnable-plays`), while the step-debugger (`play/variant-play-steps`) and the scrubber (`play/variant-play-events`) parsed the registered body's raw `:script`. Anything the plan compiler rewrites was therefore stepped differently from how it ran:

- the stepper dispatched an `[:arg key]` placeholder verbatim, and the scrubber's events never matched the run's epoch tape;
- a `:compose`d fragment's script, which the compiler prepends, was missing;
- a `:plays` variant has no `:script` slot at all, so the stepper read "no steps".

## The change (`tools/story/src/re_frame/story/play.cljc` only)

- One private `stepped-program` returns the scripts of the compiled plan's auto-runnable plays, concatenated in order. That is the same expression `run-phase-4!` executes, compiled with `rf.story.args/run-arg-layers` exactly as `runtime/prepare-context` does.
  - The bead's suggested smallest change read `[:world :scripts 0 :script]`. The runtime runs ALL auto-runnable plays, so a `:plays` variant with two auto-run plays would still have diverged under that read. The `:plays` witness pins this case.
- A variant that auto-runs nothing yields its primary compiled play, so a script the author opted out of auto-running can still be stepped by hand. The existing `:auto-run? false` stepper test depends on this. An unregistered variant still yields `[]`.
- `variant-play-events` degrades to `[]` on a plan-construction failure, such as an `[:arg]` that only an active mode or cell override supplies. That way the scrubber cannot throw out of the handler that stores the run result.
- `variant-play-steps`, `variant-play-events` and `begin-stepper!` gain an `opts` arity (the `run-variant` opts map). The 1-arity forms match `stepper-state/begin!`, which prepares with no opts.
- `execute-play!`, `dispatch-one!` and `read-assertions-after` are untouched, because rf2-tb75 owns them.
- Requiring `plan` and `args` from `play` adds no require cycle: none of plan's direct dependencies require `play`.

## Evidence

The new JVM suite is `tools/story/test/re_frame/story/stepper_compiled_plan_test.clj`.

- **Witnesses.** Every witness is a variant whose raw `:script` and compiled plan DIFFER. Each first asserts that divergence through the pre-fix reader, reproduced verbatim. It then compares against what `run-variant` actually did (final app-db, epoch tape), never against a re-derivation of the reader's own plan expression. The seven witnesses:
  - `[:arg]` substitution (the case the bead names);
  - `:plays` with two auto-run plays and one manual play;
  - a `:compose` fragment script;
  - scrubber alignment against the run's epoch tape;
  - run-opts threading;
  - the mode-only-arg degrade;
  - the `:auto-run? false` fallback.
- **Control.** A plain `:script` variant, where both readers agree.
- **Sabotage.** With the raw read planted back into `stepped-program`, 13 assertions failed across exactly those seven witnesses. The control and the unregistered-variant test stayed green.

## Quality gates

Each number below is the runner's own exit code, captured on the same command line as its log redirect.

**Ran locally**

- Worker worktree guard (`scripts/assert-worker-worktree.sh`): ran, exit 0.
- Focused JVM run (`clojure -M:test -n` over the new suite, `re-frame.story-play-test` and `re-frame.story.stepper-start-test`): exit 0, 41 tests, 129 assertions.
- New suite alone: exit 0, 9 tests, 31 assertions.
- Sabotage run, with the raw read planted in the line the fix changed:
  - exit 1, with 13 failures, all in the seven witnesses;
  - totals unchanged at 9 tests / 31 assertions, so no namespace crashed;
  - restore verified by blob hash against the committed object.
- Full `jvm-tools-story` (`cd tools/story && clojure -M:test`) on the final base: exit 0, 1923 tests, 7078 assertions, 0 failures.
- Gates that grade these paths, each run as self-test then gate:
  - require-alias dialect 0 / 0;
  - test-lane bijection 0 / 0;
  - retired spellings 0 / 0;
  - egress-walker residue 0 / 0;
  - view-lifetime vocabulary 0 / 0.
- `check-no-hardcoded-paths.sh`: exit 0.
- `check_doc_slugs.py`: exit 0.
- `lint_kondo.py`: exit 0, 0 errors. The one warning on the new file is the repo-wide `Unresolved var: rf/reg-event` pattern.

**Relying on CI**

- The CLJS lanes (`cljs_node_test`, `cljs_browser`, `examples_compile`).
- `story_xray_browser`, the pane gate the bead names.
- `mcp_conformance`, Splint and the api-manifest check.

The worktree has no `implementation/node_modules`, so the node lanes cannot run locally. For those lanes, `play.cljc` only gains requires of namespaces the CLJS builds already compile, and no CLJS test stubs the three fns that gained an arity.

## Not in this PR

- The UI call sites still use the 1-arity readers: `ui/test_mode/state.cljs` `store-result!` and `stepper_state.cljs` `begin!`. Those files are fenced to another worker, so the change is filed as rf2-ad25, together with the `tools/story/spec/009-Test-Mode.md` wording.
- This defect is not one of rf2-fzbj.3's findings. That finding's only step-debugger mention defers to the closed rf2-k6y2.
