### PR TITLE
fix(skills/re-frame-migration): M-1 keeps the re-frame.subs.tooling import O-12 requires (rf2-z9xl)

### DIFF
--- a/scripts/check_skill_migration_contract_drift.py
+++ b/scripts/check_skill_migration_contract_drift.py
@@ -209,7 +209,11 @@ A fourth, structurally different guard (rf2-3fc89f.35) rides the same gate:
     must-exempt set with four public namespaces the filter had omitted
     (`re-frame.resources`, `re-frame.story`, `re-frame.fresco`,
     `re-frame.test-helpers`) — the skill routes into two of them, and M-1's
-    rewrite removes the require outright.
+    rewrite removes the require outright. rf2-z9xl added the exact
+    `re-frame.subs.tooling` (O-12 routes tools and tests into it; there is no
+    `re-frame.core` alias) and the private `re-frame.subs.cache` sibling as a
+    must-flag control, so the exemption cannot widen to the `re-frame.subs`
+    subtree.
 
   * **M-51 sweep — the executable unary-`reg-fx` sweep must see every common
     unary shape (rf2-0tur).** M-51 is SILENT-fail: a unary fx handler compiles,
@@ -1354,6 +1358,9 @@ M1_FLAG_NSES = [
     "re-frame.events", "re-frame.registrar", "re-frame.loggers",
     "re-frame.interceptor", "re-frame.fx", "re-frame.cofx",
     "re-frame.std-interceptors",
+    # rf2-z9xl: a private subs sibling. With bare `re-frame.subs` it proves the
+    # `re-frame.subs.tooling` exemption stays exact, not subtree-wide.
+    "re-frame.subs.cache",
 ]
 # The M-1 scan MUST NOT flag these (the public-surface exceptions — the
 # invert-filter removes them).
@@ -1369,6 +1376,9 @@ M1_EXEMPT_NSES = [
     # "remove the :require entirely", so a false flag deletes a live import.
     "re-frame.resources", "re-frame.story", "re-frame.fresco",
     "re-frame.test-helpers",
+    # rf2-z9xl: O-12 tells tools, dev overlays and tests to require this exact
+    # namespace (sub-topology / sub-cache-snapshot), and core has no alias.
+    "re-frame.subs.tooling",
 ]
 
 # Extract the documented rg patterns. The broad-scan line ends `' . \` (space-dot);
