### PR TITLE
test(story): run three more host-free .cljc suites on the CLJS lane (rf2-1ep8)

### DIFF
--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
@@ -4,7 +4,7 @@
 
   The pure helpers under `re-frame.story.ui.sidebar-search` already
   have a JVM-portable test corpus
-  (`sidebar_search_test.cljc`). This namespace exercises the
+  (`sidebar_search_cljs_test.cljc`). This namespace exercises the
   **integration** at the live sidebar hiccup level: register variants,
   render the sidebar, drive the `:on-change` handler on the search
   `<input>`, and assert the surviving variant rows match the live

--- a/tools/story/test/re_frame/story/promotion_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/promotion_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.promotion-test
+(ns re-frame.story.promotion-cljs-test
   "Tests for the run-artifact → variant promotion bridge (rf2-5x1wt.25,
   spec/017-Testing-Story.md §Promotion — Promotion bridge; NewTestStory
   §C1).
@@ -17,7 +17,10 @@
   The variant-plan compiler is pure data → data and the registrar is a
   pure side-table, so every test runs on both targets with no host — a
   fresh side-table per test via the fixture, and an explicit `:lookup`
-  for `:extends` resolution where needed."
+  for `:extends` resolution where needed.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-1ep8)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as rf.epoch]

--- a/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/promotion_cljs_test.cljc
@@ -28,7 +28,7 @@
 ;;
 ;; Reset the Story side-table around each test so the `promote!` /
 ;; substrate register assertions start from a clean registrar. Mirrors the
-;; substrate `promotion_test` fixture shape — a one-arg fn that runs on both
+;; substrate `promotion_cljs_test` fixture shape — a one-arg fn that runs on both
 ;; targets.
 
 (defn reset-state! [t]

--- a/tools/story/test/re_frame/story/ui/sidebar_search_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_search_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.story.ui.sidebar-search-test
+(ns re-frame.story.ui.sidebar-search-cljs-test
   "JVM-portable regression net for the sidebar search-as-you-type filter
   (rf2-yngai). Every fn under test is `.cljc`-pure so this corpus runs
   on both JVM (`clojure -M:test`) and CLJS (`npm run test:cljs`) — see
@@ -13,7 +13,10 @@
   - `filter-grouped-tree`  — story-keeps-children / variant-narrow /
                               prune-empty-stories
   - `filter-workspaces`    — workspace map narrowing
-  - `highlight-segments`   — match / non-match segmentation"
+  - `highlight-segments`   — match / non-match segmentation
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-1ep8)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.ui.sidebar-search :as rf.story.ui.sidebar-search]))
 

--- a/tools/story/test/re_frame/story/ui/sidebar_signals_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_signals_cljs_test.cljc
@@ -1,8 +1,8 @@
-(ns re-frame.story.ui.sidebar-signals-test
+(ns re-frame.story.ui.sidebar-signals-cljs-test
   "JVM-portable regression net for the sidebar's five-axis signal chips
   (rf2-ba86n.4, spec/018 §7.1 + §12.6). Every fn under test is `.cljc`-pure
   so this corpus runs on both JVM (`clojure -M:test`) and CLJS
-  (`npm run test:cljs`) — see the sibling `sidebar-search-test`.
+  (`npm run test:cljs`) — see the sibling `sidebar-search-cljs-test`.
 
   ## The contract under test
 
@@ -11,7 +11,10 @@
   fx-overrides are world inputs, NOT fidelity; browser is a runner
   requirement, NOT fidelity; attached / MCP-bound are frame bindings, NOT
   runner tiers. This corpus asserts the derivation keeps them in separate
-  buckets and reads only the variant body's real metadata."
+  buckets and reads only the variant body's real metadata.
+
+  Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp
+  selects it; under its old `-test` name it ran on the JVM only (rf2-1ep8)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.story.ui.sidebar-signals :as rf.story.ui.sidebar-signals]))
 


### PR DESCRIPTION
## What

