### PR TITLE
fix(story): :extends merges :network per route and :sub-overrides per query key; spec 017 catches up with #9717 (rf2-pwwu, rf2-z8ta)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1370,9 +1370,8 @@ Execution order is:
 3. Run setup.
 4. Render if the chosen runner requires rendering.
 5. Run script.
-6. Run checks.
-7. Run terminal assertions.
-8. Build run result.
+6. Run checks and terminal assertions — one terminal pass (§Checks).
+7. Build run result.
 
 ### Merge rules
 
@@ -1460,6 +1459,11 @@ resolves each id against the fragment registry first, then the check
 registry; an id matching neither FAILS plan construction with
 `:rf.error/story-compose-unknown`.
 
+Every id in `:checks` — the variant's own, or one inherited through
+`:extends` — MUST likewise resolve to a registered check, or plan
+construction FAILS with `:rf.error/story-check-unknown`. An unresolved
+check id would otherwise expand to no atoms and pass vacuously.
+
 `:compose` is a **child-only directive** — like `:extends`, it is not
 itself inherited down an `:extends` chain. It is applied at step 3 of the
 total resolution order, between the parent-chain merge (step 2) and the
@@ -1486,7 +1490,8 @@ list of fragments `F1 … Fn`:
 | `:args` / `:argtypes` | DEEP-MERGE root → fragments → child (last wins). |
 | `:checks` | inherited+own (root→child) ++ composed check-ids. |
 | `:assertions` | child-only (own terminal judgement). |
-| `:network` | per-route merge: composed fragments under the variant chain. |
+| `:network` | per-route merge: composed fragments under the variant chain. The `:extends` chain merges per route too — a child's route replaces the parent's reply. |
+| `:sub-overrides` | per-query-key merge: composed fragments under the variant chain. The `:extends` chain merges per query key too — a child's value replaces the parent's. |
 | `:fx-overrides` / `:interceptor-overrides` | strict-conflict, per-key (below). |
 | `:loaders` / `:loaders-teardown` | APPEND: composed fragments (declared order) ++ the variant chain's own (`:extends`-merged, child-wins). |
 | `:decorators` | APPEND: globals → story → composed fragments (declared order) → the variant chain's own. |
@@ -1608,6 +1613,13 @@ Checks are named assertion packs. Checks preserve identity in results,
 and they **inherit and compose** (the inheritable form, distinct from
 own-only assertions). A failed check result MUST show both the check id
 and the underlying assertion records.
+
+A check's assertion atoms run as **terminal expectations**: after the
+script settles, the runner dispatches them in one pass with the variant's
+terminal `:assertions`, against the final state. The pass is deduplicated,
+so an atom a check shares with `:assertions` (or with another check)
+dispatches and records once, and every check naming it groups that one
+record.
 
 ### Canonical P1 assertions
 
@@ -2738,10 +2750,12 @@ per-route reply data may carry `[:arg key]` placeholders, substituted on
 the same pass as setup / script / sub-overrides; an undeclared arg FAILS
 plan construction with `:rf.error/story-missing-arg`.
 
-Because `:network` is world context, it **inherits through `:extends`**
-(deep-merged root → child): a child variant's routes merge over the
-parent's, and the single managed-stub override covers the inherited and
-own routes alike.
+Because `:network` is world context, it **inherits through `:extends`**,
+merged **per route** root → child: a child's route replaces the parent's
+reply for that same route wholesale (so a child can flip a route from `:ok`
+to `:failure`), routes only the parent names are inherited, and the single
+managed-stub override covers the inherited and own routes alike. A route's
+reply is never deep-merged — it carries exactly one of `:ok` / `:failure`.
 
 ### Conflict with generic `:fx-overrides`
 

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -233,7 +233,8 @@
 
 (def ^:private context-keys
   "World/context keys inherited through `:extends` (deep-merge for maps,
-  child-wins for scalars; see `merge-context`).
+  except the per-entry `per-entry-context-keys`; child-wins for scalars;
+  see `merge-context`).
 
   `:args` / `:argtypes` are deliberately ABSENT: they are resolved by the
   dedicated `merge-key` deep-merge over the inherited → composed → child
