### PR TITLE
test(pair): track the project's React in the pair fixture and guard it in lockstep (rf2-ajnk)

### DIFF
--- a/skills/re-frame2-pair/tests/fixture/package.json
+++ b/skills/re-frame2-pair/tests/fixture/package.json
@@ -3,11 +3,11 @@
  "version": "0.0.0-SNAPSHOT",
  "private": true,
  "description": "Minimal re-frame2 fixture app for re-frame2-pair validation tests.",
- "//": "React pin, recorded so version sweeps stop re-deriving it (rf2-2z4c): test:pure is a :node-test build and never loads react, but the app build does, and tools/mcp-conformance's hermetic live suite renders this fixture in headless Chromium -- per PR via the mcp_live surface, and again nightly. The pin is therefore exercised, and moving it changes what that lane covers rather than being a free version sweep.",
+ "//": "React pin, ruled 2026-09-13 (rf2-ajnk): this fixture TRACKS the project's React. react and react-dom must equal implementation/package.json's and move with it; the pair-fixture-react-lockstep row in tools/template/test/day8/re_frame2_template/version_lockstep_test.clj enforces that, and runs whenever implementation/package.json changes. The live lane -- tools/mcp-conformance's hermetic live suite, which renders this fixture in headless Chromium per PR via the mcp_live surface and again nightly -- is NOT React-18 coverage: the earlier 18.3.1 was never chosen, only left behind when implementation moved to 19 (rf2-2z4c recorded it, rf2-ajnk ruled it). test:pure is a :node-test build and never loads react.",
  "devDependencies": {
  "shadow-cljs": "3.4.10",
- "react": "18.3.1",
- "react-dom": "18.3.1"
+ "react": "19.3.0",
+ "react-dom": "19.3.0"
  },
  "scripts": {
  "watch": "shadow-cljs watch app",

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -20,6 +20,14 @@
     - org.clojure/clojure      ↔ `implementation/core/deps.edn` :deps
     - org.clojure/clojurescript ↔ `implementation/core/deps.edn` :deps
 
+  One pin OUTSIDE the template rides along, and deliberately:
+  `skills/re-frame2-pair/tests/fixture/package.json`'s react / react-dom
+  ↔ `implementation/package.json` (rf2-ajnk, ruled 2026-09-13: that
+  fixture TRACKS the project's React). It lives here rather than beside
+  the fixture because this suite is the gate the classifier arms on an
+  `implementation/package.json` change, which is exactly the move that
+  left the fixture behind on 18.3.1 — no fixture-side lane runs then.
+
   The package.json reader searches both `:dependencies` and
   `:devDependencies` (first hit wins) so the guard doesn't false-fail
   if the impl tree ever relocates a pin between the two sections.
@@ -75,23 +83,27 @@
   JSON library — the template test artefact has no JSON dep today, and
   the package.json shape is stable enough that a regex (the section
   body, then `\"pkg\": \"value\"` inside it) reads simply and fails
-  loudly on shape drift."
-  [pkg]
-  (let [text     (slurp (io/file (repo-root) "implementation/package.json"))
-        section  (fn [name]
-                   ;; Find `"<name>": { ... }`; the closing brace ends at
-                   ;; the first `}` after the section name.
-                   (some-> (re-find (re-pattern (str "\"" name "\":\\s*\\{([^}]*)\\}"))
-                                    text)
-                           second))
-        pin      (some #(some-> (section %) (pin-from-json-text pkg))
-                       ["dependencies" "devDependencies"])]
-    (when-not pin
-      (throw (ex-info (str "Couldn't find pin for " pkg
-                           " in :dependencies or :devDependencies of "
-                           "implementation/package.json")
-                      {:pkg pkg})))
-    pin))
+  loudly on shape drift.
+
+  The two-arity form reads the same way from another repo-relative
+  package.json (the re-frame2-pair fixture's, below)."
+  ([pkg] (read-package-json-pin "implementation/package.json" pkg))
+  ([rel-path pkg]
+   (let [text     (slurp (io/file (repo-root) rel-path))
+         section  (fn [name]
+                    ;; Find `"<name>": { ... }`; the closing brace ends at
+                    ;; the first `}` after the section name.
+                    (some-> (re-find (re-pattern (str "\"" name "\":\\s*\\{([^}]*)\\}"))
+                                     text)
+                            second))
+         pin      (some #(some-> (section %) (pin-from-json-text pkg))
+                        ["dependencies" "devDependencies"])]
+     (when-not pin
+       (throw (ex-info (str "Couldn't find pin for " pkg
+                            " in :dependencies or :devDependencies of "
+                            rel-path)
+                       {:pkg pkg :package-json rel-path})))
+     pin)))
 
 ;; --- deps.edn :mvn/version readers --------------------------------------
 
@@ -179,6 +191,19 @@
                    "implementation/package.json :react-dom (" pkg-react-dom ")")))
         (finally
           (delete-recursively tmp))))))
