### PR TITLE
docs(story): scope spec 017's check deduplication to the terminal pass (rf2-80cp)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1615,11 +1615,24 @@ own-only assertions). A failed check result MUST show both the check id
 and the underlying assertion records.
 
 A check's assertion atoms run as **terminal expectations**: after the
-script settles, the runner dispatches them in one pass with the variant's
-terminal `:assertions`, against the final state. The pass is deduplicated,
-so an atom a check shares with `:assertions` (or with another check)
-dispatches and records once, and every check naming it groups that one
-record.
+script settles, the runner evaluates them in one pass with the variant's
+terminal `:assertions`, against the final state. That terminal pass is
+deduplicated, so an atom it evaluates that a check shares with
+`:assertions` (or with another check) runs and records once, and every
+check naming it groups that one record.
+
+The deduplication stops at that pass. The tape-evaluated atoms —
+`:rf.assert/schema-error` and the causal / cascade pair
+(`:rf.assert/caused`, `:rf.assert/no-cascade-rerender`) — are not run
+there. The result boundary collects them from every position (terminal
+`:assertions`, every check, in-script checkpoints) without deduplicating,
+and evaluates each occurrence against the epoch tape. For
+`:rf.assert/schema-error` that multiplicity is the contract: each
+declaration consumes exactly one matching violation
+([§Schema rule](#schema-rule)), so a schema-error atom shared by two
+checks, or by a check and `:assertions`, is two expectations and needs
+two violations. Against one violation it records one `:pass` and one
+`:fail`.
 
 ### Canonical P1 assertions
 


### PR DESCRIPTION
## Summary

Fixes rf2-80cp. The Checks paragraph that rf2-z8ta added to `tools/story/spec/017-Testing-Story.md` (PR #9722) said that an atom shared by two checks, or by a check and the terminal `:assertions`, "dispatches and records once". That is true of the terminal executor's `distinct` union. It is false for tape-evaluated atoms. This PR corrects the prose only.

## Why the old sentence was false (verified at source on this branch)

- `runtime.cljc` `plan-assertion-atoms` concatenates the terminal, check and in-script atoms with no `distinct`. `plan-schema-expectations` and `plan-causal-expectations` are each a `filterv` over its output.
- `result.cljc` `match-schema-expectations` is the exact-consumption multiset matcher. Each declared `:rf.assert/schema-error` consumes exactly one matching violation, so N declarations consume N (§Schema rule, rule 2).
- `settle-terminal-assertions!` is the only place that deduplicates (`distinct` over `:assertions` plus the check atoms). `exec-assert!` step-skips tape-evaluated atoms there, so they never reach that union.
- `match-causal-expectations` returns one record per declared atom. The causal collector does not deduplicate either, and the new text does not claim it does.

**Probe at this branch's base (`40f80973e2`, after #9723).** I re-ran the audit's out-of-repo shared-atom probe (`audit-re-frame2-pr9722-shared-atom-probe-1.clj`) with `clojure -M -i` from `tools/story`. It exited 0, and it reported loading this worktree's `runtime.cljc` and `result.cljc`. It goes through the real plan compiler, collector and matcher against one event-schema violation for `:audit/submit`:

| case | collected | records |
|---|---|---|
| one check | 1 | `[:pass]` |
| same atom in two checks | 2 | `[:pass :fail]` |
| same atom in a check and `:assertions` | 2 | `[:pass :fail]` |

**#9723 did not move any of this.** Five function bodies are byte-identical between the audited commit `0e1d8fc2f0` and `40f80973e2`: `plan-checks`, `plan-assertion-atoms`, `plan-schema-expectations`, `plan-causal-expectations` and `settle-terminal-assertions!`. `result.cljc` has no diff across that range.

## Wording

Old:

```markdown
A check's assertion atoms run as **terminal expectations**: after the
script settles, the runner dispatches them in one pass with the variant's
terminal `:assertions`, against the final state. The pass is deduplicated,
so an atom a check shares with `:assertions` (or with another check)
dispatches and records once, and every check naming it groups that one
record.
```

New:

```markdown
A check's assertion atoms run as **terminal expectations**: after the
script settles, the runner evaluates them in one pass with the variant's
terminal `:assertions`, against the final state. That terminal pass is
deduplicated, so an atom it evaluates that a check shares with
`:assertions` (or with another check) runs and records once, and every
check naming it groups that one record.

The deduplication stops at that pass. The tape-evaluated atoms —
`:rf.assert/schema-error` and the causal / cascade pair
(`:rf.assert/caused`, `:rf.assert/no-cascade-rerender`) — are not run
there. The result boundary collects them from every position (terminal
`:assertions`, every check, in-script checkpoints) without deduplicating,
and evaluates each occurrence against the epoch tape. For
`:rf.assert/schema-error` that multiplicity is the contract: each
declaration consumes exactly one matching violation
([§Schema rule](#schema-rule)), so a schema-error atom shared by two
checks, or by a check and `:assertions`, is two expectations and needs
two violations. Against one violation it records one `:pass` and one
`:fail`.
```

"dispatches" became "evaluates" / "runs" because the terminal executor evaluates the DOM and browser-tier families directly rather than dispatching them.

## Not changed

- **No code.** The bead says adding `distinct` to the collector would erase intentional repeated expectations. Reading the code gave me no reason to think the behaviour is wrong: the multiset rule is the spec's own §Schema rule.
- The Total resolution order execution list (step 6: "one terminal pass (§Checks)") is still accurate, because tape-evaluated atoms are evaluated when the run result is built (step 7). I left it alone.
- None of the held `rf2-fzbj.*` findings records this defect.

## Quality gates

Every exit code below was captured by the command that ran the gate.

- **`scripts/check_doc_slugs.py`** is the gate for this path: it covers `tools/*/spec`, and its `--verbose` output lists `tools/story/spec` at 31 files.
  - Base, before the edit: exit 0.
  - After the edit: exit 0.
  - **Planted fault:** I changed `#schema-rule` to `#schema-rule-planted` on the edited line. Exit 1, `BROKEN ANCHOR: tools\story\spec\017-Testing-Story.md:1632 -> #schema-rule-planted`.
  - Restored with `git checkout`. The default-form blob hash `c3ee77adc9` equals the committed blob hash, and `git diff --quiet` exits 0.
  - After rebasing onto `13d4b62265`: exit 0.
- **Other ratchets that scan `tools/*/spec`**, re-run after the rebase:
  - `scripts/check_readme_links.py --ci`: exit 0.
  - `scripts/check_retired_composition_vocab.py`: exit 0.
  - `scripts/check_retired_image_keys.py`: exit 0.
  - `scripts/check_retired_spellings.py`: exit 0.
- **Not evidence for this file:** `scripts/check_flattened_lists.py` and `scripts/check_escaped_continuations.py` both exited 0, but their 291-file corpus does not include `tools/story/spec`.
- **Checked by hand:** no gate reads prose. I touched no table in the spec. The one new link, `#schema-rule`, is verified by the slug gate going green with it and red when broken.
- **Left to CI:** the other checks. This is a prose-only change, so I ran no CLJS or JVM test lane.
