### PR TITLE
docs(pair,spec,skills): retire rf/sub-cache and the implementor 'or substrate' wording (rf2-p4dd, rf2-yog0)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -28,7 +28,7 @@ The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKI
 | [**re-frame2-setup**](re-frame2-setup.md) | Bootstrap a fresh re-frame2 ClojureScript project from nothing. Walks the author to a working counter under `shadow-cljs watch`. |
 | [**re-frame-migration** (v1→v2)](re-frame-migration.md) | Migrate an existing re-frame v1.x codebase to re-frame2. Applies the mechanical `M-rules` automatically; flags judgment calls. |
 | [**reagent-migration** (views→Fresco)](reagent-migration.md) | The genuinely **optional, second** step after v1→v2: rewrite Reagent **view** code into **Fresco**, re-frame2's re-frame-native view layer. Runs the migration reporter, applies the mechanical `MIG` rewrites, reasons through the judgment calls, declines what Fresco has no equivalent for. The v1→v2 move **completes on its own** — the Reagent adapter is first-class and no view rewrite is required to land on re-frame2. |
-| [**re-frame2-implementor**](re-frame2-implementor.md) | Build a new re-frame2 implementation in a different host language or substrate. Two-phase workflow — Phase 1 locks the decisions; Phase 2 walks the spec corpus with conformance as the acceptance test. |
+| [**re-frame2-implementor**](re-frame2-implementor.md) | Build a new re-frame2 implementation in one of the eight in-scope JS-cross-compile-to-React+VDOM host languages. Two-phase workflow — Phase 1 records the port profile; Phase 2 walks the spec corpus with conformance as the acceptance test. |
 | [**re-frame2-xray**](re-frame2-xray.md) | Read-only tour of the **Xray** devtools panel — how to launch it and which tab, across its Dynamic event-spine and Static registry-browse modes, shows X. |
 | [**re-frame2-pair**](re-frame2-pair.md) | Pair-program with a live, running re-frame2 app. Dispatch events, inspect `app-db`, walk epochs, hot-swap handlers — all via Tool-Pair contract. |
 | [**re-frame2-pair-retro**](re-frame2-pair-retro.md) | Retrospect a `re-frame2-pair` session. Surfaces friction; proposes targeted improvements; routes upstream GitHub issues to re-frame2 when the cause is framework-shaped. |
