### PR TITLE
fix(ssr-node): contain malformed targets, settle boot exits, keep split surrogates, refuse unechoable requestIds

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -280,7 +280,9 @@ Joining is the transport's decision, made once, at the edge. The HTTP
 transport has a buffered mode (collect, set `Content-Length`, write once)
 and a streaming mode (write each chunk as it arrives). They are 2
 readings of one protocol, and the witness requires their output to be
-byte-identical. `service.renderToString()` is a wrapper over the same
+byte-identical — even when a chunk boundary splits a surrogate pair, which
+the streaming mode handles by holding back that one code unit until its mate
+arrives. `service.renderToString()` is a wrapper over the same
 generator, so the string-shaped call is the derived one — a streaming
 caller is declining a convenience rather than asking for a second
 semantics.
@@ -386,10 +388,10 @@ does not carry it, and has no render to have torn.
 
 | Code | Meaning |
 |---|---|
-| `:rf.ssr-node/malformed-request` | not an object, or not decodable |
+| `:rf.ssr-node/malformed-request` | not an object, or not decodable — over HTTP, also a request target that is not a valid URL |
 | `:rf.ssr-node/protocol-version` | `protocol` is absent or not this version |
 | `:rf.ssr-node/unknown-request-field` | a field the contract does not name |
-| `:rf.ssr-node/bad-request-field` | a named field of the wrong shape |
+| `:rf.ssr-node/bad-request-field` | a named field of the wrong shape — over HTTP, also a `requestId` no response header can carry |
 | `:rf.ssr-node/request-too-large` | over the body ceiling, or over the one `state` + `runtime` shares |
 | `:rf.ssr-node/unknown-entry` | an id the loaded bundle does not carry |
 | `:rf.ssr-node/state-key-not-allowed` | a `state` or `runtime` key the entry does not declare for that partition |
@@ -399,7 +401,7 @@ does not carry it, and has no render to have torn.
 | `:rf.ssr-node/isolate-lost` | the worker died mid-render, an exception escaped the render call, or the pool could not replace a terminated isolate |
 | `:rf.ssr-node/service-saturated` | no isolate free within the admission budget |
 | `:rf.ssr-node/service-closed` | the service is shutting down |
-| `:rf.ssr-node/malformed-render-module` | the bundle failed validation at boot |
+| `:rf.ssr-node/malformed-render-module` | the bundle failed validation at boot, or its worker never became ready — past the boot deadline, or exiting before it |
 
 The `:rf.ssr-node/*` family is a new reserved-namespace tenant. Cataloguing
 it in `spec/Conventions.md` is a sequenced follow-up; that file is a
@@ -641,6 +643,15 @@ Response headers: `x-rf-ssr-build` (the build identity), `x-rf-ssr-chunks`,
 `requestId`. A refusal answers with `application/json`, the refusal frame
 as its body, and `x-rf-ssr-refusal` carrying the code — 4xx for a caller
 fault, 503 for saturation or shutdown, 504 for a deadline, 500 for ours.
+
+Because that echo is a header, HTTP narrows `requestId` to what Node will
+put in one: a token carrying a control character, a CR/LF, or anything
+above U+00FF is refused `:rf.ssr-node/bad-request-field` (400, with
+`detail.field` `"requestId"`) before any render, rather than failing at the
+response it would have been echoed on. Printable ASCII is the portable
+choice. The in-process API takes any string. A request target that is not a
+valid URL is refused `:rf.ssr-node/malformed-request` (400), and the service
+keeps serving.
 
 ### The ready line
 

--- a/implementation/ssr-node/src/http.cjs
+++ b/implementation/ssr-node/src/http.cjs
@@ -126,7 +126,27 @@ function readBody(req, maxBytes) {
   });
 }
 
