### PR TITLE
docs(xray,pair): name :no-substrate-adapter in the status docstring; resolve the replay-epoch Tool-Pair cite (rf2-cd45)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -2254,7 +2254,8 @@
 
 (defn replay-epoch
   "(rf/replay-epoch! frame-id epoch-id {:origin :pair}) — the ONE-CALL strict
-   replay of a retained epoch (rf2-ov144, Tool-Pair §Replay). The framework
+   replay of a retained epoch (rf2-ov144; Tool-Pair §Time-travel, the
+   `replay-epoch` and `replay-mint-policy` anchors). The framework
    resolves the raw record in-process and re-drives its `:trigger-event`
    with the recorded post-generation `:rf.cofx` under
    `:rf.cofx/mint-policy :strict` plus the record's own `:fx-overrides` /

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -160,6 +160,9 @@
 
   - `:missing-layout-host` — no element matched the configured
     `[data-rf-xray-host]` selector; nothing mounted (`console.error`).
+  - `:no-substrate-adapter` — the preload waited about 6 s for a
+    substrate adapter and none arrived: the host never called
+    `rf/init!`. Recorded only while auto-open is on.
   - `:auto-open-disabled` — the preload found auto-open switched off.
     Health, not failure: `:ok?` stays true.
   - `:unsupported-substrate` — **RESERVED, NEVER PRODUCED** (rf2-k97c.4).
@@ -171,8 +174,9 @@
     read surface a consumer may key on; it is not recycled for any other
     meaning.
 
-  `popout!` additionally answers `:no-substrate-adapter` and
-  `:popup-blocked` in its own RETURN value; neither is published here."
+  `popout!` answers `:popup-blocked` and `:no-substrate-adapter` in its
+  own RETURN value and publishes neither here; the preload's
+  `:no-substrate-adapter` above is a separate write."
   []
   {:mounted?      (mounted?)
    :visible?      (visible?)


### PR DESCRIPTION
Two docstring accuracy fixes for rf2-cd45. **Docstrings only; no behaviour change.**

## What landed

1. **`tools/xray/src/day8/re_frame2_xray/mount.cljs`: the `status` docstring now lists four `:diagnostic` `:reason` values.** `:no-substrate-adapter` was missing. Confirmed at source: the preload's auto-open tick gives up after 120 × 50 ms with no adapter installed and, when auto-open is on, calls `report-diagnostic!`. That function `reset!`s the same `diagnostic-state` atom that `status` returns under `:diagnostic`. The one-line meaning matches the four-row table PR #9734 landed in `docs/xray/api/mount-control.md` and `skills/re-frame2-xray/references/launch-modes.md`.
   * The docstring's closing sentence said `:no-substrate-adapter` is "neither … published here". That became false once the reason was listed, so it now says `popout!`'s return-value copy is not published here and the preload's write is a separate one.
2. **`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`: the `replay-epoch` docstring cite.**
   * It read "Tool-Pair §Replay". `spec/Tool-Pair.md` has no heading of that name.
   * It now names the real heading, §Time-travel (`## Time-travel: epoch snapshots and undo`), and the two anchors under it: `replay-epoch`, the rf2-ov144 one-call gesture this function wraps, and `replay-mint-policy`, the strict-replay contract it performs.
   * The held rf2-fzbj.15 lines in this file are untouched.

## A finding on item 2's premise

"Tool-Pair §Replay" is not a one-off stale cite; it is a working label used at roughly 50 sites across `implementation/`, `tools/` and `spec/`. `spec/Tool-Pair.md` uses it itself: rows at lines 310 and 617 render `[§Replay](#replay-epoch)`. So the label is established shorthand for the `replay-epoch` anchor, even though no heading carries it. This PR fixes only the one docstring the bead names. A tree-wide sweep would be taste at P4 and would cross several files other workers hold, so it is not proposed.

## Fences

No `rf2-fzbj.*` or `rf2-gwye.*` finding is touched. Both files are this worker's rows in the wave's fence table.

## Quality gates

- **Worker worktree guard.** `sh scripts/assert-worker-worktree.sh` ran before the first edit and exited 0.
- **Pair preload structural pins.**
  * CI job: `skills-structural` (*Skills structural tests (changed skill paths only)*, `.github/workflows/test.yml`). It runs `bb tests/prompts/prompt_regression_test.clj` and every `tests/runtime/*_test.clj` from `skills/re-frame2-pair`. The runtime pins parse `runtime.cljs`.
  * Local run on the final commit: captured exit 0; 14 suites, 0 failures, 0 errors.
  * Proof it read this tree: an invalid string escape planted on the edited docstring line turned the same run red, captured exit 1. The failures fell in the pure-delegation, recorder, undo-restore, frame-registrar and DOM-readback pins.
  * The file was then restored. Its default-form blob hash equals the committed blob, and `git diff --quiet` reports exit 0. A post-restore re-run was green again: captured exit 0, 14 suites, 0 failures.
- **CLJS compile of both files.**
  * Local: `npx shadow-cljs compile examples/two-frame-isolation` from `implementation/`. That build preloads both `re-frame2-pair.runtime` and `day8.re-frame2-xray.preload`, and the Xray preload requires `day8.re-frame2-xray.mount`.
  * Result: captured exit 0, `546 files, 545 compiled, 0 warnings`. The config line it printed named this worktree's `shadow-cljs.edn`.
  * In CI, `cljs-examples-compile` (*CLJS (compile every standalone example build, coverage gate)*) compiles the same build. `mount.cljs` is also compiled by `cljs` (*CLJS (shadow-cljs :node-test)*), whose `:node-test` build takes `tools/xray/{src,test}`. That full `:node-test` run is **relied on from CI**, not reproduced locally.
- **clj-kondo.**
  * CI: `lint.yml`'s `clj-kondo` job lints `tools/`, which includes `mount.cljs`.
  * Local: `clj-kondo --fail-level error` over both files exited 0 with 0 errors. There are 8 warnings, all pre-existing and none on an edited line.
  * The local version (2025.10.23) is not CI's pinned one (2026.04.15), so this run is indicative and CI is authoritative.
- **Final base.**
  * The branch was rebased onto trunk `e1dbf0ed5e`. None of the five commits it picked up touches either edited file.
  * Both gates were re-run on the rebased tree. The pair lane captured exit 0 (14 suites, 0 failures). The `two-frame-isolation` compile captured exit 0 with 0 warnings, and again named this worktree's config.
- **Other CI jobs these paths trigger.** `.github/scripts/report-changed-surfaces.sh` lights these surfaces for the two paths: `cljs_node_test`, `cljs_browser`, `examples_compile`, `tools_jvm`, `mcp_conformance`, `mcp_live`, `story_xray_browser`, `skills_structural`. All of them run in CI.

**No gate reads docstring prose.** The gates above prove that both files still parse and compile, and that the pair runtime's structural pins still hold. Whether the wording is accurate was checked by hand against the source and the PR #9734 table. No markdown changed, so `scripts/check_doc_slugs.py` and `scripts/check_readme_links.py` have nothing of this diff to read.