+
+(deftest pair-fixture-react-lockstep
+  ;; Not a template literal — see the ns docstring for why it rides here.
+  (testing "re-frame2-pair fixture's react / react-dom match implementation/package.json"
+    (let [fixture "skills/re-frame2-pair/tests/fixture/package.json"]
+      (doseq [pkg ["react" "react-dom"]]
+        (let [impl-pin    (read-package-json-pin pkg)
+              fixture-pin (read-package-json-pin fixture pkg)]
+          (is (= impl-pin fixture-pin)
+              (str fixture " " pkg " (" fixture-pin ") must match "
+                   "implementation/package.json (" impl-pin ") — the fixture "
+                   "TRACKS the project's React (rf2-ajnk). Bump its "
+                   "devDependencies in the same change.")))))))
 
 (deftest shadow-version-lockstep
   (testing "Template's :shadow-version literal matches implementation/package.json"


### PR DESCRIPTION
## rf2-ajnk: the re-frame2-pair fixture tracks the project's React

**Operator decision: TRACK 19.3.0 (Mike, ruled 2026-09-13).** Mike adopted the mayor's 2026-09-12 recommendation. The pair fixture's live browser lane is **not** React-18 coverage, and it tracks the project's React. That ruling lifts the bead's earlier rule that the pin stays at 18.3.1 until answered. The 18.3.1 pin was never chosen: the fixture was created on 2026-05-13 while 18.3.1 was the tree-wide value. `implementation/package.json` moved to 19 four days later, and the fixture was never updated.

### What landed

1. **The bump.** `skills/re-frame2-pair/tests/fixture/package.json`: `react` and `react-dom` go from 18.3.1 to 19.3.0, the value `implementation/package.json` carries at this PR's base. The `//` key now records the ruling in one string under the same key:
   - the fixture tracks the project's React;
   - the live lane is not React-18 coverage;
   - the pin moves with `implementation/package.json`, and the guard below enforces that.

   The fixture has no lockfile: `package-lock.json` is in its `.gitignore`, and the hermetic suite runs `npm install` against it. So there was nothing to regenerate.
2. **The guard.** A new `pair-fixture-react-lockstep` deftest in `tools/template/test/day8/re_frame2_template/version_lockstep_test.clj` asserts that the fixture's `react` and `react-dom` equal `implementation/package.json`'s. It reuses the file's existing package.json reader, which now takes an optional repo-relative path (one-arity behaviour unchanged; the error message now names the file it read). The ns docstring says in one paragraph why a non-template pin rides in this file.

### Why the guard lives in the template suite

The drift came from `implementation/package.json` moving while the fixture stayed put, so the guard has to run when that file changes.

- **Classifier line:** in `.github/scripts/report-changed-surfaces.sh`, the `implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)` arm contains the inner case `implementation/package.json|implementation/package-lock.json) template_expensive=true ;;` (rf2-6yuzo4, the template npm-pin lockstep).
- **CI job:** `jvm-tools-template` in `.github/workflows/test.yml` (`if: needs.detect_changed_surfaces.outputs.template_expensive == 'true'`) runs `clojure -M:test` from `tools/template`, and that suite includes `version_lockstep_test.clj`. This PR arms it too, through the `tools/template/*)` arm.
- No lane beside the fixture runs on an `implementation/package.json` change. The fixture's own arm (`skills/re-frame2-pair/tests/fixture/*)`) sets `skills_structural`, `mcp_conformance` and `mcp_live`, and `implementation/package.json` arms none of those three. Getting either direction onto a fixture-side lane would have needed a hot-zone classifier or workflow edit.
- **Known limit, not closed here:** a fixture-only edit that moves the pin away from `implementation/package.json` does not arm `template_expensive` at PR time. The nightly `template-emitted-app` job in `expensive-tests.yml` runs the same `clojure -M:test` with no surface guard, so that direction is caught nightly. Anyone editing the fixture pin also sees the `//` key right next to it saying the pin moves with the implementation.
- `.github/scripts/verify-version-lockstep.sh` was not used: its header scopes it to the Clojars VERSION and local-root contract.

### Overlap with held items

None. rf2-fzbj.15 lists this fixture's `package.json` in its owned-scope inventory but has no finding about the React pin. rf2-fzbj.44 concerns the reagent-migration skill's fixture. Also untouched, as out of scope per the bead: `skills/re-frame-migration/references/floor-gate.md`'s `^19.0.0`, and the two 19.3.0 pins moved by PR #9576.

## Quality gates

- **Worker worktree guard:** `sh scripts/assert-worker-worktree.sh` ran and exited 0.
- **Guard lane, green:** `cd tools/template && clojure -M:test` → captured exit **0**, 42 tests, 319 assertions, 0 failures.
- **Control (the property removed):** after committing, I set the fixture's `react` and `react-dom` back to 18.3.1 (single-line anchors, match count 1 each, checked before the run) and ran `clojure -M:test -n day8.re-frame2-template.version-lockstep-test` → captured exit **1**, with **2 failures, both in `pair-fixture-react-lockstep`**: `react` and `react-dom`, each reading 19.3.0 against 18.3.1. 6 tests, 11 assertions.
- **Restore:** `git checkout HEAD -- <fixture package.json>`, verified by blob hash. The default-form `git hash-object` equals the committed blob hash 4aadf7a4e3, and `git diff --quiet HEAD` exits 0.
- **Ratchets on these paths:** `scripts/check_retired_spellings.py`, `scripts/check_retired_composition_vocab.py` and `scripts/check_retired_image_keys.py` each exit 0.
- **The `//` string:** nothing validates it. I checked the wording by hand, and `node` parses the file (both pins read 19.3.0).
- **Line endings:** both edited files still carry CR count == CRLF count, measured by reading the bytes with Python.
- **Live lane: relying on CI.** The bump arms `mcp_live` through the `skills/re-frame2-pair/tests/fixture/*)` arm, so `test.yml`'s `mcp-conformance-re-frame2-pair` job runs the hermetic live suite over the fixture at React 19.3.0. I did not run it locally; that CI run is the merge evidence. `jvm-tools-template` also reruns the guard in CI.
- **Base:** the only trunk commit since this branch's merge base touches `.beads/issues.jsonl` alone, and `git diff origin/main...HEAD` shows only this PR's two files.