@@ -272,12 +273,26 @@
   [body]
   (:setup body))
 
+(def ^:private per-entry-context-keys
+  "The `context-keys` whose map ENTRIES are atomic. A `:network` route's
+  value is one reply and a `:sub-overrides` query's value is one pinned
+  value, so through `:extends` the child wins per route / per query key —
+  the same per-entry `merge` `:compose` applies to both slots (rf2-pwwu).
+  Deep-merging them fused a parent's `{:reply {:ok …}}` with a child's
+  `{:reply {:failure …}}` into a reply the schema rejects and the stub
+  answers with `:ok`."
+  #{:network :sub-overrides})
+
 (defn- merge-context
-  "Deep-merge one context value root→child. Maps recurse (per
-  `rf.story.args/deep-merge`); everything else is child-wins replacement."
-  [parent child]
+  "Merge context key `k`'s value root→child. A `per-entry-context-keys` map
+  merges per top-level entry (child wins the entry); any other map recurses
+  (per `rf.story.args/deep-merge`); everything else is child-wins
+  replacement."
+  [k parent child]
   (if (and (map? parent) (map? child))
-    (rf.story.args/deep-merge parent child)
+    (if (contains? per-entry-context-keys k)
+      (merge parent child)
+      (rf.story.args/deep-merge parent child))
     (if (some? child) child parent)))
 
 ;; Tags are additive through `:extends` (§Merge rules — append/union), then
@@ -1297,7 +1312,7 @@
                        (fn [acc layer]
                          (reduce (fn [m k]
                                    (if (contains? layer k)
-                                     (update m k merge-context (get layer k))
+                                     (update m k #(merge-context k % (get layer k)))
                                      m))
                                  acc context-keys))
                        {}

--- a/tools/story/test/re_frame/story/network_runtime_test.clj
+++ b/tools/story/test/re_frame/story/network_runtime_test.clj
@@ -117,6 +117,26 @@
       (is (= [] @live-requests)
           "SENTINEL: an unmatched route still issues no live request"))))
 
