### PR TITLE
fix(conformance): fixtures are plain EDN; no bare ::after-elapsed (rf2-vc2a)

### DIFF
--- a/scripts/check_conformance_fixture_edn.py
+++ b/scripts/check_conformance_fixture_edn.py
@@ -4,7 +4,8 @@
 The invariant this gate enforces:
 
     Every file under `spec/conformance/fixtures/` is a well-formed EDN file
-    holding EXACTLY ONE top-level form, with nothing after it.
+    holding EXACTLY ONE top-level form, with nothing after it — and it is
+    PLAIN EDN: no auto-resolved `::name` keyword outside a string (rf2-vc2a).
 
 The defect this prevents (rf2-5mr6): both fixture loaders read a fixture with
 `clojure.edn/read-string` over the whole file. `read-string` returns the FIRST
@@ -30,6 +31,14 @@ EVERY HALF OF THE CHECK IS LOAD-BEARING, and none alone is enough:
 So this scans for four things: each closer matching the delimiter kind it
 closes, bracket depth that never goes negative, a final depth of zero, and
 exactly one top-level form.
+
+And one more, which is about portability rather than about what the
+reference loaders silently discard (rf2-vc2a): no `::` outside a string or
+comment. `::name` is Clojure reader syntax, not EDN — `clojure.edn` itself
+rejects it — so a port's spec-conformant EDN reader throws on such a fixture.
+The reference loaders used to paper over six `::after-elapsed` tokens with a
+regex rewrite, which a port cannot know to replicate. A `::` INSIDE a string
+(the CEDN byte strings carry `"k::answer"`) is ordinary EDN and passes.
 
 WHY A SCANNER AND NOT A PARSER. Python has no EDN reader in the stdlib, and
 this gate must run in the fast-PR spine with no dependency to install. The
@@ -99,6 +108,7 @@ class Scan:
         "unterminated_string_line",
         "mismatch",
         "unclosed_opener",
+        "auto_resolved_keyword",
     )
 
     def __init__(self) -> None:
@@ -114,6 +124,8 @@ class Scan:
         # (opener_char, opener_line) for the outermost delimiter still open at
         # end of file, else None.
         self.unclosed_opener: tuple[str, int] | None = None
+        # (token, line) for the first `::` outside a string or comment.
+        self.auto_resolved_keyword: tuple[str, int] | None = None
 
     @property
     def ok(self) -> bool:
@@ -123,6 +135,7 @@ class Scan:
             and self.top_level_forms == 1
             and self.unterminated_string_line is None
             and self.mismatch is None
+            and self.auto_resolved_keyword is None
         )
 
     def summary(self) -> str:
@@ -213,6 +226,17 @@ def scan_edn(text: str) -> Scan:
             i += 1
             continue
 
+        if ch == ":" and text.startswith("::", i):
+            # Outside a string, comment or char literal — all consumed above —
+            # `::` is never EDN (rf2-vc2a). Record the first, whole token.
+            if s.auto_resolved_keyword is None:
+                j = i + 2
+                while j < n and text[j] not in _WS + "\n;\"" + _OPEN + _CLOSE:
+                    j += 1
+                s.auto_resolved_keyword = (text[i:j], line)
+            i += 2
+            continue
+
         if ch in _OPEN:
             stack.append((ch, line))
             depth += 1
@@ -288,6 +312,14 @@ def _defect_reason(s: Scan) -> str | None:
             f"only the FIRST, so everything after it is silently discarded "
             f"({s.summary()})"
         )
+    if s.auto_resolved_keyword is not None:
+        token, token_line = s.auto_resolved_keyword
+        return (
+            f"auto-resolved keyword `{token}` at line {token_line} — `::name` "
+            f"is Clojure reader syntax, not EDN, so a conforming EDN reader "
+            f"(clojure.edn included) rejects it. Write the keyword fully "
+            f"qualified, e.g. `:rf.machine.timer/after-elapsed` (rf2-vc2a)"
+        )
     return None
 
 
@@ -330,10 +362,13 @@ def check(fixtures_root: Path, verbose: bool = False, ci: bool = False) -> tuple
             "returns the first form and ignores the rest — so a fixture in this "
             "state loads, runs and reports as PASSING while the assertions "
             "outside the first form are never executed. (rf2-x91a, rf2-5mr6)\n"
+            "It must also be PLAIN EDN — every keyword fully qualified — so a "
+            "port's EDN reader loads it with no resolver or rewrite. (rf2-vc2a)\n"
         )
     elif verbose:
         sys.stderr.write(
-            f"all {n_scanned} conformance fixture(s) are one well-formed EDN form.\n"
+            f"all {n_scanned} conformance fixture(s) are one well-formed, "
+            f"plain-EDN form.\n"
         )
 
     return n_scanned, len(findings)
