### PR TITLE
fix(story): Story UI — canvas reads only its run inputs, guarded poll, one dispatch-console rule (rf2-ohc5, rf2-k8mz, rf2-qpvk)

### DIFF
--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -391,6 +391,18 @@
    :cell-overrides   (get-in shell [:cell-overrides variant-id])
    :substrate        (:substrate shell)})
 
+(defn- selected-run-key
+  "The focused variant's `run-key`, or nil when nothing is selected. The
+  canvas derefs this through `r/track` (rf2-ohc5): the track re-derives it
+  on every shell write, but the canvas re-renders only when the key itself
+  changes — so a rail drag, a panel toggle, a tag filter or a test-run
+  record no longer re-renders the canvas, re-hashes its snapshot identity or
+  recompiles the variant plan."
+  []
+  (let [shell @rf.story.ui.state/shell-state-atom]
+    (when-let [variant-id (:selected-variant shell)]
+      (run-key shell variant-id))))
+
 (defonce ^:private canvas-last-run-key
   (atom nil))
 
@@ -416,22 +428,23 @@
   ([] (reset! first-rendered? #{}) nil)
   ([variant-id] (swap! first-rendered? disj variant-id) nil))
 
-(defn- prepare-with-shell-opts!
-  "PREPARE the variant's one run owner (rf2-j538f7.34) with the shell's
-  current modes / cell overrides / substrate: allocate + reset the frame and
-  run loaders + setup, WITHOUT executing the play script. Idempotent per
-  `:run-key`, so this canvas prepare and the shell's selection-edge prepare
-  for the same logical run collapse to ONE frame reset + ONE generation. The
-  single resume owner runs the script exactly once. Returns nothing — the
-  canvas reads the variant's app-db-value reactively after each run."
-  [variant-id]
-  (let [shell @rf.story.ui.state/shell-state-atom
-        opts  {:active-modes   (:active-modes shell)
-               :cell-overrides (get-in shell [:cell-overrides variant-id])
-               :substrate      (:substrate shell)
-               :run-key        (run-key shell variant-id)}]
-    (rf.story.runtime/prepare-run! variant-id opts)
-    nil))
+(defn- prepare-for-run-key!
+  "PREPARE the variant's one run owner (rf2-j538f7.34) for the run named by
+  `key` — a `run-key` map, whose `:active-modes` / `:cell-overrides` /
+  `:substrate` are exactly the shell slots the run reads: allocate + reset
+  the frame and run loaders + setup, WITHOUT executing the play script.
+  Idempotent per `:run-key`, so this canvas prepare and the shell's
+  selection-edge prepare for the same logical run collapse to ONE frame
+  reset + ONE generation. The single resume owner runs the script exactly
+  once. Returns nothing — the canvas reads the variant's app-db-value
+  reactively after each run."
+  [variant-id key]
+  (rf.story.runtime/prepare-run! variant-id
+                                 {:active-modes   (:active-modes key)
+                                  :cell-overrides (:cell-overrides key)
+                                  :substrate      (:substrate key)
+                                  :run-key        key})
+  nil)
 
 (defn- run-if-needed!
   "The canvas's single-owner lifecycle hook (rf2-j538f7.34). Runs only when
@@ -444,20 +457,27 @@
   Called from `component-did-mount` / `component-did-update`, both POST-commit,
   so the resumed script's DOM steps see the mounted view. `resume-run!` is
   idempotent per generation, so the shell selection-watcher / mount-time block
-  calling it too for the same generation collapses to one execution."
-  []
-  (when rf.story.config/enabled?
-    (let [shell      @rf.story.ui.state/shell-state-atom
-          variant-id (:selected-variant shell)]
-      (if-not variant-id
-        (reset! canvas-last-run-key nil)
-        (let [key (run-key shell variant-id)]
-          (when (not= key @canvas-last-run-key)
-            (reset! canvas-last-run-key key)
-            (prepare-with-shell-opts! variant-id)
-            ;; RESUME the one run owner post-commit. The generation guard makes
-            ;; this exactly-once even though the shell also schedules a resume.
-            (rf.story.runtime/resume-run! variant-id)))))))
+  calling it too for the same generation collapses to one execution.
+
+  The 0-arity reads the shell, for the lifecycle hooks (which run outside
+  render). The 2-arity takes a `run-key` the caller already holds, so
+  `canvas-inner`'s render-phase call never derefs the shell atom — a deref
+  there would subscribe that render to every shell write (rf2-ohc5)."
+  ([]
+   (when rf.story.config/enabled?
+     (let [shell      @rf.story.ui.state/shell-state-atom
+           variant-id (:selected-variant shell)]
+       (run-if-needed! variant-id (when variant-id (run-key shell variant-id))))))
+  ([variant-id key]
+   (when rf.story.config/enabled?
+     (if-not variant-id
+       (reset! canvas-last-run-key nil)
+       (when (not= key @canvas-last-run-key)
+         (reset! canvas-last-run-key key)
+         (prepare-for-run-key! variant-id key)
+         ;; RESUME the one run owner post-commit. The generation guard makes
+         ;; this exactly-once even though the shell also schedules a resume.
+         (rf.story.runtime/resume-run! variant-id))))))
 
 (defn variant-substrate-set
   "Resolve the variant's effective substrate set. Per `001-Authoring.md` §Registration macros
@@ -470,13 +490,20 @@
   renders a variant too, and must resolve its substrate by the SAME policy
   rather than a second copy of it (rf2-r4coe). The resolution order is
   itself the answer to \"declared set or host substrate?\" — it is both,
-  in that precedence, with the shell's substrate as the fallback."
-  [variant-id]
-  (let [vb (rf.story.registrar/handler-meta :variant variant-id)
-        sid (rf.story.args/parent-story-id variant-id)
-        sb (when sid (rf.story.registrar/handler-meta :story sid))]
-    (rf.story.ui.multi-substrate/resolve-substrate-set
-      vb sb (or (:substrate @rf.story.ui.state/shell-state-atom) :reagent))))
+  in that precedence, with the shell's substrate as the fallback.
+
+  The 2-arity takes that host substrate from the caller rather than
+  dereffing the shell atom — the canvas passes the one its `run-key`
+  already carries, so its render does not subscribe to every shell write
+  (rf2-ohc5)."
+  ([variant-id]
+   (variant-substrate-set variant-id (:substrate @rf.story.ui.state/shell-state-atom)))
+  ([variant-id host-substrate]
+   (let [vb (rf.story.registrar/handler-meta :variant variant-id)
+         sid (rf.story.args/parent-story-id variant-id)
+         sb (when sid (rf.story.registrar/handler-meta :story sid))]
+     (rf.story.ui.multi-substrate/resolve-substrate-set
+       vb sb (or host-substrate :reagent)))))
 
 (defn- canvas-inner
   "The inner render fn — reads the variant's app-db-value reactively. Split
@@ -486,9 +513,17 @@
   The inner render branches on
   `(count (variant-substrate-set variant-id))`:
   - 1 substrate → single-pane render
-  - >1 substrate → multi-substrate side-by-side grid (`002-Runtime.md` §Substrate hooks)."
-  [variant-id]
-  (let [view-id        (variant-component variant-id)
+  - >1 substrate → multi-substrate side-by-side grid (`002-Runtime.md` §Substrate hooks).
+
+  `rk` is the outer `canvas`'s `run-key` (rf2-ohc5). Every shell input this
+  render needs is read off it, never off the shell atom, so an unrelated
+  shell write (a rail drag, a panel toggle, a test-run record) cannot reach
+  this render, and Reagent skips it whenever the outer passes an equal key.
+  When omitted it is read from the shell (a caller rendering this pane on
+  its own)."
+  [variant-id & [rk]]
+  (let [rk             (or rk (run-key @rf.story.ui.state/shell-state-atom variant-id))
+        view-id        (variant-component variant-id)
         variant-body   (rf.story.registrar/handler-meta :variant variant-id)
         ;; The SAME per-run opts the `eff-args` resolve below
         ;; uses, threaded into `resolve-decorators` so the plan it
@@ -498,18 +533,15 @@
         ;; (never the variant chain) throws `:rf.error/story-missing-arg`
         ;; here even though the runtime's plan compile handles it — the
         ;; canvas decorator recompile needs the same opts.
-        run-opts       {:active-modes
-                        (:active-modes @rf.story.ui.state/shell-state-atom)
-                        :cell-overrides
-                        (get-in @rf.story.ui.state/shell-state-atom
-                                [:cell-overrides variant-id])}
+        run-opts       {:active-modes   (:active-modes rk)
+                        :cell-overrides (:cell-overrides rk)}
         decorator-pack (rf.story.decorators/resolve-decorators variant-id run-opts)
         eff-args       (rf.story.args/resolve-args variant-id run-opts)
         assertions     (rf.story.runtime/read-assertions variant-id)
         ;; Resolve the variant's view-state subscription
         ;; overrides (arg-substituted) for the render-path binding below.
         sub-ovr        (resolve-sub-overrides variant-id eff-args)
-        substrates     (variant-substrate-set variant-id)
+        substrates     (variant-substrate-set variant-id (:substrate rk))
         multi?         (and variant-id (> (count substrates) 1))
         ;; Events-only variants take the lifecycle fast-
         ;; path (`mount-ready!` jumps :pre-mount → :ready directly) so
@@ -548,7 +580,7 @@
         ;; reaching `frame-provider` before allocation. Runs BEFORE
         ;; `lifecycle-phase` / `first?` below so those reads see the
         ;; POST-allocation state (the fast-path `:ready`) on this same pass.
-        _              (when events-only? (run-if-needed!))
+        _              (when events-only? (run-if-needed! variant-id rk))
         ;; Skeleton gating. The lifecycle machine reports
         ;; :pre-mount / :mounting / :loading while the four-phase
         ;; loader cascade runs; once :ready / :error lands, the
@@ -751,14 +783,15 @@
             (reset-first-rendered!))))
      :reagent-render
      (fn []
-       (let [shell      @rf.story.ui.state/shell-state-atom
-             variant-id (:selected-variant shell)
-             opts       {:active-modes   (:active-modes shell)
-                         :cell-overrides (get-in shell [:cell-overrides variant-id])
-                         :substrate      (:substrate shell)}
+       (let [;; rf2-ohc5: the run inputs only, through `r/track` — see
+             ;; `selected-run-key`. `:hot-reload-tick` is one of them, so a
+             ;; tick still re-renders (and, post-commit, re-runs) the canvas.
+             rk         @(r/track selected-run-key)
+             variant-id (:variant-id rk)
              snapshot   (when variant-id
-                          (rf.story.runtime/snapshot-identity variant-id opts))
-             _tick      (:hot-reload-tick shell)]   ;; deref to subscribe
+                          (rf.story.runtime/snapshot-identity
+                            variant-id
+                            (select-keys rk [:active-modes :cell-overrides :substrate])))]
          ;; The canvas wrap is the scrollable container
          ;; for variant content; `tab-index "0"` makes it keyboard-
          ;; focusable so axe-core's `scrollable-region-focusable` rule
@@ -779,6 +812,6 @@
                      (:content-hash snapshot) (assoc :data-snapshot-hash
                                                      (:content-hash snapshot)))
           (if variant-id
-            [canvas-inner variant-id]
+            [canvas-inner variant-id rk]
             [:div {:style (:empty styles)}
              "select a variant from the sidebar"])]))}))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -55,7 +55,6 @@
             [re-frame.story.config :as rf.story.config]
             [re-frame.story.decorators :as rf.story.decorators]
             [re-frame.story.frames :as rf.story.frames]
