### PR TITLE
fix(story): reg-story forwards a computed :variants to reg-story* (rf2-g2k4)

### DIFF
--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -32,11 +32,18 @@
 
   ## Form-B `:variants` desugaring
 
-  `expand-reg-story` checks for a literal `:variants` map in the body
-  and, if present, emits N independent `reg-variant*` calls as siblings
-  of the parent `reg-story*` call. Per `001-Authoring.md` §Registration macros this preserves
+  `expand-reg-story` checks for a literal `:variants` map in a literal
+  body and, if present, emits N independent `reg-variant*` calls as
+  siblings of the parent `reg-story*` call. Per `001-Authoring.md` §Registration macros this preserves
   hot-reload-by-variant: each variant is a separate top-level form so
-  save-and-reload only invalidates the changed slot."
+  save-and-reload only invalidates the changed slot.
+
+  A `:variants` the macro cannot walk — a symbol, a `let` local, a
+  `merge` or any other expression, or a body computed as a whole — is
+  forwarded unchanged to `reg-story*`, which evaluates it and registers
+  each entry through the same `reg-variant*` rail, under the same
+  `<story-id>/<variant-name>` ids and the same bound source coords. That
+  path is one registration form, so it reloads as a whole."
   (:require [re-frame.source-coords :as rf.source-coords]))
 
 ;; ---- source-coord helper -------------------------------------------------