@@ -1501,6 +1511,7 @@ def m1_anchor_problems() -> list[str]:
             )
         for token in (
             "re-frame.adapter", "re-frame.spec", "re-frame.interop", "re-frame.core",
+            "re-frame.subs.tooling",
         ):
             if token not in acs:
                 problems.append(
@@ -3088,7 +3099,17 @@ def _self_test() -> int:
     good_broad = re.compile(r"\[\s*re-frame\.[a-z-]+")
     good_invert = re.compile(
         r"\[\s*re-frame\.(adapter|core|interop|schemas|machines|routing|flows|"
+        r"http|ssr|epoch|resources|fresco|story|subs\.tooling|test-support|"
+        r"test-helpers|spec)\b"
+    )
+    pre_z9xl_invert = re.compile(  # the rf2-0tur filter rf2-z9xl widened
+        r"\[\s*re-frame\.(adapter|core|interop|schemas|machines|routing|flows|"
         r"http|ssr|epoch|resources|fresco|story|test-support|test-helpers|spec)\b"
+    )
+    subtree_invert = re.compile(  # the over-wide fix rf2-z9xl refuses: all of subs
+        r"\[\s*re-frame\.(adapter|core|interop|schemas|machines|routing|flows|"
+        r"http|ssr|epoch|resources|fresco|story|subs|test-support|test-helpers|"
+        r"spec)\b"
     )
     bad_invert = re.compile(  # the exact pre-fix filter — no `adapter`, no `spec`
         r"\[\s*re-frame\.(core|interop|schemas|machines|routing|flows|"
@@ -3133,6 +3154,16 @@ def _self_test() -> int:
     for ns in rf2_0tur_nses:
         m1_expect(ns, good_invert, "exempt", f"M1-good-exempt {ns}")
         m1_expect(ns, pre_0tur_invert, "flag", f"M1-regression-detected {ns}")
+    # rf2-z9xl: the exact O-12 tooling namespace is exempt and the rf2-0tur filter
+    # flagged it; bare subs, db and a private subs sibling stay flagged, and the
+    # subtree-wide spelling is caught because it exempts those two subs controls.
+    ns = "re-frame.subs.tooling"
+    m1_expect(ns, good_invert, "exempt", f"M1-good-exempt {ns}")
+    m1_expect(ns, pre_z9xl_invert, "flag", f"M1-regression-detected {ns}")
+    for ns in ("re-frame.subs", "re-frame.db", "re-frame.subs.cache"):
+        m1_expect(ns, good_invert, "flag", f"M1-good-flag {ns}")
+    for ns in ("re-frame.subs", "re-frame.subs.cache"):
+        m1_expect(ns, subtree_invert, "exempt", f"M1-subtree-overreach-seen {ns}")
 
     # --- M-51 sweep fixtures (rf2-0tur) -----------------------------------------
     # The corrected sweep sees all four unary shapes and skips the binary control;

--- a/skills/re-frame-migration/references/auto-call-site-rewrites.md
+++ b/skills/re-frame-migration/references/auto-call-site-rewrites.md
@@ -50,6 +50,7 @@ This is the **single, canonical allowlist** of `re-frame.*` namespaces the M-1 s
 - **`re-frame.interop`** (JVM interop) — explicitly preserved (see [`breaking-changes.md` §What stays the same](breaking-changes.md#what-stays-the-same-do-not-change)). Not off-contract; leave it.
 - **`re-frame.spec`** — the namespace is **NOT renamed**; its alias is preserved for back-compat. M-54 renames the `:spec` metadata *key* to `:schema` — it does **not** touch the `re-frame.spec` *namespace* (see [`auto-cross-cutting.md` §M-54](auto-cross-cutting.md#m-54--schema-vocabulary-unification-spec--schema) / [`MIGRATION.md` §M-54](https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#m-54-schema-vocabulary-unification--spec--schema)). Leave the require in place; boundary validation is opted into with `:boundary? true` on the registration, never by rewriting the require away.
 - **The v2-only public namespaces** — `re-frame.resources` (declarative server-state; the re-frame-query conversion lands here), `re-frame.fresco` (the re-frame-native view layer the reagent-migration hand-off targets), `re-frame.story` (Story), and the test-side `re-frame.test-helpers` (view-assertion helpers, a documented public exception in `spec/API.md`). Each has manifest rows, and a migration routes *into* the first two — flagging them would have M-1 delete a live import.
+- **`re-frame.subs.tooling`** — the subscription-tooling namespace (`sub-topology` / `sub-cache-snapshot`) that [O-12](https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#o-12-introspect-the-static-sub-graph-via-re-framesubstoolingsub-topology) tells tools, dev overlays and tests to require. `re-frame.core` has no alias for either fn (`spec/API.md` §Public registrar query API), so flagging it would have M-1 delete a live import. The exemption covers **this exact namespace only**: bare `re-frame.subs` and its private siblings, such as `re-frame.subs.cache`, stay M-1 sites.
 
 **`re-frame.std-interceptors` is NOT on the surface** — it is off-contract, and its v1 helpers (`unwrap` / `debug` / `trim-v` / `on-changes` / `enrich` / `after`) are removed under M-21, so a require of it is itself an M-1 site and each helper call site is an M-21 / M-19 / M-70 rewrite.
 
@@ -66,11 +67,13 @@ Everything else under `re-frame.*` is off-contract. `re-frame.alpha` is **not** 
 # in step. `adapter\b` exempts all three published adapters (M-38/M-40 destination);
 # `http\b` covers re-frame.http.managed / .http.test-support (the \b fires at
 # the following dot); `spec\b` exempts the preserved re-frame.spec (M-54);
-# `resources|fresco|story|test-helpers` exempt the v2-only public namespaces.
-# Private re-frame.db / .utils / .router / .subs / .registrar / .loggers are NOT
-# listed, so they survive and ARE flagged.
+# `resources|fresco|story|test-helpers` exempt the v2-only public namespaces;
+# `subs\.tooling` exempts exactly the O-12 subscription-tooling namespace, never
+# the whole subs subtree.
+# Private re-frame.db / .utils / .router / .subs / .subs.cache / .registrar /
+# .loggers are NOT listed, so they survive and ARE flagged.
 rg -n '\[\s*re-frame\.[a-z-]+' . \
-  | rg -v '\[\s*re-frame\.(adapter|core|interop|schemas|machines|routing|flows|http|ssr|epoch|resources|fresco|story|test-support|test-helpers|spec)\b'
+  | rg -v '\[\s*re-frame\.(adapter|core|interop|schemas|machines|routing|flows|http|ssr|epoch|resources|fresco|story|subs\.tooling|test-support|test-helpers|spec)\b'
 ```
 
 (**Do not** reach for an inline negative-lookahead — `rg -n '\[\s*re-frame\.(?!core\b|…)…'` — in the *default* engine: ripgrep's default Rust `regex` engine rejects look-around and exits non-zero *before scanning* with "look-around … is not supported", so the M-1 inventory silently produces nothing and reads as a false-clean sweep. The broad-scan-then-invert-filter form above works on **any** ripgrep build; an equivalent single-command form needs `rg -P`/`--pcre2`, which only works on a ripgrep compiled with PCRE2. Each surviving hit is an M-1 site: find a public equivalent in `re-frame.core`, or — if none — flag for human review with the call site and what it is doing.)


### PR DESCRIPTION
Fixes rf2-z9xl, which the merged-PR audit of #9733 (rf2-0tur) filed.

## Summary

The migration skill's M-1 public-surface allowlist and its executable two-stage `rg` invert filter both omitted `re-frame.subs.tooling`. O-12 tells tools, dev overlays and tests to require that exact namespace, for `sub-topology` and `sub-cache-snapshot`, and `re-frame.core` has no alias for either. So the sweep flagged a required import, and M-1's "remove the `:require` entirely" rewrite would have deleted it.

- **`skills/re-frame-migration/references/auto-call-site-rewrites.md`**: adds the exact namespace to the canonical allowlist prose and to the invert alternation, as `subs\.tooling`. Bare `re-frame.subs`, `re-frame.db` and the private subs siblings stay flagged. The whole `re-frame.subs` subtree is **not** exempted.
- **`scripts/check_skill_migration_contract_drift.py`**:
  - `re-frame.subs.tooling` goes on the must-exempt list, and `re-frame.subs.cache` on the must-flag list, so a subtree-wide exemption goes red.
  - The prose token is pinned.
  - The self-test covers both the pre-fix filter and the subtree-wide spelling.

## The control

- **Pre-fix leaf against the updated gate:** `--ci` exits 1 with `M1-FALSE-POSITIVE` for `re-frame.subs.tooling`, plus `M1-EXCEPTIONS-INCOMPLETE`.
- **Fixed leaf:** `--ci` exits 0. The classifier now runs over 32 representative requires, up from 30.
- **Plant A** drops `subs\.tooling` from the committed leaf's invert line. `--ci` exits 1 with exactly one error, `M1-FALSE-POSITIVE re-frame.subs.tooling`.
- **Plant B** swaps in a bare `subs`, the subtree-wide fix the bead forbids. `--ci` exits 1 with two errors, `M1-FALSE-NEGATIVE` for `re-frame.subs` and for `re-frame.subs.cache`.
- **Restores:** both were verified by blob hash. The restored file's default-form blob hash equals the committed blob (the file is `i/lf`), and `git diff --quiet` exits 0.
- **The copied fence, run directly.** Link gates skip fences, so both extracted patterns went through real ripgrep 14.1.1 over 11 require lines:
  - Pre-fix: 1 of 11 misclassified (`re-frame.subs.tooling` flagged).
  - Fixed: 0 of 11 misclassified.
  - Controls, all correct on the fixed run: `re-frame.subs`, `.db`, `.subs.cache` and `.subs.memo` flagged; `core`, `resources`, `fresco`, `story`, `test-helpers` and `adapter.reagent` kept.

## Census: does any other namespace migrators are told to require fail the same way?

- **Against `spec/api-manifest.edn`:**
  - The manifest has 31 distinct `re-frame.*` namespaces. The filter flags 4: `re-frame.mcp-base.elision`, `re-frame.mcp-base.sensitive`, `re-frame.performance` and `re-frame.trace.projection`. None is named anywhere in `migration/from-re-frame-v1/` or `skills/re-frame-migration/`, and no migration routes into them, so none was added. Adding them would be a speculative widening.
  - **The manifest has no row for `re-frame.subs.tooling` at all.** It is documented only in `spec/API.md` Â§Public registrar query API. So a census against the manifest alone cannot see the namespace this bead is about.
- **Against the migration corpus and the skill:** a second census took all 58 `re-frame.*` tokens in `migration/from-re-frame-v1/` and `skills/re-frame-migration/`.
  - `re-frame.subs.tooling` is the only namespace migrators are told to require that the filter flags.
  - The other flagged tokens are v1 internals to remove, v1 names that other rules rename (`alpha`, `substrate`, `test`), the codemod's own namespaces, or internals the corpus names without telling anyone to require them (`trace.tooling`, `event-emit`, `error-emit`, `frame`, `late-bind`).
- **Near miss, filed rather than fixed: rf2-1zsa.** O-18's `observability-logging-sweep.md` samples call `re-frame.elision/elide-wire-value` directly. `spec/API.md` rules that walker internal (rf2-kuky.9 ruling A), so M-1 is right to flag it, and it is the sample that is stale. The file is outside this fence.
- **Observation, not built:** every alternative in the invert filter ends in `\b`, and `\b` fires at a hyphen. So `core\b` also exempts the internal `re-frame.core-epoch`, and `subs\.tooling\b` would exempt a hypothetical `re-frame.subs.tooling-x`. This class predates the PR, and no v1 app requires either namespace, so it was left alone.

## Quality gates

These are local exit codes on the final base (`origin/main` at `601dee93cb`). Each was captured with its own redirect and exit file.

| Gate | Local exit | CI job |
|---|---|---|
| `scripts/check_skill_migration_contract_drift.py --self-test` | 0 | `verify-skill-mcp-drift` (Repo invariant checks (skills, MCP, catalogues, namespaces)) |
| `scripts/check_skill_migration_contract_drift.py --verbose --ci` | 0 | `verify-skill-mcp-drift` |
| `scripts/check_skill_migration_o1617_router_drift.py --self-test` / `--verbose --ci` | 0 / 0 | `verify-skill-mcp-drift` |
| `scripts/check_skill_migration_cites.py --self-test` / `--verbose --ci` | 0 / 0 | `verify-skill-mcp-drift` |
| `scripts/check_doc_slugs.py --self-test --verbose` / `--verbose` | 0 / 0 | `verify-readme-links` |

`check_doc_slugs.py` covers `skills/` by path. It reads no fenced block and does not validate the absolute GitHub URL to O-12. Three things were checked by hand:

- The new bullet's O-12 anchor is the same slug the migration README itself links to in-file, and the slug gate validates that one.
- The `rg` fence was verified with real ripgrep, as above.
- No tables were touched.

The full check rollup is left to CI.

The worker worktree guard ran and exited 0. The PR touches no hot-zone files and none of the held `rf2-fzbj.*` / `rf2-gwye.*` findings.