rf2-1ep8, part (2) only (part (1), the stale pointers to #9720's renames, is split to rf2-jo3g).

Three `.cljc` suites said in their docstrings that they run on both the JVM and CLJS, but each namespace ended `-test`, which the `:node-test` build's `cljs-test$` ns-regexp never selects, and nothing required them, so they ran on the JVM only. This renames each the way PR #9720 did for its seven siblings:

| before | after |
|---|---|
| `test/re_frame/story/promotion_test.cljc` (`re-frame.story.promotion-test`) | `promotion_cljs_test.cljc` (`re-frame.story.promotion-cljs-test`) |
| `test/re_frame/story/ui/sidebar_search_test.cljc` (`re-frame.story.ui.sidebar-search-test`) | `ui/sidebar_search_cljs_test.cljc` (`re-frame.story.ui.sidebar-search-cljs-test`) |
| `test/re_frame/story/ui/sidebar_signals_test.cljc` (`re-frame.story.ui.sidebar-signals-test`) | `ui/sidebar_signals_cljs_test.cljc` (`re-frame.story.ui.sidebar-signals-cljs-test`) |

(all under `tools/story/`; renamed with `git mv`, so history follows)

Each docstring gains #9720's sentence ("Named `-cljs-test` so the `:node-test` build's `cljs-test$` ns-regexp selects it; ..."). Two prose references to the old file names in unheld files are repointed: `panels_e2e/sidebar_search_e2e_cljs_test.cljs` and `ui/promotion_cljs_test.cljc`. `implementation/shadow-cljs.edn` does not change.

**No new CLJS reds.** All 32 deftests pass on CLJS as written, including the promotion suite's three `:network` replay rows, which are the first CLJS exercise of `replay-run-artifact`. Nothing is skip-marked, no test needed a portability fix, and no suite fell back to a docstring correction.

**Not touched, deliberately:** `tools/story/spec/015-Test-Coverage.md` line 142 still names `sidebar_search_test.cljc` (a code span, so no link gate reads it). That file is fenced to rf2-jo3g, the pointer bead, and the pointer is recorded there as its fourth.

## Quality gates

Every exit code below was captured by the run itself (redirect and echo on one command line), never read off a pipeline. `npm run test:cljs` was run as its two phases (compile, then the run gated on the compile's exit), with `compile-node-test.cjs` and the bundle invoked by absolute path.

| gate | before (base `c6b487bfb3`) | after, final base `7606f9ec73` (head `4606930ff7`) |
|---|---|---|
| CLJS compile (`:node-test`) | exit 0, 1987 files, 0 warnings | exit 0, 1990 files, 0 warnings |
| CLJS run (`node out/node-test.js`) | exit 0, **11791** tests / **58884** assertions, 0 failures | exit 0, **11823** tests / **59049** assertions, 0 failures |
| JVM lane (`cd tools/story && clojure -M:test`) | exit 0, **1934** / **7142**, 0 failures | exit 0, **1937** / **7149**, 0 failures |

- **The CLJS delta is exactly the three suites.** It is +32 tests / +165 assertions, and a focused run of just the three renamed namespaces (`node out/node-test.js --test=<the three>`) reads exit 0, 32 tests / 165 assertions. That matches the deftest count (11 + 15 + 6). The build's file count also rose by exactly 3.
- **The JVM lane did not move because of this change.** Before the rebase, the post-change run read 1934 / 7142, identical to the baseline. The +3 / +7 on the final base is #9722 (rf2-pwwu), whose three new deftests sit in JVM-only `-test` files (`network_runtime_test.clj`, `plan_network_test.cljc`, `plan_test.cljc`), counted from the diff between the two bases. The CLJS lane stayed at 11823 across that same rebase, which is consistent. A focused JVM run of the three new names (`clojure -M:test -n <the three>`) reads exit 0, 32 / 165, so the JVM runner still selects a `-cljs-test` namespace.
- **Both lanes read this branch's tree.** The compile's config line names this worktree, and both focused runs select namespace names that exist only on this branch; each returned 32 tests rather than an empty-selector refusal.
- **Ratchets covering these paths, all exit 0 on the final base:** `scripts/check_test_lane_bijection.py` (1659 test-defining files, 45 lanes, every file selected), `check_retired_spellings.py`, `check_retired_composition_vocab.py`, `check_retired_image_keys.py`, `check_thrown_error_messages.py`, `check_inject_cofx_residue.py`, `check_gate_scheduling.py`, `check-ai-tracking-ratchet.sh`.
- **Classifier** (`report-changed-surfaces.sh` over the changed paths, old and new names both): arms `cljs_node_test`, `tools_jvm` and `mcp_conformance`. The first two are the lanes above. **`mcp_conformance` was not run locally; this relies on CI for it.**
- No markdown is touched, so no link gate applies.
- The three-dot diff against the merge base was read for reverts: it carries only these five files.
