### PR TITLE
docs(xray-skill): render the launch tree, route rf/init! to the host, publish all four status reasons (rf2-askl)

### DIFF
--- a/docs/xray/api/mount-control.md
+++ b/docs/xray/api/mount-control.md
@@ -56,7 +56,18 @@ The three verbs are **not** a mode-symmetric triplet — there is no `open-inlin
   ```clojure
   (xray/status) → map
   ```
-- **Description**: Inspectable shell state. Returns `{:mounted? :visible? :last-host-diagnostic ...}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_xray.status()`.
+- **Description**: Inspectable shell state. Returns `{:mounted? :visible? :mode :diagnostic :host-selector :auto-open?}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_xray.status()`.
+
+`:diagnostic` is where a launch that did not happen says why. A healthy mount reads `{:ok? true :reason nil}`; otherwise `:reason` is one of four public values, and the set is a contract — a member is retired by reservation, never deleted or reused:
+
+| `:reason` | `:ok?` | Meaning |
+| --- | --- | --- |
+| `:missing-layout-host` | `false` | No element matched the layout-host selector, so nothing mounted. Also logged through `console.error`, with the selector and a host snippet. |
+| `:no-substrate-adapter` | `false` | The preload waited about 6 s for a substrate adapter and none arrived: the host never called `rf/init!`. Recorded only while auto-open is on. |
+| `:auto-open-disabled` | `true` | Auto-open is switched off (`:rf.xray/auto-open? false`). Health, not failure. |
+| `:unsupported-substrate` | — | Reserved and never produced. Xray paints through its own React root, so no installed adapter is refused; the id stays so a consumer keying on it keeps working. |
+
+`popout!` reports its failures in its own return value, not here.
 
 ## Manual install — the alternative to `:preloads`
 

--- a/docs/xray/api/reference.md
+++ b/docs/xray/api/reference.md
@@ -18,7 +18,7 @@ The canonical facade. The day-to-day require for host integrations: mount contro
 | `close!` | `(close!)` | Hide the shell — flip the container to `display: none`. DOM stays in place. |
 | `toggle!` | `(toggle!)` | Flip visibility. Wired to `Ctrl+Shift+C`. |
 | `popout!` | `(popout!)` | Open Xray in a same-origin second window. Own React root, own keybinding. |
-| `status` | `(status)` → map | Inspectable shell state. `{:mounted? :visible? :last-host-diagnostic ...}`. |
+| `status` | `(status)` → map | Inspectable shell state. `{:mounted? :visible? :mode :diagnostic ...}`; `:diagnostic :reason` names why a launch failed — see [Mount control](mount-control.md#status). |
 | `target-frame` | `(target-frame)` → keyword \| nil | Read the currently-selected inspected-host frame, or `nil` when none is selected (never defaulted to `:rf/default`). One-shot read; not reactive. |
 | `set-target-frame!` | `(set-target-frame! frame-id)` → nil | Set the inspected-host frame Xray targets. `nil` resets to the **unselected** state (not `:rf/default`). |
 | `focus!` | `(focus! command)` → map | Host-facing focus handoff. Story and other hosts use it to focus a panel, epoch, cascade row, app-db path, or source target without rebuilding Xray's diagnostic UI. |

--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -19,7 +19,7 @@ Xray is the human-facing panel; when the user asks an agent to inspect or change
 ## Repo contents
 
 - `SKILL.md` — the question-first router: the actor fork, the route card (question → first surface), the launch quick-reference, chrome one-liners, and the leaf-loading guide
-- `references/launch-modes.md` — the launch decision tree (preload, `:rf.xray/layout-host-selector`, host-CSS-variable resize, suppress-auto-open, missing-host recovery, the `open-overlay!` no-layout-host fallback)
+- `references/launch-modes.md` — the launch decision tree (preload, `:rf.xray/layout-host-selector`, host-CSS-variable resize, suppress-auto-open, the four `status()` launch-diagnostic reasons + missing-host recovery, the `open-overlay!` no-layout-host fallback)
 - `references/launch-programmatic.md` — driving Xray from code: `init!` opts and the `focus!` deep-link command
 - `references/launch-lifecycle.md` — pop-out lifecycle, the wired hotkey contract, hidden-state semantics, disabling Xray, production posture
 - `references/panels.md` — the compact canonical tab inventory (10 Dynamic + 5 Static), the scope matrix, and the panel → content-home mapping for surfaces that are not their own tab

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -124,7 +124,10 @@ full-inventory request, not for routine routing.
 ## Launching Xray — pick a mode
 
 Four launch surfaces ship: one mount facade with three open verbs
-(inline / overlay / window) plus the programmatic `init!`.
+(inline / overlay / window) plus the programmatic `init!`. Xray mounts on
+any installed browser adapter — the ratom family (Reagent, reagent-slim)
+or the React-hook substrates (UIx, Fresco) — because it paints through its
+own React root; all it needs is that the host called `rf/init!`.
 
 | User wants to … | Use | How |
 |---|---|---|
@@ -142,10 +145,14 @@ page loaded, no inline panel = a **missing layout host**: nothing matched
 `[data-rf-xray-host]` when the adapter became ready. Xray fails loudly but
 safely — a `console.error` plus the same diagnostic at
 **`window.day8.re_frame2_xray.status()`**. First response: check the
-console / call `status()`. The three recoveries (add the column · point
-the selector · fall back to `open-overlay!`) and the full decision tree
+console / call `status()`, whose `:diagnostic :reason` names which of four
+it is — `:missing-layout-host`, `:no-substrate-adapter` (the host never
+called its own `rf/init!`), `:auto-open-disabled` (health, not failure),
+or the reserved, never-produced `:unsupported-substrate`. The reason
+table, the three missing-host recoveries (add the column · point the
+selector · fall back to `open-overlay!`) and the full decision tree
 (preload vs `init!`, suppress-auto-open, resize) live in
-[`references/launch-modes.md`](references/launch-modes.md); the pop-out
+[`references/launch-modes.md` §Launch diagnostics](references/launch-modes.md#launch-diagnostics); the pop-out
 lifecycle is in
 [`references/launch-lifecycle.md`](references/launch-lifecycle.md).
 
@@ -160,7 +167,7 @@ per-key contract + suppression knob:
 | `Ctrl+Shift+C` | global | Toggle the Xray shell (`Ctrl+Shift` avoids Safari's `Cmd+Shift+C` Inspect collision). |
 | `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static. |
 | `Cmd/Ctrl+K` | global | Open the command palette (**wired** — don't tell users the K-binding is unavailable); opens the shell first if hidden. |
-| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts, only while the shell is visible and focused. Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step focused event · `G` = fast-forward to head · `,`/`s` = Settings popup. |
+| `Space` `l` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts, only while the shell is visible and focused. Space = pause/resume LIVE · `l` (unshifted) = snap to LIVE · `j`/`k` = step focused event · `G` (Shift+G) = fast-forward to head · `,`/`s` = Settings popup. |
 
 Only these are wired: `Esc` is modal-local, not a spine key; the
 **pop-out has no hotkey** (its canonical path is the visible `⛶`
@@ -179,7 +186,7 @@ the control-by-control inventory.
  `:rf/re-frame2-pair`) are filtered out unconditionally — "I can't find
  frame X in the picker" → it's a tool frame.
 - **LIVE vs RETRO spine** — the L2 spine live-tails at the head until you
- pick a historical event or pause; `Space` pauses/resumes, `L` snaps back.
+ pick a historical event or pause; `Space` pauses/resumes, `l` snaps back.
 - **Time-travel: passive inspect vs explicit rewind** — picking an epoch
  is *passive inspection*: panels rebase, the live frame does NOT move.
  Live rewind is the separate, explicit **`Reset` button** on the L3
@@ -211,7 +218,7 @@ deeper question loads at most **one** focused leaf:
 
 | Deep question about… | Load |
 |---|---|
-| Launch in depth — preload, the `[data-rf-xray-host]` contract, missing-host recovery, `open-overlay!` | [`references/launch-modes.md`](references/launch-modes.md) |
+| Launch in depth — preload, the `[data-rf-xray-host]` contract, launch diagnostics + missing-host recovery, `open-overlay!` | [`references/launch-modes.md`](references/launch-modes.md) |
 | Driving Xray from code — `init!` opts, the `focus!` deep-link command | [`references/launch-programmatic.md`](references/launch-programmatic.md) |
 | Pop-out lifecycle, the full hotkey contract, hidden-state semantics, disabling Xray + production posture | [`references/launch-lifecycle.md`](references/launch-lifecycle.md) |
 | The full tab inventory + scope matrix + the Static catalogues (explicit "list every tab") | [`references/panels.md`](references/panels.md) |

--- a/skills/re-frame2-xray/evals/README.md
+++ b/skills/re-frame2-xray/evals/README.md
@@ -41,7 +41,7 @@ when the eval shape changes in a way that breaks readers.
 ## Coverage
 
 33 evals, covering Xray's trigger surface and answer quality: 24 positives
-(skill should fire) and 9 negatives (skill should stay quiet). 20
+(skill should fire) and 9 negatives (skill should stay quiet). 22
 positives carry the Layer-2 answer-quality `expectations[]`; they target the
 prompts whose answer drifts fastest as the Xray UI moves, plus the
 route-quality contract (one first surface in the first paragraph, no
@@ -70,7 +70,9 @@ only the focused family leaf):
 | 29 | `tab-inventory-count` | yes | The full ordered **10-tab** Dynamic list incl. Frames and Fresco (count is 10, not 9); correct `:order`; no retired label ("Modules"); no removed tab (Issues / Event / Chrome A11y / Machines-Canvas). |
 | 30 | `graph-projection-vs-static-mode` | yes | The Graph tab's registration-derived view is its OWN per-panel projection toggle (Declared/Realized; shipped-labelled static/live), NOT the L1 Static mode pill; Graph is a Dynamic tab, so Static mode does not show it at all. |
 | 32 | `panel-route-resources` | yes | Route quality: server-state staleness / in-flight → the Dynamic **Resources** tab; live instances follow the L1 frame picker, not the epoch; a deep follow-up loads only `references/panels-resources.md`. |
-| 4, 5, 10, 25 | `launch-hotkey` … `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
+| 4 | `launch-hotkey` | yes | `Ctrl+Shift+C` toggles the shell (first press mounts) and is `Ctrl+Shift` on macOS too; no hotkey opens the pop-out; snap-to-LIVE, if listed, is unshifted `l`. |
+| 5 | `hotkey-mode-toggle` | yes | `Cmd/Ctrl+Shift+M` flips Dynamic ↔ Static, same as the L1 mode pill; not `Ctrl+Shift+C`, not a bare letter. |
+| 10, 25 | `static-mode-name`, `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
 | 13–20, 31 | `neg-*` | no | Negatives — adjacent surfaces (agent runtime → pair, whether mutating (13) or read-only (31); implement→spec, author→re-frame2, setup, migration, implementor, vocab-only). |
 
 The Layer-2 set covers two contracts. The high-drift facts:

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -68,8 +68,31 @@
  "The output does NOT claim open! is inert in production because no substrate adapter is installed — an app that called rf/init! has one in production too."
  ]
  },
