### PR TITLE
fix(story): run-scoped tape assertions, no-frame runs error, one phase-1/2 exception path, run chains settle (rf2-3okc, rf2-poty, rf2-izz5, rf2-9ppq)

### DIFF
--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -123,15 +123,61 @@
 ;; them without a payload-leak risk.
 ;; ---------------------------------------------------------------------------
 
+;; ---------------------------------------------------------------------------
+;; Run scope — the epoch baseline (rf2-3okc)
+;;
+;; The epoch ring is FRAME-owned and survives the runtime's in-place
+;; fresh-run reset (`re-frame.story.runtime/ensure-fresh-frame!` resets
+;; app-db / runtime-db, not the ring), so an unscoped read answers for EVERY
+;; run the frame has hosted: a same-id re-run whose script had stopped
+;; dispatching an event still passed `:rf.assert/dispatched?` on the previous
+;; run's epoch. Phase 0 therefore records the last committed `:epoch-id` as
+;; the frame's run baseline — the SAME `:epoch-baseline` the run-result tape
+;; is scoped by — and `frame-tape` keeps only newer records, through the one
+;; `run-slice` rule both readers share.
+;;
+;; `:epoch-id` is globally monotonic and never reset, so a baseline left
+;; behind by a destroyed frame sits BELOW every epoch a later incarnation
+;; commits: a stale entry is inert, never a hidden epoch.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private run-epoch-baselines (atom {}))
+
+(defn run-slice
+  "The records of epoch `ring` committed AFTER `epoch-baseline` — one run's
+  slice of a frame-owned ring. The ONE scoping rule shared by the
+  tape-projected assertions (`frame-tape`) and the run-result tape
+  (`re-frame.story.runtime/record-result-map`). A nil baseline keeps the
+  whole ring (`0` is never a real `:epoch-id`). Pure data → data."
+  [epoch-baseline ring]
+  (filterv #(> (or (:epoch-id %) 0) (or epoch-baseline 0)) ring))
+
+(defn set-run-epoch-baseline!
+  "Scope `frame-id`'s tape-projected assertions to the epochs committed
+  after `epoch-id` — the run's `:epoch-baseline`, recorded by the runtime's
+  phase 0. Returns nil."
+  [frame-id epoch-id]
+  (swap! run-epoch-baselines assoc frame-id epoch-id)
+  nil)
+
+(defn clear-run-epoch-baseline!
+  "Drop `frame-id`'s run baseline (an inline frame's teardown — its minted
+  id is never reused). Returns nil."
+  [frame-id]
+  (swap! run-epoch-baselines dissoc frame-id)
+  nil)
+
 (defn- frame-tape
-  "The retained epoch tape for `frame-id` via the late-bound
-  `re-frame.core/epoch-history` facade (the SSOT the run-result evidence
-  slots read). Degrades to `[]` on a host without the epoch artefact
+  "The CURRENT RUN's slice of the retained epoch tape for `frame-id`, via
+  the late-bound `re-frame.core/epoch-history` facade (the SSOT the
+  run-result evidence slots read) scoped by the frame's run baseline
+  (`run-slice`). A frame no run has prepared carries no baseline and reads
+  its whole ring. Degrades to `[]` on a host without the epoch artefact
   (production Story jars) — exactly what the run-result projection sees.
   Tolerant: any read error returns `[]`."
   [frame-id]
   (try
-    (vec (rf/epoch-history frame-id))
+    (run-slice (get @run-epoch-baselines frame-id) (rf/epoch-history frame-id))
     (catch #?(:clj Throwable :cljs :default) _ [])))
 
 (defn dispatched-events

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -85,10 +85,13 @@
 ;; throwing. Story's phase runners convert those trace events
 ;; into assertion records (per `002-Runtime.md` §Error projection).
 ;;
-;; The capture pattern: register a trace listener around each phase
-;; that collects matching errors into an atom. After the phase, walk
-;; the atom and record each into the variant frame's `:rf.story/
-;; assertions` accumulator.
+;; The capture pattern: the play-runner's per-frame trace listener
+;; (installed at phase 0) collects matching errors into its
+;; `pending-exceptions` slot, and each phase driver drains that slot onto
+;; the variant frame's `:rf.story/assertions` accumulator after every
+;; dispatch — ONE recording path for phases 1, 2 and 4 (rf2-izz5).
+;; `capture-phase-errors` brackets phases 1-2 only to keep the
+;; privacy-suppressed failures' framework fact (rf2-k6y2).
 
 (defonce ^:private capture-counter (atom 0))
 
@@ -106,70 +109,50 @@
 
 (defn- capture-phase-errors
   "Run `body-fn` (a 0-arg thunk) with a registered trace listener that
-  collects PIPELINE-EXCEPTION events targeting `variant-id`'s frame.
-  After the body returns, walks the captured errors and records each as
-  a phase-tagged assertion via `record-error!`. Returns `body-fn`'s
-  return value.
+  captures the PRIVACY-SUPPRESSED half of a loader / setup phase's failure
+  picture. Returns `body-fn`'s return value.
 
-  The capture set is every operation in
-  `rf.story.error/pipeline-exception-operations` (handler-exception,
-  coeffect-exception, interceptor-exception), not just
-  `:rf.error/handler-exception`. A loader/event phase whose cofx
-  injector or user interceptor throws is caught by the shared
-  `pipeline-exception-event?` predicate, and the originating
-  `:operation` / `:failing-id` are preserved onto the record so a cofx
-  failure is distinguishable from a handler failure.
+  RECORDING a phase's pipeline exceptions is not this listener's job. The
+  play-runner's per-frame listener (`rf.story.play/install-trace-listener!`,
+  installed by phase 0 before any loader fires) captures every pipeline
+  exception — handler, coeffect and interceptor alike, through the shared
+  `pipeline-exception-event?` predicate, with the originating `:operation`
+  / `:failing-id` preserved — into `pending-exceptions`, and the phase
+  driver drains that slot after each dispatch. That is the ONE recording
+  path, for phases 1, 2 and 4 alike. This listener used to record the same
+  events a second time, so every loader / setup failure appeared twice in
+  the result and doubled `:failures` (rf2-izz5).
 
-  Per Spec 009 §Privacy + EP-0015: pipeline-exception trace
-  events whose `:sensitive?` flag is true are dropped from the capture
-  set when Story's local-render egress profile redacts
-  (`:rf.egress/local-redacted` — the default). A counter bump is recorded
-  so the UI's redaction hint can surface 'N sensitive events suppressed'.
-
-  The suppress branch ALSO records the dropped event's framework
-  `:operation` via `note-redacted-failure!` when the event is a pipeline
-  exception for THIS variant. That is not a second capture path and it
-  reveals nothing further: the assertion records stay exactly as redacted
-  as before, and what is kept is one member of the closed
-  `pipeline-exception-operations` enum — no message, no `ex-data`, no
-  failing event. It exists because the assertion accumulator is the
-  DISPLAY path, so a caller that must answer 'did phases 0-2 succeed?'
-  cannot read it: under the default profile a sensitive `:setup` failure
-  left the accumulator empty, and `prepare-variant` published a
-  step-debugger over a frame whose `:setup` never ran (rf2-k6y2,
-  post-merge audit of PR #9252). Readiness therefore rests on a fact the
-  egress filter cannot erase, rather than on redaction being weakened."
-  [variant-id phase body-fn]
-  (let [collected (atom [])
-        listener  (fn [ev]
-                    (cond
-                      ;; Resolve the suppress decision against the event's
-                      ;; own frame (per-(tool,frame) visibility).
-                      (rf.story.config/suppress-sensitive? ev)
-                      (do
-                        (rf.story.config/note-suppressed!
-                          (rf.trace/trace-event-frame ev))
-                        ;; `pipeline-exception-event?` also checks the event
-                        ;; targets THIS variant's frame, so a sibling
-                        ;; frame's suppressed failure never marks this
-                        ;; preparation unready.
-                        (when (rf.story.error/pipeline-exception-event? variant-id ev)
-                          (rf.story.config/note-redacted-failure!
-                            variant-id (:operation ev))))
-
-                      (rf.story.error/pipeline-exception-event? variant-id ev)
-                      (swap! collected conj ev)))]
-    (with-trace-listener
-      listener
-      (fn []
-        (let [result (body-fn)]
-          (doseq [ev @collected]
-            (record-error! variant-id phase
-                           (get-in ev [:tags :event])
-                           (get-in ev [:tags :exception])
-                           {:operation  (:operation ev)
-                            :failing-id (get-in ev [:tags :failing-id])}))
-          result)))))
+  What it owns is the fact the egress filter would otherwise erase. Per
+  Spec 009 §Privacy + EP-0015 a trace event whose `:sensitive?` flag is
+  true is dropped while Story's local-render egress profile redacts
+  (`:rf.egress/local-redacted` — the default), so it leaves no assertion.
+  A counter bump is recorded so the UI's redaction hint can surface 'N
+  sensitive events suppressed', and — when the dropped event is a pipeline
+  exception for THIS variant — its framework `:operation` via
+  `note-redacted-failure!`. That reveals nothing further: what is kept is
+  one member of the closed `pipeline-exception-operations` enum — no
+  message, no `ex-data`, no failing event. It exists because the assertion
+  accumulator is the DISPLAY path, so a caller that must answer 'did phases
+  0-2 succeed?' cannot read it: under the default profile a sensitive
+  `:setup` failure left the accumulator empty, and `prepare-variant`
+  published a step-debugger over a frame whose `:setup` never ran
+  (rf2-k6y2, post-merge audit of PR #9252). Readiness therefore rests on a
+  fact the egress filter cannot erase, rather than on redaction being
+  weakened."
+  [variant-id body-fn]
+  (with-trace-listener
+    (fn [ev]
+      ;; Resolve the suppress decision against the event's own frame
+      ;; (per-(tool,frame) visibility).
+      (when (rf.story.config/suppress-sensitive? ev)
+        (rf.story.config/note-suppressed! (rf.trace/trace-event-frame ev))
+        ;; `pipeline-exception-event?` also checks the event targets THIS
+        ;; variant's frame, so a sibling frame's suppressed failure never
+        ;; marks this preparation unready.
+        (when (rf.story.error/pipeline-exception-event? variant-id ev)
+          (rf.story.config/note-redacted-failure! variant-id (:operation ev)))))
+    body-fn))
 
 ;; ---- phase-2 events execution --------------------------------------------
 
@@ -263,7 +246,7 @@
   [variant-id plan]
   (let [all-events (plan-setup-events variant-id plan)]
     (capture-phase-errors
-      variant-id :phase-2-events
+      variant-id
       (fn []
         (doseq [ev all-events]
           (try
@@ -316,7 +299,7 @@
           loader-events (or (:loaders variant-body) [])]
       (rf.story.loaders/start-loaders! variant-id)
       (capture-phase-errors
-        variant-id :phase-1-loaders
+        variant-id
         (fn []
           (doseq [ev loader-events]
             (try
@@ -622,8 +605,9 @@
         ;; causal `:pass` against a finite upper bound resolves `:cannot-run`
         ;; rather than a truncation false-green.
         truncated? (rf.story.play.evidence/run-tape-truncated? full-ring epoch-baseline)
-        tape     (vec (filter #(> (or (:epoch-id %) 0) (or epoch-baseline 0))
-                              full-ring))
+        ;; The SAME `run-slice` rule the tape-projected assertions scope by
+        ;; (rf2-3okc), so a verdict and the evidence slots read one run.
+        tape     (rf.story.assertions/run-slice epoch-baseline full-ring)
         ;; The runner-recorded per-dispatch-step settle boundaries light
         ;; up the EXACT narrative attribution
         ;; (`rf.story.play.evidence/spans-from-stamps`). The
@@ -830,6 +814,17 @@
   (when (contains? (set (rf/frame-ids)) variant-id)
     (rf.story.frames/reset-state! variant-id)))
 
+(defn- stamp-epoch-baseline!
+  "Record the run's `:epoch-baseline` — the last committed `:epoch-id` at
+  the fresh-run boundary — on `ctx` AND as the frame's assertion scope, so
+  the run-result tape (`record-result-map`) and the tape-projected
+  assertions (`dispatched?` / `effect-emitted` / `no-warnings`) read the
+  same run (rf2-3okc). Returns the ctx."
+  [{:keys [variant-id] :as ctx}]
+  (let [baseline (rf.story.play.runner-events/last-epoch-id variant-id)]
+    (rf.story.assertions/set-run-epoch-baseline! variant-id baseline)
+    (assoc ctx :epoch-baseline baseline)))
+
 (defn- run-phase-0!
   "Phase 0: enforce a fresh-run boundary, allocate the variant frame
   with its decorator stack, then install the play-runner's privacy
@@ -860,9 +855,10 @@
   accumulator, so there is no accumulator to seed here.
 
   Because an in-place reset preserves the frame-owned epoch ring, phase 0
-  records the current last-committed `:epoch-id` as `:epoch-baseline`.
-  `record-result-map` uses that identity to project evidence from this run
-  only.
+  records the current last-committed `:epoch-id` as `:epoch-baseline`
+  (`stamp-epoch-baseline!`). `record-result-map` uses that identity to
+  project evidence from this run only, and so do the tape-projected
+  assertions (rf2-3okc).
 
   Classification comes from the already-compiled plan's
   `[:world :sensitive]` / `[:world :large]` slots, after `:extends`
@@ -886,7 +882,7 @@
   (swap! rf.story.play/pending-exceptions assoc variant-id [])
   (rf.story.config/reset-redacted-failures! variant-id)
   (rf.story.play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (rf.story.play.runner-events/last-epoch-id variant-id)))
+  (stamp-epoch-baseline! ctx))
 
 (defn- db-seed-violations
   "Validate the seeded `db` against the frame's REGISTERED app-db schemas
@@ -1134,16 +1130,29 @@
                                                {:clear-boundaries? false}))))]
                (step! auto-plays))))]))))
 
+(declare handle-run-error!)
+
 (defn- finalise-run!
   "Build and deliver the result map once phase 4's promise settles.
   This chain is load-bearing: `execute-play!` resolves the promise to the
   assertions vector, and we want the result map to read the post-play
-  app-db."
+  app-db.
+
+  The `catch*` is the chain's rejection path (rf2-9ppq). Without it a
+  throw while assembling the result — or a rejected play promise — left
+  `resolve` uncalled: `then` derives a NEW promise and never settles the
+  outer one, so `run-variant`'s promise stayed pending for ever (a JVM
+  deref timed out, a CLJS await never resolved) with no error recorded
+  anywhere. `handle-run-error!` never throws, so the run always settles."
   [resolve play-promise ctx start-ms]
   (-> play-promise
       (rf.story.async/then
         (fn [_]
           (resolve (record-result-map ctx start-ms))
+          nil))
+      (rf.story.async/catch*
+        (fn [e]
+          (handle-run-error! resolve (:variant-id ctx) e start-ms)
           nil))))
 
 (defn- plan-construction-error?
@@ -1161,11 +1170,13 @@
 
   Matching on `:where` (not on any `:rf.error/id`) is load-bearing:
   framework runtime errors thrown LATER in the phase chain also carry an
-  `:rf.error/id` — e.g. `:rf.error/no-adapter-installed` from
-  `make-frame` → `make-state-container` when the host installed no
-  adapter (the JVM-standalone story-mcp server). Those land after the
-  frame exists at `:pre-mount`, so they must take the frame-bound
-  record/transition branch, NOT `plan-error-result`."
+  `:rf.error/id`, and they must NOT take `plan-error-result`, which would
+  stamp that raw id as a plan failure. One of them —
+  `:rf.error/no-adapter-installed` from `make-frame` →
+  `make-state-container` when the host installed no adapter — throws
+  BEFORE the frame is registered, so it has no frame to record onto
+  either; `run-error-result`'s no-live-frame branch answers it
+  (rf2-poty)."
   [e]
   (= 'rf.story/variant-plan (:where (ex-data e))))
 
@@ -1173,25 +1184,38 @@
   #?(:clj  (.getMessage ^Throwable e)
      :cljs (str e)))
 
-(defn- plan-error-result
-  "The error result returned when `re-frame.story.plan/variant-plan`
-  FAILS to compile the variant (§B8). The frame is not
-  allocated when plan construction throws, so the result is built
-  directly from the exception — mirroring `unknown-variant-result`'s
-  frame-free shape. The `:rf.error/story-*` id rides the assertion record
-  so tools surface the plan failure the same way a registration failure
-  surfaces."
-  [variant-id e]
+(defn- frame-free-error-result
+  "An `:error` run result built from the exception `e` alone, reading no
+  frame — mirroring `unknown-variant-result`'s frame-free shape. Its ONE
+  assertion record carries `assertion-id` (merged with `extras`) plus the
+  exception's `:reason` / `:error`, so a tool surfaces the failure the same
+  way it surfaces a registration failure. The `:error` map is projected
+  frameless: its `ex-data` is framework metadata (`:rf.error/id`,
+  `:where`), not app-db-sourced (`rf.story.error/throwable->error-map`)."
+  [variant-id assertion-id extras e]
   (assoc (empty-result variant-id)
          :status     :error
          :lifecycle  :error
-         :assertions [{:assertion  (or (:rf.error/id (ex-data e))
-                                       :rf.error/story-plan-invalid)
-                       :variant-id variant-id
-                       :status     :error
-                       :passed?    false
-                       :reason     (exception-message e)
-                       :error      (rf.story.error/throwable->error-map e)}]))
+         :assertions [(merge {:assertion  assertion-id
+                              :variant-id variant-id
+                              :status     :error
+                              :passed?    false
+                              :reason     (exception-message e)
+                              :error      (rf.story.error/throwable->error-map e)}
+                             extras)]))
+
+(defn- plan-error-result
+  "The error result returned when `re-frame.story.plan/variant-plan`
+  FAILS to compile the variant (§B8). The frame is not allocated when
+  plan construction throws, so the result is built directly from the
+  exception (`frame-free-error-result`). The `:rf.error/story-*` id rides
+  the assertion record so tools surface the plan failure the same way a
+  registration failure surfaces."
+  [variant-id e]
+  (frame-free-error-result variant-id
+                           (or (:rf.error/id (ex-data e)) :rf.error/story-plan-invalid)
+                           nil
+                           e))
 
 (defn- db-seed-error?
   "True iff `e` is the structured `:db-seed` schema-validation failure
@@ -1225,26 +1249,38 @@
       (catch #?(:clj Throwable :cljs :default) _ nil))
     record))
 
-(defn- handle-run-error!
-  "Catch-branch for the orchestrator: record the exception as a
-  phase-0-setup assertion (covers any sync throw from the phase chain),
-  transition the lifecycle machine to `:error`, then resolve with the
-  best result map we can build from whatever the run accumulated. The
-  recorded `:rf.error/exception` assertion (`:passed? false`) flows into
-  the unified result's `:assertions`, so the aggregation reports `:fail`
-  (the error record is a failed expectation) even when the tape is sparse.
+(defn- run-error-result
+  "The run result for a throw `e` anywhere in the run chain — the
+  orchestrator's catch-branch, the play chain's rejection path and the
+  inline run's failure path all come here. NEVER throws: every caller
+  hands the answer straight to the run's `resolve`, and a throw here would
+  leave the run's promise pending for ever (rf2-9ppq).
 
-  §B8 — a plan-construction failure (thrown in
-  `prepare-context`, before frame allocation) cannot be recorded onto a
-  frame, so it is projected directly via `plan-error-result`. Every other
-  throw lands after the frame exists and routes through the frame-bound
-  record/transition path.
+  §B8 — a plan-construction failure (thrown in `prepare-context`, before
+  frame allocation) is projected directly via `plan-error-result`.
 
-  A `:db-seed` schema-validation failure (`run-db-seed!`)
-  throws AFTER the frame is allocated, so it takes the frame-bound branch,
-  but is recorded as its own structured `:rf.error/story-db-seed-invalid`
-  assertion (carrying the path/value/explain violations) rather than the
-  opaque `:rf.error/exception` shape.
+  NO LIVE FRAME (rf2-poty). A throw that lands before the frame exists —
+  `:rf.error/no-adapter-installed` from `make-frame` is the common one, a
+  JVM or REPL host that never ran `rf/init!` — has nowhere to record.
+  `record-error!` swallows its dispatch into the missing frame, and
+  `record-result-map` reads a nil app-db and aggregates zero records to
+  `:pass`, so the frame-bound path answered a run that never ran with a
+  success. It resolves a frame-free `:error` result carrying the exception
+  instead. A variant that genuinely RAN with no assertions is still
+  vacuously green; this is the state where nothing ran at all.
+
+  Every other throw lands after the frame exists and takes the frame-bound
+  path: record the exception (a `:db-seed` schema failure from
+  `run-db-seed!` as its own structured `:rf.error/story-db-seed-invalid`
+  assertion carrying the path/value/explain violations; anything else as
+  the opaque `:rf.error/exception` shape at `:phase-0-setup`, which covers
+  any sync throw from the phase chain), transition the lifecycle machine
+  to `:error`, then assemble the best result `ctx` allows from whatever
+  the run accumulated. The record (`:passed? false`) flows into the
+  unified result's `:assertions`, so the aggregation reports a failure
+  even when the tape is sparse. If that assembly itself throws (a frame
+  torn down mid-run, a malformed plan slot), the frame-free result is the
+  answer.
 
   The plan-construction branch is gated SOLELY on
   `plan-construction-error?` (the `:where 'rf.story/variant-plan` marker
@@ -1254,22 +1290,29 @@
   lifecycle state is not needed to route correctly — gating on lifecycle
   state would be stale-frame-sensitive (a PRIOR `:ready` run on the same
   id leaves `rf.story.loaders/current-state` at `:ready`, not `:pre-mount`)."
+  [{:keys [variant-id] :as ctx} e start-ms]
+  (let [frame-free #(frame-free-error-result variant-id :rf.error/exception
+                                             {:phase :phase-0-setup} e)]
+    (try
+      (cond
+        (plan-construction-error? e)        (plan-error-result variant-id e)
+        (nil? (rf/app-db-value variant-id)) (frame-free)
+        :else
+        (do
+          (if (db-seed-error? e)
+            (record-seed-error! variant-id e)
+            (record-error! variant-id :phase-0-setup nil e))
+          (rf.story.loaders/error! variant-id (ex-data e))
+          (record-result-map ctx start-ms)))
+      (catch #?(:clj Throwable :cljs :default) _
+        (frame-free)))))
+
+(defn- handle-run-error!
+  "Catch-branch for the orchestrator and for the play chain's rejection
+  path: resolve `resolve` with `run-error-result` for `e`. Never throws,
+  so the run's promise always settles."
   [resolve variant-id e start-ms]
-  (cond
-    (plan-construction-error? e)
-    (resolve (plan-error-result variant-id e))
-
-    (db-seed-error? e)
-    (do
-      (record-seed-error! variant-id e)
-      (rf.story.loaders/error! variant-id (ex-data e))
-      (resolve (record-result-map {:variant-id variant-id} start-ms)))
-
-    :else
-    (do
-      (record-error! variant-id :phase-0-setup nil e)
-      (rf.story.loaders/error! variant-id (ex-data e))
-      (resolve (record-result-map {:variant-id variant-id} start-ms)))))
+  (resolve (run-error-result {:variant-id variant-id} e start-ms)))
 
 (defn- unknown-variant-result
   "The error result returned when `rf.story.frames/variant-body` finds no
@@ -1525,14 +1568,26 @@
                  ;; flag, so its loader-incomplete contract (play skipped,
                  ;; lifecycle parks at :loading) is unchanged.
                  :else
-                 (let [[ctx' play-promise] (run-phase-4! (assoc (:ctx attempt) :force-play? true))]
+                 (let [[ctx' play-promise] (run-phase-4! (assoc (:ctx attempt) :force-play? true))
+                       ;; Publish via `publish!` unless superseded, then fire
+                       ;; `done-cb` — once, on whichever path settles.
+                       settle! (fn [publish!]
+                                 (if (= my-gen (current-generation variant-id))
+                                   (publish!)
+                                   (resolve (superseded-result variant-id my-gen)))
+                                 (when done-cb (try (done-cb) (catch #?(:clj Throwable :cljs :default) _ nil))))]
                    (-> play-promise
                        (rf.story.async/then
                          (fn [_]
-                           (if (= my-gen (current-generation variant-id))
-                             (resolve (record-result-map ctx' start-ms))
-                             (resolve (superseded-result variant-id my-gen)))
-                           (when done-cb (try (done-cb) (catch #?(:clj Throwable :cljs :default) _ nil)))
+                           (settle! #(resolve (record-result-map ctx' start-ms)))
+                           nil))
+                       ;; rf2-9ppq — the rejection path `finalise-run!` has: a
+                       ;; throw assembling the result (or a rejected play
+                       ;; promise) settles the run with an error instead of
+                       ;; leaving it pending for ever.
+                       (rf.story.async/catch*
+                         (fn [e]
+                           (settle! #(handle-run-error! resolve variant-id e start-ms))
                            nil)))))
                (catch #?(:clj Throwable :cljs :default) e
                  (handle-run-error! resolve variant-id e start-ms))))))))))
@@ -1660,7 +1715,7 @@
                            (select-keys (:world plan) [:sensitive :large]))
   (swap! rf.story.play/pending-exceptions assoc variant-id [])
   (rf.story.play/install-trace-listener! variant-id)
-  (assoc ctx :epoch-baseline (rf.story.play.runner-events/last-epoch-id variant-id)))
+  (stamp-epoch-baseline! ctx))
 
 (defn run-inline-plan
   "Execute an inline plan MAP (spec/017 §Inline plan) and
@@ -1722,6 +1777,10 @@
                (let [ctx*       (volatile! nil)
                      allocated? (volatile! false)
                      teardown!  (fn []
+                                  ;; An inline frame's id is minted once and
+                                  ;; never reused, so its run baseline goes
+                                  ;; with it (rf2-3okc).
+                                  (rf.story.assertions/clear-run-epoch-baseline! frame-id)
                                   (when @allocated?
                                     (try
                                       (rf.story.frames/destroy-inline!
@@ -1729,16 +1788,17 @@
                                         (get-in plan [:world :loaders-teardown]))
                                       (catch #?(:clj Throwable :cljs :default) _ nil))))
                      fail!      (fn [e]
-                                  ;; A `:db-seed` schema-validation
-                                  ;; failure records as its own structured
-                                  ;; assertion; every other throw stays the
-                                  ;; opaque `:rf.error/exception` shape.
-                                  (if (db-seed-error? e)
-                                    (record-seed-error! frame-id e)
-                                    (record-error! frame-id :phase-0-setup nil e))
-                                  (rf.story.loaders/error! frame-id (ex-data e))
-                                  (let [result (record-result-map
-                                                 {:variant-id frame-id :plan plan} start-ms)]
+                                  ;; The SAME error assembly the registered
+                                  ;; path uses (`run-error-result`): a
+                                  ;; `:db-seed` failure records as its own
+                                  ;; structured assertion, a throw before the
+                                  ;; frame exists (no adapter installed)
+                                  ;; resolves `:error` rather than a vacuous
+                                  ;; `:pass` (rf2-poty), and the assembly
+                                  ;; never throws, so this catch path always
+                                  ;; settles (rf2-9ppq).
+                                  (let [result (run-error-result
+                                                 {:variant-id frame-id :plan plan} e start-ms)]
                                     (teardown!)
                                     (resolve result)))]
                  (try
@@ -1790,9 +1850,10 @@
   as a (possibly empty) vector of the `:rf.error/exception` records.
 
   `run-loaders!` / `run-events!` deliberately do not rethrow a failing
-  `:loaders` / `:setup` handler: `capture-phase-errors` collects the
-  pipeline-exception trace events and `record-error!` projects each onto
-  `[:rf.story/assertions]`, then the phase RETURNS. That is
+  `:loaders` / `:setup` handler: the play-runner's per-frame listener
+  captures the pipeline-exception trace events and the phase driver drains
+  each onto `[:rf.story/assertions]` (once — rf2-izz5), then the phase
+  RETURNS. That is
   `run-variant`'s gather-the-full-picture contract, and it stays — a run
   result is meant to report every failure it saw, not abort at the first.
   The consequence is that `prepare-ctx!` can complete WITHOUT THROWING over
@@ -1824,9 +1885,9 @@
   empty) set.
 
   `captured-prepare-failures` above reads `[:rf.story/assertions]`, and
-  those records are produced AFTER the egress gate. `capture-phase-errors`'
-  first `cond` branch drops a `:sensitive?` trace event before
-  `record-error!` ever runs, so under the default
+  those records are produced AFTER the egress gate. The per-frame
+  listener's gate drops a `:sensitive?` trace event before it is ever
+  captured, so under the default
   `:rf.egress/local-redacted` profile a `:setup` / `:loaders` handler whose
   failure is classified sensitive leaves NO assertion — and the predicate
   above then has nothing to refuse on. That is the shape rf2-k6y2's
@@ -1893,7 +1954,7 @@
     and return normally (`run-variant`'s gather-the-full-picture contract),
     so `prepare-ctx!` completes over a frame whose `:setup` never ran.
   - REDACTED — the same captured failure, but CLASSIFIED SENSITIVE. The
-    privacy egress gate drops the trace event before `record-error!`, so
+    privacy egress gate drops the trace event before it is recorded, so
     it leaves no assertion either: the frame looks not merely healthy but
     UNEVENTFUL.
 

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -36,7 +36,8 @@
             [re-frame.story.assertions :as rf.story.assertions]
             [re-frame.story.async      :as rf.story.async]
             [re-frame.story.config     :as rf.story.config]
-            [re-frame.story.loaders    :as rf.story.loaders]))
+            [re-frame.story.loaders    :as rf.story.loaders]
+            [re-frame.trace            :as rf.trace]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -776,3 +777,71 @@
       (is (false? (get by-need :ssot.fx/never))
           "an fx never emitted (stubbed or otherwise) → fail"))
     (rf.story/destroy-variant! :story.ssot/stubbed)))
+
+;; ===========================================================================
+;; rf2-3okc — the tape-projected assertions read ONLY the current run
+;;
+;; A same-id re-run resets the frame IN PLACE (`ensure-fresh-frame!`), so the
+;; frame-owned epoch ring still carries the previous run's epochs. The three
+;; tape-projected handlers used to read ALL of it, so a script that had stopped
+;; dispatching an event kept passing `dispatched?` on the previous run's
+;; evidence. Each shape below is one run that establishes a fact, then the SAME
+;; id re-registered without it: the second record must read only its own run.
+;; ===========================================================================
+
+(defn- okc-run-verdict
+  "Run `variant-id`; return `[status passed?]` for its last `assertion-id` record."
+  [variant-id assertion-id]
+  (let [r (rf.story.async/deref-blocking (rf.story/run-variant variant-id) 5000)]
+    [(:status r)
+     (:passed? (last (filter #(= assertion-id (:assertion %)) (:assertions r))))]))
+
+(deftest dispatched-assertion-reads-only-the-current-run
+  (testing "rf2-3okc C1/C2/C3 — a same-id re-run does not inherit the previous run's dispatch"
+    (rf/reg-event :okc/ok (fn [{:keys [db]} _] {:db (assoc db :ok true)}))
+    (rf.story/reg-variant :story.okc/dispatched
+      {:script [[:dispatch [:okc/ok]] [:assert [:rf.assert/dispatched? [:okc/ok]]]]})
+    (is (= [:pass true] (okc-run-verdict :story.okc/dispatched :rf.assert/dispatched?))
+        "C1 — the first run dispatches, and dispatched? passes on real evidence")
+    (rf.story/reg-variant :story.okc/dispatched
+      {:script [[:assert [:rf.assert/dispatched? [:okc/ok]]]]})
+    (is (= [:fail false] (okc-run-verdict :story.okc/dispatched :rf.assert/dispatched?))
+        "C2 — the SAME id re-run WITHOUT the dispatch fails: the previous run's
+         epoch is not this run's evidence")
+    (rf.story/reg-variant :story.okc/dispatched-fresh
+      {:script [[:assert [:rf.assert/dispatched? [:okc/ok]]]]})
+    (is (= [:fail false] (okc-run-verdict :story.okc/dispatched-fresh :rf.assert/dispatched?))
+        "C3 control — a fresh id with the same assert-only script fails, and C2 agrees with it")
+    (rf.story/destroy-variant! :story.okc/dispatched)
+    (rf.story/destroy-variant! :story.okc/dispatched-fresh)))
+
+(deftest effect-emitted-and-no-warnings-read-only-the-current-run
+  (testing "rf2-3okc — effect-emitted and no-warnings are run-scoped too, in both directions"
+    (rf/reg-fx :okc/fx {:platforms #{:client :server}} (fn [_ _] nil))
+    (rf/reg-event :okc/emit (fn [_ _] {:fx [[:okc/fx 1]]}))
+    (rf/reg-event :okc/ok (fn [{:keys [db]} _] {:db (assoc db :ok true)}))
+    (rf/reg-event :okc/warn (fn [{:keys [db]} _]
+                              (rf.trace/emit! :warning :okc/warned {})
+                              {:db db}))
+    (rf.story/reg-variant :story.okc/fx
+      {:script [[:dispatch-sync [:okc/emit]] [:assert [:rf.assert/effect-emitted :okc/fx]]]})
+    (is (= [:pass true] (okc-run-verdict :story.okc/fx :rf.assert/effect-emitted))
+        "the first run emits, and effect-emitted passes")
+    (rf.story/reg-variant :story.okc/fx
+      {:script [[:assert [:rf.assert/effect-emitted :okc/fx]]]})
+    (let [[status passed?] (okc-run-verdict :story.okc/fx :rf.assert/effect-emitted)]
+      (is (false? passed?)
+          "a same-id re-run that emits nothing records effect-emitted FALSE — the
+           record no longer inherits the previous run's fx")
+      (is (not= :pass status)))
+    (rf.story/reg-variant :story.okc/warn
+      {:script [[:dispatch-sync [:okc/warn]] [:assert [:rf.assert/no-warnings]]]})
+    (is (= [:fail false] (okc-run-verdict :story.okc/warn :rf.assert/no-warnings))
+        "control — a run that warns fails no-warnings, so the warning reaches the tape")
+    (rf.story/reg-variant :story.okc/warn
+      {:script [[:dispatch-sync [:okc/ok]] [:assert [:rf.assert/no-warnings]]]})
+    (is (= [:pass true] (okc-run-verdict :story.okc/warn :rf.assert/no-warnings))
+        "a clean same-id re-run PASSES no-warnings — the previous run's warning
+         no longer fails it")
+    (rf.story/destroy-variant! :story.okc/fx)
+    (rf.story/destroy-variant! :story.okc/warn)))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -28,6 +28,7 @@
             [re-frame.late-bind       :as rf.late-bind]
             [re-frame.machines        :as rf.machines]
             [re-frame.registrar       :as rf.registrar]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.story           :as rf.story]
             [re-frame.story.args      :as rf.story.args]
@@ -1679,8 +1680,82 @@
       ;; terminal state per `002-Runtime.md` §Error projection — we record and continue.
       (is (some #(= :rf.error/exception (:assertion %)) (:assertions r))
           "an exception assertion was recorded")
-      (is (some #(= :phase-2-events (:phase %)) (:assertions r))))
+      (is (some #(= :phase-2-events (:phase %)) (:assertions r)))
+      ;; rf2-izz5 — ONE record per failure. Phases 1-2 used to record it
+      ;; through two live paths (the per-phase capture AND the drain).
+      (is (= 1 (count (filter #(= :rf.error/exception (:assertion %)) (:assertions r))))
+          "the setup failure is recorded exactly once"))
     (rf.story/destroy-variant! :story.err/v)))
+
+(deftest phase-1-and-2-exceptions-record-once
+  (testing "rf2-izz5 — a loader failure records once, and a setup failure never
+            resurfaces as a phase-4 record at the script's first drain"
+    (rf/reg-event :test/boom-once (fn [_ _] (throw (ex-info "bang" {:why :test}))))
+    (rf/reg-event :test/fine-once (fn [{:keys [db]} _] {:db db}))
+    (rf.story/reg-variant :story.err-once/loader {:loaders [[:test/boom-once]]})
+    (rf.story/reg-variant :story.err-once/setup-then-script
+      {:setup [[:test/boom-once]] :script [[:dispatch-sync [:test/fine-once]]]})
+    (let [exception-phases (fn [id]
+                             (->> (rf.story.async/deref-blocking (rf.story/run-variant id) 5000)
+                                  :assertions
+                                  (filter #(= :rf.error/exception (:assertion %)))
+                                  (mapv :phase)))]
+      (is (= [:phase-1-loaders] (exception-phases :story.err-once/loader)))
+      (is (= [:phase-2-events] (exception-phases :story.err-once/setup-then-script))))
+    (rf.story/destroy-variant! :story.err-once/loader)
+    (rf.story/destroy-variant! :story.err-once/setup-then-script)))
+
+;; ---- rf2-poty — a throw BEFORE the frame exists is :error, never :pass ----
+
+(deftest no-adapter-installed-run-is-an-error-not-a-pass
+  (testing "with no adapter installed, run-variant and an inline run resolve
+            :status :error carrying the exception — not a vacuous :pass with
+            zero assertions over a frame that was never created"
+    (rf.story/reg-variant :story.no-adapter/v {:setup []})
+    (with-redefs [rf.substrate.adapter/adapter-lifecycle-state
+                  (atom {:installed nil :disposed? false})]
+      (doseq [[label p] [["run-variant" (rf.story/run-variant :story.no-adapter/v)]
+                         ["inline run"  (rf.story/run {:setup []})]]]
+        (let [r   (rf.story.async/deref-blocking p 5000)
+              rec (first (:assertions r))]
+          (is (= :error (:status r)) label)
+          (is (= :error (:lifecycle r)) label)
+          (is (= 1 (count (:assertions r))) label)
+          (is (= :rf.error/exception (:assertion rec)) label)
+          (is (= :rf.error/no-adapter-installed (get-in rec [:error :data :rf.error/id]))
+              (str label " — the record names the missing adapter")))))
+    (testing "control — the same variant WITH the adapter still runs green"
+      (let [r (rf.story.async/deref-blocking (rf.story/run-variant :story.no-adapter/v) 5000)]
+        (is (= :pass (:status r)))
+        (is (= :ready (:lifecycle r)))))
+    (rf.story/destroy-variant! :story.no-adapter/v)))
+
+;; ---- rf2-9ppq — every run chain has a rejection path ----------------------
+
+(deftest run-chains-settle-when-result-assembly-throws
+  (testing "a throw inside record-result-map settles every run chain :error
+            inside the deref timeout — it used to leave the promise pending for
+            ever (a JVM TimeoutException)"
+    (rf/reg-event :test/fine-9ppq (fn [{:keys [db]} _] {:db db}))
+    (rf.story/reg-variant :story.chain-9ppq/v {:script [[:dispatch-sync [:test/fine-9ppq]]]})
+    (with-redefs [rf.story.runtime/record-result-map
+                  (fn [& _] (throw (ex-info "record-result-map threw" {})))]
+      (is (= :error (:status (rf.story.async/deref-blocking
+                               (rf.story/run-variant :story.chain-9ppq/v) 3000)))
+          "run-variant (finalise-run!)")
+      (rf.story.runtime/prepare-run! :story.chain-9ppq/v {:run-key :chain-9ppq})
+      (is (= :error (:status (rf.story.async/deref-blocking
+                               (rf.story.runtime/resume-run! :story.chain-9ppq/v) 3000)))
+          "resume-run!")
+      (is (= :error (:status (rf.story.async/deref-blocking
+                               (rf.story/run {:script [[:dispatch-sync [:test/fine-9ppq]]]})
+                               3000)))
+          "an inline run"))
+    (testing "control — without the throw the same variant settles :pass"
+      (is (= :pass (:status (rf.story.async/deref-blocking
+                              (rf.story/run-variant :story.chain-9ppq/v) 3000)))))
+    (rf.story.runtime/reset-run-owner! :story.chain-9ppq/v)
+    (rf.story/destroy-variant! :story.chain-9ppq/v)))
 
 ;; ---- rf2-294yq5.5 — exception ex-data wire-elision -----------------------
 


### PR DESCRIPTION
Four Story runtime correctness fixes from the rf2-wd2t senior-developer review, landed in the reviewer's order. They touch only `tools/story/src/re_frame/story/runtime.cljc` and `assertions.cljc` and their JVM suites. rf2-3okc and rf2-poty belong to the same family as rf2-b2mt, a Story check that passes without evidence, so each is shown below as a probe that used to read `:pass` and now reads `:fail`/`:error`, beside a control that still passes.

## rf2-3okc (P1): tape-projected assertions read only the current run

`dispatched?`, `effect-emitted` and `no-warnings` read the frame's WHOLE epoch ring. That ring survives the in-place fresh-run reset, so a same-id re-run inherited the previous run's facts. A script that stopped dispatching an event kept passing.

The fix: phase 0 now records the run's `:epoch-baseline` as the frame's assertion scope as well (`stamp-epoch-baseline!`). `frame-tape` and `record-result-map` share one `run-slice` rule, so a verdict and the evidence slots read one run. `:epoch-id` is globally monotonic and never reset, so a baseline a destroyed frame leaves behind is inert. An inline frame clears its own baseline on teardown.

## rf2-poty (P1): no adapter installed means `:error`, not `:pass`

With no adapter, `make-frame` throws before the frame exists. `record-error!` swallowed its dispatch into the missing frame, and `record-result-map` read a nil app-db, so core `run-variant` answered `:pass` with zero assertions. rf2-c9t52 had closed this only for story-mcp. The inline path (`story/run` with a map) had the same defect.

The fix: the one error assembler, `run-error-result`, now resolves a frame-free `:error` result carrying the exception when there is no live frame. That result is `:rf.error/exception` at `:phase-0-setup`, with `:error :data :rf.error/id :rf.error/no-adapter-installed`. A variant that genuinely ran with no assertions is still vacuously green. The `plan-construction-error?` docstring claimed that no-adapter errors "land after the frame exists"; it has been corrected.

## rf2-izz5 (P2): phase-1/2 exceptions recorded once

Loader and setup pipeline exceptions were recorded twice, once by `capture-phase-errors` and once by the per-event drain, so `:failures` doubled. The drain is now the one recording path for phases 1, 2 and 4. `capture-phase-errors` keeps only the privacy-suppressed failure fact that rf2-k6y2's `prepare-variant` readiness check needs. I chose this direction over deleting the drain for three reasons:
- It keeps `spec/002-Runtime.md` (§Error projection) and `play.cljc`'s drain docstring accurate with no edits outside this fence.
- It never leaves a stale copy in `pending-exceptions` to resurface as a `:phase-4-play` record.
- It gives every phase the same capture.

## rf2-9ppq (P3): the run chains have a rejection path

`finalise-run!` and `resume-run!` chained `then` only. The inline path's `catch*` re-threw through the same `record-result-map`. So a throw while assembling the result left the promise pending for ever: the JVM deref timed out, the CLJS await never resolved, and no error was recorded anywhere. Both registered chains now `catch*` into `handle-run-error!`. `resume-run!` still settles a superseded attempt as superseded and fires `done-cb` once. `run-error-result` never throws: if assembly fails, it falls back to the frame-free result.

## Evidence

The evidence is one JVM probe run through `clojure.main` on the `:test` classpath (live epoch tape, plain-atom adapter). The before run is at `cfe0559ded`; the after run is on this branch. Times come from `System/nanoTime` in the runner.

| probe | before | after |
|---|---|---|
| 3okc C1: first run dispatches, asserts `dispatched?` | `:pass` true | `:pass` true |
| 3okc C2: same id, re-registered with no dispatch | **`:pass` true** | `:fail` false |
| 3okc C3 control: fresh id, same script | `:fail` false | `:fail` false |
| 3okc E2: same id, re-run emits nothing, `effect-emitted` record | **true** (run `:cannot-run`) | false (`:fail`) |
| 3okc W1 control: the run warns | `:fail` false (warnings slot 1) | `:fail` false (warnings slot 1) |
| 3okc W2: same id, clean re-run, `no-warnings` | **`:fail` false** (warnings slot 0) | `:pass` true |
| poty: registered run, no adapter | **`:pass` `:pre-mount`, 0 assertions, frame-ids `#{}`** | `:error` `:error`, 1 exception record |
| poty: inline run, no adapter | **`:pass`, 0 assertions** | `:error` `:error`, 1 exception record |
| poty control: adapter installed | `:pass` `:ready` | `:pass` `:ready` |
| izz5: `:setup` throws | 2 records (both `:phase-2-events`) | 1 |
| izz5: `:loaders` throws | 2 records (both `:phase-1-loaders`) | 1 |
| izz5 control: `:script` throws | 1 (`:phase-4-play`) | 1 |
| izz5: `:setup` throws, then a script dispatch | 2 | 1 (`:phase-2-events`, no phase-4 leak) |
| 9ppq: `run-variant`, `record-result-map` throws | **TimeoutException at 3020 ms** | settled `:error` in 14 ms |
| 9ppq: `resume-run!`, same throw | **TimeoutException at 3003 ms** | settled `:error` in 6 ms |
| 9ppq: inline run, same throw | **TimeoutException at 3011 ms** | settled `:error` in 21 ms |
| 9ppq control: no throw | settled `:pass` in 6 ms | settled `:pass` in 12 ms |

## Tests added

- `story_assertions_test.clj`: `dispatched-assertion-reads-only-the-current-run` (C1/C2/C3) and `effect-emitted-and-no-warnings-read-only-the-current-run`.
- `story_runtime_test.clj`:
  - `event-throwing-projects-as-assertion` now pins the count at exactly 1.
  - New: `phase-1-and-2-exceptions-record-once`, `no-adapter-installed-run-is-an-error-not-a-pass` (a real `:rf.error/no-adapter-installed` via a scoped `with-redefs` of the adapter state, plus a with-adapter control), and `run-chains-settle-when-result-assembly-throws` (all three chains, plus a control).

The `:checks` and play-map constraints from #9717/#9719 are respected: no fixture names a check, and every play map carries only `:script`.

## Quality gates

These are the runner's own exit codes. Each run was redirected to a per-attempt log, and its exit code was echoed on the same command line.

| gate | tree | captured exit | totals |
|---|---|---|---|
| `jvm-tools-story` (`cd tools/story && clojure -M:test`), the gate all four beads name | final rebased head `cf9ae3c050` | **0** | 1939 tests / 7169 assertions, 0 failures, 0 errors |
| same | the pre-rebase head | 0 | 1938 / 7163, 0 failures, 0 errors |
| same, **sabotaged**: one planted fault per bead, each in the lines this PR changes | planted working tree | **1** | 1938 / 7163 (same totals as the clean run, so nothing crashed a namespace); 20 failures, 1 error |
| all 40 non-self-test python gates the fast-PR spine runs (retired spellings and vocabulary, thrown-error messages, ambient durable reads, keyword catalogue, egress residue, lane rosters, provenance pins, doc links, and more) | final head | 40/40 rc=0 | |
| clj-kondo `--fail-level error` on the four files (local v2025.10.23; CI pins v2026.04.15) | final head | 0 | 0 errors; 1 warning, a pre-existing unused `re-frame.story.registrar` require that is present at the base |

**Sabotage.** The four plants:
- **A:** `frame-tape` reads the whole ring again.
- **B:** the no-live-frame branch is disabled.
- **C:** `capture-phase-errors` records the phase exceptions again.
- **D:** `finalise-run!` loses its `catch*`.

The tests that went red:
- `dispatched-assertion-reads-only-the-current-run` (1) and `effect-emitted-and-no-warnings-read-only-the-current-run` (2).
- `no-adapter-installed-run-is-an-error-not-a-pass` (10).
- `event-throwing-projects-as-assertion` (1) and `phase-1-and-2-exceptions-record-once` (2).
- `run-chains-settle-when-result-assembly-throws` (an ERROR: the deref timed out).
- Collateral from plant C: three rf2-k6y2 redacted-refusal tests, because the planted listener dropped the sensitive filter.

Both files were restored from the commit. The committed blob hash matches (default form), and `git diff --quiet` exits 0.

**Relying on CI.** For these paths the changed-surface classifier arms `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance` and `story_xray_browser`. I did not run `npm run test:cljs` (the CLJS lane for these `.cljc` files) or the browser and Xray lanes locally; those are left to CI.

## Notes

- **rf2-5zgx is not touched.** No listener bracket was extracted; `capture-phase-errors` still uses the existing `with-trace-listener`.
- **rf2-fzbj.3 (held):** none of these four defects is one of its three findings (registered loader slots, hot-reload loader cleanup, render/save effective args).
- **`macros.clj` was not opened.** The ride-along was withdrawn to rf2-g2k4.
- **Test suites:** new tests went into existing suites that no open PR renames. #9720 renames only the render/run_owner/stepper_start/tags suites.
- **Observed from the source, not measured, out of scope:** during phases 1-2 a sensitive trace event for the variant frame bumps the suppressed-events counter twice, once from `capture-phase-errors` and once from the per-frame play listener. That is a count, not an exception record, and rf2-izz5 does not cover it.