-            [re-frame.story.predicates :as rf.story.predicates]
             [re-frame.story.registrar :as rf.story.registrar]
             [re-frame.story.runtime :as rf.story.runtime]
             [re-frame.trace :as rf.trace]
@@ -225,6 +224,26 @@
          :recovery  :next-tick-retry})
       nil)))
 
+(defn- hot-reload-tick!
+  "One pass of the hot-reload fingerprint detector. Wraps
+  `detect-and-tick!` in the same try / `emit-error!` shape as
+  `watch-mode-tick!` (rf2-k8mz). `resolution-fingerprints` can throw on
+  this very poll (`:rf.error/story-missing-arg`, rf2-eyrpr — see
+  `compute-fingerprint-snapshot`), and a bare throw here used to abort
+  `poll-tick!` before `watch-mode-tick!` ran: one bad frame silently
+  stopped watch mode while its eye icon still read 'watching'. The next
+  tick retries."
+  []
+  (try
+    (detect-and-tick!)
+    (catch :default e
+      (rf.trace/emit-error!
+        :rf.story.shell/hot-reload-tick-failed
+        {:exception e
+         :where     :rf.story.shell/detect-and-tick!
+         :recovery  :next-tick-retry})
+      nil)))
+
 (defonce ^:private hot-reload-poll-handle (atom nil))
 
 (defn- poll-tick!
@@ -232,9 +251,10 @@
   detector (decorator drift → bump `:hot-reload-tick`) followed by the
   watch-mode detector (per-testable-variant snapshot-identity drift →
   dispatch `rf.story.ui.sidebar/watch-rerun!` when watch mode is on). Two
-  detectors, one cadence."
+  detectors, one cadence — each guarded on its own, so a throw in one
+  never starves the other (rf2-k8mz)."
   []
-  (detect-and-tick!)
+  (hot-reload-tick!)
   (watch-mode-tick!))
 
 (defn- start-hot-reload-poll!
@@ -689,19 +709,11 @@
      ;; reset assertion (`count === 0`); a default-on dispatch-console
      ;; chip would break that gate. Toolbar real-estate is precious too —
      ;; opt-in is the more polite default.
-     (when (and variant-id
-                (let [vis-flag (:dispatch-console vis)
-                      var-body (rf.story.registrar/handler-meta :variant variant-id)
-                      story-id (rf.story.predicates/parent-story-id variant-id)
-                      sty-body (when story-id
-                                 (rf.story.registrar/handler-meta :story story-id))
-                      ;; Story slot default; variant overrides; user toggle wins.
-                      story-default (get sty-body  :dispatch-console? false)
-                      var-default   (get var-body  :dispatch-console? story-default)]
-                  (cond
-                    (true?  vis-flag) true
-                    (false? vis-flag) false
-                    :else             var-default)))
+     ;;
+     ;; rf2-qpvk: resolved by `rf.story.ui.state/dispatch-console-visible?` —
+     ;; the one rule the toolbar chip's pressed state reads too, so a
+     ;; story-body opt-in never shows this panel beside an un-pressed chip.
+     (when (rf.story.ui.state/dispatch-console-visible? shell variant-id)
        [:section {:style (:rhs-section styles)
                   :data-rf-rhs-section "dispatch"}
         [:div {:style (:rhs-section-h styles)}

--- a/tools/story/src/re_frame/story/ui/shell/rails.cljs
+++ b/tools/story/src/re_frame/story/ui/shell/rails.cljs
@@ -74,11 +74,23 @@
       (rf.story.ui.state/swap-state! assoc :rail-widths widths)))
   nil)
 
-(defn set-width! [side width]
+(defn- apply-width!
+  "Write a clamped `width` for `side` into shell state WITHOUT persisting,
+  returning the new widths. A splitter drag calls this per mousemove and
+  persists once, on release (rf2-ohc5): a localStorage write per mouse
+  event was synchronous main-thread work for a value read only at the
+  next page load."
+  [side width]
   (let [widths (normalise-widths
                  (assoc (current-widths) side width))]
     (rf.story.ui.state/swap-state! assoc :rail-widths widths)
-    (persist! widths)))
+    widths))
+
+(defn set-width!
+  "Set and persist `side`'s rail width — the discrete path (keyboard
+  steps, Home / End)."
+  [side width]
+  (persist! (apply-width! side width)))
 
 (defn- adjust-width! [side delta]
   (set-width! side (+ (get (current-widths) side) delta)))