+(deftest extends-child-flipping-a-route-to-failure-fires-the-failure
+  (testing "a child that :extends an :ok variant and flips the SAME route to
+            :failure gets its failure on a live run (rf2-pwwu). Before the fix
+            the route deep-merged to {:reply {:ok .. :failure ..}}, the stub
+            tested :ok first, and the child silently answered the parent's :ok"
+    (rf.story/reg-variant :story.netext/ok
+                          {:network cart-fixture
+                           :setup   [[:dispatch [:net/load]]]})
+    (rf.story/reg-variant :story.netext/fails
+                          {:extends :story.netext/ok
+                           :network {[:get "/api/cart"]
+                                     {:reply {:failure {:kind :rf.http/http-4xx :status 409}}}}})
+    (let [db (:app-db (run-target :story.netext/fails))]
+      (is (nil? (:cart db)) "the parent's :ok reply did NOT answer")
+      (is (= :rf.http/http-4xx (get-in db [:error :error :kind]))
+          "the child's :failure reply answered")
+      (is (= 409 (get-in db [:error :error :status])))
+      (is (= [] @live-requests)
+          "SENTINEL: no managed request reached the production fx slot"))))
+
 ;; ===========================================================================
 ;; The inline path
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story/plan_network_test.cljc
+++ b/tools/story/test/re_frame/story/plan_network_test.cljc
@@ -229,14 +229,14 @@
 ;; ===========================================================================
 
 (deftest network-inherits-through-extends
-  (testing ":network is world context — it inherits root→child (deep-merge)"
+  (testing ":network is world context — it inherits root→child (per-route merge)"
     (let [m {:story.n/parent
              {:network {cart-route {:reply {:ok {:items []}}}}}
              :story.n/child
              {:extends :story.n/parent
               :network {checkout-route {:reply {:failure {:kind :rf.http/http-4xx}}}}}}
           p (plan-of :story.n/child m)]
-      (testing "both parent + child routes present (deep-merge of the world map)"
+      (testing "both parent + child routes present (disjoint routes union)"
         (is (= {:reply {:ok {:items []}}}
                (get-in p [:world :network cart-route])))
         (is (= {:reply {:failure {:kind :rf.http/http-4xx}}}
@@ -244,6 +244,23 @@
       (testing "one managed-stub override covers the inherited + own routes"
         (is (= {:rf.http/managed :rf.http/managed-test-stub}
                (get-in p [:world :frame :fx-overrides])))))))
+
+(deftest network-same-route-child-reply-replaces-parent-through-extends
+  (testing "a child flipping the SAME route :ok -> :failure REPLACES the parent's
+            reply (rf2-pwwu). A route's value is one reply, so the child wins per
+            route — exactly as :compose resolves the same slot. A deep merge
+            compiled {:reply {:ok .. :failure ..}}, which the :reply schema
+            rejects and the stub answers with :ok, losing the failure case."
+    (let [failure {:kind :rf.http/http-4xx :status 409}
+          m {:story.n/ok    {:network {cart-route {:reply {:ok {:items [1]}}}}}
+             :story.n/fails {:extends :story.n/ok
+                             :network {cart-route {:reply {:failure failure}}}}}
+          p (plan-of :story.n/fails m)]
+      (is (= {:reply {:failure failure}}
+             (get-in p [:world :network cart-route]))
+          "the child's reply replaces the parent's wholesale")
+      (is (nil? (rf.story.schemas/validate :variant {:network (get-in p [:world :network])}))
+          "the COMPILED route map satisfies the schema registration applies to bodies"))))
 
 ;; ===========================================================================
 ;; Schema — the Variant schema accepts :network and rejects malformed shapes

--- a/tools/story/test/re_frame/story/plan_test.cljc
+++ b/tools/story/test/re_frame/story/plan_test.cljc
@@ -735,6 +735,20 @@
              (get-in p [:world :render :sub-overrides])))
       (is (= #{:sub-overrides} (get-in p [:world :fidelity]))))))
 
+(deftest sub-overrides-same-key-child-replaces-parent-through-extends
+  (testing "a child overriding the SAME query key REPLACES the parent's pinned
+            value (rf2-pwwu): the variant chain wins per query key, exactly as
+            :compose resolves it. A deep merge pinned a value neither author
+            wrote — here {:items [1 2] :total 2 :status :empty}."
+    (let [m {:story.cart/full  {:sub-overrides {[:cart/summary] {:items [1 2] :total 2}
+                                                [:cart/open?]   true}}
+             :story.cart/empty {:extends       :story.cart/full
+                                :sub-overrides {[:cart/summary] {:status :empty}}}}
+          p (rf.story.plan/variant-plan :story.cart/empty {:lookup m})]
+      (is (= {[:cart/summary] {:status :empty}   ; child's value, wholesale
+              [:cart/open?]   true}              ; untouched parent key inherited
+             (get-in p [:world :render :sub-overrides]))))))
+
 ;; ---- :db-seed — the MIDDLE fidelity rung (rf2-blw1q) ---------------------
 ;;
 ;; `:db-seed` is the schema-checked direct app-db seed. The compiler accepts


### PR DESCRIPTION
## What this fixes

**rf2-pwwu (P2 bug).** `:extends` deep-merged every context map. A child variant that flipped a parent's route from `:ok` to `:failure` therefore compiled `{:reply {:ok .. :failure ..}}`. The `:reply` schema rejects that shape, and the stub tests `:ok` first, so the child's failure case silently answered `:ok`. `:sub-overrides` had the same defect: the child's pinned value was fused into the parent's, which produced a value neither author wrote.

`merge-context` in `tools/story/src/re_frame/story/plan.cljc` now merges `:network` and `:sub-overrides` per top-level entry through `:extends`, so the child wins per route and per query key. That is the rule `:compose` already applies to both slots. Every other context map still deep-merges.

`:db-seed` is deliberately unchanged. Spec 017 documents its `:extends` deep merge (§Direct app-db seeding, item 2), so it is not part of this bug. That spec text says the `:extends` chain deep-merges and then wins per key against composed fragments. It describes two different merges and does not contradict itself. It does diverge from `:compose`, which replaces a seed path wholesale. Aligning the two is a design call, not a bug fix, so I left it alone.

**rf2-z8ta.** Spec 017 lagged PR #9717. It now states both things that PR made true.

## Spec changes (`tools/story/spec/017-Testing-Story.md`)

- §Total resolution order, execution list: "Run checks" and "Run terminal assertions" are merged into one terminal pass. The runtime dispatches them together in one deduplicated pass, so two separate steps no longer described it.
- §`:compose` resolution: an unresolved `:checks` id (own or inherited) MUST fail plan construction with `:rf.error/story-check-unknown`.
- §Total merge order table: the `:network` row states the per-route rule for the `:extends` chain, and a new `:sub-overrides` row states the per-query-key rule.
- §Checks: a check's atoms run as terminal expectations. They run in one pass with the terminal `:assertions`, after the script settles, against the final state, and the pass is deduplicated.
- §Network world, "What the compiler emits": the sentence that called the `:extends` network merge "deep-merged" is corrected to per-route. It was the one place the spec endorsed the bug.

## Evidence: same-route and same-key witnesses

These tests were committed before the fix (`0ace3ea13f`) and run against the unfixed code:

- `plan-network-test/network-same-route-child-reply-replaces-parent-through-extends`: a parent route answers `:ok` and the child flips that same route to `:failure`. It asserts the compiled reply is the child's and that the compiled route map passes the `:variant` schema.
- `plan-test/sub-overrides-same-key-child-replaces-parent-through-extends`: the child re-pins the same query key the parent pinned. The untouched parent key is still inherited.
- `network-runtime-test/extends-child-flipping-a-route-to-failure-fires-the-failure`: a live run of the `:extends` child. The failure reply lands, the parent's `:ok` does not, and the sentinel sees no live request.

Before the fix, all six new assertions failed. The compiled route read `{:reply {:ok {:items [1]}, :failure {...}}}` and was rejected by the schema. The live run answered `:ok`. The sub-override read `{:items [1 2], :total 2, :status :empty}`. After the fix all of them pass. The existing disjoint-route test `network-inherits-through-extends` stays green; only its testing labels changed, from "deep-merge" to "per-route merge".

No test file here is renamed by the open test-rename PR #9720, so the new tests sit beside the tests they extend rather than in new files.

## Quality gates

All exit codes below were captured by my own redirect.

- **jvm-tools-story** (`cd tools/story && clojure -M:test`):
  - baseline on the untouched tree: exit 0, 1933 tests / 7136 assertions, 0 failures.
  - witnesses only, before the fix: exit 1, 1936 / 7143, 6 failures, all in the three new tests.
  - after the fix: exit 0, 1936 / 7143, 0 failures, 0 errors.
- **`scripts/check_doc_slugs.py`**, the gate for `tools/*/spec` links and anchors: exit 0.
  - I planted a broken anchor on a line this PR edits. The gate went red (exit 1) and named that line. After restoring the file I checked it against the committed blob hash, and the re-run exited 0.
- **Ratchets over the touched paths**, each exit 0: `check_retired_spellings.py`, `check_keyword_catalogue_drift.py`, `check_flattened_lists.py`, `check_escaped_continuations.py`, `check_require_alias_dialect.py`, `check_thrown_error_messages.py`, `check_retired_composition_vocab.py`, `check-no-hardcoded-paths.sh`.
- **Table shape**: checked by hand. Every row of the merge-order table carries two cells, matching its header.
- **`mkdocs build --strict` is not a gate for this page.** `tools/` is outside `docs_dir`, and `mkdocs_hooks.py` does not stage it.
- **Relying on CI** for the classifier-selected lanes I did not run locally: `cljs_node_test`, `cljs_browser`, `examples_compile`, `mcp_conformance`, `story_xray_browser`. The code change is a `merge` in portable `.cljc`.

## Scope notes

- This is not one of the held rf2-fzbj.3 findings. That review covers loaders and args, and it does not reopen the network work.
