### PR TITLE
test(story): run four host-free .cljc suites on the CLJS lane; state the node skip in dom_capture (rf2-exlh, rf2-s6uu)

### DIFF
--- a/tools/story/test/re_frame/story/compose_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/compose_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.compose-test
+(ns re-frame.story.compose-cljs-test
   "Tests for strict `:compose` composition — fragments, checks, total merge
   order, variant-owned-wins, and the silent-conflict failure (rf2-5x1wt.15).
 
@@ -6,7 +6,10 @@
   §Conflict resolution + `ai/findings/NewTestStory` §B3. The compiler is a
   pure data → data fn, so every test runs on both the JVM and CLJS without
   a host: fragment / check / variant bodies are supplied through explicit
-  `:lookup` / `:fragment-lookup` / `:check-lookup` maps of RAW bodies."
+  `:lookup` / `:fragment-lookup` / `:check-lookup` maps of RAW bodies.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.plan :as rf.story.plan]
             [re-frame.story.schemas :as rf.story.schemas]))

--- a/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/login_example_seed_cljs_test.cljs
@@ -18,7 +18,7 @@
    The fix registers ONE `:fragment.login/form-base` fragment whose
    `:setup` is `[[:auth.login/initialise-form]]` and composes it into every
    variant. Because the plan compiler appends a composed fragment's `:setup`
-   BEFORE the variant's own (spec/017 §`:compose`; re-frame.story.compose-test),
+   BEFORE the variant's own (spec/017 §`:compose`; re-frame.story.compose-cljs-test),
    the compiled `[:world :setup]` of EVERY variant must LEAD with
    `[:auth.login/initialise-form]`. This test compiles each registered
    variant plan (a pure data → data compile, no host) and asserts exactly