@@ -105,7 +117,10 @@
          (when-let [{:keys [move up]} @drag-handlers]
            (reset! drag-handlers nil)
            (.removeEventListener js/document "mousemove" move)
-           (.removeEventListener js/document "mouseup" up)))
+           (.removeEventListener js/document "mouseup" up)
+           ;; A drag cut short by unmount never reaches `up-fn`; persist
+           ;; the widths it reached here instead (rf2-ohc5).
+           (persist! (current-widths))))
        :reagent-render
        (fn [side]
          (let [widths  (current-widths)
@@ -147,14 +162,16 @@
                                         (reset! dragging? true)
                                         (letfn [(move-fn [move-e]
                                                   (let [dx (- (.-clientX move-e) start-x)]
-                                                    (set-width!
+                                                    ;; rf2-ohc5: state only — persisted on release.
+                                                    (apply-width!
                                                       side
                                                       (+ start-w (if left? dx (- dx))))))
                                                 (up-fn [_]
                                                   (reset! dragging? false)
                                                   (reset! drag-handlers nil)
                                                   (.removeEventListener js/document "mousemove" move-fn)
-                                                  (.removeEventListener js/document "mouseup" up-fn))]
+                                                  (.removeEventListener js/document "mouseup" up-fn)
+                                                  (persist! (current-widths)))]
                                           (reset! drag-handlers {:move move-fn :up up-fn})
                                           (.addEventListener js/document "mousemove" move-fn)
                                           (.addEventListener js/document "mouseup" up-fn))))}

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -187,6 +187,7 @@
 (def record-fingerprints       rf.story.ui.state.transitions/record-fingerprints)
 (def pin-snapshot              rf.story.ui.state.transitions/pin-snapshot)
 (def toggle-panel              rf.story.ui.state.transitions/toggle-panel)