@@ -409,6 +444,22 @@ _ONLY_COMMENTS = """;; nothing but commentary
 ;; and more of it
 """
 
+# rf2-vc2a exactly: structurally perfect, one form, and still not EDN — the
+# bare `::after-elapsed` token is Clojure reader syntax. Every aggregate
+# number is the clean file's, so only the `::` rule can red this.
+_AUTO_RESOLVED_KEYWORD = """;; a conformance fixture
+{:call  :machine-transition
+ :event [::after-elapsed 5000 1 [:loading]]}
+"""
+
+# `::` inside a string (the CEDN byte strings) or a comment is ordinary EDN
+# and must NOT be flagged — otherwise the gate reds the corpus for no reason.
+_DOUBLE_COLON_NOT_A_TOKEN = """;; a comment may say ::after-elapsed freely
+{:call   :cedn/encode
+ :expect "k::answer"
+ :event  [:rf.machine.timer/after-elapsed 5000 1 [:loading]]}
+"""
+
 
 def _run_self_tests(verbose: bool = False) -> int:
     cases: list[tuple[str, str, int]] = [
@@ -422,6 +473,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("bad_unclosed_form.edn", _UNCLOSED, 1),
         ("bad_unterminated_string.edn", _UNTERMINATED_STRING, 1),
         ("bad_no_form_at_all.edn", _ONLY_COMMENTS, 1),
+        ("bad_auto_resolved_keyword.edn", _AUTO_RESOLVED_KEYWORD, 1),
+        ("ok_double_colon_in_string_and_comment.edn", _DOUBLE_COLON_NOT_A_TOKEN, 0),
     ]
 
     failures = 0

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -26,6 +26,8 @@ EDN is the natural data format for the CLJS reference. For other-host implementa
 
 A JSON-translated corpus may be published in the future for hosts where EDN is too much friction; if and when it ships, the JSON form will be mechanically derived from the EDN source so the two cannot drift. Until then, the EDN files in `fixtures/` are the canonical source. Implementors targeting non-EDN hosts either ship a small EDN reader (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap.
 
+The fixtures are plain EDN, so a conforming EDN reader loads every one of them with no resolver and no rewrite: every keyword is written fully qualified — the synthetic machine-timer event is `:rf.machine.timer/after-elapsed`, never Clojure's auto-resolved `::after-elapsed`, which is reader syntax rather than EDN.
+
 ## Fixture format
 
 Each fixture is an EDN map. A fixture exercises the spec in one of two modes:

--- a/spec/conformance/fixtures/after-hierarchy.edn
+++ b/spec/conformance/fixtures/after-hierarchy.edn
@@ -145,7 +145,7 @@
    :snapshot     {:state :idle :data {:rf/after-epoch {[:authenticated] 2}}}
    ;; The synthetic timer-elapsed event carries (delay, epoch, decl-path):
    ;; the parent-level timer scheduled at epoch 1 for [:authenticated].
-   :event        [::after-elapsed 30000 1 [:authenticated]]
+   :event        [:rf.machine.timer/after-elapsed 30000 1 [:authenticated]]
    :expect-next-snapshot {:state :idle :data {:rf/after-epoch {[:authenticated] 2}}}
    :expect-effects       []
    :expect-trace

--- a/spec/conformance/fixtures/after-single-delay.edn
+++ b/spec/conformance/fixtures/after-single-delay.edn
@@ -85,7 +85,7 @@
    :snapshot     {:state :loading :data {:rf/after-epoch {[:loading] 1} :entered? true}}
    ;; The synthetic timer-elapsed event carries (delay, epoch, decl-path);
    ;; the harness supplies it as the dispatched event.
-   :event        [::after-elapsed 5000 1 [:loading]]
+   :event        [:rf.machine.timer/after-elapsed 5000 1 [:loading]]
    :expect-next-snapshot {:state :timeout :data {:rf/after-epoch {[:loading] 2} :entered? true}}
    ;; Per rf2-3y3y, exiting an :after-bearing state emits a
    ;; :rf.machine/after-cancel fx so the runtime layer releases the

--- a/spec/conformance/fixtures/after-stale-detection.edn
+++ b/spec/conformance/fixtures/after-stale-detection.edn
@@ -83,7 +83,7 @@
                    :timeout {}
                    :ready   {}}}
    :snapshot     {:state :ready :data {:rf/after-epoch {[:loading] 2}}}