- {"id": 4, "name": "launch-hotkey", "should_trigger": true, "prompt": "What's the Ctrl+Shift+C hotkey wired to?"},
- {"id": 5, "name": "hotkey-mode-toggle", "should_trigger": true, "prompt": "Is there a keyboard shortcut to switch Xray between its Dynamic and Static modes?"},
+ {
+ "id": 4,
+ "name": "launch-hotkey",
+ "should_trigger": true,
+ "prompt": "What's the Ctrl+Shift+C hotkey wired to?",
+ "expected_output": "The agent says Ctrl+Shift+C toggles the Xray shell: the first press mounts and shows it, later presses flip its visibility (the shell stays mounted while hidden). The chord is Ctrl+Shift on every platform, macOS included, because Cmd+Shift+C is Safari's Inspect. It does not claim the chord opens the pop-out. If it lists the other wired keys, it gives them as shipped: Cmd/Ctrl+Shift+M mode toggle, Cmd/Ctrl+K palette, and unshifted l for snap-to-LIVE.",
+ "expectations": [
+ "The output says Ctrl+Shift+C toggles the Xray shell (show / hide; the first press mounts it).",
+ "The output does NOT give the chord as Cmd+Shift+C on macOS — it is Ctrl+Shift+C everywhere (Cmd+Shift+C is Safari's Inspect).",
+ "The output does NOT claim Ctrl+Shift+C (or any hotkey) opens the pop-out window.",
+ "If the output lists the focus-gated spine keys, it gives snap-to-LIVE as unshifted l, not Shift+L."
+ ]
+ },
+ {
+ "id": 5,
+ "name": "hotkey-mode-toggle",
+ "should_trigger": true,
+ "prompt": "Is there a keyboard shortcut to switch Xray between its Dynamic and Static modes?",
+ "expected_output": "The agent answers YES: Cmd/Ctrl+Shift+M (Cmd on macOS, Ctrl elsewhere) toggles Dynamic ↔ Static, the same flip as clicking the L1 mode pill. It does not offer the Ctrl+Shift+C shell toggle or a bare letter as the mode switch.",
+ "expectations": [
+ "The output names Cmd/Ctrl+Shift+M as the Dynamic ↔ Static mode toggle (Cmd on macOS, Ctrl elsewhere).",
+ "The output mentions the L1 mode pill as the equivalent click path.",
+ "The output does NOT give Ctrl+Shift+C (the shell toggle) or a bare letter key as the mode switch."
+ ]
+ },
  {
  "id": 6,
  "name": "panel-route-state",

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -59,7 +59,7 @@ Spec [`007-UX-IA.md` §Frame slot contract](https://github.com/day8/re-frame2/bl
 
 The L2 spine live-tails new events at the head (**LIVE**) until you pick a
 historical event or pause, which drops to **RETRO** (inspecting a past
-epoch). `Space` pauses/resumes LIVE; `L` snaps back to LIVE. There is **no
+epoch). `Space` pauses/resumes LIVE; `l` (unshifted) snaps back to LIVE. There is **no
 mode pill and no animated head-row cue** — LIVE vs RETRO is conveyed by the
 `[◀ ▶ ⏭]` nav cluster plus the focused-row state (a background wash + a
 leading `>` caret on the focused row, which in LIVE tracks the head). Spec

--- a/skills/re-frame2-xray/references/launch-lifecycle.md
+++ b/skills/re-frame2-xray/references/launch-lifecycle.md
@@ -50,8 +50,20 @@ Caveats inherited from the `window.opener` posture:
  on opener reload; nothing in `tools/xray/src` ever sets that handle, so
  it is normative-future.) Close the pop-out and open a fresh one from the
  reloaded opener.