+(def dispatch-console-visible? rf.story.ui.state.transitions/dispatch-console-visible?)
 
 ;; ---- Xray-embed collapse re-exports -------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -11,7 +11,8 @@
 
   The parent ns `re-frame.story.ui.state` re-exports every Var here,
   so consumer requires keep working unchanged."
-  (:require [re-frame.story.registrar :as rf.story.registrar]))
+  (:require [re-frame.story.predicates :as rf.story.predicates]
+            [re-frame.story.registrar :as rf.story.registrar]))
 
 ;; ---- selection / filters -------------------------------------------------
 
@@ -389,6 +390,28 @@
   "Flip a panel's visibility."
   [state panel-id]
   (update-in state [:panel-visibility panel-id] not))
+
+(defn dispatch-console-visible?
+  "Effective visibility of the Dispatch Console panel for `variant-id` — the
+  ONE rule both the RHS panel and the toolbar chip's pressed state read
+  (rf2-qpvk). An explicit user toggle (`[:panel-visibility
+  :dispatch-console]` true / false) wins; otherwise the variant body's
+  `:dispatch-console?`, else its parent story's, else false (opt-in
+  default). A nil `variant-id` is never visible."
+  [state variant-id]
+  (let [vis-flag (get-in state [:panel-visibility :dispatch-console])]
+    (cond
+      (nil? variant-id) false
+      (true? vis-flag)  true
+      (false? vis-flag) false
+      :else
+      (let [var-body (rf.story.registrar/handler-meta :variant variant-id)
+            story-id (rf.story.predicates/parent-story-id variant-id)
+            sty-body (when story-id
+                       (rf.story.registrar/handler-meta :story story-id))]
+        ;; Story slot default; variant overrides.
+        (boolean (get var-body :dispatch-console?
+                      (get sty-body :dispatch-console? false)))))))
 
 ;; ---- Xray-embed collapse -------------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -339,11 +339,9 @@
         modes    (rf.story.registrar/registrations :mode)
         variant  (:selected-variant shell)
         {:keys [axes unaxed]} (rf.story.ui.state/group-modes-by-axis modes)
-        vis-flag (get-in shell [:panel-visibility :dispatch-console])
-        dc-effective? (cond
-                        (true?  vis-flag) true
-                        (false? vis-flag) false
-                        :else             false)]
+        ;; rf2-qpvk: the SAME predicate the RHS panel reads, so a story's
+        ;; `:dispatch-console? true` opt-in renders the chip pressed.
+        dc-effective? (rf.story.ui.state/dispatch-console-visible? shell variant)]
     [:header
      {:style      (:strip styles)
       :role       "toolbar"
@@ -375,11 +373,12 @@
                    [chip mid (get modes mid) (contains? active mid)])]]])))])
      [:span {:style (:spacer styles)}]
      ;; ── DATA cluster (variant-scoped affordances) ─────────────────