--- a/tools/story/test/re_frame/story/plan_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/plan_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.plan-test
+(ns re-frame.story.plan-cljs-test
   "Tests for the variant-plan compiler + explain base (rf2-5x1wt.10).
 
   Per `tools/story/spec/017-Testing-Story.md` §Four-bucket authoring
@@ -7,7 +7,10 @@
   host: variant bodies are supplied through an explicit `:lookup` map of
   RAW bodies (the parent-chain resolution is the compiler's job, so the
   test bodies still carry `:extends` rather than relying on the
-  registrar's eager merge)."
+  registrar's eager merge).
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [re-frame.story.assertions :as rf.story.assertions]

--- a/tools/story/test/re_frame/story/plan_network_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/plan_network_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.plan-network-test
+(ns re-frame.story.plan-network-cljs-test
   "Tests for the first-class `:network` world slot (rf2-5x1wt.14).
 
   Per `tools/story/spec/017-Testing-Story.md` §Network world +
@@ -15,7 +15,10 @@
   id. These tests pin: mixed success/failure per route, the fail-closed
   posture for unmatched routes (documented; enforced by the helper at run
   time), the predictable `:network` vs explicit `:fx-overrides` conflict,
-  explain visibility, plan-hash sensitivity, and the schema acceptance."
+  explain visibility, plan-hash sensitivity, and the schema acceptance.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [re-frame.story.plan        :as rf.story.plan]

--- a/tools/story/test/re_frame/story/recorder/dom_capture_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_dom_cljs_test.cljs
@@ -27,8 +27,9 @@
   it never matched the `:browser-test` gate, so its ~25 assertions
   ran in NO gate (latent false-green). The `-dom-cljs-test` suffix
   fixes that — `:node-test`'s `cljs-test$` regex still matches it
-  too (bodies stay green-by-short-circuit on node), and
-  `:browser-test` now picks it up and runs the real assertions."
+  too, where every row reports a STATED skip through `skip!` rather
+  than passing with zero assertions (rf2-s6uu), and `:browser-test`
+  now picks it up and runs the real assertions."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story.config :as rf.story.config]
             [re-frame.story.recorder :as rf.story.recorder]
@@ -41,6 +42,14 @@
 (defn- dom-available? []
   (and (exists? js/document)
        (some? (.-body js/document))))
+
+(defn- skip!
+  "The stated skip for a row under `:node-test`, which has no
+  `js/document`: one marker assertion, so the row reports a skip instead
+  of passing with zero assertions (rf2-s6uu). Under `:browser-test` the
+  real body runs."
+  []
+  (is true "skipped: needs a real DOM — the assertions run under :browser-test"))
 
 ;; ---- transient DOM root --------------------------------------------------
 
@@ -61,8 +70,8 @@
 
 (defn- reset-all! [f]
   (if-not (dom-available?)
-    ;; node-test: skip the DOM fixture entirely. The individual
-    ;; deftest bodies short-circuit on `dom-available?` too.
+    ;; node-test: skip the DOM fixture entirely. Each deftest body
+    ;; states its own skip through `skip!`.
     (f)
     (do
       (rf.story.recorder/clear!)
@@ -87,7 +96,8 @@
 ;; ---- selector picking via real DOM elements ------------------------------
 
 (deftest pick-for-element-prefers-data-test
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "pick-for-element walks priority on a real DOM element"
       (let [btn (.createElement js/document "button")]
         (.setAttribute btn "data-test" "go")
@@ -96,7 +106,8 @@
                (rf.story.recorder.selector/pick-for-element btn)))))))
 
 (deftest pick-for-element-falls-back-to-nth
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "no useful attributes → nth-of-type fallback"
       (let [parent (.createElement js/document "div")
             a (.createElement js/document "button")
@@ -111,33 +122,40 @@
 ;; ---- impure recorder seams ----------------------------------------------
 
 (deftest record-dom-click-appends-entry
-  (when (dom-available?)
-    (rf.story.recorder/start-recording! :story.x/y)
-    (rf.story.recorder.dom-capture/record-dom-click! "[data-test=\"go\"]")
-    (let [entries (rf.story.recorder/recorded-entries)]
-      (is (= 1 (count entries)))
-      (let [{:keys [kind selector t]} (first entries)]
-        (is (= :dom/click kind))
-        (is (= "[data-test=\"go\"]" selector))
-        (is (number? t))))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/record-dom-click! "[data-test=\"go\"]")
+      (let [entries (rf.story.recorder/recorded-entries)]
+        (is (= 1 (count entries)))
+        (let [{:keys [kind selector t]} (first entries)]
+          (is (= :dom/click kind))
+          (is (= "[data-test=\"go\"]" selector))
+          (is (number? t)))))))
 
 (deftest record-dom-type-appends-entry
-  (when (dom-available?)
-    (rf.story.recorder/start-recording! :story.x/y)
-    (rf.story.recorder.dom-capture/record-dom-type! "[id=\"name\"]" "alice")
-    (let [{:keys [kind selector text]} (first (rf.story.recorder/recorded-entries))]
-      (is (= :dom/type kind))
-      (is (= "[id=\"name\"]" selector))
-      (is (= "alice" text)))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/record-dom-type! "[id=\"name\"]" "alice")
+      (let [{:keys [kind selector text]} (first (rf.story.recorder/recorded-entries))]
+        (is (= :dom/type kind))
+        (is (= "[id=\"name\"]" selector))
+        (is (= "alice" text))))))
 
 (deftest record-dom-submit-appends-entry
-  (when (dom-available?)
-    (rf.story.recorder/start-recording! :story.x/y)
-    (rf.story.recorder.dom-capture/record-dom-submit! "[id=\"login\"]")
-    (is (= :dom/submit (:kind (first (rf.story.recorder/recorded-entries)))))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder/start-recording! :story.x/y)
+      (rf.story.recorder.dom-capture/record-dom-submit! "[id=\"login\"]")
+      (is (= :dom/submit (:kind (first (rf.story.recorder/recorded-entries))))))))
 
 (deftest noops-when-not-recording
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "DOM-event records drop when no recording is in flight"
       (is (not (rf.story.recorder/recording?)))
       (rf.story.recorder.dom-capture/record-dom-click! "anywhere")
@@ -146,7 +164,8 @@
       (is (= [] (rf.story.recorder/recorded-entries))))))
 
 (deftest noops-when-dom-capture-disabled
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "DOM-event records drop when the toggle is off — even mid-recording"
       (rf.story.recorder.dom-capture/set-enabled! false)
       (rf.story.recorder/start-recording! :story.x/y)
@@ -160,21 +179,24 @@
 ;; ---- click handler via synthetic DOM events ------------------------------
 
 (deftest click-listener-captures-with-selector
-  (when (dom-available?)
-    (rf.story.recorder/start-recording! :story.x/y)
-    (let [btn (.createElement js/document "button")]
-      (.setAttribute btn "data-test" "submit")
-      (.appendChild @test-root btn)
-      (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
-      (let [entries (rf.story.recorder/recorded-entries)]
-        (is (= 1 (count entries)))
-        (is (= :dom/click (:kind (first entries))))
-        (is (= "[data-test=\"submit\"]" (:selector (first entries))))))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder/start-recording! :story.x/y)
+      (let [btn (.createElement js/document "button")]
+        (.setAttribute btn "data-test" "submit")
+        (.appendChild @test-root btn)
+        (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
+        (let [entries (rf.story.recorder/recorded-entries)]
+          (is (= 1 (count entries)))
+          (is (= :dom/click (:kind (first entries))))
+          (is (= "[data-test=\"submit\"]" (:selector (first entries)))))))))
 
 ;; ---- type debounce (final-value semantics) ------------------------------
 
 (deftest rapid-typing-folds-to-single-entry
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "many input events on the same input → ONE :dom/type entry with the final value"
       (rf.story.recorder/start-recording! :story.x/y)
       ;; Bump the debounce window high so the buffer holds the
@@ -207,7 +229,8 @@
 ;; short-circuit on node).
 
 (deftest change-event-flushes-immediately
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "a `change` event drains the per-selector type buffer"
       (rf.story.recorder/start-recording! :story.x/y)
       (let [input (.createElement js/document "input")]
@@ -221,20 +244,23 @@
           (is (= "alice" (:text (first type-entries)))))))))
 
 (deftest submit-listener-captures-form-selector
-  (when (dom-available?)
-    (rf.story.recorder/start-recording! :story.x/y)
-    (let [form (.createElement js/document "form")]
-      (.setAttribute form "id" "login")
-      (.appendChild @test-root form)
-      (let [ev (js/Event. "submit" #js {:bubbles true :cancelable true})]
-        (.dispatchEvent form ev))
-      (let [submit-entries (filterv #(= :dom/submit (:kind %))
-                                    (rf.story.recorder/recorded-entries))]
-        (is (= 1 (count submit-entries)))
-        (is (= "[id=\"login\"]" (:selector (first submit-entries))))))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder/start-recording! :story.x/y)
+      (let [form (.createElement js/document "form")]
+        (.setAttribute form "id" "login")
+        (.appendChild @test-root form)
+        (let [ev (js/Event. "submit" #js {:bubbles true :cancelable true})]
+          (.dispatchEvent form ev))
+        (let [submit-entries (filterv #(= :dom/submit (:kind %))
+                                      (rf.story.recorder/recorded-entries))]
+          (is (= 1 (count submit-entries)))
+          (is (= "[id=\"login\"]" (:selector (first submit-entries)))))))))
 
 (deftest click-flushes-pending-type
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "a click after typing flushes the type buffer first, preserving order"
       (rf.story.recorder/start-recording! :story.x/y)
       (let [input (.createElement js/document "input")
@@ -256,16 +282,19 @@
 ;; ---- enabled? / set-enabled! --------------------------------------------
 
 (deftest set-enabled-roundtrips
-  (when (dom-available?)
-    (rf.story.recorder.dom-capture/set-enabled! false)
-    (is (not (rf.story.recorder.dom-capture/enabled?)))
-    (rf.story.recorder.dom-capture/set-enabled! true)
-    (is (rf.story.recorder.dom-capture/enabled?))))
+  (if-not (dom-available?)
+    (skip!)
+    (do
+      (rf.story.recorder.dom-capture/set-enabled! false)
+      (is (not (rf.story.recorder.dom-capture/enabled?)))
+      (rf.story.recorder.dom-capture/set-enabled! true)
+      (is (rf.story.recorder.dom-capture/enabled?)))))
 
 ;; ---- timestamps ride through to entries ---------------------------------
 
 (deftest dom-entries-carry-relative-timestamps
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "the recorded :t is relative to the recording's :started-ms"
       (rf.story.recorder/start-recording! :story.x/y)
       (rf.story.recorder.dom-capture/record-dom-click! "[data-test=\"a\"]")
@@ -296,7 +325,8 @@
     input))
 
 (deftest password-field-type-is-redacted-in-generated-snippet
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "RED→GREEN (rf2-0qoi0): a typed <input type=password> value is
               SCRUBBED — neither the recorded :dom/type entry nor the
               generated play-script :type step carries the plaintext"
@@ -320,7 +350,8 @@
                 "the rendered snippet text leaks no plaintext")))))))
 
 (deftest email-and-tel-and-autocomplete-fields-are-redacted
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "email / tel inputs + a credential autocomplete token are scrubbed"
       (doseq [attrs [{:type "email" :id "e"}
                      {:type "tel" :id "t"}
@@ -337,7 +368,8 @@
                 (str "scrubbed for attrs " (pr-str attrs)))))))))
 
 (deftest ordinary-text-field-is-not-redacted
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "a plain <input type=text> + a <select> choice flow through verbatim
               — only sensitive typed inputs are scrubbed (no over-redaction)"
       (rf.story.recorder/start-recording! :story.x/y)
@@ -349,7 +381,8 @@
                                       (rf.story.recorder/recorded-entries))))))))))
 
 (deftest local-raw-profile-opts-into-verbatim-capture
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing ":rf.egress/local-raw → the DOM rail captures the verbatim
               password (host opt-in, mirrors the dispatch rail; EP-0015 rf2-3t26eh)"
       (rf.story.config/set-egress-profile! :rf.egress/local-raw)
@@ -362,7 +395,8 @@
                                       (rf.story.recorder/recorded-entries))))))))))
 
 (deftest redacting-a-password-bumps-the-suppressed-counter
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "the suppressed-events counter for the recording variant is bumped
               on redaction so the UI's REDACTED hint stays accurate"
       (rf.story.config/reset-suppressed-count!)

--- a/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_stop_flush_dom_cljs_test.cljs
@@ -8,7 +8,9 @@
   only place the DOM assertions, and the bug these pin (a flush firing
   AFTER `:recording?` is cleared), are observable. (The sibling was
   previously misnamed `-cljs-test`, so its DOM assertions ran in NO gate;
-  fixed under rf2-jmfvc.)
+  fixed under rf2-jmfvc.) `:node-test`'s `cljs-test$` regex matches the
+  suffix too; there, with no `js/document`, every row reports a STATED
+  skip through `skip!` rather than passing with zero assertions (rf2-s6uu).
 
   THE BUG (rf2-eztym.3): a typed `:dom/type` entry is buffered with a
   debounce timer. `flush-type-buffer!` previously routed through
