### PR TITLE
fix(story): reg-story* desugars non-literal :variants; play maps are closed (rf2-pjay, rf2-uys9)

### DIFF
--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -256,34 +256,44 @@
       (when (<= d threshold) k))))
 
 (defn- extra-key-errors
-  "Pull the `:malli.core/extra-key` errors out of a malli `explain`.
-  Each carries the offending key in `:in` and the offending `:map`
-  subschema in `:schema` (from which the declared key set is read).
-  Dedups by unknown key (an `:or` schema reports one per branch)."
+  "Pull the `:malli.core/extra-key` errors out of a malli `explain`, keyed
+  by the full `:in` path. The path's LAST element is the unknown key; what
+  precedes it locates the closed map that rejected it — empty for a
+  top-level slot, `[:script]` / `[:plays 0]` for a nested play map
+  (rf2-uys9). Each value is that map's subschema, from which its declared
+  key set is read. Dedups by path (an `:or` schema reports one per branch)."
   [explain]
   (->> (:errors explain)
        (filter #(= :malli.core/extra-key (:type %)))
        (reduce (fn [acc {:keys [in schema]}]
-                 (let [k (first in)]
-                   (if (contains? acc k) acc (assoc acc k schema))))
+                 (let [in (vec in)]
+                   (if (contains? acc in) acc (assoc acc in schema))))
                {})))
 
 (defn- unknown-key-reason
   "Build the actionable unknown-key clause for the error `:reason`, or
   nil when the explain carries no `:malli.core/extra-key` errors (a
-  different shape failure — :reason falls back to the generic message)."
+  different shape failure — :reason falls back to the generic message).
+  A key rejected by a NESTED closed map is named with its location, and
+  its suggestion and allowed-key list come from that map, not the body."
   [kind explain]
   (let [extras (extra-key-errors explain)]
     (when (seq extras)
-      (let [declared (sort (m/explicit-keys (val (first extras))))
-            clauses  (for [k (sort (keys extras))
-                           :let [hint (nearest-key k declared)]]
-                       (str k
-                            (when hint (str " (did you mean " hint "?)"))))]
+      (let [declared (fn [schema] (sort (m/explicit-keys schema)))
+            at-str   (fn [at] (when (seq at) (str " in " (pr-str at))))
+            entries  (sort-by #(mapv pr-str (key %)) extras)
+            clauses  (for [[in schema] entries
+                           :let [k    (peek in)
+                                 hint (nearest-key k (declared schema))]]
+                       (str k (at-str (pop in))
+                            (when hint (str " (did you mean " hint "?)"))))
+            allowed  (for [[at group] (group-by #(pop (key %)) entries)]
+                       (str "Allowed keys" (at-str at) ": "
+                            (pr-str (vec (declared (val (first group))))) ". "))]
         (str "re-frame2-story: unknown " (name kind) " slot(s) "
              (str/join ", " clauses)
              " — the " (name kind) " authoring body is closed (rf2-mantt). "
-             "Allowed keys: " (pr-str (vec declared)) ". "
+             (apply str allowed)
              "Remove the slot, or fix the typo.")))))
 
 (defn- validate-shape!
@@ -438,7 +448,7 @@
 ;; seven helpers with NO per-kind preprocessing (fragment / check / workspace /
 ;; mode / story-panel / decorator / tag) share their ENTIRE body: auto-install,
 ;; assert the id shape, merge source-coords, validate the shape, store
-;; (`reg-simple!`). `reg-story*` (Form-B `:variants` strip + tag check) and
+;; (`reg-simple!`). `reg-story*` (Form-B `:variants` desugar + tag check) and
 ;; `reg-variant*` (tag check) carry kind-specific steps, so they expand the
 ;; flow inline but still finish through `store!`.
 
@@ -464,23 +474,33 @@
        (validate-shape! kind id)
        (store! kind id)))
 
-(defn reg-story*
-  "Runtime helper for `reg-story` macro. Validates the body, stamps
-  source coords, writes to the side-table. Returns `id`.
+(declare reg-variant*)
 
-  Form-B `:variants` desugaring lives in the *macro* — by the time the
-  helper is called, the body's `:variants` (if any) has been peeled off
-  and the N independent `reg-variant*` calls have been emitted as
-  siblings. So the helper sees only the parent-story slice."
+(defn reg-story*
+  "Runtime helper for `reg-story` macro, and its public programmatic twin.
+  Validates the body, stamps source coords, writes the story to the
+  side-table, then registers each Form-B `:variants` entry. Returns `id`.
+
+  The macro peels a LITERAL `:variants` map at expansion time into N
+  top-level `reg-variant*` forms (hot-reload-by-variant). Any `:variants`
+  that still reaches this helper — a def'd or merged map handed to the
+  macro, or a programmatic call — is desugared HERE through the same
+  `reg-variant*` rail, under the same `<story-id>/<variant-name>` ids and
+  the same bound source coords, rather than dropped (rf2-pjay). The stored
+  story body never carries `:variants`."
   [id body]
   (maybe-auto-install!)
   (assert-id! :story id)
-  (let [body (-> body
-                 (dissoc :variants)               ; Form-B sugar is removed by the macro
-                 merge-coords
-                 (->> (validate-shape! :story id)))
-        _    (validate-tag-membership! id (:tags body))]
-    (store! :story id body)))
+  (let [variants (:variants body)
+        body     (-> body
+                     merge-coords
+                     (->> (validate-shape! :story id))
+                     (dissoc :variants))
+        _        (validate-tag-membership! id (:tags body))]
+    (store! :story id body)
+    (doseq [[v-name v-body] variants]
+      (reg-variant* (keyword (name id) (name v-name)) v-body))
+    id))
 
 (defn reg-variant*
   "Runtime helper for `reg-variant` macro. Per `001-Authoring.md` §Registration macros + spec/017

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -454,8 +454,9 @@
   - `:modes` — saved-tuple mode ids opt-in.
   - `:substrates` — default substrate set for variants.
   - `:platforms` — SSR opt-in.
-  - `:variants` — the Form-B combined-form sugar; the macro desugars
-    into N independent `reg-variant` calls.
+  - `:variants` — the Form-B combined-form sugar; desugared into N
+    independent `reg-variant` calls (by the macro for a literal map, by
+    `reg-story*` for anything else).
   - `:dispatch-console?` — Story-shell dispatch console panel opt-in.
     Default false (panel hidden). Set true to surface the per-variant
     dispatch console for this story / its variants. Toolbar
@@ -525,8 +526,9 @@
    ;; not fork that validation — one source of truth.
    [:images     {:optional true} [:vector :any]]
    ;; The Form-B combined-form sugar. Variant-name keys map to variant
-   ;; bodies — the macro expands these into N independent reg-variant
-   ;; calls. Validated separately when the macro desugars.
+   ;; bodies, desugared into N independent reg-variant calls (the macro
+   ;; for a literal map, `reg-story*` otherwise); each body is then
+   ;; validated as a `Variant` on its own registration.
    [:variants   {:optional true} [:map-of :keyword :map]]])
 
 ;; ---- :rf/variant ----------------------------------------------------------
@@ -576,10 +578,15 @@
 
   Per `tools/story/spec/017-Testing-Story.md` §Public vocabulary the
   authoring key for ordered behaviour-under-test is `:script`, and the
-  registered body carries it under that same key."
+  registered body carries it under that same key.
+
+  The map is `{:closed true}` (rf2-uys9): an absent `:auto-run?` means
+  auto-run, so a misspelt opt-out (`:auto-run`, `:autorun?`) would
+  otherwise run the script with no error. It is rejected at registration
+  instead, naming the key, its location and the nearest declared key."
   [:or
    PlayScript
-   [:map
+   [:map {:closed true}
     [:script    PlayScript]
     [:auto-run? {:optional true} :boolean]
     [:name      {:optional true} :string]]])
@@ -590,14 +597,14 @@
   "A single entry in a `:plays` vector. Same shape as `PlaySpec` (map
   form) but `:name` is REQUIRED — multi-play needs a stable label per
   play so the toolbar dropdown + the CI runner can identify each