-     ;; rf2-q9kv5 — Dispatch console toolbar toggle. The chip flips the
-     ;; chrome-level visibility override; the right-panel resolves
-     ;; story-flag + chrome-toggle together. Shown only when a variant
-     ;; is focused (the panel is per-variant — no variant, nothing to
-     ;; dispatch into).
+     ;; rf2-q9kv5 — Dispatch console toolbar toggle. The chip writes the
+     ;; chrome-level visibility override as the negation of the EFFECTIVE
+     ;; visibility, which it and the right panel both read through
+     ;; `rf.story.ui.state/dispatch-console-visible?` (rf2-qpvk). Shown
+     ;; only when a variant is focused (the panel is per-variant — no
+     ;; variant, nothing to dispatch into).
      ;; rf2-8i2a9 — Play-script status chip. Visible only when a variant
      ;; is focused AND the variant carries a `:script` body.
      (when variant

--- a/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
@@ -97,10 +97,16 @@
             (is (= "n=3" (some-> (.querySelector mount-node "[data-test=\"ohc5-probe\"]")
                                  .-textContent))
                 "precondition: the variant rendered")
+            ;; Fixed arities, not `[& args]`: the canvas calls both fns at a
+            ;; known arity, which compiles to a direct-arity dispatch that a
+            ;; variadic stand-in does not answer — the render would throw and
+            ;; every count would read a vacuous 0.
             (with-redefs [rf.story.decorators/resolve-decorators
-                          (fn [& args] (swap! inner inc) (apply resolve args))
+                          (fn ([a] (swap! inner inc) (resolve a))
+                              ([a b] (swap! inner inc) (resolve a b)))
                           rf.story.runtime/snapshot-identity
-                          (fn [& args] (swap! outer inc) (apply snapshot args))]
+                          (fn ([a] (swap! outer inc) (snapshot a))
+                              ([a b] (swap! outer inc) (snapshot a b)))]
               (write-and-flush! assoc :rail-widths {:left 300 :right 320})
               (write-and-flush! rf.story.ui.state/toggle-panel :controls)
               (write-and-flush! rf.story.ui.state/toggle-tag-filter :ohc5-tag)
@@ -109,6 +115,9 @@
               ;; Control: the tick IS a run input.
               (write-and-flush! rf.story.ui.state/bump-hot-reload-tick)
               (is (pos? @outer) "control: a hot-reload tick re-renders the outer canvas")
-              (is (pos? @inner) "control: a hot-reload tick re-renders canvas-inner"))
+              (is (pos? @inner) "control: a hot-reload tick re-renders canvas-inner")
+              (is (= "n=3" (some-> (.querySelector mount-node "[data-test=\"ohc5-probe\"]")
+                                   .-textContent))
+                  "control: the re-rendered view still paints (the render did not throw)"))
             (finally
               (try (.unmount root) (catch :default _ nil)))))))))

--- a/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
@@ -1,0 +1,114 @@
+(ns re-frame.story.ui.canvas-unrelated-write-dom-cljs-test
+  "DOM-mount regression for rf2-ohc5: a shell-state write that cannot
+  change the variant's run must not re-render the canvas.
+
+  The canvas used to deref the WHOLE shell atom in both its outer render
+  (then hash the snapshot identity) and `canvas-inner` (then resolve the
+  decorator stack, which compiles the variant plan). So a rail drag, a
+  panel toggle, a tag filter or a test-run record — none of which is a run
+  input — re-ran all of that. The outer now reads the `run-key` through
+  `r/track` and hands it to `canvas-inner`, so only a change to a run input
+  (selection, hot-reload tick, modes, cell overrides, substrate) reaches
+  either render.
+
+  Counted at the two seams each render crosses exactly once:
+  `rf.story.runtime/snapshot-identity` (outer) and
+  `rf.story.decorators/resolve-decorators` (inner). The hot-reload tick is
+  the control — a run input, so it MUST still reach both.
+
+  Ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build mounts
+  real DOM; `:node-test` also loads it, where the body self-gates on
+  `(browser?)` and records a visible skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.story :as rf.story]
+            [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.subs :as rf.subs]))
+
+;; ---- fixture (mirrors events_only_first_render_frame_provider_dom) ------
+
+(defn- reset-all! []
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.adapter.reagent/adapter)
+       (catch :default _ nil))
+  (rf.subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf.story.ui.canvas/reset-first-rendered!))
+
+(use-fixtures :each {:before reset-all!})
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (let [node (js/document.createElement "div")]
+    (js/document.body.appendChild node)
+    node))
+
+(defn- write-and-flush! [f & args]
+  (react-dom/flushSync
+    (fn []
+      (apply rf.story.ui.state/swap-state! f args)
+      (r/flush))))
+
+(deftest unrelated-shell-writes-do-not-re-render-the-canvas
+  (testing "rf2-ohc5: rail-width, panel-visibility and tag-filter writes
+            leave the canvas alone; a hot-reload tick still re-renders it"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (let [variant-id :story.ohc5/probe]
+        (rf/reg-event :ohc5/seed (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+        (rf/reg-sub :ohc5/n (fn [db _] (:n db)))
+        (rf/reg-view* :views/ohc5-probe
+          (fn [_] [:div {:data-test "ohc5-probe"} (str "n=" @(rf/subscribe [:ohc5/n]))]))
+        (rf.story/reg-variant variant-id
+          {:component :views/ohc5-probe
+           :setup     [[:ohc5/seed 3]]})
+        (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant variant-id)
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)
+              inner      (atom 0)
+              outer      (atom 0)
+              resolve    rf.story.decorators/resolve-decorators
+              snapshot   rf.story.runtime/snapshot-identity]
+          (try
+            (react-dom/flushSync
+              (fn [] (rdc/render root [rf.story.ui.canvas/canvas])))
+            (is (= "n=3" (some-> (.querySelector mount-node "[data-test=\"ohc5-probe\"]")
+                                 .-textContent))
+                "precondition: the variant rendered")
+            (with-redefs [rf.story.decorators/resolve-decorators
+                          (fn [& args] (swap! inner inc) (apply resolve args))
+                          rf.story.runtime/snapshot-identity
+                          (fn [& args] (swap! outer inc) (apply snapshot args))]
+              (write-and-flush! assoc :rail-widths {:left 300 :right 320})
+              (write-and-flush! rf.story.ui.state/toggle-panel :controls)
+              (write-and-flush! rf.story.ui.state/toggle-tag-filter :ohc5-tag)
+              (is (= 0 @outer) "no unrelated write re-rendered the outer canvas")
+              (is (= 0 @inner) "no unrelated write re-rendered canvas-inner")
+              ;; Control: the tick IS a run input.
+              (write-and-flush! rf.story.ui.state/bump-hot-reload-tick)
+              (is (pos? @outer) "control: a hot-reload tick re-renders the outer canvas")
+              (is (pos? @inner) "control: a hot-reload tick re-renders canvas-inner"))
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))

--- a/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell/rails_splitter_unmount_dom_cljs_test.cljs
@@ -101,6 +101,53 @@
           (finally
             (try (.unmount root) (catch :default _ nil))))))))
 