@@ -33,6 +35,14 @@
 (defn- dom-available? []
   (and (exists? js/document)
        (some? (.-body js/document))))
+
+(defn- skip!
+  "The stated skip for a row under `:node-test`, which has no
+  `js/document`: one marker assertion, so the row reports a skip instead
+  of passing with zero assertions (rf2-s6uu). Under `:browser-test` the
+  real body runs."
+  []
+  (is true "skipped: needs a real DOM — the assertions run under :browser-test"))
 
 ;; ---- transient DOM root --------------------------------------------------
 
@@ -77,7 +87,8 @@
 ;; ---- stop-before-flush regression (rf2-eztym.3) --------------------------
 
 (deftest stop-before-flush-still-captures-final-type
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "a buffered keystroke survives a flush that fires AFTER the
               recording was stopped — the final :dom/type entry is NOT
               dropped when stop-recording! clears :recording? before the
@@ -115,7 +126,8 @@
                 "the generated :type step carries the final value")))))))
 
 (deftest remove-after-stop-drains-final-type
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "rf.story.recorder.dom-capture/remove! after stop-recording! still drains the pending type
               buffer (the worst-case teardown ordering — remove! routes
               through flush-type-buffer!)"
@@ -135,7 +147,8 @@
           (is (= "bob" (:text (first type-entries)))))))))
 
 (deftest in-session-flush-unchanged
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "the fix does not regress the in-session path — a flush WHILE
               recording still appends exactly one entry with the final value"
       (rf.story.recorder/start-recording! :story.x/y)
@@ -167,7 +180,8 @@
 ;; pending buffer via the `:recorder/reset-dom-buffer` late-bind seam.
 
 (deftest stop-then-restart-does-not-bleed-across-recordings
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "a keystroke buffered under recording A, then a NON-flushing
               stop + start-recording! B within the debounce window, does NOT
               land in B's :entries — start-recording! drains + cancels the
@@ -197,7 +211,8 @@
               "A's buffered keystroke did NOT bleed into recording B"))))))
 
 (deftest clear-while-typing-leaves-no-phantom-in-next-recording
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "clear! while a keystroke is buffered cancels the pending flush,
               so a subsequent recording sees no phantom entry (rf2-x76af2.18)"
       (rf.story.recorder/start-recording! :story.a/rec)
@@ -217,7 +232,8 @@
             "clear! cancelled the pending flush — no phantom entry in C")))))
 
 (deftest stop-into-same-recording-final-keystroke-still-survives
-  (when (dom-available?)
+  (if-not (dom-available?)
+    (skip!)
     (testing "rf2-eztym.3 guard still holds under the rf2-x76af2.18 fix:
               stop-recording! does NOT drain the buffer, so a flush firing
               after stop (with NO intervening start/clear) still captures the

--- a/tools/story/test/re_frame/story/render_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/render_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.render-test
+(ns re-frame.story.render-cljs-test
   "Tests for `render-variant` + the workshop-superset plan slots
   (rf2-5x1wt.24).
 
@@ -10,7 +10,10 @@
   + view metadata are supplied through explicit `:lookup` / `:view-lookup`
   maps. The host-render path (`render-variant` proper) is exercised by
   installing a fake `:render-host` hook so the `:rendered` shape + the
-  no-host `:cannot-run` refusal are both pinned."
+  no-host `:cannot-run` refusal are both pinned.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.story.fingerprint :as rf.story.fingerprint]

--- a/tools/story/test/re_frame/story/run_owner_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/run_owner_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.run-owner-cljc-test
+(ns re-frame.story.run-owner-cljs-test
   "Regression net for Story's ONE run owner (rf2-j538f7.34).
 
   A focused shell selection used to have THREE execution owners — the
@@ -14,7 +14,11 @@
   `rf.story.async/promise` executes synchronously, so the frame's app-db and the
   external-effect counter are settled the instant `resume-run!` returns — no
   awaiting needed. The one supersession test that needs an async barrier is
-  JVM-gated (it blocks a thread)."
+  JVM-gated (it blocks a thread).
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it. Under its old `-cljc-test` name no CLJS build selected it, so
+  the `:cljs` branches below never compiled (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]

--- a/tools/story/test/re_frame/story/stepper_start_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/stepper_start_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.stepper-start-test
+(ns re-frame.story.stepper-start-cljs-test
   "Regression net for the step-debugger's START ordering (rf2-k6y2).
 
   The `:test` pane's step-debugger promises that cursor 0 IS the pre-play
@@ -26,7 +26,12 @@
 
   Runs on BOTH runtimes: phases 0-2 are synchronous and the script steps
   are pure `:dispatch-sync`, so the frame's app-db and the external-effect
-  counter are settled the instant each call returns — no awaiting needed."
+  counter are settled the instant each call returns — no awaiting needed.
+  The preparation-failure rows further down read `begin!`'s resolve/reject
+  branch by blocking on the promise, so those are JVM-gated.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as rf.epoch]

--- a/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/sub_overrides_cljs_test.cljs
@@ -13,8 +13,8 @@
   bound on the render-path resolver, `compute-sub` (the exact seam the
   assertion uses) still returns the REAL app-db value, so the override
   cannot make a false subscription assertion pass. The pure-data resolver
-  tests live JVM-side in `re-frame.story.plan-test`; this file is CLJS
-  because `compute-sub` + `reg-sub` need the framework runtime."
+  tests live in the host-free `re-frame.story.plan-cljs-test`; this file is
+  separate because `compute-sub` + `reg-sub` need the framework runtime."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.subs :as rf.subs]

--- a/tools/story/test/re_frame/story/tags_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/tags_cljs_test.cljc
@@ -1,11 +1,14 @@
-(ns re-frame.story.tags-test
+(ns re-frame.story.tags-cljs-test
   "Tests for the shared effective-tag resolver (rf2-n0vmq2).
 
   `re-frame.story.tags` is pure data → data, so every test runs on both the
   JVM and CLJS without a host: inheritance layers are supplied through
   explicit `{id → body}` lookup maps. The plan regressions drive the real
   compiler (`re-frame.story.plan`) with an explicit `:lookup`; the filter
-  regression proves the snapshot projection feeds the sidebar filter."
+  regression proves the snapshot projection feeds the sidebar filter.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-exlh)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.tags :as rf.story.tags]
             [re-frame.story.plan :as rf.story.plan]

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -8,7 +8,7 @@
   - Tag membership (`:rf.error/unknown-tag`).
   - `:extends` raw storage at registration + unknown-parent detection at
     plan-compile (the compiler is the merge authority; cycle and depth-cap
-    detection live with it in `re-frame.story.plan-test`).
+    detection live with it in `re-frame.story.plan-cljs-test`).
   - Form-B `:variants` desugaring.
   - Source-coord stamping.
   - Query API (`registrations`, `handler-meta`, `variants-with-tags`,
@@ -307,12 +307,12 @@
 ;; standalone `re-frame.story.extends` resolver, which was retired
 ;; (rf2-6r9j.11) — it had drifted from the compiled-plan merge semantics, so a
 ;; green witness there proved nothing about the shipped runtime. Both now sit
-;; on the merge authority in `re-frame.story.plan-test`
+;; on the merge authority in `re-frame.story.plan-cljs-test`
 ;; (§`extends-cycle-fails`, §`extends-depth-cap-fails`). Being `.cljc` they are
-;; host-free, but the gate that RUNS them is the JVM one (`jvm-tools-story` /
-;; `clojure -M:test` here) — the CLJS `:node-test` build selects on
-;; `cljs-test$`, which a plain `-test` namespace does not match. Same reach as
-;; the JVM-only witnesses they replaced.
+;; host-free, and since that suite took its `-cljs-test` name (rf2-exlh) both
+;; gates run them: `jvm-tools-story` (`clojure -M:test` here) and the CLJS
+;; `:node-test` build, whose `cljs-test$` ns-regexp a plain `-test` namespace
+;; does not match.
 
 ;; ---- Form-B desugaring -------------------------------------------------
 


### PR DESCRIPTION
Two Story test defects of the same kind: suites that read green while running nothing.

## rf2-exlh: `.cljc` suites that said "both runtimes" ran on the JVM only

`implementation/shadow-cljs.edn`'s `:node-test` build selects `cljs-test$`, so a `.cljc` namespace ending `-test` or `-cljc-test` never reaches the CLJS lane. This PR renames all seven such suites the bead names to `*_cljs_test.cljc`, the shape of their dual-lane siblings: `tags`, `render`, `run-owner`, `stepper-start`, `plan`, `plan-network` and `compose`.
- `run-owner`'s `:cljs` branch now compiles and runs.
- `stepper-start`'s docstring now says which rows are JVM-gated.

The JVM lane still selects every one of them through cognitect's default `-test$`, and `shadow-cljs.edn` is not edited. Prose pointers to the old names are updated in `story_test.clj`, `sub_overrides_cljs_test.cljs` and `login_example_seed_cljs_test.cljs`.

**Sequencing.** Three sibling PRs landed on files or behaviour this PR touches, and this branch rebased onto each after it merged:
- #9717 edited `plan_test` and `compose_test`.
- #9722 edited `plan_test` and `plan_network_test`.
- #9723 changed `runtime.cljc`, which the newly CLJS-selected `run-owner` and `stepper-start` drive.

A rename-detected diff of each renamed file against trunk shows only the `ns` line and one docstring sentence (98-99% similarity), so every sibling hunk carries over unchanged.

#9722's two witnesses now run on CLJS for the first time, and both pass:
- `sub-overrides-same-key-child-replaces-parent-through-extends`: 1/1
- `network-same-route-child-reply-replaces-parent-through-extends`: 1/2

**Follow-ups.** The three more same-class suites I filed as rf2-1ep8 were renamed by #9725. The stale prose pointers to the old names, outside this worker's fence, are tracked on rf2-jo3g: `network_runtime_test.clj:30`, `ui/test_mode/stepper_state_cljs_test.cljs:317` and `tools/story/spec/015-Test-Coverage.md:303`.

## rf2-s6uu: 25 DOM-gated deftests passed on node with zero assertions

`recorder/dom_capture_dom_cljs_test.cljs` (19) and `dom_capture_stop_flush_dom_cljs_test.cljs` (6) wrapped every body in `(when (dom-available?) ...)`. Each body now reads `(if-not (dom-available?) (skip!) ...)`, where `skip!` is one `(is true ...)` marker. This is the stated-skip shape the sibling DOM suites use. `:browser-test` runs the real body unchanged.

## Quality gates (tip on trunk `b966c3a764`)

Every exit code was captured on the same command line as its run.

| gate | base: trunk `b966c3a764` | this branch |
|---|---|---|
| `npm run test:cljs`, split into compile then run | compile 0; run 0, **11827 tests / 59064 assertions** | compile 0; run 0, **11990 / 59581** (predicted before running: 11990 / 59581) |
| focused `--test=` runs of the renamed suites | not selected | tags 13/34, render 18/76, run-owner 6/39, stepper-start 5/18, plan 67/213, plan-network 22/43, compose 32/69. That is +163 tests, which is the lane's whole test delta, with 0 failures |
| focused runs of the two `dom_capture` suites | 19/**0** and 6/**0** | 19/19 and 6/6 (+25 assertions, one skip marker per row) |
| `clojure -M:test` (`tools/story`, jvm-tools-story) | 0, **1946 / 7224** | 0, **1946 / 7224** (unchanged) |
| `scripts/check_test_lane_bijection.py` | 0 | 0 |
| `scripts/check_retired_spellings.py` | not run | 0 |
| `scripts/check_doc_slugs.py` | not run | 0 |

492 assertions from the seven suites plus 25 skip markers is 517, which is exactly the lane's assertion delta.

**Planted faults.** Each was a single line, the anchor count was read first, the tree was committed beforehand, and each file was restored and verified by blob hash against `HEAD`.
- In `skip!`, `(is true` became `(is false`. `dom-capture` went red with **19 failures of 19**, exit 1. The unplanted `stop-flush` stayed 6/6.
- In `run-owner`'s `:cljs` branch, 3 became 4. It went red with **1 failure** at `run_owner_cljs_test.cljc:231`, exit 1.

**CI.** At an earlier head, `b32a104ef5`, all 87 checks passed with 0 failures, including `CLJS (shadow-cljs :browser-test, headless Chromium)`, which runs s6uu's real DOM assertions. Checks for this head are relied on in CI.

Trunk has since gained only a docs-only commit, 49cfe07294 (rf2-80cp, spec 017 wording), plus tracker bookkeeping. No test reads that spec file, so this branch was not rebased for it.