-  play unambiguously.
+  play unambiguously. Closed, for the same reason as `PlaySpec`.
 
   Example:
       {:name      \"happy path\"
        :auto-run? true
        :script    [[:dispatch-sync [:counter/initialise 3]]
                    [:assert-db [:count] 3]]}"
-  [:map
+  [:map {:closed true}
    [:name      :string]
    [:script    PlayScript]
    [:auto-run? {:optional true} :boolean]])

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -36,7 +36,8 @@
   the macro expands them at the parent's expansion site. A consumer
   authoring the combined form expects every generated variant's
   `:source` to point back at the same `(reg-story ...)` call."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as rf.story]
             [re-frame.story.macros :as rf.story.macros]
             [re-frame.story.plan :as rf.story.plan]))
@@ -497,6 +498,64 @@
           (is (= :rf.error/fragment-shape (:rf.error/id (ex-data e)))
               (str label " rejects with :rf.error/fragment-shape")))))))
 
+;; ---- rf2-uys9 — play maps are closed --------------------------------------
+;;
+;; An absent `:auto-run?` means auto-run (`play.runner/default-auto-run?`),
+;; so a misspelt opt-out used to RUN the script with no error. The
+;; `PlaySpec` / `NamedPlaySpec` map branches are closed: the typo rejects
+;; at reg-time, naming the key, WHERE it sits, and the nearest declared key.
+
+(defn- shape-data
+  "Call `f` and return the thrown ex-data, or nil when it did not throw."
+  [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(deftest reg-variant-rejects-misspelt-play-map-key
+  (doseq [[label body at]
+          [[":script map, :autorun?"
+            {:setup [] :script {:script [[:dispatch [:x]]] :autorun? false}}
+            "[:script]"]
+           [":script map, :auto-run (no ?)"
+            {:setup [] :script {:script [[:dispatch [:x]]] :auto-run false}}
+            "[:script]"]
+           [":plays entry, :autorun?"
+            {:setup [] :plays [{:name "a" :script [[:dispatch [:x]]]}
+                               {:name "b" :script [] :autorun? false}]}
+            "[:plays 1]"]]]
+    (testing label
+      (let [data   (shape-data #(rf.story/reg-variant* :story.play-typo/v body))
+            reason (str (:reason data))]
+        (is (= :rf.error/variant-shape (:rf.error/id data))
+            "a misspelt play key is a shape error, not a silent auto-run")
+        (is (str/includes? reason (str " in " at " (did you mean :auto-run??)"))
+            ":reason names where the key sits and the key it meant")
+        (is (str/includes? reason (str "Allowed keys in " at ": [:auto-run? :name :script]"))
+            ":reason lists the PLAY map's keys, not the variant body's")
+        (is (not (rf.story/registered? :variant :story.play-typo/v))
+            "nothing is registered")))))
+
+(deftest reg-fragment-rejects-misspelt-play-map-key
+  (testing "a fragment's :script map is held to the same closed shape"
+    (let [data (shape-data #(rf.story/reg-fragment* :fragment.play-typo/f
+                              {:script {:script [] :autorun? false}}))]
+      (is (= :rf.error/fragment-shape (:rf.error/id data)))
+      (is (str/includes? (str (:reason data)) ":autorun? in [:script]")))))
+
+(deftest unknown-key-reason-locates-each-offender
+  (testing "a TOP-level typo keeps the unlocated form — no \" in [\" clause"
+    (let [reason (str (:reason (shape-data #(rf.story/reg-variant* :story.play-typo/top
+                                              {:scripts [[:dispatch [:x]]]}))))]
+      (is (str/includes? reason ":scripts (did you mean :script?)"))
+      (is (str/includes? reason "Allowed keys: ["))
+      (is (not (str/includes? reason " in [")))))
+  (testing "a top-level AND a nested typo are each named against their own map"
+    (let [reason (str (:reason (shape-data #(rf.story/reg-variant* :story.play-typo/both
+                                              {:scriptz []
+                                               :script  {:script [] :autorun? false}}))))]
+      (is (str/includes? reason ":scriptz (did you mean :script?), :autorun? in [:script] (did you mean :auto-run??)"))
+      (is (str/includes? reason "Allowed keys: ["))
+      (is (str/includes? reason "Allowed keys in [:script]: [:auto-run? :name :script]")))))
+
 (deftest reg-variant-canonical-body-round-trips-verbatim
   (testing ":setup / :script (bare vector) register and read back under the
             same keys — the write/read round trip is an identity"
@@ -718,6 +777,54 @@
       (is (= (:line (:source body-a))
              (:line (:source body-b)))
           "both generated variants share the parent's expansion line"))))
