### PR TITLE
fix(story): the :test pane's scrubber and step-debugger compile against the run's opts (rf2-ad25)

### DIFF
--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -407,10 +407,14 @@ will land); watch mode has nothing to detect in that build.
 > [spec/004 §Play sequence execution](004-Assertions.md#play-sequence-execution).
 > What this section locks is the chrome that surfaces it.
 >
-> **rf2-ee38b.3 — full-script stepping.** The substrate walks the FULL
-> coerced `:script` — EVERY step type (`:dispatch` /
+> **rf2-ee38b.3 — full-script stepping.** The substrate walks the
+> compiled plan's auto-run program (rf2-499z) — the auto-runnable plays'
+> scripts concatenated, or the primary play when nothing auto-runs,
+> `[:arg]`-substituted against the same run opts Re-run uses (active modes
+> and cell overrides included, rf2-ad25) and with `:compose`d fragment
+> scripts prepended — EVERY step type (`:dispatch` /
 > `:dispatch-sync` / `:wait` / `:click` / `:type` / `:assert-db` /
-> `:assert-dom`) — driving each through the SAME rich-DSL executor
+> `:assert-dom`), driving each through the SAME rich-DSL executor
 > (`runner-events/run-step!`) the canvas auto-run path uses. Each
 > `step-once!` returns the executed STEP (a coerced step vector) and
 > records the step-result into `play/stepper-state`'s `:results`. The
@@ -652,7 +656,7 @@ The section renders (top-to-bottom):
 |---|---------------------|---------------------------------------------------------------|
 | 1 | Header strip        | "Step-debugger · {progress-label} · playing?" + keyboard hint |
 | 2 | Controls strip      | Start (inactive) OR Stop / Back / Step / Pause/Play / Rewind  |
-| 3 | Step list           | One row per coerced `:script` step (EVERY step type — rf2-ee38b.3) with glyph / index / label / BP chip; active state only |
+| 3 | Step list           | One row per step of the compiled auto-run program (EVERY step type — rf2-ee38b.3) with glyph / index / label / BP chip; active state only |
 | 3'| Inactive hint       | One-line "Click Start to step…" placeholder; inactive only    |
 
 Each step row carries:

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -10,7 +10,7 @@
        :expanded        #{<row-key>}      ; expanded assertion rows
        :expanded-checks #{<check-id>}     ; expanded check groups
        :failed-only?    <bool>            ; failed-only filter
-       :play-events     <vector>          ; flat event-vec list derived from :script
+       :play-events     <vector>          ; dispatch events of the compiled program, run opts threaded
        :epoch-ids       <vector>          ; trailing epoch-id slice
        :selected-step   <int|nil>}
 
@@ -55,6 +55,23 @@
 
 (defonce results-atom (r/atom {}))
 