-- No keybinding is wired pre-alpha. The visible `⛶` top-bar button is the
+- **No key opens the pop-out.** The visible `⛶` top-bar button is the
  canonical chrome launch; the programmatic call is the secondary path.
+ **Inside it, the keyboard works**: the pop-out installs its own keydown
+ listener, so `Cmd/Ctrl+K`, `Cmd/Ctrl+Shift+M` and the spine keys
+ (`Space` `l` `j` `k` `G` `,`/`s`) act on it while it has focus. The one
+ exception is `Ctrl+Shift+C`, which toggles only the opener's in-app
+ shell; in the pop-out that chord is left to the browser.
+
+**Return shapes.** `popout!` returns the pop-out's state map (`:ok? true`,
+and the same map again while that window is open),
+`{:ok? false :reason :popup-blocked}` when the browser refuses
+`window.open`, or `{:ok? false :reason :no-substrate-adapter}` when the
+host has not yet called `rf/init!`. Neither failure is written to
+`status()` ([`launch-modes.md` §Launch diagnostics](launch-modes.md#launch-diagnostics)).
 
 ## Wired hotkeys
 
@@ -64,7 +76,7 @@ Four hotkey families have keydown listeners attached today
 | `Ctrl+Shift+C` | global | Toggle the Xray shell (mount on first press; CSS show/hide thereafter). `Ctrl+Shift` avoids Safari's `Cmd+Shift+C` Inspect collision on macOS. |
 | `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static (`:rf.xray/toggle-mode`). Cmd on macOS, Ctrl elsewhere. |
 | `Cmd/Ctrl+K` | global | Open the command palette (`:rf.xray/palette-toggle`); opens the shell first if it's hidden. Cmd on macOS, Ctrl elsewhere. |
-| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts. Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step focused event back/forward · `G` (Shift+G) = fast-forward to head · `,` or `s` = Settings popup. (`Esc` is **not** a wired spine key — it is a modal-local close handler owned by the palette / Settings popup, plus one global case: the shell-level listener dismisses the open-in-editor hint toast when it is open; otherwise Esc falls through to the host.) |
+| `Space` `l` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts. Space = pause/resume LIVE · `l` (unshifted; `Shift+L` does nothing) = snap to LIVE · `j`/`k` = step focused event back/forward · `G` (Shift+G) = fast-forward to head · `,` or `s` = Settings popup. (`Esc` is **not** a wired spine key — it is a modal-local close handler owned by the palette / Settings popup, plus one global case: the shell-level listener dismisses the open-in-editor hint toast when it is open; otherwise Esc falls through to the host.) |
 
 [`spec/007-UX-IA.md` §Keyboard](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/007-UX-IA.md#keyboard)
 catalogues additional shortcuts that remain normative for the future but

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -6,40 +6,36 @@ on a corner it doesn't cover, defer to the spec doc.
 
 ## Decision tree
 
-```
-Is the host app's dev build running with the Xray preload? ── no ──► §Install the preload
- │
- yes
- │
- Has `rf/init!` run? ── no ──► §Programmatic init!
- │
- yes
- │
- Is there a [data-rf-xray-host] in the page layout?
- │
- ┌──────────────┴──────────────┐
- yes no
- │ │
- ▼ ▼
- Xray auto-opened into the Xray logged the missing-host
- inline host on page load. diagnostic (console.error +
- Toggle with Ctrl+Shift+C. window.day8.re_frame2_xray.status)
- │ │
- ▼ ┌────────────┴────────────┐
- Need a second monitor? Can the host give Xray a layout column?
- │ │
- yes ┌─────────┴─────────┐
- │ yes no
- ▼ │ │
- Click the ⛶ top-bar pop-out ▼ ▼
- button (canonical) — same-origin §Layout host §Overlay fallback
- second window reading the opener's contract (open-overlay!) —
- atoms directly; (xray/popout!) (add the column) floats above the host,
- is the secondary code path. no column needed.
-```
+1. **Is the host app's dev build running with the Xray preload?**
+   - **No** → [§Install the preload](#install-the-preload). Installing
+     from code instead? That is
+     [`launch-programmatic.md` §Programmatic init!](launch-programmatic.md#programmatic-init),
+     called *after* the host's `rf/init!`.
+   - **Yes** → question 2.
+2. **Has the host app called its own `(rf/init! adapter)`?**
+   - **No** → call the host's `(rf/init! adapter)` before the app
+     renders. Xray's `init!` installs no adapter and cannot stand in for
+     it. The preload waits about 6 s (120 × 50 ms) for an adapter, then
+     records `:no-substrate-adapter` ([§Launch diagnostics](#launch-diagnostics)).
+   - **Yes** → question 3.
+3. **Is there a `[data-rf-xray-host]` in the page layout?**
+   - **Yes** → Xray auto-opened into the inline host on page load; toggle
+     it with `Ctrl+Shift+C`. **Need a second monitor?**
+     - **No** → done.
+     - **Yes** → click the `⛶` top-bar pop-out button (canonical): a
+       same-origin second window reading the opener's atoms directly.
+       `(xray/popout!)` is the secondary code path
+       ([`launch-lifecycle.md` §Pop-out](launch-lifecycle.md#pop-out-to-a-second-window)).
+   - **No** → Xray logged the `:missing-layout-host` diagnostic
+     (`console.error` + `window.day8.re_frame2_xray.status()`). **Can the
+     host give Xray a layout column?**
+     - **Yes** → [§Layout host contract](#layout-host-contract) — add the
+       column.
+     - **No** → [§Overlay fallback](#overlay-fallback-open-overlay) —
+       `open-overlay!` floats above the host, no column needed.
 
-Two branches of that tree live in sibling leaves: **§Programmatic init!**
-and **§Programmatic focus** in
+Sibling leaves carry the rest: **§Programmatic init!** and
+**§Programmatic focus** in
 [`launch-programmatic.md`](launch-programmatic.md), and **§Pop-out**,
 **§Wired hotkeys** and **§Production posture** in
 [`launch-lifecycle.md`](launch-lifecycle.md).
@@ -75,6 +71,12 @@ matching the `init!` docstring's enumeration in `core.cljs`):
 It schedules an auto-open into `[data-rf-xray-host]` once
 `current-adapter` is ready. The preload MUST NOT mount synchronously
 during namespace load; it MAY schedule a bounded adapter-ready retry.
+
+**Any installed browser adapter will do.** Xray paints through its own
+React root, so the ratom family (Reagent, reagent-slim) and the
+React-hook substrates (UIx, Fresco) mount it alike; all it needs is that
+the host called `rf/init!` with one
+([`008-Embedding-Contract.md` §The minimum host contract](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/008-Embedding-Contract.md#the-minimum-host-contract)).
 
 Idempotency: every step is `defonce`-guarded. shadow-cljs `:after-load`
 reruns are safe — no double-attached listeners, no double-mount, no
@@ -161,18 +163,17 @@ open with no host still emits the actionable missing-host diagnostic.
 App dev pages should keep the default `true` posture and provide
 `[data-rf-xray-host]`.
 
-## Missing host — diagnostic + recovery
+## Launch diagnostics
 
-The single most common "Xray didn't open" cause: the preload ran but no
-element matched the layout-host selector when the substrate adapter became
-ready. Per [`spec/011-Launch-Modes.md`](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/011-Launch-Modes.md)
+When Xray does not appear, `status()` says why. Per
+[`spec/011-Launch-Modes.md`](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/011-Launch-Modes.md)
 Xray **must fail loudly but safely** — it MUST NOT `alert()` and MUST NOT
-block host app startup. The same diagnostic lands in two places (source
+block host app startup. A failure lands in two places (source
 [`mount.cljs`](https://github.com/day8/re-frame2/blob/main/tools/xray/src/day8/re_frame2_xray/mount.cljs)
-`missing-host-diagnostic` / `report-diagnostic!`):
+`report-diagnostic!`):
 
-1. **`console.error`** — names the expected selector + the host snippet to
-   add.
+1. **`console.error`** — the message; for a missing host it also names the
+   expected selector + the host snippet to add.
 2. **`window.day8.re_frame2_xray.status()`** — the inspectable mount/API
    status map (wired by `install.cljs`, defined at `mount.cljs` `status`):
 
@@ -189,11 +190,25 @@ block host app startup. The same diagnostic lands in two places (source
     :auto-open?    true}
    ```
 
+`:diagnostic :reason` names the cause. A healthy mount reads
+`{:ok? true :reason nil}`; the four public reasons are:
+
+| `:reason` | `:ok?` | What happened | Fix |
+|---|---|---|---|
+| `:missing-layout-host` | `false` | The adapter was ready but nothing matched the layout-host selector, so nothing mounted. **The most common cause.** | One of the three recoveries below. |
+| `:no-substrate-adapter` | `false` | The preload waited about 6 s (120 × 50 ms) and no substrate adapter was ever installed: the host never called `rf/init!`. Recorded only while auto-open is on. | Call the host's own `(rf/init! adapter)` before app render. Xray's `init!` is not the fix. |
+| `:auto-open-disabled` | `true` | The host set `:rf.xray/auto-open? false`, so the preload skipped the page-load open. Health, not failure. | Open it yourself (`Ctrl+Shift+C` or `(xray/open!)`), or drop the setting ([§Suppress auto-open](#suppress-auto-open)). |
+| `:unsupported-substrate` | — | Reserved and never produced. Xray paints through its own React root, so no installed adapter is refused; the id stays so a consumer keying on it keeps working. | Nothing to fix. |
+
+`popout!` reports its own failures (`:popup-blocked`,
+`:no-substrate-adapter`) in its return value, not here — see
+[`launch-lifecycle.md` §Pop-out](launch-lifecycle.md#pop-out-to-a-second-window).
+
 An explicit `(xray/open!)` / `(xray/toggle!)` against a missing host
 **returns the same diagnostic map** (and logs the `console.error`) rather
 than throwing — so a programmatic caller can branch on `:ok?`.
 
-Three recoveries, in order of preference:
+For `:missing-layout-host`, three recoveries, in order of preference:
 
 - **Add the `[data-rf-xray-host]` column** to your app layout (§Layout host
   contract above) — the default fix.

--- a/skills/re-frame2-xray/references/panels-domains.md
+++ b/skills/re-frame2-xray/references/panels-domains.md
@@ -75,7 +75,9 @@ id; silent when no routes are registered.
 **Open when:** "what route am I on?", "what params resolved?", "did the
 route change this epoch?" To rank an arbitrary URL against every
 registered route, use the Simulate-URL input — promoted in **Static →
-Routes**.
+Routes**, where each row's Simulate navigation button also previews what
+a navigation would land (matched params, the `:on-match` event, the route
+slice) without dispatching anything.
 
 Spec: [`021-Dynamic-Panel-Designs.md` §7](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/021-Dynamic-Panel-Designs.md)
 + [`spec/012-Routing.md`](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md).

--- a/skills/re-frame2-xray/references/panels-resources.md
+++ b/skills/re-frame2-xray/references/panels-resources.md
@@ -11,16 +11,26 @@ stream. Inventory + scope matrix: [panels.md](panels.md).
 
 Question: **Where is my server state — what owns it, and is it stale?**
 
-The sections, top → bottom:
+The fourteen sections, top → bottom (the two marked *quiet* render
+nothing until they have something to show):
 
 - **STATIC RESOURCE REGISTRY** — every registered resource + scope,
  stale-after, GC-after, and the routes that activate it.
+- **NAMED SCOPE RESOLVERS** — the registered resource-scope resolvers
+ and their inputs.
 - **LIVE INSTANCES** (per frame) — each scoped cache entry with state,
  generation, owner count, and freshness.
 - **WORK LEDGER** — live fetch attempts (running · cancellable ·
  deadline).
+- **WHAT IS STILL RUNNING?** *(quiet)* — live managed-async work in this
+ frame, with its stale-suppression tally.
+- **STALE RACES** *(quiet)* — the arcs that hit the stale-suppression
+ boundary.
 - **ROUTE / RESOURCE GRAPH** — blocking activations (the SSR wait
- points), the lifecycle timeline, cache growth.
+ points) for each route that declares `:resources`.
+- **LIFECYCLE TIMELINE** — this epoch's resource lifecycle events.
+- **INVALIDATION / MUTATION GRAPH** — this epoch's invalidations and
+ what each one matched.
 - **SCOPE RESOLUTION TIMELINE** — which named scope resolver ran, its
  inputs, the resolved scope — including fail-closed nil evidence (a
  scope-requiring site that got nil and produced NO global fallback).
@@ -29,7 +39,10 @@ The sections, top → bottom:
  cache" visible: did the accepted reply continue into app workflow, and
  which scopes a write resolved, refetched, or left stale — fail-closed,
  never an implicit global blast.
-- **SCOPE AUDIT** — every `:rf.scope/global` use + lints.
+- **OPTIMISTIC MUTATIONS** — this epoch's optimistic mutations, plus a
+ loud warning when a `:force` write clobbered a concurrent one.
+- **CACHE GROWTH** — entry, GC-eligible and live-work totals.
+- **SCOPE AUDIT + LINTS** — every `:rf.scope/global` use + lints.
 
 **The absence-is-evidence rule.** A continuation / refetch the runtime
 *suppresses* (a stale or superseded reply, an `ensure` that skips a fresh

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -77,7 +77,7 @@ letters, not keys: pressing one selects nothing, and the palette entry is
 | Tab | Tooltip | Question it answers |
 |---|---|---|
 | **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + full topology (picker + zoom/pan/fit) + a 4-mode sub-strip incl. the Sim engine. |
-| **Routes** | `r` | "Which route would `/orders/42` match?" Every registered route + a Simulate-URL input. |
+| **Routes** | `r` | "Which route would `/orders/42` match?" Every registered route + a Simulate-URL input + a per-row Simulate navigation preview (matched params, the `:on-match` event, the expected route slice; hermetic, nothing is dispatched). |
 | **Schemas** | `c` | "Show me the shape of `:order/schema`." Every registered app-db / event / sub schema as its Malli EDN, with `:doc`, searchable, + jump-to-source. |
 | **Flows** | `f` | "What flows are registered?" The flows catalogue. |
 | **Interceptors** | `i` | "What runs, and in what order?" Pure-browse over the registered interceptor chains. |


### PR DESCRIPTION
## Summary

rf2-askl: skills/re-frame2-xray. The launch decision tree has never rendered and misroutes one branch. The skill answers only one of the four `status()` reasons. There are five smaller drifts. F1-F5 and F7-F9 land here; F6 is skipped (reason below).

- **F1 + F5 (P2/P3).** `references/launch-modes.md`'s decision tree was a fenced block. Its two-column lines had collapsed at authoring, so it never rendered as a tree. It also sent "rf/init! has not run" to Xray's own `init!`. It is now a nested list: 5 questions and 6 leaves. The bead says 4 questions, but the faithful tree also asks the second-monitor and layout-column questions. The `rf/init!` branch now sends the reader to the host's own `(rf/init! adapter)`. The preload polls 120 x 50 ms and then records `:no-substrate-adapter` (mount.cljs, the auto-open tick).
- **F2 (P2).** `§Missing host` is renamed `§Launch diagnostics`. It carries a four-row reason/ok?/meaning/fix table: `:missing-layout-host`, `:no-substrate-adapter`, `:auto-open-disabled` (`:ok? true`) and the reserved `:unsupported-substrate`. SKILL.md gets one clause. `launch-lifecycle.md` §Pop-out names `popout!`'s return shapes (`:popup-blocked`, `:no-substrate-adapter`).
- **F2 adjacent: `docs/xray/api/mount-control.md`.** It now carries the same reason vocabulary. Its `status` description named a key that does not exist (`:last-host-diagnostic`), now corrected to the real keys (`:mounted? :visible? :mode :diagnostic :host-selector :auto-open?`). The same wrong key sat in one row of `docs/xray/api/reference.md`, fixed there too. That file is outside this worker's fence table, but no row holds it.
- **F3 (P3).** One adapter-neutrality sentence under SKILL.md §Launching, mirrored in launch-modes.md §Install the preload. The per-panel mount exception is deliberately not taught.
- **F4 (P3).** Snap-to-LIVE is unshifted `l` (keybinding.cljs `spine-key-id`: `(and (not shift?) (or (= "l" k) (= "KeyL" code)))`). There were four sites, not three: SKILL.md has two, one in the hotkey table and one in the chrome bullet. Evals 4 (`launch-hotkey`) and 5 (`hotkey-mode-toggle`) gain `expected_output` + `expectations[]` naming the chords. The evals README coverage table and Layer-2 count move with them (20 -> 22).
- **F7 (P4).** One caveat bullet under §Pop-out. No key opens the pop-out. Inside it, every hotkey works except `Ctrl+Shift+C`, which is opener-owned and falls through to the browser there (keybinding.cljs `popout-surface`).
- **F8 (P4).** One clause on Static Routes' per-row hermetic Simulate navigation preview (`static/routes/simulate_nav.cljs`). It goes on the Static Routes row of `panels.md` and on the "Open when" paragraph of `panels-domains.md`. **Neither is a held rf2-fzbj.43 row.** The held Dynamic Routes row (`panels.md` Dynamic table) and the stale two-block layout (`panels-domains.md` §Routes) are untouched.
- **F9 (P4).** The bead said the Resources panel renders 8 sections. At tip, `panel-tree` in `panels/resources.cljs` composes **14**, two of them quiet until they have data. The list now names all 14 in rendered order.

**Skipped: F6 (optional S-series for the Static roster in `scripts/check_skill_xray_tab_inventory_drift.py`).** Reason: the Static roster matches the shipped registry at tip (Machines m 0, Routes r 1, Schemas c 2, Flows f 3, Interceptors i 4). This PR fixes no Static-roster defect for it to guard, and the stance defaults optional gate candidates to not-built.

## Where this differs from the bead

- **F2.** The `status` docstring in `mount.cljs` lists three live reasons. It says `popout!`'s reasons are "not published here", which is true of `popout!`. But the preload's give-up path writes `:no-substrate-adapter` into the same `diagnostic-state` that `status()` returns, so the four-reason table is correct and the docstring is incomplete. `tools/xray/src` is outside this fence, so that docstring is a follow-up and is not edited here.
- **F5** is 5 questions / 6 leaves, not 4 / 6. **F4** is 4 sites, not 3. **F9** is 14 sections, not 8.
- No change here is a Codex rf2-fzbj.43 finding.

## Quality gates

Every exit code below is one I captured from the runner itself, on the rebased base (attempt 2):

| Gate | Exit | CI job |
|---|---:|---|
| `scripts/check_skill_xray_tab_inventory_drift.py --self-test` / `--verbose --ci` | 0 / 0 | `test.yml` `verify-skill-mcp-drift` |
| `scripts/check_skill_eval_docs.py --self-test` / `--verbose --ci` | 0 / 0 | `test.yml` `verify-skill-mcp-drift` |
| `scripts/check_doc_slugs.py --verbose` (covers `skills/` and `docs/`) | 0 | `test.yml` `verify-readme-links` |
| `scripts/check_readme_links.py --ci` | 0 | `test.yml` `verify-readme-links` |
| `scripts/check_skill_description_budget.py --verbose --ci` | 0 | `test.yml` `verify-readme-links` |
| `scripts/check_skill_package_refs.py`, `check_skill_eval_packaging.py`, `check_skill_mcp_drift.py`, `check_skill_redirect_anchors.py`, `check_retired_spellings.py` | 0 each | `test.yml` `verify-skill-mcp-drift` |
| `python -m mkdocs build --strict` (covers `docs/xray/api/*.md`) | 0 | `docs.yml` `build` |
| `scripts/check_retired_composition_vocab.py`, `check_retired_image_keys.py` (ratchets) | 0 each | `docs.yml` `build` |
| `clojure -M -m re-frame.api-manifest.skills-check` (617 public-var refs) | 0 | `lint.yml` `api-manifest` |

**Proof the gates read this tree.** None of them prints its root, so the proof is a planted fault that exists only in this tree. Each was a single-line plant with its match count read first (1 each). Every one went red, then was restored and checked by blob hash, default form or no-filters form:

- `check_doc_slugs.py`: exit 1, naming the planted anchor at `launch-modes.md:19`. This also shows the gate now sees the tree's links, which it could not while they sat inside a fence.
- `mkdocs build --strict`: exit 1 on a planted link target in `mount-control.md`.
- xray tab drift gate: exit 1 on a planted mnemonic swap in SKILL.md (A3).
- `check_skill_eval_docs.py`: exit 1 with the eval-4 table row removed (A2 names).
  - The first plant for this gate, on the "22 positives" figure, stayed **green**. That figure is not a graded token; the gate grades the table's ID set, the total sentence and the tally. So the 22 was checked by hand instead.

**Checked by hand (no gate covers these).** Nothing validates prose, tables or rendering, so:

- The nested decision tree was read back line by line (indentation 3/5 under an ordered list).
- Every edited table was counted for consistent columns: launch-modes reason table 4 columns, mount-control reason table 3, evals README 4, and the SKILL.md / panels.md / launch-lifecycle.md tables all consistent.
- `evals.json` parses: 33 evals, 22 carrying `expectations[]`.
- Line endings were checked with Python on the bytes: CR == CRLF == LF in all 12 files.

The three-dot diff against the merge base was read for reverts. Every removed line is one of this PR's intended hunks.