+
+;; ---- rf2-pjay — a NON-literal :variants map is desugared at runtime -------
+;;
+;; The macro peels only a LITERAL `:variants` map. A def'd or merged map —
+;; and every programmatic `reg-story*` call — reaches the runtime helper
+;; with `:variants` still on the body, which used to be dropped silently:
+;; story registered, zero variants, success return. The helper now
+;; desugars it through the same `reg-variant*` rail.
+
+(def ^:private formb-variants
+  {:a {:setup [[:init-a]]}
+   :b {:setup [[:init-b]] :tags #{:dev}}})
+
+(deftest reg-story*-desugars-programmatic-variants
+  (testing "the programmatic twin registers each :variants entry as <story-id>/<name>"
+    (is (= :story.prog.formb
+           (rf.story/reg-story* :story.prog.formb {:doc "p" :variants formb-variants})))
+    (is (rf.story/registered? :story :story.prog.formb))
+    (is (= {:setup [[:init-a]]}
+           (dissoc (rf.story/handler-meta :variant :story.prog.formb/a) :source)))
+    (is (= {:setup [[:init-b]] :tags #{:dev}}
+           (dissoc (rf.story/handler-meta :variant :story.prog.formb/b) :source)))
+    (is (= {:doc "p"} (dissoc (rf.story/handler-meta :story :story.prog.formb) :source))
+        "the stored story body never carries :variants")))
+
+(deftest reg-story-macro-desugars-non-literal-variants
+  (testing "a computed :variants map handed to the reg-story MACRO registers its
+            variants, each stamped with the macro site's source coords"
+    (rf.story/reg-story :story.prog.macro (assoc {:doc "m"} :variants formb-variants))
+    (let [story (rf.story/handler-meta :story :story.prog.macro)
+          a     (rf.story/handler-meta :variant :story.prog.macro/a)]
+      (is (= [[:init-a]] (:setup a)))
+      (is (rf.story/registered? :variant :story.prog.macro/b))
+      (is (= 're-frame.story-authoring-validation-test (:ns (:source a))))
+      (is (= (:line (:source story)) (:line (:source a)))
+          "a desugared variant shares the parent's expansion line, as on the literal path"))))
+
+(deftest reg-story*-rejects-malformed-variants
+  (testing "a non-keyword variant name is a :rf.error/story-shape, not a silent drop"
+    (is (= :rf.error/story-shape
+           (:rf.error/id (shape-data #(rf.story/reg-story* :story.prog.badname
+                                        {:variants {"a" {:setup []}}})))))
+    (is (not (rf.story/registered? :story :story.prog.badname))))
+  (testing "a desugared variant body is validated like any reg-variant* body"
+    (let [data (shape-data #(rf.story/reg-story* :story.prog.badbody
+                              {:variants {:a {:scripts [[:dispatch [:x]]]}}}))]
+      (is (= :rf.error/variant-shape (:rf.error/id data)))
+      (is (str/includes? (str (:reason data)) ":scripts (did you mean :script?)")))))
 
 ;; ===========================================================================
 ;; MACRO HELPER — `variant-id-for` enforces keyword grammar


### PR DESCRIPTION
Fixes two Story registration inputs that were silently accepted and silently wrong. Beads: rf2-pjay (P2), rf2-uys9 (P3), both discovered by the senior-developer review rf2-wd2t.

## rf2-pjay: `reg-story*` dropped `:variants` for a non-literal body

The `reg-story` macro peels a LITERAL `:variants` map at expansion time. Anything else reached the runtime helper with `:variants` still on the body, and the helper did `(dissoc :variants)` before validating. That covered a def'd or merged map handed to the macro, and every programmatic `reg-story*` call. The result was a registered story with zero variants and a success return.

Re-measured at base `5b89378c45` with a JVM probe (`clojure -M -i <probe>` from `tools/story`): `(reg-story* :story.probe-s {:doc "p" :variants vs})` with `vs` def'd returned the id. The story was registered, variant `:story.probe-s/v` was NOT, and nothing was thrown.

**Fix (runtime desugar, not a throw).** `tools/story/spec/Conventions.md` pairs `reg-story*` with "optional `:variants` desugaring (Form B)", and `001-Authoring.md` makes the `*` helpers the public programmatic path. So the helper now does what the macro does:
- It validates the body with `:variants` present, which makes the `Story` schema's existing `[:map-of :keyword :map]` entry live. A non-keyword variant name is now a `:rf.error/story-shape`.
- It stores the story without `:variants`.
- It registers each entry through `reg-variant*` under `<story-id>/<variant-name>`. That call runs inside the macro's bound `*pending-coords*`, so a desugared variant carries the same `:source` stamp as on the literal path.

The macro and `macros.clj` are untouched. The macro's non-literal branch already calls `reg-story*` with the full body, so it is fixed by this change too.

## rf2-uys9: `PlaySpec` / `NamedPlaySpec` maps were open

An absent `:auto-run?` means auto-run (`play.runner/default-auto-run?`). So a misspelt opt-out such as `:auto-run false` or `:autorun? false` silently RAN the script. That contradicted the closed-shape promise in the `Variant` docstring. Re-measured at base: all three typo shapes were accepted (`:script` map `:auto-run`, `:script` map `:autorun?`, and a `:plays` entry `:autorun?`).

**Fix.** Both map branches are now `{:closed true}`. The unknown-key `:reason` now keys on the full malli `:in` path rather than `(first in)`; with `(first in)` a nested typo would have been reported as `:script`. A nested key is named with its location, and its suggestion and allowed keys come from the map that rejected it:

```
re-frame2-story: unknown variant slot(s) :autorun? in [:plays 0] (did you mean :auto-run??) — the variant authoring body is closed (rf2-mantt). Allowed keys in [:plays 0]: [:auto-run? :name :script]. Remove the slot, or fix the typo.
```

A top-level typo reads exactly as before, and a test pins that.

**Blast radius checked.** A worktree-wide census found no play map carrying a key other than `:script` / `:auto-run?` / `:name`. That covered 33 `:plays` sites, 67 map-form `:script` sites, and every code path that builds one: the recorder, play-export, and the runner normalisers.

## Scope

- **Files:** `registrar.cljc`, `schemas.cljc`, and `story_authoring_validation_test.clj`. That is the dispatched fence.
- **No overlap with held finding rf2-fzbj.3.** Its findings concern loaders and args resolution in the runtime, canvas and share code.
- **One stale comment left outside the fence.** `tools/story/src/re_frame/story/macros.clj` still says the non-literal branch "punt[s] to runtime (helper drops :variants)". The helper no longer drops them; the punt is now correct and only the parenthetical is stale. It is recorded on rf2-pjay for whoever next touches that file.

## Quality gates

| Gate | Tree | Captured exit | Tests / assertions |
|---|---|---|---|
| `jvm-tools-story` (`clojure -M:test` from `tools/story`), baseline | base `5b89378c45` | 0 | 1914 / 7047 |
| same, with the fix | working tree == `0062ea7994` | 0 | 1920 / 7080 |
| same, **sabotaged** (see below) | fix + 3 planted faults | **1**, 24 failures | 1920 / 7080 |
| same, post-restore | `0062ea7994` (blob-hash verified) | 0 | 1920 / 7080 |

- **Counts.** The +6 tests and +33 assertions are exactly the new deftests and `is` forms.
- **Sabotage.** Three lines I changed were reverted: the `reg-variant*` call inside `reg-story*`'s desugar was replaced with `nil`, and `{:closed true}` was removed from both `PlaySpec` and `NamedPlaySpec`. Each anchor was checked to match exactly once. The run failed in exactly the 6 new deftests (12 + 4 + 2 + 2 + 2 + 2 = 24), with totals unchanged, so no plant crashed a namespace or hid anything.
- **Restore.** Verified by blob hash against the committed object, and by `git diff --quiet HEAD` exiting 0.
- **Static checks.** The repo-wide static and residue checks run locally all exited 0: retired spellings, thrown-error messages, require-alias dialect, test-lane bijection, JVM lane rosters, inject-cofx, failure-corpus, composition-vocab, image-keys, keyword catalogue, no-hardcoded-paths, ai-tracking, and others.
- **Relied on CI.** `npm run test:cljs` (the CLJS `:node-test` lane) was not run locally, because this worktree has no `node_modules`. The new tests are JVM-only (`.clj`). The source change is `.cljc` using only core fns (`peek`, `pop`, `group-by`, `declare`).
- **Merge-base diff.** `origin/main...HEAD` touches only these three files, and nothing has landed in `tools/story` since base.