@@ -155,30 +162,23 @@
 
 (defn expand-reg-story
   "Macro-side expansion for `reg-story`. Handles the Form-B `:variants`
-  sugar: if `metadata` is a literal map with `:variants`, emit a `do`
-  block with the parent registration plus N independent `reg-variant*`
-  calls. Otherwise emit a single registration call.
+  sugar: when `metadata` is a literal map whose `:variants` is itself a
+  literal map, emit a `do` block with the parent registration (minus
+  `:variants`) plus N independent `reg-variant*` calls. Otherwise emit
+  ONE `reg-story*` call carrying `metadata` exactly as written — a
+  `:variants` that needs runtime evaluation is desugared by `reg-story*`
+  itself. Every registration sits under `emit-reg`'s elision gate, so a
+  disabled build neither registers nor evaluates a forwarded `:variants`.
 
   Returns the syntax-quoted expansion."
   [form-meta file ns-sym id metadata]
-  (let [coords      (coords-form form-meta file ns-sym)
-        literal-map (when (map? metadata) metadata)
-        variants    (when literal-map (:variants literal-map))
-        ;; The runtime helper expects the parent slice (no :variants);
-        ;; for literal maps strip it at expansion time, for non-literal
-        ;; metadata punt to runtime (helper drops :variants).
-        body-form   (if variants
-                      (dissoc literal-map :variants)
-                      metadata)
-        story-call  (emit-reg coords
-                              're-frame.story.registrar/reg-story*
-                              id body-form)]
-    (if variants
+  (let [coords   (coords-form form-meta file ns-sym)
+        variants (when (map? metadata) (:variants metadata))]
+    (if (map? variants)
       `(do
-         ~story-call
+         ~(emit-reg coords 're-frame.story.registrar/reg-story*
+                    id (dissoc metadata :variants))
          ~@(for [[v-name v-body] variants]
-             (let [v-id (variant-id-for id v-name)]
-               (emit-reg coords
-                         're-frame.story.registrar/reg-variant*
-                         v-id v-body))))
-      story-call)))
+             (emit-reg coords 're-frame.story.registrar/reg-variant*
+                       (variant-id-for id v-name) v-body)))
+      (emit-reg coords 're-frame.story.registrar/reg-story* id metadata))))

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -38,6 +38,7 @@
   `:source` to point back at the same `(reg-story ...)` call."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.walk :as walk]
             [re-frame.story :as rf.story]
             [re-frame.story.macros :as rf.story.macros]
             [re-frame.story.plan :as rf.story.plan]))
@@ -825,6 +826,121 @@
                               {:variants {:a {:scripts [[:dispatch [:x]]]}}}))]
       (is (= :rf.error/variant-shape (:rf.error/id data)))
       (is (str/includes? (str (:reason data)) ":scripts (did you mean :script?)")))))
+
+;; ---- rf2-g2k4 — a computed :variants inside a LITERAL body ---------------
+;;
+;; rf2-pjay taught `reg-story*` to desugar a runtime `:variants`, but the
+;; macro never reached it for the commonest shape: a literal outer body
+;; whose `:variants` is a symbol or an expression. The macro classified only
+;; the OUTER map as literal and walked whatever `:variants` held with `for`,
+;; so `{:variants vs}` failed expansion with "Don't know how to create ISeq
+;; from: clojure.lang.Symbol" and `{:variants (merge vs ...)}` with "nth not
+;; supported on this type: Symbol". Only a literal `:variants` MAP is peeled
+;; now; every other `:variants` form reaches `reg-story*` unchanged.
+;;
+;; The public-macro rows expand at TEST time (`eval-here`), not load time, so
+;; a regressed expansion fails its own row instead of the whole namespace.
+
+(defn- expand
+  "`expand-reg-story` for `metadata` at a fixed call site in this ns."
+  [id metadata]
+  (rf.story.macros/expand-reg-story {:line 7 :column 3} "stories.clj"
+                                    're-frame.story-authoring-validation-test
+                                    id metadata))
+
+(defn- eval-here
+  "Expand and run `form` in this ns, at test time."
+  [form]
+  (binding [*ns* (the-ns 're-frame.story-authoring-validation-test)]
+    (eval form)))
+
+(defn- gated?
+  "Is `form` one registration under the production-elision gate?"
+  [form]
+  (and (seq? form)
+       (= 'clojure.core/when (first form))
+       (= 're-frame.story.config/enabled? (second form))))
+
+(defn- reg-call
+  "The registrar call inside one gated registration:
+  `(when enabled? (binding [...] <call>))` → `<call>`."
+  [gated-form]
+  (last (last gated-form)))
+
+(deftest expand-reg-story-forwards-computed-variants-unchanged
+  (doseq [md ['{:doc "s" :variants formb-variants}
+              '{:doc "s" :variants (merge formb-variants {:c {:setup []}})}]]
+    (testing (pr-str (:variants md))
+      (is (gated? (expand :story.g2k4.fwd md))
+          "ONE gated registration — no do-block of peeled variants")
+      (is (= (list 're-frame.story.registrar/reg-story* :story.g2k4.fwd md)
+             (reg-call (expand :story.g2k4.fwd md)))
+          "reg-story* receives the body exactly as written, :variants included"))))
+
+(deftest expand-reg-story-still-peels-a-literal-variants-map
+  (testing "a literal :variants map — even one whose VALUES are symbols — still
+            expands into the parent plus one independent registration per variant"
+    (let [exp (expand :story.g2k4.lit '{:doc "l" :variants {:a {:setup []} :b vb}})]
+      (is (= 'do (first exp)))
+      (is (every? gated? (rest exp)) "each registration is its own gated form")
+      (is (= [(list 're-frame.story.registrar/reg-story*   :story.g2k4.lit {:doc "l"})
+              (list 're-frame.story.registrar/reg-variant* :story.g2k4.lit/a {:setup []})
+              (list 're-frame.story.registrar/reg-variant* :story.g2k4.lit/b 'vb)]
+             (map reg-call (rest exp)))))))
+
+(deftest reg-story-macro-registers-computed-variants-in-a-literal-body
+  (doseq [[id form want]
+          [[:story.g2k4.sym
+            '(rf.story/reg-story :story.g2k4.sym {:doc "s" :variants formb-variants})
+            formb-variants]
+           [:story.g2k4.let
+            '(let [vs formb-variants]
+               (rf.story/reg-story :story.g2k4.let {:doc "s" :variants vs}))
+            formb-variants]
+           [:story.g2k4.merge
+            '(rf.story/reg-story :story.g2k4.merge
+               {:doc "s" :variants (merge formb-variants {:c {:setup [[:init-c]]}})})
+            (assoc formb-variants :c {:setup [[:init-c]]})]]]
+    (testing (name id)
+      (is (= id (eval-here form)))
+      (let [story (rf.story/handler-meta :story id)]
+        (is (= {:doc "s"} (dissoc story :source))
+            "the stored story body never carries :variants")
+        (doseq [[v-name v-body] want
+                :let [v (rf.story/handler-meta :variant
+                                               (rf.story.macros/variant-id-for id v-name))]]
+          (is (= v-body (dissoc v :source)) (str "variant " v-name))
+          (is (= 're-frame.story-authoring-validation-test (:ns (:source v))))
+          (is (integer? (:line (:source v))))
+          (is (= (:line (:source story)) (:line (:source v)))
+              "each variant carries the macro site's coords, as on the literal path"))))))
+
+(def ^:private evaluations
+  "How many times a forwarded `:variants` expression was evaluated."
+  (atom 0))
+
+(deftest reg-story-expansion-elides-both-forms
+  ;; `enabled?` is a JVM `^:const true`, so a production build is simulated by
+  ;; writing `false` over the gate in the expansion before running it.
+  (let [run     (fn [enabled? exp]
+                  (eval-here (walk/postwalk-replace
+                              {'re-frame.story.config/enabled? enabled?} exp)))
+        literal '{:variants {:a {:setup []}}}
+        counted '{:variants (do (swap! evaluations inc) formb-variants)}]
+    (reset! evaluations 0)
+    (testing "gate off: neither form registers, and the forwarded :variants is never evaluated"
+      (run false (expand :story.g2k4.gate-lit literal))
+      (run false (expand :story.g2k4.gate-fwd counted))
+      (is (not (rf.story/registered? :story :story.g2k4.gate-lit)))
+      (is (not (rf.story/registered? :variant :story.g2k4.gate-lit/a)))
+      (is (not (rf.story/registered? :story :story.g2k4.gate-fwd)))
+      (is (zero? @evaluations)))
+    (testing "control, gate on: the same expansions register, evaluating :variants once"
+      (run true (expand :story.g2k4.gate-lit literal))
+      (run true (expand :story.g2k4.gate-fwd counted))
+      (is (rf.story/registered? :variant :story.g2k4.gate-lit/a))
+      (is (rf.story/registered? :variant :story.g2k4.gate-fwd/a))
+      (is (= 1 @evaluations)))))
 
 ;; ===========================================================================
 ;; MACRO HELPER — `variant-id-for` enforces keyword grammar


### PR DESCRIPTION
## What

`reg-story` crashed at macro expansion when a literal story body carried a computed `:variants` (rf2-g2k4, filed by the merged-PR audit of #9719):

```clojure
(def vs {:v {:setup []}})
(story/reg-story :story.x {:variants vs})
;; IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Symbol
(story/reg-story :story.y {:variants (merge vs {:w {:setup []}})})
;; UnsupportedOperationException: nth not supported on this type: Symbol
```

`expand-reg-story` classified only the OUTER metadata map as literal, then walked any truthy `:variants` form with `for`, so these calls never reached the runtime desugar that #9719 (rf2-pjay) added to `reg-story*`.

## Change

Only `tools/story/src/re_frame/story/macros.clj` changes. `expand-reg-story` now peels `:variants` at expansion time only when `:variants` is itself a literal map. Any other `:variants` (a symbol, a `let` local, a `merge`, any expression) is forwarded unchanged to `reg-story*` as one registration. `reg-story*` desugars it at runtime under the same `<story-id>/<variant-name>` ids and the same bound source coords. There is no new public API and no new validation.

- **Literal Form-B expansion keeps its shape:** `(do <gated reg-story*> <gated reg-variant*> ...)`, one independent registration per variant, so hot-reload-by-variant is preserved.
- **Source coords:** the forwarded call is bound under `*pending-coords*` exactly as before, so runtime-desugared variants carry the macro site's `:ns` and `:line`.
- **Production elision:** every emitted registration still sits under `(when re-frame.story.config/enabled? ...)`.
  - The literal form elides as before.
  - For the forwarded form, the `:variants` expression sits inside that gate, so a disabled build neither registers the story nor evaluates the expression.
  - The author's own `(def vs ...)` is outside the macro and follows ordinary dead-code elimination.
- **Docstrings:** the ns docstring states the forwarding rule. The stale comment saying the helper "drops :variants" is gone; it has been false since #9719.

## Tests

All tests are in `tools/story/test/re_frame/story_authoring_validation_test.clj`, where #9719 put its `reg-story*` tests. No live worker holds this file, and #9720 does not touch it. I left `story_test.clj` (held by #9720) untouched.

**Failing before, passing after:**

- `expand-reg-story-forwards-computed-variants-unchanged`: the symbol and `merge` forms each expand to one gated `reg-story*` call carrying the body unchanged.
- `reg-story-macro-registers-computed-variants-in-a-literal-body`: the public macro with a def-bound symbol, a `let`-bound local and a `merge`. For each, the story and every variant register, the stored story body carries no `:variants`, and each variant carries the macro site's coords. These rows expand at test time (`eval`), so a regressed expansion fails its own row rather than the namespace load.
- `reg-story-expansion-elides-both-forms`: with the gate written to `false`, neither form registers and the forwarded `:variants` is never evaluated. With the gate on (the control), both register and the expression is evaluated exactly once.

**Measured on the same namespace:**

| Run | Tests | Assertions | Failures | Errors | Exit |
|---|---|---|---|---|---|
| Before the fix | 59 | 187 | 26 | 8 | 1 |
| After the fix | 59 | 191 | 0 | 0 | 0 |

Before the fix, every failure and error sat in the three tests above, and the errors carried exactly the bead's two exceptions.

**Controls, passing both before and after:**

- `expand-reg-story-still-peels-a-literal-variants-map` (new): a literal map, including a symbol-valued variant, still peels into N+1 gated registrations.
- `combined-form-stamps-source-on-parent-story` and `combined-form-stamps-source-on-generated-variants`: the literal form, with source coords.
- `reg-story*-desugars-programmatic-variants`: `reg-story*` called with a computed map.
- `reg-story-macro-desugars-non-literal-variants`: `reg-story` called with a computed body (`(assoc ... :variants ...)`).

This is not one of the fenced `rf2-fzbj.*` findings. None of them names `macros.clj` or `expand-reg-story`. Two of them (`.3` and `.31`) call `reg-story` only as reproducer setup, with an empty body.

## Quality gates

Every gate below ran on the final base, after rebasing past #9722. Each exit code was captured on the same command line as its run, and the numbers are those captured exits.

- `cd tools/story && clojure -M:test -n re-frame.story-authoring-validation-test`
  - before the fix: exit 1 (59 tests, 187 assertions, 26 failures, 8 errors)
  - after the fix: exit 0 (59 tests, 191 assertions, 0 failures, 0 errors)
- `cd tools/story && clojure -M:test` (the full `jvm-tools-story` lane): exit 0, 1941 tests, 7197 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: exit 0, 11791 tests, 58884 assertions, 0 failures, 0 errors. It was compiled fresh from this tree, from a real `npm ci` install rather than a link, so every Story namespace that calls `reg-story` expanded under the new macro.
- `clj-kondo --fail-level error` on both changed files: exit 0, 0 errors. Its one warning is an unused private var at line 456 that predates this change.
- `clojure -M:splint --fail-on-errors` on both changed files: exit 0. Its one style warning is `.getMessage` at line 993, which also predates this change.
- The fast-PR spine's ratchet scripts that grade these paths (require-alias dialect, retired spellings and vocab, thrown-error messages, test-lane bijection, JVM lane rosters, hardcoded paths, provenance pins and the rest): all 16 exit 0.

I didn't touch any spec page. #9719 left `tools/story/spec/001-Authoring.md` describing only the literal sugar, and that description is still true.