+(defn run-opts
+  "The `run-variant` opts the `:test` pane runs `variant-id` with, read from
+  shell state: the chrome-wide `:active-modes` and `:substrate`, and the
+  variant's OWN `:cell-overrides` entry — the slots the canvas's `run-key`
+  reads, so the pane runs against the effective args the user has been
+  editing in the controls panel.
+
+  Re-run, the scrubber and the step-debugger all take their opts here, so
+  all three compile ONE program (rf2-ad25). A script `[:arg]` fed by a mode
+  or an override would otherwise be scrubbed or stepped as a different
+  program from the one Re-run executed."
+  [variant-id]
+  (let [shell @rf.story.ui.state/shell-state-atom]
+    {:active-modes   (:active-modes shell)
+     :cell-overrides (get-in shell [:cell-overrides variant-id])
+     :substrate      (:substrate shell)}))
+
 (defn- begin-run!
   "Mark the variant's slot as running. Returns nothing. Stamps the
   shell-state `[:tests :runs]` slot too so the chrome-level test widget
@@ -76,14 +93,18 @@
 
   Folds the run's aggregate into the shell-state `[:tests :runs]` slot
   too — the chrome-level test widget + sidebar dots read off that
-  slot."
-  [variant-id result]
+  slot.
+
+  `opts` is the `run-variant` opts map the run received (`run-opts`)."
+  [variant-id opts result]
   (let [now          (rf.interop/now-ms)
-        ;; `:script` is the canonical phase-4 slot.
-        ;; `rf.story.play/variant-play-events` extracts a flat event-vec list
-        ;; (one per `:dispatch`/`:dispatch-sync` step), the shape the
-        ;; scrubber's slot expects.
-        play-events  (rf.story.play/variant-play-events variant-id)
+        ;; `rf.story.play/variant-play-events` extracts the compiled
+        ;; program's flat event-vec list (one per `:dispatch` /
+        ;; `:dispatch-sync` step), the shape the scrubber's slot expects.
+        ;; Compiled against the run's OWN opts: without them an `[:arg]` a
+        ;; mode or cell override supplied differs from the event the run
+        ;; dispatched, and matches nothing on the tape below (rf2-ad25).
+        play-events  (rf.story.play/variant-play-events variant-id opts)
         ;; rf2-4e545l finding 4: match against THIS run's own scoped
         ;; `:epoch-tape` (the result's raw `:rf/epoch-record` vector,
         ;; each carrying its `:trigger-event`) by trigger-event identity
@@ -182,18 +203,16 @@
   swap the result into local state when it resolves. No-ops if
   the slot already carries `:running?`.
 
-  The variant's run threads its OWN cell-overrides entry from shell
-  state — same lookup the canvas / sidebar / share-url paths perform —
-  so the test pane re-runs against the same effective-args the user has
-  been editing in the controls panel."
+  The run's opts come from `run-opts` — the variant's OWN cell-overrides
+  entry plus the active modes and substrate — so the test pane re-runs
+  against the same effective-args the user has been editing in the
+  controls panel, and the scrubber compiles its events against those
+  same opts."
   [variant-id]
-  (let [shell @rf.story.ui.state/shell-state-atom
-        opts  {:active-modes   (:active-modes shell)
-               :cell-overrides (get-in shell [:cell-overrides variant-id])
-               :substrate      (:substrate shell)}]
+  (let [opts (run-opts variant-id)]
     (begin-run! variant-id)
     (-> (rf.story.runtime/reset-variant variant-id opts)
-        (rf.story.async/then  (fn [r] (store-result! variant-id r) nil))
+        (rf.story.async/then  (fn [r] (store-result! variant-id opts r) nil))
         (rf.story.async/catch* (fn [_]
                         ;; Even a rejection clears :running? so the
                         ;; UI button comes back to "Re-run". Drop

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -16,10 +16,11 @@
        :auto-playing?  <bool>         ; the interval is ticking
        :cursor         <int>          ; number of steps run so far
        :total          <int>          ; count of play-script STEPS in this run
-       :play-steps     <vector>       ; immutable snapshot of the FULL coerced
-                                      ;   :script step vector (every step
-                                      ;   type; derived via
-                                      ;   re-frame.story.play/variant-play-steps)
+       :play-steps     <vector>       ; immutable snapshot of the compiled
+                                      ;   auto-run program (every step type;
+                                      ;   derived via
+                                      ;   re-frame.story.play/variant-play-steps
+                                      ;   with the run opts)
        :statuses       <vector>       ; `rf.story.ui.test-mode.stepper-pure/enrich-statuses` rows
        :breakpoints    #{<int>}       ; step indices that pause auto-play
        :epoch-stack    <vector>       ; per-step :epoch-id pre-images, for
@@ -53,6 +54,7 @@
             [re-frame.core                                :as rf]
             [re-frame.story.play                          :as rf.story.play]
             [re-frame.story.runtime                       :as rf.story.runtime]
+            [re-frame.story.ui.test-mode.state            :as rf.story.ui.test-mode.state]
             [re-frame.story.ui.test-mode.stepper-pure     :as rf.story.ui.test-mode.stepper-pure]))
 
 ;; ---- ratom ---------------------------------------------------------------
@@ -118,60 +120,70 @@
   stops, so the frame the user is shown at cursor 0 is the one the
   variant's `:setup` describes and every step is still to run.
 
+  `opts` is the `run-variant` opts map. The one-argument form (the Start
+  button's) reads it through `rf.story.ui.test-mode.state/run-opts`, the
+  SAME opts Re-run runs with, and ONE map feeds `prepare-variant`,
+  `variant-play-steps` and `begin-stepper!` alike. So the frame is
+  prepared, listed and stepped against the args the canvas and Re-run use,
+  the controls panel's overrides and the active modes included — never a
+  second program compiled against the static args (rf2-ad25).
+
   Asynchronous: the caller may await the returned promise to drive a
   follow-up auto-resume, but the UI does not need to — the slot's
   `:active?` flag drives the view."
-  [variant-id]
-  ;; If a prior stepper is active for this variant, tear it down first.
-  (when (get @results-atom variant-id)
-    (swap! results-atom update variant-id clear-interval!))
-  (rf.story.play/end-stepper! variant-id)
-  ;; Re-allocate the variant frame so the stepper starts from the
-  ;; documented initial state — WITHOUT running the script.
-  (-> (rf.story.runtime/prepare-variant variant-id)
-      (.then  (fn [_]
-                ;; The stepper walks the FULL coerced :script
-                ;; (every step type), not just the dispatch-bearing
-                ;; events. `rf.story.play/variant-play-steps` returns the complete
-                ;; step vector and `rf.story.play/begin-stepper!` seeds the
-                ;; substrate from the same source.
-                (let [play-steps (rf.story.play/variant-play-steps variant-id)
-                      total      (count play-steps)]
-                  (rf.story.play/begin-stepper! variant-id)
-                  (swap! results-atom assoc variant-id
-                         {:variant-id     variant-id
-                          :active?        true
-                          :auto-playing?  false
-                          :cursor         0
-                          :total          total
-                          :play-steps     (vec play-steps)
-                          :statuses       []
-                          :breakpoints    #{}
-                          :epoch-stack    [(current-epoch-id variant-id)]
-                          :interval-id    nil
-                          :tick-ms        default-tick-ms})
-                  (swap! results-atom update variant-id recompute-statuses)
-                  nil)))
-      (.catch (fn [_]
-                ;; A preparation failure (unknown variant, an invalid
-                ;; `:db-seed`, a throwing loader / `:setup` handler) rejects.
-                ;; Leave the slot cleared so the section returns to its
-                ;; honest inactive state rather than offering step controls
-                ;; over a frame whose `:setup` never ran.
-                ;;
-                ;; This branch is the ONLY thing standing between a failed
-                ;; preparation and an active cursor-0 stepper over it, and
-                ;; only HALF the failures arrive as a throw: a failing
-                ;; `:loaders` / `:setup` handler is CAPTURED onto
-                ;; `[:rf.story/assertions]` by `run-loaders!` / `run-events!`,
-                ;; which then return normally. `prepare-variant` inspects the
-                ;; accumulator and rejects explicitly for that class — do not
-                ;; "simplify" that check away on the reading that a
-                ;; preparation which did not throw succeeded (rf2-k6y2
-                ;; post-merge audit). The records stay on the frame either
-                ;; way, so the pane can still say what failed.
-                (swap! results-atom dissoc variant-id)
-                nil))))
+  ([variant-id] (begin! variant-id (rf.story.ui.test-mode.state/run-opts variant-id)))
+  ([variant-id opts]
+   ;; If a prior stepper is active for this variant, tear it down first.
+   (when (get @results-atom variant-id)
+     (swap! results-atom update variant-id clear-interval!))
+   (rf.story.play/end-stepper! variant-id)
+   ;; Re-allocate the variant frame so the stepper starts from the
+   ;; documented initial state — WITHOUT running the script.
+   (-> (rf.story.runtime/prepare-variant variant-id opts)
+       (.then  (fn [_]
+                 ;; The stepper walks the compiled auto-run program (every
+                 ;; step type), not just the dispatch-bearing events.
+                 ;; `rf.story.play/variant-play-steps` returns the complete
+                 ;; step vector and `rf.story.play/begin-stepper!` seeds the
+                 ;; substrate from the same source — both with the opts the
+                 ;; frame was prepared with.
+                 (let [play-steps (rf.story.play/variant-play-steps variant-id opts)
+                       total      (count play-steps)]
+                   (rf.story.play/begin-stepper! variant-id opts)
+                   (swap! results-atom assoc variant-id
+                          {:variant-id     variant-id
+                           :active?        true
+                           :auto-playing?  false
+                           :cursor         0
+                           :total          total
+                           :play-steps     (vec play-steps)
+                           :statuses       []
+                           :breakpoints    #{}
+                           :epoch-stack    [(current-epoch-id variant-id)]
+                           :interval-id    nil
+                           :tick-ms        default-tick-ms})
+                   (swap! results-atom update variant-id recompute-statuses)
+                   nil)))
+       (.catch (fn [_]
+                 ;; A preparation failure (unknown variant, an invalid
+                 ;; `:db-seed`, a throwing loader / `:setup` handler) rejects.
+                 ;; Leave the slot cleared so the section returns to its
+                 ;; honest inactive state rather than offering step controls
+                 ;; over a frame whose `:setup` never ran.
+                 ;;
+                 ;; This branch is the ONLY thing standing between a failed
+                 ;; preparation and an active cursor-0 stepper over it, and
+                 ;; only HALF the failures arrive as a throw: a failing
+                 ;; `:loaders` / `:setup` handler is CAPTURED onto
+                 ;; `[:rf.story/assertions]` by `run-loaders!` / `run-events!`,
+                 ;; which then return normally. `prepare-variant` inspects the
+                 ;; accumulator and rejects explicitly for that class — do not
+                 ;; "simplify" that check away on the reading that a
+                 ;; preparation which did not throw succeeded (rf2-k6y2
+                 ;; post-merge audit). The records stay on the frame either
+                 ;; way, so the pane can still say what failed.
+                 (swap! results-atom dissoc variant-id)
+                 nil)))))
 
 (defn step!
   "Dispatch the next event in the play sequence. No-ops when the stepper

--- a/tools/story/test/re_frame/story/ui/test_mode/run_opts_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/run_opts_cljs_test.cljs
@@ -12,7 +12,8 @@
   - the scrubber's events never matched the run's epoch tape, so
     `epoch-id-slice` returned [] and the scrubber showed no epochs;
   - the step-debugger stepped the static value — a different program from
-    the one Re-run and the canvas execute.
+    the one Re-run and the canvas execute — or, for an arg only a mode
+    supplies, could not compile the plan and refused to start.
 
   Each witness compares against what `run-variant-pane!` actually DID (the
   run result's app-db and epoch tape), never against a re-derivation of the
@@ -75,9 +76,9 @@
 ;; ---- helpers -------------------------------------------------------------
 
 (defn- reg-arg-variant!
-  "A variant whose one script step dispatches the `:value` arg, statically
-  \"static\". Whatever mode or override the run applies is visible in the
-  dispatched event, so a reader compiled against other args disagrees."
+  "A variant whose one script step dispatches its `:value` arg, statically
+  \"static\". A cell override sits ABOVE the variant layer, so it shows in
+  the dispatched event and a reader compiled without it disagrees."
   [vid]
   (rf.story/reg-variant vid
     {:args   {:value "static"}
@@ -125,7 +126,7 @@
   (testing "a controls-panel override feeding a script `[:arg]`: the
             scrubber's events are compiled against the args Re-run used, so
             every tick resolves to the epoch the run committed"
-    (let [vid :story.run-opts/override]
+    (let [vid :story.run-opts/scrubbed]
       (reg-arg-variant! vid)
       (rf.story.ui.state/swap-state! assoc-in [:cell-overrides vid] {:value "override"})
       (async done
@@ -144,14 +145,12 @@
             (rf.story.async/catch* (fail-on-reject vid done)))))))
 
 (deftest stepper-steps-the-program-re-run-executed
-  (testing "an active mode feeding a script `[:arg]`: Start prepares and
-            lists the program compiled against the same modes Re-run used,
-            so stepping it to the end reaches the app-db Re-run reached"
-    (let [vid  :story.run-opts/moded
-          mode :Mode.run-opts/moded]
-      (rf.story/reg-mode mode {:args {:value "moded"}})
+  (testing "a controls-panel override feeding a script `[:arg]`: Start
+            prepares and lists the program compiled against the args Re-run
+            used, so stepping it to the end reaches the app-db Re-run reached"
+    (let [vid :story.run-opts/stepped]
       (reg-arg-variant! vid)
-      (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes [mode])
+      (rf.story.ui.state/swap-state! assoc-in [:cell-overrides vid] {:value "override"})
       (async done
         (-> (re-run! vid)
             (rf.story.async/then
@@ -159,13 +158,44 @@
                 (rf.story.async/then
                   (start-and-step! vid)
                   (fn [{:keys [slot app-db]}]
-                    (is (= "moded" (get-in ran [:result :app-db :value]))
-                        "PRECONDITION — Re-run ran with the active mode")
-                    (is (= [[:dispatch-sync [:tmo/set-value "moded"]]] (:play-steps slot))
+                    (is (= "override" (get-in ran [:result :app-db :value]))
+                        "PRECONDITION — Re-run ran with the controls-panel override")
+                    (is (= [[:dispatch-sync [:tmo/set-value "override"]]] (:play-steps slot))
                         "the step list is the program Re-run executed, not the
                          static-args one")
-                    (is (= "moded" (:value app-db))
+                    (is (= "override" (:value app-db))
                         "stepping to the end reaches the app-db Re-run reached")
+                    (finish! vid done)))))
+            (rf.story.async/catch* (fail-on-reject vid done)))))))
+
+(deftest mode-only-arg-reaches-the-scrubber-and-the-stepper
+  (testing "an `[:arg]` only an active mode supplies. Modes sit BELOW the
+            variant's own `:args` (`rf.story.args/run-arg-layers` `:pre`), so
+            this variant declares no `:value` of its own. Compiled without the
+            run's opts the plan cannot resolve the arg at all: the scrubber
+            degraded to no events and Start refused to start. With them both
+            read the program Re-run executed"
+    (let [vid  :story.run-opts/moded
+          mode :Mode.run-opts/moded]
+      (rf.story/reg-mode mode {:args {:value "moded"}})
+      (rf.story/reg-variant vid
+        {:script [[:dispatch-sync [:tmo/set-value [:arg :value]]]]})
+      (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes [mode])
+      (async done
+        (-> (re-run! vid)
+            (rf.story.async/then
+              (fn [ran]
+                (is (= "moded" (get-in ran [:result :app-db :value]))
+                    "PRECONDITION — Re-run ran with the active mode")
+                (is (= [[:tmo/set-value "moded"]] (scrubbed-events ran))
+                    "the scrubber offers the epoch the moded event committed")
+                (rf.story.async/then
+                  (start-and-step! vid)
+                  (fn [{:keys [slot]}]
+                    (is (:active? slot)
+                        "Start prepared the frame and published a stepper")
+                    (is (= [[:dispatch-sync [:tmo/set-value "moded"]]] (:play-steps slot))
+                        "the step list is the moded program Re-run executed")
                     (finish! vid done)))))
             (rf.story.async/catch* (fail-on-reject vid done)))))))
 

--- a/tools/story/test/re_frame/story/ui/test_mode/run_opts_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/run_opts_cljs_test.cljs
@@ -1,0 +1,194 @@
+(ns re-frame.story.ui.test-mode.run-opts-cljs-test
+  "rf2-ad25 — the `:test` pane's scrubber and step-debugger read the
+  program compiled against the SAME run opts Re-run uses.
+
+  rf2-499z gave `play/variant-play-events`, `play/variant-play-steps` and
+  `play/begin-stepper!` an `opts` arity (the `run-variant` opts map), folded
+  into the plan compile exactly as the runtime folds it. The pane's call
+  sites still used the one-argument forms, so a script `[:arg]` fed by an
+  active mode or a cell override compiled there against the variant's
+  STATIC args while the run itself used the moded / overridden ones:
+
+  - the scrubber's events never matched the run's epoch tape, so
+    `epoch-id-slice` returned [] and the scrubber showed no epochs;
+  - the step-debugger stepped the static value — a different program from
+    the one Re-run and the canvas execute.
+
+  Each witness compares against what `run-variant-pane!` actually DID (the
+  run result's app-db and epoch tape), never against a re-derivation of the
+  reader. The no-mode, no-override variant is the CONTROL: static and run
+  args coincide there, so it is green before and after.
+
+  The reader's `opts` arity itself is pinned on the JVM by
+  `re-frame.story.stepper-compiled-plan-test`
+  (`run-opts-thread-into-the-stepped-program`); this suite pins the pane
+  call sites that feed it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as rf.epoch]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.play :as rf.story.play]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.ui.test-mode.state :as rf.story.ui.test-mode.state]
+            [re-frame.story.ui.test-mode.stepper-state :as rf.story.ui.test-mode.stepper-state]
+            [re-frame.subs :as rf.subs]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn- reset-all! []
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  ;; Requiring `re-frame.epoch` installs the epoch artefact's late-bind
+  ;; hooks, so a run records the real `:epoch-tape` the scrubber aligns
+  ;; against. Clear it so each test reads only its own epochs.
+  (rf.epoch/clear-history!)
+  (rf.epoch/clear-epoch-listeners!)
+  (try (rf/init! rf.substrate.plain-atom/adapter)
+       (catch :default _ nil))
+  (rf.subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (reset! rf.story.play/stepper-state {})
+  (reset! rf.story.play.runner-events/run-state {})
+  (reset! rf.story.play.runner-events/step-boundaries {})
+  (rf.story.runtime/reset-run-owner!)
+  (reset! rf.story.ui.test-mode.state/results-atom {})
+  (reset! rf.story.ui.test-mode.stepper-state/results-atom {})
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (rf/reg-event :tmo/set-value (fn [{:keys [db]} [_ v]] {:db (assoc db :value v)})))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- reg-arg-variant!
+  "A variant whose one script step dispatches the `:value` arg, statically
+  \"static\". Whatever mode or override the run applies is visible in the
+  dispatched event, so a reader compiled against other args disagrees."
+  [vid]
+  (rf.story/reg-variant vid
+    {:args   {:value "static"}
+     :script [[:dispatch-sync [:tmo/set-value [:arg :value]]]]}))
+
+(defn- re-run!
+  "What Re-run DOES: `run-variant-pane!`, resolving to the slot it stored."
+  [vid]
+  (rf.story.async/then (rf.story.ui.test-mode.state/run-variant-pane! vid)
+                       (fn [_] (get @rf.story.ui.test-mode.state/results-atom vid))))
+
+(defn- scrubbed-events
+  "The trigger event of each epoch the scrubber offers, in tick order."
+  [slot]
+  (let [tape (get-in slot [:result :epoch-tape])]
+    (mapv (fn [id] (:trigger-event (first (filter #(= id (:epoch-id %)) tape))))
+          (:epoch-ids slot))))
+
+(defn- start-and-step!
+  "What the step-debugger DOES: Start (`begin!`, the one-argument form the
+  Start button calls), then Step once per listed step. Resolves to the slot
+  Start published and the frame's app-db after the last step."
+  [vid]
+  (rf.story.async/then
+    (rf.story.ui.test-mode.stepper-state/begin! vid)
+    (fn [_]
+      (let [slot (get @rf.story.ui.test-mode.stepper-state/results-atom vid)]
+        (dotimes [_ (or (:total slot) 0)]
+          (rf.story.ui.test-mode.stepper-state/step! vid))
+        {:slot slot :app-db (rf/app-db-value vid)}))))
+
+(defn- finish! [vid done]
+  (rf.story.ui.test-mode.stepper-state/end! vid)
+  (rf.story/destroy-variant! vid)
+  (done))
+
+(defn- fail-on-reject [vid done]
+  (fn [e]
+    (is (nil? e) "the promise chain rejected")
+    (finish! vid done)))
+
+;; ---- witnesses -----------------------------------------------------------
+
+(deftest scrubber-reads-the-cell-override-the-run-used
+  (testing "a controls-panel override feeding a script `[:arg]`: the
+            scrubber's events are compiled against the args Re-run used, so
+            every tick resolves to the epoch the run committed"
+    (let [vid :story.run-opts/override]
+      (reg-arg-variant! vid)
+      (rf.story.ui.state/swap-state! assoc-in [:cell-overrides vid] {:value "override"})
+      (async done
+        (-> (re-run! vid)
+            (rf.story.async/then
+              (fn [slot]
+                (is (= "override" (get-in slot [:result :app-db :value]))
+                    "PRECONDITION — Re-run ran with the controls-panel override")
+                (is (= [[:tmo/set-value "override"]] (:play-events slot))
+                    "the scrubber's events are the ones the run dispatched")
+                (is (= [[:tmo/set-value "override"]] (scrubbed-events slot))
+                    "each tick resolves to the epoch that event committed; read
+                     against the static args, `epoch-id-slice` matched nothing
+                     and the scrubber offered no epochs")
+                (finish! vid done)))
+            (rf.story.async/catch* (fail-on-reject vid done)))))))
+
+(deftest stepper-steps-the-program-re-run-executed
+  (testing "an active mode feeding a script `[:arg]`: Start prepares and
+            lists the program compiled against the same modes Re-run used,
+            so stepping it to the end reaches the app-db Re-run reached"
+    (let [vid  :story.run-opts/moded
+          mode :Mode.run-opts/moded]
+      (rf.story/reg-mode mode {:args {:value "moded"}})
+      (reg-arg-variant! vid)
+      (rf.story.ui.state/swap-state! rf.story.ui.state/set-active-modes [mode])
+      (async done
+        (-> (re-run! vid)
+            (rf.story.async/then
+              (fn [ran]
+                (rf.story.async/then
+                  (start-and-step! vid)
+                  (fn [{:keys [slot app-db]}]
+                    (is (= "moded" (get-in ran [:result :app-db :value]))
+                        "PRECONDITION — Re-run ran with the active mode")
+                    (is (= [[:dispatch-sync [:tmo/set-value "moded"]]] (:play-steps slot))
+                        "the step list is the program Re-run executed, not the
+                         static-args one")
+                    (is (= "moded" (:value app-db))
+                        "stepping to the end reaches the app-db Re-run reached")
+                    (finish! vid done)))))
+            (rf.story.async/catch* (fail-on-reject vid done)))))))
+
+;; ---- the control ---------------------------------------------------------
+
+(deftest control-no-mode-no-override-agrees
+  (testing "CONTROL — no active mode and no override: the static args ARE
+            the run args, so the scrubber and the stepper agree with Re-run
+            on either side of the fix"
+    (let [vid :story.run-opts/plain]
+      (reg-arg-variant! vid)
+      (async done
+        (-> (re-run! vid)
+            (rf.story.async/then
+              (fn [ran]
+                (is (= "static" (get-in ran [:result :app-db :value])))
+                (is (= [[:tmo/set-value "static"]] (:play-events ran)))
+                (is (= [[:tmo/set-value "static"]] (scrubbed-events ran))
+                    "the scrubber has its epoch")
+                (rf.story.async/then
+                  (start-and-step! vid)
+                  (fn [{:keys [slot app-db]}]
+                    (is (= [[:dispatch-sync [:tmo/set-value "static"]]] (:play-steps slot)))
+                    (is (= "static" (:value app-db)))
+                    (finish! vid done)))))
+            (rf.story.async/catch* (fail-on-reject vid done)))))))


### PR DESCRIPTION
Closes rf2-ad25, the fenced UI residual of rf2-499z (PR #9718).

## What changed

rf2-499z made the play readers (`variant-play-events`, `variant-play-steps`, `begin-stepper!`) read the COMPILED plan and gave each an `opts` arity: the `run-variant` opts map, folded into the compile exactly as the runtime folds it. The `:test` pane still called the one-argument forms. So a script `[:arg]` fed by an active mode or a cell override compiled against the variant's static args in the scrubber and the step-debugger, while Re-run used the moded or overridden ones.

1. **`ui/test_mode/state.cljs`.** One public `run-opts` reader builds the opts from the shell slots the canvas's `run-key` reads (`:active-modes`, the variant's own `:cell-overrides` entry, `:substrate`). `run-variant-pane!` runs with it, and `store-result!` now takes that same map and passes it to `variant-play-events`. The scrubber's events are compiled against the args the run used, so `epoch-id-slice` finds the run's epochs.
2. **`ui/test_mode/stepper_state.cljs`.** `begin!` passes ONE opts map to `prepare-variant`, `variant-play-steps` and `begin-stepper!` (the mayor's call on the bead's open question). Its one-argument form, the one the Start button calls, reads that map through `run-opts`, so the stepper steps the program the canvas and Re-run execute. A two-argument form takes explicit opts. The route stays inside the two fenced files: `stepper_state` now requires `test_mode.state`, and nothing requires them the other way, so there is no cycle.
3. **`tools/story/spec/009-Test-Mode.md`.** In the Play step-debugger section, "The substrate walks the FULL coerced `:script`" now reads: "The substrate walks the compiled plan's auto-run program (rf2-499z) — the auto-runnable plays' scripts concatenated, or the primary play when nothing auto-runs, `[:arg]`-substituted against the same run opts Re-run uses (active modes and cell overrides included, rf2-ad25) and with `:compose`d fragment scripts prepended". Row 3 of the section-composition table restated the same stale claim ("One row per coerced `:script` step"), so it now reads "One row per step of the compiled auto-run program". The table keeps 3 columns on every row, checked by hand.

`play.cljc` is untouched: the opts arity it needs already existed there.

## Evidence

This is a NEW suite, `tools/story/test/re_frame/story/ui/test_mode/run_opts_cljs_test.cljs` (ns `re-frame.story.ui.test-mode.run-opts-cljs-test`, CLJS `:node-test` lane). A new file was needed because the suite requires a real-runtime fixture that neither existing `test_mode` state suite carries. It drives the real `run-variant-pane!` and `begin!`, and compares each reader against what Re-run actually DID (the result's app-db and epoch tape):

- **Scrubber, with a cell override:** the scrubber's events and epochs are the ones the run dispatched and committed.
- **Stepper, with a cell override:** Start lists the overridden program, and stepping it to the end reaches Re-run's app-db.
- **Mode-only arg, in both readers:** the scrubber finds the moded epoch, and Start starts and lists the moded program.
- **Control, with no mode and no override:** it passes on both sides of the fix.

It builds on the JVM pin of the reader's `opts` arity (`stepper_compiled_plan_test.clj`, `run-opts-thread-into-the-stepped-program`) rather than duplicating it.

- **Before the fix** (the suite committed alone, pre-fix sources): exit 1, 4 tests / 15 assertions, **7 failures**, 0 errors. Every PRECONDITION held and the control's assertions all passed. The failures:
  - the scrubber read `[[:tmo/set-value "static"]]` and offered `[]` epochs;
  - the stepper listed and stepped `"static"` against a run that used `"override"`;
  - the mode-only arg left the scrubber empty, and Start never published a stepper.
- **After the fix:** exit 0, 4 tests / 15 assertions, 0 failures.

**A finding the fixture had to respect:** modes sit BELOW a variant's own `:args` (`rf.story.args/run-arg-layers` puts mode args in `:pre`), so a mode can feed an `[:arg]` only when the variant declares no value of its own. That is why the mode witness uses a mode-only arg and the step-list-disagrees witness uses a cell override. Before the fix, a mode-only arg left Start unable to start at all: `prepare-variant` without opts cannot compile the plan.

## Quality gates

Every exit code below was captured from the runner itself: the log redirect and the exit echo sat on one command line. The compile and the run are the two halves of `npm run test:cljs`, and each run was gated on the compile's captured exit.

- **CLJS witness, before the fix:** exit 1. 4 tests, 15 assertions, 7 failures.
- **CLJS `:node-test` compile, after the fix:** exit 0. 1988 files, 0 warnings.
- **CLJS witness plus the sibling `test_mode` suites** (`stepper-state`, `test-mode-state`, `test-mode-pane`), after the fix: exit 0. 31 tests, 101 assertions, 0 failures.
- **Full `:node-test` lane (`npm run test:cljs`), after the fix:** exit 0. 11795 tests, 58899 assertions, 0 failures, 0 errors.
- **On the final base after rebase** (trunk `827dfdd41a`, which includes PR #9722's `plan.cljc` change):
  - compile: exit 0, 1988 files, 0 warnings
  - witness alone: exit 0, 4 tests / 15 assertions, 0 failures
  - full `:node-test` lane: exit 0, 11795 tests / 58899 assertions, 0 failures, 0 errors
- **Ratchet and lint scripts over the tree, all exit 0:**
  - `check_require_alias_dialect.py`, `check_retired_spellings.py`, `check_retired_composition_vocab.py`
  - `check_doc_slugs.py`, which covers `tools/*/spec` links and anchors
  - `check_escaped_continuations.py`, `check_flattened_lists.py`
  - `check_test_lane_bijection.py`: 1660 test-defining files, every file selected
  - `check_jvm_lane_rosters.py`, `check_readme_inventories.py`, `check_keyword_catalogue_drift.py`
- **clj-kondo `--fail-level error`** over the three changed Clojure files: exit 0. 0 errors, 0 warnings.
- **Relied on CI, not run locally:**
  - `jvm-tools-story`: no `.clj`/`.cljc` source changed.
  - The browser/DOM lanes: the new suite needs no DOM.

## Scope notes

- **Not an `rf2-fzbj.*` finding.** No `rf2-fzbj.*` record names these call sites, and rf2-fzbj.3's files do not include `ui/test_mode/**`.
- **One stale comment is left alone.** `ui/test_mode/stepper_pure.cljc` still has a comment saying the step-debugger "walks the FULL coerced :script". It sits outside this change's file fence, so it is untouched.