-   :event        [::after-elapsed 5000 1 [:loading]]
+   :event        [:rf.machine.timer/after-elapsed 5000 1 [:loading]]
    :expect-next-snapshot {:state :ready :data {:rf/after-epoch {[:loading] 2}}}
    :expect-effects       []
    :expect-trace

--- a/spec/conformance/fixtures/cross-spec-machine-after-hydration-rearm.edn
+++ b/spec/conformance/fixtures/cross-spec-machine-after-hydration-rearm.edn
@@ -262,7 +262,7 @@
                           :timeout {}}}
    :snapshot   {:state :waiting
                 :data  {:entries 1 :rf/after-epoch {[:waiting] 1}}}
-   :event      [::after-elapsed 5000 1 [:waiting]]
+   :event      [:rf.machine.timer/after-elapsed 5000 1 [:waiting]]
    :expect-next-snapshot {:state :timeout
                           :data  {:entries 1 :rf/after-epoch {[:waiting] 2}}}
    :expect-effects [[:rf.machine/after-cancel

--- a/spec/conformance/fixtures/machine-timeout-spawn-fire.edn
+++ b/spec/conformance/fixtures/machine-timeout-spawn-fire.edn
@@ -110,7 +110,7 @@
    :snapshot     {:state :loading
                   :data  {:rf/spawned     {[:loading] :fetch/user#1}
                           :rf/after-epoch {[:loading] 1}}}
-   :event        [::after-elapsed 10000 1 [:loading]]
+   :event        [:rf.machine.timer/after-elapsed 10000 1 [:loading]]
    :expect-next-snapshot {:state :timed-out
                           :data  {:rf/spawned     {[:loading] :fetch/user#1}
                                   :rf/after-epoch {[:loading] 2}}}

--- a/spec/conformance/fixtures/machine-timeout-state-fire.edn
+++ b/spec/conformance/fixtures/machine-timeout-state-fire.edn
@@ -69,7 +69,7 @@
                              :on-timeout {:target :timed-out}}
                    :timed-out {}}}
    :snapshot     {:state :waiting :data {:rf/after-epoch {[:waiting] 1}}}
-   :event        [::after-elapsed 5000 1 [:waiting]]
+   :event        [:rf.machine.timer/after-elapsed 5000 1 [:waiting]]
    :expect-next-snapshot {:state :timed-out :data {:rf/after-epoch {[:waiting] 2}}}
    :expect-effects [[:rf.machine/after-cancel
                      {:rf/parent-id :rf/transition-pure


### PR DESCRIPTION
Closes rf2-vc2a.

## Summary

Six conformance fixtures carried a bare `::after-elapsed` token. That is Clojure reader syntax, not EDN: `clojure.edn` rejects it, and so does any port's spec-conformant EDN reader, before any capability filter runs. The reference loaders hid it with a regex rewrite to `:rf.machine.timer/after-elapsed`, which a port has no way to know it must replicate.

- **Fixtures.** The six tokens now read `:rf.machine.timer/after-elapsed`. The files are `after-hierarchy.edn`, `after-single-delay.edn`, `after-stale-detection.edn`, `cross-spec-machine-after-hydration-rearm.edn`, `machine-timeout-spawn-fire.edn` and `machine-timeout-state-fire.edn`, one line each.
- **Guard.** It lives in `scripts/check_conformance_fixture_edn.py`, the corpus's existing shape gate (rf2-x91a: one form, balanced and matched delimiters). The gate now also refuses any `::` outside a string or comment. The scanner already lexes strings, comments and char literals, so the 17 `"k::answer"` CEDN byte strings stay legal. Two self-test cases pin both directions: a bare token goes red, and `::` inside a string or a comment stays green.
- **README.** `spec/conformance/README.md` §Why EDN gains one sentence saying the fixtures are plain EDN, with every keyword fully qualified.
- **Loader rewrites are left in place.** They are now inert on the corpus. rf2-6r9j.49 removed the schemas loader's copy and said to leave the others alone.

## Loader census (every reader of `spec/conformance/fixtures` at tip)

| Reader | Files it reads | How it handles `::` | After this PR |
|---|---|---|---|
| `implementation/core/test/re_frame/conformance_test.clj` | all | lookbehind rewrite `::name` → `:rf.machine.timer/name` | inert; same keyword |
| `implementation/core/test/re_frame/conformance_fixtures.clj` (a CLJS macro that runs on the JVM at compile time and feeds `conformance_corpus_cljs_test.cljs` in `:node-test`) | all | the same lookbehind rewrite | inert; CLJS inlines identical data |
| `implementation/machines/test/re_frame/machines_conformance_test.clj` | all (filtered after load) | plain rewrite, no lookbehind | inert on the six |
| `implementation/flows/test/re_frame/flows_conformance_test.clj` | `flow-*.edn` | plain rewrite | reads none of the six |
| `implementation/ssr/test/re_frame/ssr_conformance_test.clj` | `ssr-*.edn` | plain rewrite | reads none of the six |
| `implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj` | `ssr-streaming.edn`, `ssr-streaming-nested.edn` | plain rewrite | reads none of the six |
| `implementation/schemas/test/re_frame/schemas_conformance_test.clj` | `schema-*.edn`, `error-schema-failure.edn` | verbatim (rf2-6r9j.49) | reads none of the six |
| `scripts/check_conformance_fixture_edn.py` | all | lexical | now refuses `::` |
| `scripts/check_retired_spellings.py` | one routing fixture, read as text | none | unaffected |

- **The keyword means the same thing to every reader.** The machines runtime's own synthetic timer event id is `:rf.machine.timer/after-elapsed` (`timer.cljc`, `transition.cljc`, `cofx_attach.cljc`). So the literal now in the fixtures is exactly what every rewrite used to produce.
- **No CLJS or JS reader handles `::` differently, because none parses the corpus itself.** The one CLJS consumer receives its data from the JVM-side macro. No node reader exists; the only JS EDN hits are mcp-conformance overflow markers. The hand-mirrored CLJS tests (`machines_after_cljs_test.cljs`, `machines_timeout_cljs_test.cljs`, `machines_spawn_cljs_test.cljs`) already spell the fully qualified keyword.
- **Noted, not fixed.** The four plain-rewrite loaders lack the core loaders' lookbehind, so they would also restamp a `::` *inside a string*. Only the machines loader reads the CEDN fixtures that carry `"k::answer"`, and it filters them out afterwards, so this is harmless today. Per rf2-6r9j.49 the loaders stay untouched.

## Control (planted fault)

- **Pre-fix corpus.** Against HEAD's fixture tree exported before this change, the new rule exits 1 with six findings: exactly the six files, at lines 148, 88, 86, 265, 113 and 72.
- **Plant.** I put one bare `[::after-elapsed 5000 1 [:loading]]` back into `after-single-delay.edn`; the anchor had one match before planting. The guard exited 1 with one finding naming that file at line 88.
- **Restore.** The restored file's default-form blob hash `28166bd4de930e168296d404f5fc33748a32b1f7` equals the committed object's. `git diff --quiet` exits 0, and the guard exits 0 again.

## Quality gates

Every exit code below was captured by redirecting the runner's own output to a log and echoing its exit status in the same shell.

| Gate | CI job | Exit |
|---|---|---|
| `python scripts/check_conformance_fixture_edn.py --self-test --verbose` (14 cases) | `Repo invariant checks (skills, MCP, catalogues, namespaces)` (`verify-skill-mcp-drift`), step "Self-test the conformance fixture EDN gate" | 0 |
| `python scripts/check_conformance_fixture_edn.py --verbose` (243 fixtures) | same job, step "Validate every conformance fixture is one well-formed EDN form"; also always-on in `scripts/test-fast-pr.sh` | 0 |
| `python scripts/check_doc_slugs.py` (covers `spec/`) | `verify-readme-links` | 0 |
| `scripts/test-jvm-implementation.sh` (every JVM corpus runner) | `JVM core`, `JVM machines`, `JVM flows`, `JVM ssr`, `JVM schemas` (`clojure -M:test`) | 0 — 21 artefacts, all "0 failures, 0 errors" (core 2307 tests, machines 1249, schemas 390, flows 266, ssr 673) |
| `scripts/test-fast-pr.sh` (classified: docs gates, JVM core, node/CLJS suite incl. `npm run test:cljs`) | `CLJS (shadow-cljs :node-test)` runs the CLJS corpus runner | 0 — mkdocs --strict built; JVM core 0 failures; node/CLJS 11990 tests, 0 failures; `re-frame.conformance-corpus-cljs-test` ok |

- **Which tree the gates read.** Every number above is from the rebased tree, head `47a8ba45ef` on trunk `2e8cdf0000`. Both heavy gates print `gate root:` and named this worktree. Trunk has since moved again by spec-prose-only commits, none of which touches these files. `git diff origin/main...HEAD` shows only the 8 files in this change, so nothing a sibling landed is reverted.
- **Checked by hand.** The README sentence is prose: it adds no link and no table, and nothing validates prose.
- **Fence.** `skills/re-frame2-implementor/references/phase-2-impl-order.md:9` belongs to rf2-0a75 and is untouched. Once this lands, that clause needs nothing. No `rf2-fzbj.*` or `rf2-gwye.*` finding is touched.