-async function handleRender(service, req, res, { maxRequestBytes }) {
+/**
+ * Split a trailing HIGH surrogate off a streamed chunk, to be written with
+ * the next one (rf2-gwye.24).
+ *
+ * `emit` takes JavaScript strings and puts no code-point boundary on them,
+ * so a module splitting its markup at a code-unit offset can end one chunk
+ * on the first half of an astral character and start the next on the
+ * second. Encoding each chunk to UTF-8 on its own turns each half into
+ * U+FFFD — a 200 whose bytes differ from the buffered mode's, which joins
+ * before it encodes. Holding back at most ONE code unit is the whole
+ * repair: the pair is encoded together once its mate arrives, and every
+ * other chunk goes out as promptly as before. One still held at the end is
+ * written alone, which is exactly what the buffered join does with an
+ * unmatched surrogate.
+ */
+function holdTrailingHighSurrogate(text) {
+  const last = text.charCodeAt(text.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? [text.slice(0, -1), text.slice(-1)] : [text, ''];
+}
+
+async function handleRender(service, req, res, requestUrl, { maxRequestBytes }) {
   let renderRequest;
   let requestId;
   try {
@@ -142,8 +162,31 @@ async function handleRender(service, req, res, { maxRequestBytes }) {
     }
     requestId =
       typeof renderRequest?.requestId === 'string' ? renderRequest.requestId : undefined;
+    // THE ECHO IS A HEADER, AND NOT EVERY STRING IS ONE (rf2-gwye.25). An
+    // ellipsis, an emoji or a CR/LF in `requestId` is a valid protocol
+    // string that Node refuses at `writeHead` — which runs AFTER the render,
+    // so a caller's unrepresentable token came back as a `render-threw` 500
+    // from a renderer that had succeeded. Checked here instead, before an
+    // isolate is acquired, and refused as the caller fault it is. The
+    // in-process protocol's string domain is untouched: this is a fact
+    // about HTTP, and the refusal body still carries the token back.
+    if (requestId !== undefined) {
+      try {
+        http.validateHeaderValue('x-rf-ssr-request', requestId);
+      } catch {
+        throw new Refusal(
+          CODE.BAD_REQUEST_FIELD,
+          '`requestId` must be representable as an HTTP header value to be echoed over HTTP',
+          { field: 'requestId' },
+        );
+      }
+    }
   } catch (err) {
-    sendRefusal(res, err instanceof Refusal ? err : new Refusal(CODE.MALFORMED_REQUEST, String(err), {}));
+    sendRefusal(
+      res,
+      err instanceof Refusal ? err : new Refusal(CODE.MALFORMED_REQUEST, String(err), {}),
+      requestId,
+    );
     return;
   }
 
@@ -156,10 +199,12 @@ async function handleRender(service, req, res, { maxRequestBytes }) {
   // caller got could be changed by a magic header or an unpinned
   // in-process option that the operational docs did not teach. Retired
   // under rf2-6r9j.72; `test/bytes.test.cjs` pins that the header is inert.
-  const requestUrl = new URL(req.url, 'http://localhost');
+  // Read off the target the listener already parsed, inside its guard —
+  // one parse, not a second unguarded one (rf2-gwye.22).
   const streaming = requestUrl.searchParams.get('stream') === '1';
 
   const bufferedHtmlChunks = [];
+  let heldHighSurrogate = '';
   try {
     for await (const frame of service.renderFrames(renderRequest)) {
       if (frame.type === 'chunk') {
@@ -174,7 +219,9 @@ async function handleRender(service, req, res, { maxRequestBytes }) {
               ...(requestId ? { 'x-rf-ssr-request': requestId } : {}),
             });
           }
-          res.write(frame.html, 'utf8');
+          const [text, held] = holdTrailingHighSurrogate(heldHighSurrogate + frame.html);
+          heldHighSurrogate = held;
+          if (text) res.write(text, 'utf8');
         } else {
           bufferedHtmlChunks.push(frame.html);
         }
@@ -191,6 +238,7 @@ async function handleRender(service, req, res, { maxRequestBytes }) {
             'x-rf-ssr-build': service.buildId,
           });
         }
+        if (heldHighSurrogate) res.write(heldHighSurrogate, 'utf8');
         res.end();
       } else {
         const body = bufferedHtmlChunks.join('');
@@ -233,12 +281,26 @@ function handleHealth(service, res) {
  */
 function serve({ service, port = 8148, host = '127.0.0.1', maxRequestBytes = 1 << 20 }) {
   const server = http.createServer((req, res) => {
-    const requestUrl = new URL(req.url, 'http://localhost');
+    // CONTAINED HERE, NOT BY THE PROCESS (rf2-gwye.22). Node's HTTP parser
+    // accepts request targets the WHATWG URL constructor refuses — `//`, or
+    // `http://[::1` — and this listener is synchronous with no catch above
+    // it, so the throw was an uncaught exception: one caller's bad request
+    // line took the whole sidecar down, and every render in flight with it.
+    // It is a malformed request like any other, so it gets that refusal.
+    let requestUrl;
+    try {
+      requestUrl = new URL(req.url, 'http://localhost');
+    } catch {
+      return sendRefusal(
+        res,
+        new Refusal(CODE.MALFORMED_REQUEST, 'the request target is not a valid URL', {}),
+      );
+    }
     if (req.method === 'GET' && requestUrl.pathname === '/health') {
       return handleHealth(service, res);
     }
     if (req.method === 'POST' && requestUrl.pathname === '/render') {
-      return void handleRender(service, req, res, { maxRequestBytes });
+      return void handleRender(service, req, res, requestUrl, { maxRequestBytes });
     }
     const body = JSON.stringify({
       type: 'refusal',

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -199,8 +199,25 @@ class Isolate {
         // the operator.
         reject(new Refusal(CODE.MALFORMED_MODULE, err.message, { stack: err.stack }));
       });
-      worker.on('exit', () => {
+      worker.on('exit', (exitCode) => {
         clearTimeout(bootTimer);
+        // THE BOOT ARM OF THIS EVENT (rf2-gwye.23). A worker that exits
+        // before it posts `ready` — a module calling `process.exit()` while
+        // it is evaluated, or from its `boot` hook — raises no `error` and
+        // posts no `boot-error`, and the line above had just cleared the one
+        // other thing that could settle startup. So startup stayed pending
+        // for ever, past `bootTimeoutMs`, and so did everything above it:
+        // `Pool.start`'s `allSettled` never reached its sibling cleanup, and
+        // a replacement never left `startingReplacements`, which `close()`
+        // waits on. A no-op once `ready` has resolved, exactly as the `error`
+        // arm's `reject` is.
+        reject(
+          new Refusal(
+            CODE.MALFORMED_MODULE,
+            `the render module's worker exited (code ${exitCode}) before it became ready`,
+            { modulePath: this.modulePath, exitCode },
+          ),
+        );
         // THE SIBLING ARM, AND IT IDENTIFIES ITSELF THE SAME WAY (rf2-rhyi).
         // `ISOLATE_LOST` covers three distinct causes — a crashed worker, a
         // worker that exited, and a replacement that will not boot — and a

--- a/implementation/ssr-node/test/bytes.test.cjs
+++ b/implementation/ssr-node/test/bytes.test.cjs
@@ -344,3 +344,160 @@ test('the state ceiling also binds INSIDE the protocol, not only at the socket',
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// The edge's own failure modes (rf2-gwye.22, rf2-gwye.24, rf2-gwye.25)
+//
+// Three ways the transport used to fail a request the protocol beneath it
+// had no quarrel with. Each is a fact about HTTP rather than about the
+// service, which is why the rows live here.
+// ---------------------------------------------------------------------------
+
+const net = require('node:net');
+const { CODE } = require('../src/protocol.cjs');
+
+/**
+ * One raw HTTP/1.1 GET on its own socket, answered as text. `fetch` cannot
+ * send these targets at all — it parses the URL before it dials — so the
+ * request line is written by hand, as a misbehaving caller would write it.
+ */
+function rawGet(port, target) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.end(`GET ${target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    });
+    let text = '';
+    socket.setEncoding('latin1');
+    socket.on('data', (chunk) => {
+      text += chunk;
+    });
+    socket.on('end', () => resolve(text));
+    socket.on('error', reject);
+    socket.setTimeout(5000, () => socket.destroy(new Error(`no answer to GET ${target}`)));
+  });
+}
+
+test('a target the URL parser refuses is a 400, and the SAME service keeps serving', async () => {
+  // The request listener parsed the target with no catch above it, so a
+  // target Node's HTTP parser accepts and the WHATWG URL constructor does
+  // not was an uncaught exception: one caller's bad request line took the
+  // whole sidecar down, and every render in flight with it. Before the fix
+  // this row does not fail — the process does.
+  await withService('chunked', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    const ok = { protocol: 1, entry: 'app/root', state: { ':bytes': '["<p>ok</p>"]' } };
+    try {
+      for (const target of ['//', 'http://[::1']) {
+        // CONTROL — the URL constructor really does refuse it, or there is
+        // nothing here to contain.
+        assert.throws(() => new URL(target, 'http://localhost'), { code: 'ERR_INVALID_URL' });
+
+        const raw = await rawGet(http.port, target);
+        assert.strictEqual(raw.split('\r\n')[0], 'HTTP/1.1 400 Bad Request', `${target}: ${raw}`);
+        // The discriminator. Node's own parser answers a request line it
+        // rejects with a bare 400 of its own, so this header is what shows
+        // the request got past the parser and into the listener.
+        assert.match(raw, /\r\nx-rf-ssr-refusal: :rf\.ssr-node\/malformed-request\r\n/i, target);
+
+        const health = await fetch(`http://127.0.0.1:${http.port}/health`);
+        assert.strictEqual(health.status, 200, `/health after ${target}`);
+        const render = await post(`http://127.0.0.1:${http.port}/render`, ok);
+        assert.strictEqual(render.status, 200, `a render after ${target}`);
+        assert.strictEqual(render.text, '<p>ok</p>');
+      }
+      // The routes the guard sits in front of are unchanged.
+      assert.strictEqual((await rawGet(http.port, '/missing')).split('\r\n')[0], 'HTTP/1.1 404 Not Found');
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+test('a surrogate pair SPLIT across streamed chunks arrives as the bytes the buffered mode sends', async () => {
+  // `emit` takes strings and promises no code-point boundary, so a module
+  // splitting markup at a code-unit offset can hand the halves of one astral
+  // character to two chunks. Encoding each chunk alone turned each half into
+  // U+FFFD — a 200 whose bytes differed from the buffered response. The
+  // reference is the joined string's own UTF-8 rather than either mode, so
+  // the two cannot agree on a wrong answer; the unmatched surrogate is the
+  // control that the reference is Node's encoding and not a cleaned one.
+  const cases = [
+    ['a split pair', ['<p>\uD834', '\uDD1E</p>']],
+    ['an empty chunk between the halves', ['<p>\uD834', '', '\uDD1E</p>']],
+    ['several split pairs', ['\uD834', '\uDD1E\uD834', '\uDD1E<i>\uD83D', '\uDE00</i>']],
+    ['a high surrogate never matched', ['<p>', '\uD834']],
+  ];
+  await withService('chunked', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    try {
+      for (const [name, parts] of cases) {
+        const expected = Buffer.from(parts.join(''), 'utf8');
+        const body = { protocol: 1, entry: 'app/root', state: { ':bytes': JSON.stringify(parts) } };
+        const buffered = await post(`http://127.0.0.1:${http.port}/render`, body);
+        const streamed = await post(`http://127.0.0.1:${http.port}/render?stream=1`, body);
+        assert.strictEqual(buffered.status, 200, name);
+        assert.strictEqual(streamed.status, 200, name);
+        assert.strictEqual(buffered.buf.toString('hex'), expected.toString('hex'), `${name}: buffered`);
+        assert.strictEqual(streamed.buf.toString('hex'), expected.toString('hex'), `${name}: streamed`);
+        assert.strictEqual(buffered.headers.get('content-length'), String(expected.length), name);
+        assert.strictEqual(streamed.headers.get('content-length'), null, name);
+      }
+    } finally {
+      await http.close();
+    }
+  });
+});
+
+test('a requestId no HTTP header can carry is refused as a caller fault, before any render', async () => {
+  // HTTP echoes `requestId` in `x-rf-ssr-request`, and Node refuses a header
+  // value outside its character set at `writeHead` — which ran AFTER the
+  // render, so the answer was a `render-threw` 500 blaming a renderer that
+  // had succeeded. Every id below is a valid protocol string, and the first
+  // loop shows the in-process API still takes each one.
+  const ids = ['correlation-…', 'correlation-\u{1F600}', 'correlation\r\nx-injected: 1'];
+  const body = (requestId) => ({
+    protocol: 1,
+    entry: 'app/root',
+    requestId,
+    state: { ':bytes': '["<p>ok</p>"]' },
+  });
+  await withService('chunked', { isolates: 1 }, async (service) => {
+    for (const id of ids) {
+      assert.strictEqual((await service.renderToString(body(id))).requestId, id, 'in-process, any string correlates');
+    }
+    // The discriminator: every render the TRANSPORT asks for is counted, so
+    // "refused before the renderer" is observed rather than read off a status.
+    const rendered = [];
+    const renderFrames = service.renderFrames.bind(service);
+    service.renderFrames = (request) => {
+      rendered.push(request.requestId);
+      return renderFrames(request);
+    };
+    const http = await serve({ service, port: 0 });
+    try {
+      for (const id of ids) {
+        for (const selector of ['/render', '/render?stream=1']) {
+          const res = await post(`http://127.0.0.1:${http.port}${selector}`, body(id));
+          assert.strictEqual(res.status, 400, `${selector} ${JSON.stringify(id)}: ${res.text}`);
+          assert.strictEqual(res.headers.get('x-rf-ssr-refusal'), CODE.BAD_REQUEST_FIELD);
+          const frame = JSON.parse(res.text);
+          assert.strictEqual(frame.detail.field, 'requestId');
+          assert.strictEqual(frame.requestId, id, 'the refusal body still carries the token back');
+        }
+      }
+      assert.deepStrictEqual(rendered, [], 'no unrepresentable id may reach the renderer');
+
+      // CONTROL — an ASCII id still renders and is echoed in both modes, and
+      // the counter really does count.
+      for (const selector of ['/render', '/render?stream=1']) {
+        const res = await post(`http://127.0.0.1:${http.port}${selector}`, body('corr-ascii-1'));
+        assert.strictEqual(res.status, 200, res.text);
+        assert.strictEqual(res.headers.get('x-rf-ssr-request'), 'corr-ascii-1');
+        assert.strictEqual(res.text, '<p>ok</p>');
+      }
+      assert.deepStrictEqual(rendered, ['corr-ascii-1', 'corr-ascii-1']);
+    } finally {
+      await http.close();
+    }
+  });
+});

--- a/implementation/ssr-node/test/fixtures/exits.cjs
+++ b/implementation/ssr-node/test/fixtures/exits.cjs
@@ -27,6 +27,31 @@
 //                      response is clean and `afterChunks` is 0.
 //   `app/exits-torn` — a chunk has already reached the caller, so the
 //                      response is TORN and the count says so.
+//
+// AND AN EXIT BEFORE READINESS (rf2-gwye.23), which reaches the same `'exit'`
+// event in the one phase where no render is pending to be refused. It is
+// switched by an environment flag for the reason `flaky-boot.cjs` gives: a
+// worker takes its own copy of `process.env` when its thread is constructed,
+// so a flag set after the pool is up reaches the next REPLACEMENT and nothing
+// already running.
+//
+//   `eval`             — the thread exits (code 7) while this module is
+//                        being evaluated, before `boot` exists to be called.
+//   `boot`             — the `boot` hook exits with code 0. A clean exit is
+//                        still a startup that never finished.
+//   `boot-even-thread` — `boot` exits only on an even thread id. A pool
+//                        constructs its isolates back to back, so their ids
+//                        are consecutive and exactly one of a pair exits —
+//                        the only way to put a healthy sibling beside it.
+//
+// Never `require` this file in the test process with the flag armed: `eval`
+// would exit THAT thread, which is the whole test run.
+
+const { threadId } = require('node:worker_threads');
+
+const EXIT_AT_FLAG = 'RF2_SSR_NODE_EXIT_AT';
+const exitAt = process.env[EXIT_AT_FLAG];
+if (exitAt === 'eval') process.exit(7);
 
 const ENTRY = { stateAllowlist: [':for-exit'], runtimeAllowlist: [] };
 
@@ -36,6 +61,10 @@ module.exports = {
   entries: {
     'app/exits': ENTRY,
     'app/exits-torn': ENTRY,
+  },
+
+  boot() {
+    if (exitAt === 'boot' || (exitAt === 'boot-even-thread' && threadId % 2 === 0)) process.exit(0);
   },
 
   render({ entry }, emit) {
@@ -50,3 +79,5 @@ module.exports = {
     return new Promise(() => {});
   },
 };
+
+module.exports.EXIT_AT_FLAG = EXIT_AT_FLAG;

--- a/implementation/ssr-node/test/timeout.test.cjs
+++ b/implementation/ssr-node/test/timeout.test.cjs
@@ -248,3 +248,145 @@ test('CONTROL — with no deadline in reach, the fault really does run forever',
   // untorn response from a path that forgot to say.
   assert.strictEqual(err.detail.afterChunks, 0, 'a close refusal names the tear count too');
 });
+
+// ---------------------------------------------------------------------------
+// A worker that EXITS before it is ready (rf2-gwye.23)
+//
+// The boot deadline had a hole. A module that calls `process.exit()` while it
+// is evaluated, or from its `boot` hook, raises no `error` and posts no
+// `boot-error` — and the exit CLEARED the boot timer, the only other thing
+// that could settle startup. So startup stayed pending for ever, and a pool
+// start and a replacement both inherited that. `bootTimeoutMs` is left at its
+// 30 s default, far past every bound below, so a green row is the EXIT
+// settling startup rather than the boot timer standing in for it — and a red
+// one reads as a failed assertion, never as a hung file.
+// ---------------------------------------------------------------------------
+
+const { createService } = require('../src/service.cjs');
+const { Isolate } = require('../src/isolate.cjs');
+const { REPLACEMENT_FAILED_REFUSAL } = require('../src/protocol.cjs');
+const { fixture } = require('./_support.cjs');
+// Required while the flag is DISARMED — see the fixture's header.
+const { EXIT_AT_FLAG } = require('./fixtures/exits.cjs');
+
+/** `promise`'s outcome within `ms`, or `pending`. The timer is cleared rather than left holding the loop. */
+async function settledWithin(promise, ms = 3000) {
+  let timer;
+  const outcome = await Promise.race([
+    promise.then(
+      (value) => ({ state: 'resolved', value }),
+      (error) => ({ state: 'rejected', error }),
+    ),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve({ state: 'pending' }), ms);
+    }),
+  ]);
+  clearTimeout(timer);
+  return outcome;
+}
+
+/** Run `fn` with the fixture's exit armed, disarming it whichever way `fn` went. */
+async function withExitAt(exitAt, fn) {
+  process.env[EXIT_AT_FLAG] = exitAt;
+  try {
+    return await fn();
+  } finally {
+    delete process.env[EXIT_AT_FLAG];
+  }
+}
+
+test('a module that EXITS while booting rejects startup promptly — clean exit or not', async () => {
+  for (const [exitAt, exitCode] of [
+    ['eval', 7],
+    ['boot', 0],
+  ]) {
+    const outcome = await withExitAt(exitAt, () =>
+      settledWithin(createService({ modulePath: fixture('exits'), isolates: 1 })),
+    );
+    if (outcome.state === 'resolved') await outcome.value.close();
+    assert.strictEqual(outcome.state, 'rejected', `${exitAt}: startup must settle, and must not succeed`);
+    assert.strictEqual(outcome.error.code, CODE.MALFORMED_MODULE, exitAt);
+    assert.strictEqual(outcome.error.detail.exitCode, exitCode, `${exitAt}: the exit is what settled it`);
+  }
+  // CONTROL — disarmed, the same module boots, so the rejections above are
+  // the exits and not a module this service would never have accepted.
+  const healthy = await settledWithin(createService({ modulePath: fixture('exits'), isolates: 1 }));
+  assert.strictEqual(healthy.state, 'resolved');
+  await healthy.value.close();
+});
+
+test('a pool start with one sibling exiting rejects, and leaves no thread running', async () => {
+  // Every isolate the pool starts is recorded with its thread and that
+  // thread's exit code, so the row can show the healthy sibling really
+  // booted — it is TERMINATED by the pool (1) rather than exiting by itself
+  // (0) — and really is gone.
+  const started = [];
+  const realStart = Isolate.prototype.start;
+  Isolate.prototype.start = function start() {
+    const booting = realStart.call(this);
+    const record = { worker: this.worker, exitCode: null };
+    this.worker.once('exit', (code) => {
+      record.exitCode = code;
+    });
+    started.push(record);
+    return booting;
+  };
+  try {
+    const outcome = await withExitAt('boot-even-thread', () =>
+      settledWithin(createService({ modulePath: fixture('exits'), isolates: 2 })),
+    );
+    if (outcome.state === 'resolved') await outcome.value.close();
+    assert.strictEqual(started.length, 2, 'both isolates were started');
+    assert.strictEqual(outcome.state, 'rejected', 'one sibling exiting must fail the pool start');
+    assert.strictEqual(outcome.error.code, CODE.MALFORMED_MODULE);
+    assert.deepStrictEqual(
+      started.map((s) => s.exitCode).sort(),
+      [0, 1],
+      'one isolate exited by itself (0), and the pool terminated its healthy sibling (1)',
+    );
+    assert.deepStrictEqual(started.map((s) => s.worker.threadId), [-1, -1], 'and no thread is left running');
+  } finally {
+    Isolate.prototype.start = realStart;
+    // A red row must not become a hung file.
+    await Promise.all(started.map((s) => s.worker.terminate()));
+  }
+});
+
+test('a REPLACEMENT that exits before it is ready refuses its waiter, tells the operator, and lets close finish', async () => {
+  const captured = [];
+  const realWrite = process.stderr.write;
+  process.stderr.write = function (chunk, ...rest) {
+    captured.push(String(chunk));
+    return realWrite.call(this, chunk, ...rest);
+  };
+  const service = await createService({ modulePath: fixture('exits'), isolates: 1, admissionTimeoutMs: 10000 });
+  let closed;
+  try {
+    const exits = { protocol: 1, entry: 'app/exits' };
+    // Back to back, in one synchronous run: the first takes the only
+    // isolate, and the second is queued behind it before anything settles.
+    const dying = refusalOf(() => collect(service, exits));
+    const queued = refusalOf(() => collect(service, exits));
+    // CONTROL — the scenario is the one claimed: a caller really is waiting.
+    assert.strictEqual(service.stats().waiting, 1, 'a caller must be queued for the replacement');
+    // Armed only now: the running isolate took its copy of `process.env` at
+    // construction, so this reaches the replacement and nothing else.
+    process.env[EXIT_AT_FLAG] = 'boot';
+
+    assert.strictEqual((await dying).code, CODE.ISOLATE_LOST, 'the render-time exit is unchanged');
+    const waiter = await settledWithin(queued);
+    assert.strictEqual(waiter.state, 'resolved', 'the waiter must be answered, not left to its admission timer');
+    assert.strictEqual(waiter.value?.code, CODE.ISOLATE_LOST);
+    assert.strictEqual(waiter.value.message, REPLACEMENT_FAILED_REFUSAL);
+    assert.strictEqual(service.stats().replacements, 1, 'the pool did try to replace it');
+  } finally {
+    delete process.env[EXIT_AT_FLAG];
+    closed = await settledWithin(service.close());
+    process.stderr.write = realWrite;
+  }
+  assert.strictEqual(closed.state, 'resolved', 'close must not wait for ever on a replacement that exited');
+  assert.ok(
+    captured.join('').includes('[rf.ssr-node] a replacement isolate failed to boot'),
+    'the operator is told, as for any replacement that will not boot',
+  );
+});


### PR DESCRIPTION
## What

This fixes four defects at the request and lifecycle edges of `implementation/ssr-node`, all from the 2026-09-12/13 surface review: the three findings of rf2-fzbj.22 plus rf2-gwye.22, .23, .24 and .25. All four reproduced at this branch's base before the fix. The package source had not changed since the revision the review read.

| Bead | Defect | Fix |
|---|---|---|
| rf2-gwye.22 (fzbj.22 finding 1, P1) | Node's parser accepts some request targets that `new URL` refuses (`//`, `http://[::1`). The URL constructor threw from the synchronous request listener, which has no catch above it. The result was an uncaught exception, process exit 1, and every in-flight render lost. | `src/http.cjs` guards the parse and answers with the existing `malformed-request` 400. `handleRender` now takes the parsed URL instead of parsing it a second time without a guard. |
| rf2-gwye.23 (fzbj.22 finding 2) | A worker that exited before `ready` cleared `bootTimer` and never settled `start()`. So `createService` stayed pending forever, past `bootTimeoutMs`, and `Pool.start` never reached its sibling cleanup. A replacement stayed in `startingReplacements`, so `close()` hung. | The `exit` arm in `src/isolate.cjs` now rejects startup as `malformed-render-module`, carrying `detail.exitCode`. Once `ready` has resolved this is a no-op, as the `error` arm's reject already is. It adds no new state and no extra timer. The existing paths still do the pool cleanup and the replacement reporting. |
| rf2-gwye.24 (fzbj.22 finding 3) | Streaming encoded each chunk to UTF-8 on its own. A surrogate pair split across two chunks therefore became two U+FFFD in a 200 response, while buffered mode sent the character correctly. | The streaming writer holds back at most one trailing high surrogate and writes it with the next chunk. If none follows, it writes it alone at the end, which is what the buffered join does with an unmatched surrogate. |
| rf2-gwye.25 | Node refuses some `requestId` values as header values (an ellipsis, an emoji, CR/LF). They failed at `writeHead`, which runs after the render, and came back as a `render-threw` 500. | `http.validateHeaderValue` now checks the ID before any render. An ID that fails is refused `bad-request-field` 400 with `detail.field: "requestId"`, and the JSON body still echoes the token. The in-process API is unchanged. |

`test/fixtures/exits.cjs` gains an environment switch for boot-time exits, `RF2_SSR_NODE_EXIT_AT`, with the values `eval`, `boot` and `boot-even-thread`. With the switch unset, the fixture behaves as before. The README documents the two HTTP constraints and widens three refusal-table rows.

## Regression rows

Each row was shown RED against the pre-fix source, then green.

- `test/bytes.test.cjs`:
  - **Malformed target.** Each target gets a 400 carrying this listener's own `x-rf-ssr-refusal` header, which proves the request got past Node's parser. `/health` and a render then succeed on the SAME server, and `/missing` still returns 404.
  - **Split surrogates.** Four cases: a split pair, an empty chunk between the halves, several split pairs, and an unmatched-surrogate control. Both modes are compared against `Buffer.from(parts.join(''), 'utf8')`, together with their Content-Length handling.
  - **Unrepresentable requestId.** Three IDs, each refused 400 in both modes. A spy shows zero renderer calls for them, and an ASCII control ID still renders and is echoed.
- `test/timeout.test.cjs`:
  - **Boot exits.** An exit during module evaluation (code 7) and an exit from the boot hook (code 0) each reject `createService` promptly. `bootTimeoutMs` stays at its 30 s default, so the rejection comes from the exit and not from the timer.
  - **Pool start.** A 2-isolate start in which one sibling exits rejects. The healthy sibling is terminated (exit codes 0 and 1), and neither thread is left running.
  - **Replacement.** A replacement that exits before `ready` does three things: it refuses its queued waiter with the existing replacement-failed refusal, it writes the operator diagnostic, and it lets `close()` complete.

**RED control.** I restored the pre-fix `src/http.cjs` and `src/isolate.cjs` from the parent commit, and confirmed their blob hashes equal the parent's. Then I ran the new rows, and every run exited 1:
- the target row died with `ERR_INVALID_URL` at `http.cjs:236`;
- the streamed body read hex `3c703eefbfbdefbfbd3c2f703e`, where `3c703ef09d849e3c2f703e` was expected;
- the requestId row got a 500 `render-threw` where it expected 400;
- all three boot rows read `pending`.

After restoring, the blob hashes match the commit and `git diff --quiet` reads 0.

## Quality gates

- `npm run test:ssr-node`, run from `implementation/`: exit 0 on the final base, all 9 suites green, and the root line names this worktree. CI runs it as `node-ssr-node` in `test.yml`, which is unconditional.
- `python scripts/check_readme_links.py --ci`: exit 0 (this PR edits the package README). CI runs it as `verify-readme-links` in `test.yml`.
- The changed-surface classifier, run over the six changed paths, arms `ssr_node` and nothing else.
- I ran these tree-wide ratchets locally, and all exit 0: `check-no-hardcoded-paths.sh`, `check_view_lifetime_residue.py`, `check_retired_composition_vocab.py`, `check_retired_image_keys.py`, `check_allocation_non_claim.py`, `check_failure_corpus_residue.py`, `check_runtime_subsystem_grading.py` and `check_ep_status_sync.py`.
- No gate validates the README's prose or its refusal table, so I checked both by hand, including the table's column count.
- I rely on CI for the rest of the rollup.

## Not done, on purpose

- **`x-rf-ssr-build`.** The response header `x-rf-ssr-build` goes through the same raw-header mechanism. Its value, though, is the module's own boot-time `buildId` rather than caller input, and the review did not claim it. So it is untouched here, and so is the render catch's `String(err)` wording, which a failure on that header would still reach.
- **Prompt delivery.** There is no timing test for "completed chunks are still delivered promptly". The writer holds back at most one code unit, and only when a chunk ends in a high surrogate.
- **Spec.** `spec/011-SSR.md` needs no edit. It names `requestId` among the fields the JVM adapter POSTs, but it states no character set for it. The adapter sends `(str (symbol frame-id))` (`implementation/ssr-ring/src/re_frame/ssr/ring/node.clj`). The spec classifies any non-200 other than a 504 as `:rf.error/ssr-node-refused`, so an ID that used to come back as a 500 and now comes back as a 400 lands under the same JVM error id either way. The new HTTP constraint is documented in the package README, which is where the wire protocol lives.