+(def ^:private rail-storage-key "re-frame.story/rail-widths")
+
+(defn- stored-widths []
+  (some-> (.getItem js/localStorage rail-storage-key) js/JSON.parse (js->clj :keywordize-keys true)))
+
+(deftest splitter-drag-persists-once-on-release
+  (testing "rf2-ohc5: a drag writes rail widths to shell state per mousemove
+            but persists them to localStorage ONCE — on mouseup, or when a
+            mid-drag unmount cuts the drag short — not per mouse event"
+    (if-not (browser?)
+      (is true ":node-test — no DOM; :browser-test runs the real assertion")
+      (doseq [ending [:mouseup :unmount]]
+        (.removeItem js/localStorage rail-storage-key)
+        (rf.story.ui.state/reset-shell-state!)
+        (let [mount-node (make-mount-node!)
+              root       (rdc/create-root mount-node)]
+          (try
+            (react-dom/flushSync
+              (fn [] (rdc/render root [rf.story.ui.shell.rails/splitter :left])))
+            (let [splitter-el (.querySelector mount-node "[data-test=\"story-left-rail-splitter\"]")
+                  move!       (fn [x]
+                                (react-dom/flushSync
+                                  (fn []
+                                    (.dispatchEvent js/document
+                                      (js/MouseEvent. "mousemove" #js {:bubbles true :clientX x})))))]
+              (react-dom/flushSync
+                (fn []
+                  (.dispatchEvent splitter-el
+                    (js/MouseEvent. "mousedown" #js {:bubbles true :clientX 100}))))
+              (move! 130)
+              (move! 160)
+              (is (not= (:left rf.story.ui.shell.rails/default-widths)
+                        (:left (rf.story.ui.shell.rails/current-widths)))
+                  (str ending ": the drag moved the rail in shell state"))
+              (is (nil? (stored-widths))
+                  (str ending ": nothing persisted while the drag is live"))
+              (if (= ending :mouseup)
+                (react-dom/flushSync
+                  (fn []
+                    (.dispatchEvent js/document
+                      (js/MouseEvent. "mouseup" #js {:bubbles true}))))
+                (react-dom/flushSync (fn [] (.unmount root))))
+              (is (= (rf.story.ui.shell.rails/current-widths) (stored-widths))
+                  (str ending ": the widths the drag reached are persisted on release")))
+            (finally
+              (try (.unmount root) (catch :default _ nil)))))))))
+
 (deftest splitter-normal-mouseup-still-tears-down-listeners
   (testing "rf2-cmjly3 finding 6 — no regression: the ORIGINAL teardown
             path (mouseup firing while the component is still mounted)

--- a/tools/story/test/re_frame/story/ui/shell_poll_tick_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/shell_poll_tick_cljs_test.cljs
@@ -1,0 +1,51 @@
+(ns re-frame.story.ui.shell-poll-tick-cljs-test
+  "rf2-k8mz — the shell's 500 ms poll runs two detectors, and a throw in
+  the fingerprint half must not starve the watch-mode half.
+
+  `poll-tick!` used to call `detect-and-tick!` bare, so a throw from
+  `resolution-fingerprints` (`:rf.error/story-missing-arg`, rf2-eyrpr)
+  aborted the tick before `watch-mode-tick!` ran: watch mode silently
+  stopped re-running while its eye icon still read 'watching'. Both halves
+  now sit behind the same try / `emit-error!` shape, so the throw is
+  observable and the other half still runs on the same tick."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.trace :as rf.trace]
+            [re-frame.story.ui.shell :as rf.story.ui.shell]))
+
+(def ^:private poll-tick! @#'rf.story.ui.shell/poll-tick!)
+
+(deftest fingerprint-throw-does-not-starve-watch-mode
+  (testing "a throwing fingerprint pass is caught and reported, and the
+            watch-mode pass still runs on the same tick"
+    (let [errors      (atom [])
+          watch-calls (atom 0)]
+      (with-redefs [rf.story.ui.shell/detect-and-tick!
+                    (fn [] (throw (ex-info "fingerprint compile failed"
+                                           {:rf.error/id :rf.error/story-missing-arg})))
+                    rf.story.ui.shell/detect-watch-drift!
+                    (fn [] (swap! watch-calls inc) nil)
+                    rf.trace/emit-error!
+                    (fn [op tags] (swap! errors conj [op (:where tags) (:recovery tags)]) nil)]
+        (is (nil? (try (poll-tick!) nil (catch :default e e)))
+            "poll-tick! does not throw")
+        (is (= 1 @watch-calls)
+            "watch-mode-tick! still ran after the fingerprint pass threw")
+        (is (= [[:rf.story.shell/hot-reload-tick-failed
+                 :rf.story.shell/detect-and-tick!
+                 :next-tick-retry]]
+               @errors)
+            "the throw is reported through emit-error!, not swallowed")))))
+
+(deftest healthy-tick-runs-both-detectors-and-reports-nothing
+  (testing "control: with nothing throwing, both detectors run once and no
+            error is emitted"
+    (let [errors      (atom [])
+          fp-calls    (atom 0)
+          watch-calls (atom 0)]
+      (with-redefs [rf.story.ui.shell/detect-and-tick!    (fn [] (swap! fp-calls inc) nil)
+                    rf.story.ui.shell/detect-watch-drift! (fn [] (swap! watch-calls inc) nil)
+                    rf.trace/emit-error!                  (fn [op _] (swap! errors conj op) nil)]
+        (poll-tick!)
+        (is (= 1 @fp-calls))
+        (is (= 1 @watch-calls))
+        (is (empty? @errors))))))

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -193,6 +193,61 @@
     (is (= [] (rf.story.share/prune-unregistered-modes
                 [:Mode.app/gone :Mode.app/also-gone] #{})))))
 
+;; ---- pure: dispatch-console visibility (rf2-qpvk) ------------------------
+
+(deftest dispatch-console-visible-resolution
+  (testing "rf2-qpvk: ONE rule for the toolbar chip and the RHS panel —
+            the user toggle wins, then the variant body, then the story
+            body, then false"
+    (rf.story/reg-story :story.dc-opt-in {:doc "probe" :dispatch-console? true})
+    (rf.story/reg-variant :story.dc-opt-in/inherits {:doc "probe"})
+    (rf.story/reg-variant :story.dc-opt-in/opts-out {:doc "probe" :dispatch-console? false})
+    (rf.story/reg-story :story.dc-default {:doc "probe"})
+    (rf.story/reg-variant :story.dc-default/plain {:doc "probe"})
+    (let [visible? rf.story.ui.state/dispatch-console-visible?
+          s        rf.story.ui.state/default-shell-state
+          on       (assoc-in s [:panel-visibility :dispatch-console] true)
+          off      (assoc-in s [:panel-visibility :dispatch-console] false)]
+      (is (true?  (visible? s :story.dc-opt-in/inherits))
+          "a story-body opt-in with no user toggle is visible")
+      (is (false? (visible? s :story.dc-opt-in/opts-out))
+          "a variant-body false overrides the story's opt-in")
+      (is (false? (visible? s :story.dc-default/plain))
+          "nothing declared is hidden (the opt-in default)")
+      (is (false? (visible? off :story.dc-opt-in/inherits))
+          "the user toggle OFF beats the story opt-in")
+      (is (true?  (visible? on :story.dc-default/plain))
+          "the user toggle ON beats the default")
+      (is (false? (visible? on nil))
+          "no focused variant is never visible"))))
+
+#?(:cljs
+   (deftest cljs-dispatch-chip-reads-effective-visibility
+     (testing "rf2-qpvk: under a story-body `:dispatch-console? true` opt-in
+               the chip renders PRESSED — agreeing with the panel that is
+               showing — and its first click hides the panel instead of
+               writing true to a panel already open"
+       (rf.story/reg-story :story.dc-chip {:doc "probe" :dispatch-console? true})
+       (rf.story/reg-variant :story.dc-chip/v {:doc "probe"})
+       (rf.story.ui.state/swap-state! rf.story.ui.state/select-variant :story.dc-chip/v)
+       (let [chip-attrs (fn []
+                          (->> (tree-seq coll? seq (rf.story.ui.toolbar/toolbar-strip))
+                               (filter map?)
+                               (filter #(= "story-toolbar-dispatch-console" (:data-test %)))
+                               first))
+             attrs      (chip-attrs)]
+         (is (= "true" (:aria-pressed attrs))
+             "the chip reads pressed under the story opt-in")
+         (is (true? (rf.story.ui.state/dispatch-console-visible?
+                      (rf.story.ui.state/get-state) :story.dc-chip/v))
+             "and the panel's rule agrees")
+         ((:on-click attrs) nil)
+         (is (false? (get-in (rf.story.ui.state/get-state)
+                             [:panel-visibility :dispatch-console]))
+             "the first click writes the negation of the EFFECTIVE state")
+         (is (= "false" (:aria-pressed (chip-attrs)))
+             "after which the chip reads un-pressed")))))
+
 ;; ---- CLJS-only: live toolbar surfaces ----------------------------------
 ;;
 ;; The localStorage / `js/window` surfaces only exist under CLJS.


### PR DESCRIPTION
Three Story UI fixes from the senior-developer review (rf2-wd2t), one PR because they share `tools/story/src/re_frame/story/ui/**`. The fourth bead in the batch, rf2-insd, was refuted in a browser and is recorded on its bead, not in this diff.

## rf2-ohc5: the canvas reads only its run inputs

`canvas.cljs` derefed the whole shell atom in its outer render and again in `canvas-inner`. So every rail drag, panel toggle, tag filter or test-run record re-hashed the snapshot identity and re-resolved the decorator stack, which compiles the variant plan. Separately, the splitter wrote localStorage on every mousemove.

- The outer render derefs `(r/track selected-run-key)`, the same `run-key` map that already defines "a new run". It hands that key to `canvas-inner` as an argument, so Reagent skips the inner render whenever the key is equal. `canvas-inner` takes modes, cell overrides and substrate from the key (a 1-arity still reads the shell, for tests that render it on its own). `run-if-needed!` gained a 2-arity so the render-phase ensure for events-only variants doesn't deref the atom either. `variant-substrate-set` gained a host-substrate arity.
- `rails.cljs`: a drag writes state per mousemove through a private `apply-width!` and persists once, on mouseup. A mid-drag unmount persists too. Keyboard steps still persist per step.

**Measured.** Headless Chromium against a compile of `:examples/counter-with-stories`, variant `:story.counter/loaded`, counting calls at the seam each render crosses once:

| unrelated write | `snapshot-identity` (outer) before → after | `resolve-decorators` from `canvas-inner` before → after | rail localStorage writes before → after |
|---|---|---|---|
| splitter drag, 20 mousemoves | 20 → 0 | 20 → 0 | 20 → 1 (on mouseup) |
| panel toggle ×2 | 2 → 0 | 2 → 0 | 0 → 0 |
| tag filter toggle ×2 | 2 → 0 | 2 → 0 | 0 → 0 |
| test-run record for another variant ×5 | 5 → 0 | 5 → 0 | 0 → 0 |

The "after" `canvas-inner` column is attributed by call stack. The "before" column is the total `resolve-decorators` count, less the one call per write that stack attribution shows comes from `re_frame.story.ui.controls/decorator_list`. That is the RHS Controls panel, whose count this change does not touch: raw totals were 40, 3, 4, 10 before against 20, 1, 2, 5 after. The Controls panel still re-resolves on unrelated writes; it's a separate component and not in this bead's scope.

The run inputs still reach the canvas:
- An in-frame click re-renders `canvas-inner` once.
- A hot-reload tick re-renders both renders and re-runs the variant, with the count back to its seeded 7.
- The three loader-diagnostic variants (`loader-success`, `loader-never-completes`, `loader-rejects`) paint immediately with no skeleton and the first-rendered sentinel set.

**Overlap with the held rf2-fzbj.3.** That finding cites `ui/canvas.cljs:497-510` for the canvas's effective-args resolver (`rf.story.args/resolve-args`), which diverges from the runtime plan's `[:world :effective-args]` under `:extends` / `:compose`. This PR edits those lines, but only where `run-opts` comes from; the canvas still calls `resolve-args` exactly as before. That finding stands unchanged and is not fixed here.

## rf2-k8mz: the poll's fingerprint half is guarded

`poll-tick!` called `detect-and-tick!` bare, so a throw from `resolution-fingerprints` aborted the tick before `watch-mode-tick!` ran. Watch mode then stopped re-running while its eye icon still read "watching". The fingerprint half now sits behind a new `hot-reload-tick!`, in the same try / `emit-error!` shape as the watch half (`:rf.story.shell/hot-reload-tick-failed`, `:recovery :next-tick-retry`).

## rf2-qpvk: one dispatch-console visibility rule

The toolbar chip resolved with `:else false` and the RHS panel with `:else var-default`. So a story using the documented `:dispatch-console? true` opt-in showed the panel beside an un-pressed chip, and the first click was a no-op. Both now call `rf.story.ui.state/dispatch-console-visible?` (defined in `ui/state/transitions.cljc`, re-exported). The chip still writes the negation of the effective state.

## Tests

- `ui/shell_poll_tick_cljs_test.cljs` (new): a throwing fingerprint pass is reported once and the watch half still runs. A control confirms both halves run with no error.
- `ui/toolbar_cljs_test.cljc`: the resolution table, on both runtimes; plus the chip reading pressed under a story opt-in and its first click hiding the panel.
- `ui/canvas_unrelated_write_dom_cljs_test.cljs` (new, `:browser-test`): rail-width, panel and tag-filter writes cause 0 outer and 0 inner renders. A hot-reload tick, as the control, causes both, and the view still paints.
- `ui/shell/rails_splitter_unmount_dom_cljs_test.cljs`: nothing persisted mid-drag; the reached widths persisted on mouseup, and on a mid-drag unmount.

The first `:browser-test` run was red on this PR's own canvas DOM test. Its `with-redefs` stand-ins were variadic, and variadic stand-ins can't answer the direct-arity calls the canvas makes, so the render threw and every count read 0. The tick controls caught it; `0a6e3a50c3` switched the stand-ins to fixed arities.

## Quality gates

Every number below is the runner's own captured exit, run from this branch's worktree.

Final tree (head `0a6e3a50c3`, rebased on trunk; trunk changed only `.beads/` since the original base):
- `npm run test:cljs` (node-test, run gated on the compile's own exit): compile exit 0 (1987 files, 0 warnings), run exit 0. 11791 tests, 58884 assertions, 0 failures, 0 errors.
- `cd tools/story && clojure -M:test` (JVM lane): exit 0. 1915 tests, 7053 assertions, 0 failures, 0 errors.
- `npm run test:browser` (`:browser-test`, headless Chromium): compile exit 0, run exit 0. 1093 tests, 5964 assertions, 0 failures, 0 errors.
- clj-kondo `--fail-level error` on the ten changed files: exit 0, 0 errors (2 pre-existing warnings, neither on a changed line).
- `scripts/check_retired_spellings.py`, `check_retired_composition_vocab.py`, `check_retired_image_keys.py`: exit 0 each.

Planted faults, each in a line this PR changed, each restored and verified by blob hash:
- node-test. Plants: `poll-tick!` calling `detect-and-tick!` bare, and the chip back on its private rule. Result: exit 1 with 6 failures, all in `fingerprint-throw-does-not-starve-watch-mode` and `cljs-dispatch-chip-reads-effective-visibility`. Totals unchanged (11791 / 58884).
- `:browser-test`. Plants: canvas-inner re-reading the shell, the outer render bypassing `r/track`, and the rails move handler persisting per mousemove. Result: exit 1 with 4 failures, all in the two new DOM assertions. Totals unchanged (1093 / 5964).
- JVM. Plant: the predicate's story default flipped. Result: `toolbar-cljs-test` exit 1 with 1 failure, in `dispatch-console-visible-resolution`.

Relying on CI for `story-xray-browser` (the play-scripts and Story browser scenarios); not run locally.