@@ -42,7 +42,7 @@ A quick decision flow (human-facing rendering of [`skills/README.md` §Skill rou
 - **Already on re-frame2 and want Fresco, the re-frame-native view layer, for your Reagent views?** → `reagent-migration` (a genuinely optional second step — the Reagent adapter is first-class, so staying put is a complete configuration, and Fresco is pre-publication).
 - **Writing new code in an existing v2 project?** → `re-frame2`.
 - **Critiquing existing v2 code on explicit pull (anti-pattern audit)?** → `re-frame2-improver`.
-- **Building a NEW re-frame2 implementation in a different host language or substrate?** → `re-frame2-implementor`.
+- **Building a NEW re-frame2 implementation in one of the eight in-scope JS-cross-compile-to-React+VDOM host languages?** → `re-frame2-implementor`.
 - **Touring the Xray devtools panel — how to launch it, or which tab / mode shows X?** → `re-frame2-xray`.
 - **Debugging or pairing with a running v2 app?** → `re-frame2-pair`.
 - **Just finished a pairing session and noticed friction?** → `re-frame2-pair-retro`.

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -974,8 +974,8 @@
 ;; ---------------------------------------------------------------------------
 
 (defn sub-cache
-  "(rf/sub-cache frame-id) — public Tool-Pair surface returning
-   `{query-v {:value v :ref-count n}}` for every materialised
+  "Tool-Pair sub-cache read: `(rf.subs.tooling/sub-cache-snapshot frame-id)`,
+   returning `{query-v {:value v :ref-count n}}` for every materialised
    subscription in the operating frame. CLJS-only; nil on JVM."
   ([] (sub-cache (current-frame)))
   ([frame-id]

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1573,7 +1573,7 @@ External tools consume re-frame2 through stable surfaces. Production builds elid
 | Hoisted top-level fields (`:source`, `:recovery`) | Preserved |
 | `re-frame.interop/debug-enabled?` (alias of `goog.DEBUG`) | Preserved |
 | Compile-time elision via `goog.DEBUG=false` + `:advanced` | Preserved |
-| Public registrar query API (`registrations`/`handler-meta`/`frame-ids`/`frame-meta`/`app-db-value`/`frame-state-value`/`sub-topology`/`sub-cache`) | See [002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api) |
+| Public registrar query API (`registrations`/`handler-meta`/`frame-ids`/`frame-meta`/`app-db-value`/`frame-state-value`/`sub-topology`/`sub-cache-snapshot`) | See [002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api) |
 | Hot-reload notifications (`:rf.registry/handler-registered`, `:rf.registry/handler-cleared`, `:rf.registry/handler-replaced`, `:rf.frame/created`, `:rf.frame/destroyed`) | Trace events |
 
 ### Capabilities tools depend on


### PR DESCRIPTION
Two stale-wording stragglers, rf2-p4dd and rf2-yog0. Each was found by census by an earlier worker who could not edit it because another holder owned the file. Five lines change across three files.

## rf2-p4dd: the retired `rf/sub-cache` spelling

- **`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`**, the `sub-cache` fn docstring (line 977). It opened `(rf/sub-cache frame-id) — public Tool-Pair surface`, naming a facade alias that is no longer in `re-frame.core`. It now reads `Tool-Pair sub-cache read: (rf.subs.tooling/sub-cache-snapshot frame-id), returning {query-v {:value v :ref-count n}} …`, which names the call the fn body two lines below actually makes. Only the docstring changes; the fn body is untouched. The rf2-fzbj.15 call-time-validation lines in this file are HELD and were not touched.
- **`spec/009-Instrumentation.md`**, the "Public registrar query API (…)" row (line 1576). The list entry `sub-cache` is now `sub-cache-snapshot`, spelled as `spec/002-Frames.md` §The public registrar query API spells it. Nothing else in spec/009 changed: every other bare `sub-cache` there names the cache itself, the MCP tool, the pair-runtime fn or the snapshot slice, and all of those still exist.

## rf2-yog0: the implementor entry in `docs/skills/index.md`

- **The table row (line 31)** now reads "in one of the eight in-scope JS-cross-compile-to-React+VDOM host languages", replacing "in a different host language or substrate". It also says "Phase 1 records the port profile" in place of "Phase 1 locks the decisions".
- **The "Picking the right one" bullet (line 45)** makes the same scope change.
- The wording comes from the page's own routing source, the implementor row of `skills/README.md`, and from the change PR #9741 proposed for this page in its body. It also matches the first sentence of the implementor `SKILL.md` description. The row names the scope, not the eight-host roster; the roster lives in the source row and on the skill's own page.

## Premises, checked at tip `031ff49a38`

- `re-frame.core` defines no `sub-cache`. `core.cljc` carries only `clear-sub-cache!` and prose mentions.
- `spec/002-Frames.md` names the query `re-frame.subs.tooling/sub-cache-snapshot`, and says the `rf/sub-cache` alias was removed (rf2-80mmlf).
- A repo-wide census for "host language or substrate" and "Phase 1 locks" (`.beads` excluded) found exactly the two `docs/skills/index.md` lines. Both are fixed.

## Ratchets

No ratchet reads the retired `rf/sub-cache` spelling on these paths:
- `skills-check` (lint.yml `api-manifest` job) reads only `skills/**/*.md`, so it never sees `runtime.cljs`.
- `xray-spec-check` reads `tools/xray/spec/API.md`.
- spec/009's row lists bare names in backticks, not the call-position `(rf/` form those extractors match.

## Quality gates

Each exit code below was captured from the runner itself: output was redirected to a log and the exit echoed on the same command line, never piped. All three ran on the committed tree at the final base. Trunk has not moved since this branch was cut, so no rebase happened between the gates and this push.

| Gate (by path) | Exit | CI job |
|---|---|---|
| Pair structural pins: `skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj` plus all 13 `tests/runtime/*_test.clj`, run with `bb` | 0 | `skills-structural` (test.yml) |
| `scripts/check_doc_slugs.py --verbose` | 0 | `verify-readme-links` (test.yml) |
| `python -m mkdocs build --strict` | 0 | `build`, "MkDocs build" (docs.yml) |

Each gate was shown to read this tree:

- **`check_doc_slugs.py`**: I planted a bogus anchor on `docs/skills/index.md:45`. The gate went red (exit 1) and named that line.
- **Pair structural pins**: I planted an unbalanced quote in the edited docstring. The run went red (exit 1), with 9 of the 13 runtime test files failing.
- **mkdocs**: the built site carries the new text on both edited pages, and that text exists only in this branch.

Both plants were restored. For each, the default-form blob hash matches the committed blob and `git diff --quiet` exits 0.

**Checked by hand, because no gate reads them:**
- The docstring and both prose edits, read back.
- The table row still has two cells.
- Line endings in all three files are uniform CRLF, with no bare CR, measured from the bytes.

## Merge-base diff

`origin/main...HEAD` removes only the five lines this change replaces on purpose. It reverts nothing.

## HELD, not touched

- No rf2-fzbj or rf2-gwye finding is touched, and none of these changes is one of them.

## Noted, not edited

- `docs/skills/re-frame2-implementor.md:3` still says "in a different host language". It does not say "or substrate", and the paragraph right after it scopes the skill to the eight in-scope hosts. It is outside both beads and not wrong, so I left it.
