### PR TITLE
fix(ssr): close the safe-redirect network-path bypass, stop refused hydration payloads claiming, readiness-driven install! recipe

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -279,7 +279,8 @@
   live payload and the roots using it untouched.
 
   Returns the payload that was applied (or `nil` on a client-only first
-  load) so the caller can branch on \"was this server-rendered?\" without
+  load, and `nil` when `:rf/hydrate` refused a malformed payload — nothing
+  was applied, so the frame IS client-only and no claim is made) so the caller can branch on \"was this server-rendered?\" without
   re-reading the DOM. A no-op second install still returns the payload —
   the page WAS server-rendered, whichever root got there first.
 
@@ -323,14 +324,32 @@
         payload (or payload
                     #?(:cljs (read-server-payload
                                (or element-id rf.ssr.constants/payload-script-id))
-                       :clj nil))]
+                       :clj nil))
+        ;; A payload the `:rf/hydrate` handler will REFUSE — not a map, or a
+        ;; present-but-non-map partition (Spec 011 §The :rf/hydrate event) —
+        ;; never commits, so it must never CLAIM (rf2-gwye.19). The seed check
+        ;; below cannot see a refusal: the handler leaves the frame live and
+        ;; returns normally, and a live incarnation proves only that the
+        ;; dispatch was delivered. So the handler's OWN predicate screens the
+        ;; payload here, before the ledger is touched. A nil payload is the
+        ;; client-only first load, not a refusal.
+        refusal (when payload
+                  (rf.ssr.hydrate/malformed-hydration-payload-reason payload))]
     (when payload
       ;; The payload's `:rf/frame-id` is metadata and validation
       ;; evidence, NOT a no-opts target resolver. Validate it against the
       ;; explicit client target: a conflict is a structured mismatch (the
       ;; server hydrated a different frame than the client is installing
       ;; into), surfaced rather than silently picking a side.
-      (validate-payload-frame-id! frame payload)
+      (validate-payload-frame-id! frame payload))
+    ;; A refused payload is still DISPATCHED, so the handler emits its
+    ;; always-on `:rf.error/malformed-hydration-payload` record exactly as it
+    ;; does for a direct `dispatch-sync`. It leaves both partitions alone,
+    ;; claims nothing and verifies nothing, and `hydrate!` returns nil — the
+    ;; client-only answer, which is what the frame now is.
+    (when refusal
+      (rf.router/dispatch-sync! [:rf/hydrate payload] {:frame frame}))
+    (when (and payload (not refusal))
       ;; PREFLIGHT (S5) — manifest discovery/validation -> payload install
       ;; decision, BEFORE anything is seeded (004C §10). The frame-id
       ;; validation above runs FIRST: a payload rendered for a different
@@ -379,9 +398,10 @@
           ;; an absent or destroyed frame is a NO-OP, not a throw — the
           ;; router reports it on its own always-on axis and returns
           ;; normally. So the condition is checked directly, and the check
-          ;; is the frame's INCARNATION token: the seed landed only if the
-          ;; exact incarnation that was live when we claimed is still live
-          ;; now. A nil token (the frame was never there) is not live, so an
+          ;; is the frame's INCARNATION token: for a payload the handler
+          ;; accepts (a refused one never gets here — see `refusal` above),
+          ;; the seed landed only if the exact incarnation that was live when
+          ;; we claimed is still live now. A nil token (the frame was never there) is not live, so an
           ;; absent frame releases too; a destroy-and-recreate during the
           ;; dispatch yields a different token and also releases. This is
           ;; the same pinned-token admission rule a cold `reg-flow` uses to
@@ -420,7 +440,7 @@
               ;; its own scope (or ignores it — a plain-hiccup fn) is unaffected.
               (when render-tree-fn
                 (rf.ssr.hydrate/verify-hydration! frame ((rf.frame/bind-fn frame render-tree-fn)))))))))
-    payload))
+    (when-not refusal payload)))
 
 ;; ---------------------------------------------------------------------------
 ;; Failed-root isolation (S5) — Spec 011 §Failed-root isolation

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -53,7 +53,7 @@
              :else (pr-str (type slice-val)))
        "); hydration rejected — the client frame-state is left unchanged"))
 
-(defn- malformed-hydration-payload-reason
+(defn malformed-hydration-payload-reason
   "Fail-closed guard for the `:rf/hydrate` boundary.
   The payload is a DESERIALISED, UNTRUSTED transport input (the server's
   `pr-str`'d EDN, round-tripped through `cljs.reader/read-string` at the
@@ -73,7 +73,11 @@
   with each partition key either absent or carrying a map). A wholly-ABSENT
   app-db / runtime-db slice key is NOT malformed — it is the documented
   client-only / no-server-slice first-load shape that falls back to the
-  existing partition value."
+  existing partition value.
+
+  Public because `re-frame.ssr.boot/hydrate!` screens with this SAME
+  predicate before it claims a payload id (rf2-gwye.19): a payload the
+  handler refuses never commits, so it must never claim."
   [payload]
   (cond
     (not (map? payload))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -916,15 +916,18 @@
 ;;      :rf.error/safe-redirect-invalid-url (:reason :scheme-without-host).
 ;;   3. :relative-only? true AND the URL is NOT a relative reference →
 ;;      :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation).
-;;      A relative reference is `scheme == nil AND authority == nil`
-;;      (e.g. `/dashboard`, `dashboard`, `a/b`). A protocol-relative
-;;      `//evil.example.com` HAS an authority and is therefore NOT
-;;      relative — it is rejected under :relative-only? .
-;;   4. :allow [...] supplied AND URL's host not in allowlist →
+;;      A relative reference is `scheme == nil AND authority == nil` AND
+;;      the raw string does not begin `//` (e.g. `/dashboard`, `dashboard`,
+;;      `a/b`). A protocol-relative `//evil.example.com` is NOT relative,
+;;      and neither is `///evil.example.com`: java.net.URI reports that one
+;;      with no authority at all, but a browser skips the extra slashes and
+;;      takes the next segment as the HOST (rf2-gwye.18).
+;;   4. :allow [...] supplied AND the URL is not a relative reference AND
+;;      its host is not in the allowlist →
 ;;      :rf.error/safe-redirect-host-disallowed (:reason :not-in-allowlist).
-;;      A non-relative target that reaches this gate has, after step 2c,
-;;      an extractable host; if it is absent from the allowlist it is
-;;      rejected.
+;;      A non-relative target whose host java.net.URI cannot extract
+;;      (`//evil_example/path`, `///evil.example/path`) names no allowlisted
+;;      host, so it is rejected rather than waved through.
 ;;   5. Pass — set Location header (same shape as redirect-fx).
 ;;
 ;; All failure modes EMIT (via re-frame.trace) rather than THROW.
@@ -1140,10 +1143,12 @@
         (:reason :scheme-without-host) — the scheme-bearing open-redirect
         bypass that defeats a host-presence-only gate
     3.  :relative-only? true + URL is NOT a relative reference (has a
-        scheme OR an authority — incl. protocol-relative `//host`) →
+        scheme OR an authority OR a raw `//` prefix — incl. protocol-relative
+        `//host` and `///host`) →
         :rf.error/safe-redirect-host-disallowed (:reason :relative-only-violation)
-    4.  :allow supplied + host ∉ allow → :rf.error/safe-redirect-host-disallowed
-        (:reason :not-in-allowlist)
+    4.  :allow supplied + non-relative URL whose host ∉ allow (a host
+        java.net.URI cannot extract is ∉ allow) →
+        :rf.error/safe-redirect-host-disallowed (:reason :not-in-allowlist)
     5.  Pass → set :redirect (same shape as :rf.server/redirect)
 
   An attacker-controlled `?next=...` parameter therefore cannot redirect
@@ -1231,7 +1236,16 @@
                 ;; `http:evil.example.com` has a scheme and is NOT
                 ;; relative — even though Java reports its host as nil.
                 ;; The policy is based on URL shape, not host presence alone.
-                relative? (and (nil? scheme) (nil? authority))]
+                ;;
+                ;; A raw `//` prefix is a NETWORK-PATH reference whatever
+                ;; java.net.URI makes of it (rf2-gwye.18). URI parses
+                ;; `///evil.example/path` with NO authority, yet a browser
+                ;; skips the extra slashes and navigates to
+                ;; https://evil.example/path. The prefix, not URI's
+                ;; authority alone, decides that a target is not relative.
+                relative? (and (nil? scheme)
+                               (nil? authority)
+                               (not (clojure.string/starts-with? location "//")))]
             (cond
               ;; Step 2: scheme rejection (post-parse path — covers
               ;; schemes whose body DID parse cleanly, e.g.
@@ -1279,18 +1293,22 @@
                                           :host     host
                                           :reason   :relative-only-violation})
 
-              ;; Step 4: :allow [...] allowlist. After step 2c every
-              ;; non-relative target reaching here has an extractable
-              ;; host. A relative reference (no host) is allowed through
-              ;; — :allow gates absolute targets, it does not block
-              ;; same-origin relative redirects. DNS hostnames are
+              ;; Step 4: :allow [...] allowlist. A relative reference (no
+              ;; host) is allowed through — :allow gates absolute targets,
+              ;; it does not block same-origin relative redirects. Every
+              ;; NON-relative target must name an allowlisted host, and one
+              ;; whose host java.net.URI cannot extract names none: step 2c
+              ;; only catches that for a scheme-bearing URL, while a browser
+              ;; still resolves a host for `//evil_example/path` and
+              ;; `///evil.example/path` (rf2-gwye.18). DNS hostnames are
               ;; case-insensitive (RFC 1035 §2.3.3), so lower-case both
               ;; sides — matching the header/cookie token-grammar
               ;; treatment elsewhere in this file.
               (and (seq allow)
-                   host
-                   (not (contains? (into #{} (map clojure.string/lower-case) allow)
-                                   (clojure.string/lower-case host))))
+                   (not relative?)
+                   (not (and host
+                             (contains? (into #{} (map clojure.string/lower-case) allow)
+                                        (clojure.string/lower-case host)))))
               (emit-safe-redirect-error! :rf.error/safe-redirect-host-disallowed
                                          {:frame    frame
                                           :location location

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -764,22 +764,37 @@
   Idempotent per chunk: the same resolved node is applied at most once
   even if the observer batches or the initial sweep races a mutation.
 
-  Usage (streaming-aware Reagent bootstrap):
+  Usage (streaming-aware Reagent-slim bootstrap, readiness-driven):
 
-      #?(:cljs
-         (defn ^:export run []
-           (rf/init! reagent-slim-adapter/adapter)
-           ;; Install BEFORE the first chunks may have arrived so the
-           ;; observer catches them; the initial sweep also covers chunks
-           ;; that landed before the bundle executed.
-           (streaming-client/install! {:frame :app/main})
-           (rdc/render react-root
-             [rf/frame-provider {:frame :app/main}
-              [(rf/view :app/root)]])
-           ;; Reconcile against the canonical payload once it lands.
-           ;; (A host typically polls / observes for `__rf_payload`, or
-           ;; the streaming bootstrap calls `ssr/hydrate!` on completion.)
-           ))"
+      ;; (:require [re-frame.core :as rf]
+      ;;           [re-frame.ssr :as ssr]
+      ;;           [re-frame.ssr.streaming.client :as streaming-client]
+      ;;           [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+      ;;           [reagent2.dom.client :as rdc])
+      (defn ^:export run []
+        (rf/init! reagent-slim-adapter/adapter)
+        ;; The live target frame exists FIRST: deltas merge into it as
+        ;; chunks land, and `hydrate!` seeds it at readiness.
+        (rf/make-frame {:id :app/main :platform :client})
+        ;; Bind everything `:on-ready` touches BEFORE `install!` — on an
+        ;; already-buffered response it fires synchronously INSIDE it.
+        (let [container (js/document.getElementById \"app\")]
+          ;; Install early: the observer catches chunks as they stream in,
+          ;; and the initial sweep covers any that landed before the bundle.
+          (streaming-client/install!
+            {:frame    :app/main
+             :on-ready (fn [_readiness-report]
+                         ;; Finalised: chunks applied, wrappers unwrapped,
+                         ;; observer disconnected. Now, and only now, seed
+                         ;; from the canonical payload and adopt the DOM.
+                         (ssr/hydrate! {:frame :app/main})
+                         (rdc/hydrate-root container
+                           [rf/frame-provider {:frame :app/main}
+                            [(rf/view :app/root)]]))})))
+
+  Nothing touches the streamed root before `:on-ready`: no `create-root`,
+  no early `hydrate-root`, no polling for `__rf_payload`. Keep the returned
+  `stop!` only if the host may abandon the stream (see above)."
   ([] (install! {}))
   ([{:keys [frame root payload-id on-ready]
      ;; No implicit default: a nil frame is an absent target that

--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
@@ -370,6 +370,82 @@
            dead root's install still protects it"))))
 
 ;; ---------------------------------------------------------------------------
+;; A payload the handler REFUSES never claims (rf2-gwye.19 / rf2-fzbj.10)
+;; ---------------------------------------------------------------------------
+;;
+;; The seed-did-not-land case above is a frame that is GONE. This is the
+;; other one: the frame is live, the dispatch is delivered, and `:rf/hydrate`
+;; correctly refuses a malformed partition (Spec 011 §The :rf/hydrate event),
+;; leaving both partitions unchanged. A live incarnation proves the dispatch
+;; reached the frame, not that the seed was accepted, so it cannot be the
+;; evidence a claim rests on.
+
+(def ^:private refused-payloads
+  "The two partition shapes the handler refuses outright."
+  [["a non-map :rf/app-db"     {:rf/app-db []}]
+   ["a non-map :rf/runtime-db" {:rf/app-db {:count 7} :rf/runtime-db []}]])
+
+(deftest a-refused-payload-leaves-no-claim-and-verifies-nothing
+  (testing "through hydrate!: nothing landed, so nothing is claimed, nothing
+            is verified, hydrate! answers as a client-only first load, and the
+            next VALID payload for the same frame installs normally"
+    (doseq [[label refused] refused-payloads]
+      (let [fid      (fresh-frame!)
+            before   (rf/app-db-value fid)
+            verified (atom 0)
+            returned (rf.ssr.boot/hydrate!
+                      {:frame fid :payload refused :root-id :page/bad
+                       :render-tree-fn (fn [] (swap! verified inc) [:div])})]
+        (is (nil? returned)
+            (str label ": nothing was applied, so hydrate! returns nil — the "
+                 "client-only answer a host branches on"))
+        (is (= before (rf/app-db-value fid))
+            (str label ": the handler refused it, so app-db is unchanged"))
+        (is (nil? (rf.ssr.install/installed-payload fid))
+            (str label ": MEASURED before the fix, the refused payload held "
+                 "the ledger claim for a seed that never landed"))
+        (is (zero? @verified)
+            (str label ": no verification runs against a seed that never landed"))
+        (rf.ssr.boot/hydrate! {:frame fid :payload (payload-for {:count 7})
+                               :root-id :page/good})
+        (is (hydrated? fid)
+            (str label ": the corrected payload installs — before the fix it "
+                 "threw :rf.error/frame-payload-conflict against data that "
+                 "was never installed"))
+        (is (= :page/good (:installed-by (rf.ssr.install/installed-payload fid)))
+            (str label ": and the claim is the corrected root's"))))))
+
+(deftest a-refused-root-cannot-block-a-corrected-sibling-sharing-its-frame
+  (testing "through hydrate-page!: a refused first root, a corrected second
+            root on the SAME frame, and an unrelated third root. The refused
+            root takes the client-only outcome; the corrected one seeds the
+            frame; the unrelated one boots as it always did."
+    (reg-bump!)
+    (let [a        (fresh-frame!)
+          b        (fresh-frame!)
+          mounted  (atom [])
+          mount!   (fn [tag] #(swap! mounted conj tag))
+          outcomes (rf.ssr/hydrate-page!
+                    [{:frame a :root-id :page/bad :payload {:rf/app-db []}
+                      :mount-fn (mount! :bad)}
+                     {:frame a :root-id :page/good :payload (payload-for {:count 7})
+                      :mount-fn (mount! :good)}
+                     {:frame b :root-id :page/peer :payload (payload-for {:count 7})
+                      :mount-fn (mount! :peer)}])]
+      (is (= [:hydrated :hydrated :hydrated] (mapv :status outcomes))
+          "MEASURED before the fix: [:hydrated :failed :hydrated] — the corrected
+           root met a conflict with the refused one's claim")
+      (is (nil? (:payload (first outcomes)))
+          "the refused root reports what a client-only root reports: no payload")
+      (is (= [:bad :good :peer] @mounted)
+          "every root mounted, the corrected one included")
+      (is (hydrated? a) "the shared frame carries the corrected server slice")
+      (is (interactive? a) "and it is running")
+      (is (= :page/good (:installed-by (rf.ssr.install/installed-payload a)))
+          "the claim belongs to the root whose seed landed")
+      (is (hydrated? b) "the unrelated root booted as before"))))
+
+;; ---------------------------------------------------------------------------
 ;; A contained failure is never silent
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -552,3 +552,100 @@
               (remove-host! host)
               (done))
             60))))))
+
+;; ---- the `install!` Usage recipe, executed (rf2-gwye.20) --------------------
+
+(defn- recipe-bootstrap!
+  "`re-frame.ssr.streaming.client/install!`'s Usage recipe, transcribed onto
+  this fixture: the frame exists first, everything the callback touches is
+  bound BEFORE `install!` (readiness can fire synchronously inside it), and
+  the frame is seeded and the root hydrated ONLY from `:on-ready`. The
+  fixture's `hydrate-capturing!` stands in for the adapter's `hydrate-root`
+  so React's complaints are heard. Each readiness appends one entry to `log`."
+  [frame-id host log]
+  (let [container (app-el host)]
+    (rf.ssr.streaming.client/install!
+      {:frame    frame-id
+       :root     host
+       :on-ready (fn [_report]
+                   (try
+                     (let [wrappers-at-ready (count (mounts host))
+                           payload           (rf.ssr/hydrate! {:frame frame-id})]
+                       (swap! log conj
+                              {:wrappers-at-ready wrappers-at-ready
+                               :payload           payload
+                               :hydration         (hydrate-capturing!
+                                                    container
+                                                    [rf/frame-provider {:frame frame-id}
+                                                     [dashboard]])}))
+                     (catch :default t
+                       (swap! log conj {:error t}))))})))
+
+(defn- assert-recipe-booted-once! [log]
+  (is (= 1 (count @log)) "exactly one seed + hydration, and it came from readiness")
+  (let [{:keys [error wrappers-at-ready payload hydration]} (first @log)]
+    (is (nil? error) (str "the recipe's :on-ready did not throw: " error))
+    (is (zero? wrappers-at-ready)
+        "no <rf-suspense> wrapper remained when the recipe took ownership")
+    (is (some? payload) "hydrate! read and installed the final payload")
+    (is (empty? (hydration-complaints (:complaints hydration)))
+        (str "hydrate-root reconciled the finalised DOM with no mismatch; got: "
+             (pr-str (:complaints hydration))))
+    (is (str/includes? (str (:html hydration)) "42375")
+        "React adopted the server DOM rather than discarding it")))
+
+(deftest the-install-recipe-boots-once-from-readiness-on-a-live-stream
+  (testing "rf2-gwye.20: with the payload still in flight the recipe owns
+            nothing; once it lands, exactly one seed + hydration runs, after
+            every wrapper is gone"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/recipe-live
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            {:keys [shell chunks failed]} (server-render!)
+            host     (make-host! shell)
+            log      (atom [])]
+        (recipe-bootstrap! frame-id host log)
+        (append-chunk! host (first chunks))
+        (async done
+          (js/setTimeout
+            (fn []
+              (is (empty? @log)
+                  "nothing seeds or hydrates while the payload is still in flight")
+              (append-chunk! host (second chunks))
+              (append-chunk! host (payload-chunk failed))
+              (js/setTimeout
+                (fn []
+                  (try
+                    (assert-recipe-booted-once! log)
+                    (catch :default t
+                      (is false (str "threw asserting the recipe: " t)))
+                    (finally
+                      (remove-host! host)
+                      (done))))
+                40))
+            40))))))
+
+(deftest the-install-recipe-boots-once-on-an-already-buffered-response
+  (testing "rf2-gwye.20: a fully buffered response boots the recipe
+            synchronously inside install!, once, without a later tick"
+    (if-not (browser?)
+      (is true "skipped under node — no js/document")
+      (let [frame-id :test/recipe-buffered
+            _        (do (rf/make-frame {:id frame-id :platform :client})
+                         (register-app! frame-id))
+            {:keys [shell chunks failed]} (server-render!)
+            host     (make-host! shell)
+            log      (atom [])]
+        (doseq [c chunks] (append-chunk! host c))
+        (append-chunk! host (payload-chunk failed))
+        (recipe-bootstrap! frame-id host log)
+        (assert-recipe-booted-once! log)
+        (async done
+          (js/setTimeout
+            (fn []
+              (is (= 1 (count @log)) "a later tick does not boot it a second time")
+              (remove-host! host)
+              (done))
+            60))))))

--- a/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
@@ -158,6 +158,65 @@
             (str label " — rejected: the response accumulator's :redirect "
                  "slot is untouched under -Dre-frame.debug=false"))))))
 
+;; ---------------------------------------------------------------------------
+;; (1b) NETWORK-PATH REFERENCES java.net.URI cannot see the host of
+;; (rf2-gwye.18 / rf2-fzbj.10 finding 1)
+;; ---------------------------------------------------------------------------
+
+(def ^:private network-path-bypasses
+  "Locations a browser resolves OFF-ORIGIN while java.net.URI reports no
+  usable host. Resolved against `https://trusted.example/login` by the
+  WHATWG URL parser (Node 24, measured for rf2-gwye.18):
+
+    ///evil.example/path   → https://evil.example/path   URI: no scheme, NO authority
+    ////evil.example/path  → https://evil.example/path   URI: no scheme, NO authority
+    //evil_example/path    → https://evil_example/path   URI: authority, NO host
+
+  The first two read as a RELATIVE reference to a gate that asks only
+  whether URI found an authority; the third has an authority but no
+  extractable host, which the allowlist arm used to wave through."
+  ["///evil.example/path" "////evil.example/path" "//evil_example/path"])
+
+(deftest a-network-path-reference-cannot-satisfy-either-policy
+  (testing "rf2-gwye.18: a caller that restricted the redirect — relative-only,
+            or a host allowlist — must not be redirected off-origin by a
+            location the browser resolves to a foreign host merely because
+            java.net.URI cannot expose that host. Each is refused with the
+            arm's existing category and reason, and the accumulator keeps
+            its default 200 with no redirect."
+    (doseq [location network-path-bypasses
+            [args expected-reason]
+            [[{:location location :relative-only? true} :relative-only-violation]
+             [{:location location :allow ["trusted.example"]} :not-in-allowlist]]]
+      (let [{:keys [records response]} (reject! args)
+            hits                       (safe-redirect-records records)]
+        (is (nil? (:redirect response))
+            (str (pr-str args) " — refused: no :redirect reaches the accumulator"))
+        (is (= 200 (:status response))
+            (str (pr-str args) " — refused: the status is the untouched default, not a 3xx"))
+        (is (= 1 (count hits))
+            (str (pr-str args) " — exactly one always-on rejection record"))
+        (is (= :rf.error/safe-redirect-host-disallowed (:error (first hits)))
+            (str (pr-str args) " — the policy arm's existing category"))
+        (is (= expected-reason (:reason (first hits)))
+            (str (pr-str args) " — the policy arm's existing reason"))))))
+
+(deftest each-policy-still-passes-its-legitimate-targets
+  (testing "rf2-gwye.18 CONTROL: the fix narrows what counts as relative and
+            what satisfies an allowlist — it must not refuse everything. An
+            ordinary local reference passes relative-only and an allowlist
+            alike, and an explicitly allowed https host passes its allowlist."
+    (doseq [args [{:location "/dashboard" :relative-only? true}
+                  {:location "dashboard/settings?tab=2" :relative-only? true}
+                  {:location "/dashboard" :allow ["trusted.example"]}
+                  {:location "https://trusted.example/path" :allow ["trusted.example"]}
+                  {:location "https://TRUSTED.example/path" :allow ["trusted.example"]}]]
+      (let [{:keys [records response]} (reject! args)]
+        (is (= (:location args) (:location (:redirect response)))
+            (str (pr-str args) " — passes, carrying its own target"))
+        (is (empty? (safe-redirect-records records))
+            (str (pr-str args) " — and ships no rejection record"))))))
+
 ;; ===========================================================================
 ;; (2) THE RECORD — the rejection reaches an off-box shipper in production
 ;; ===========================================================================

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -807,7 +807,12 @@ reads **no-op / already-installed**, a *legitimate* verdict, and skips its own
 install. The page then runs a frame nobody ever hydrated, and there is no error
 anywhere to say so. So the claim is transactional over the seed: it is released
 unless the seed provably landed, which is checked against the frame's live
-**incarnation** rather than inferred from the absence of a throw. Release is
+**incarnation** rather than inferred from the absence of a throw. Liveness is
+not acceptance, though: a live frame proves only that the dispatch was
+delivered, and the handler can still refuse the payload and leave the frame
+untouched (a malformed partition, per [§The `:rf/hydrate` event](#the-rfhydrate-event)).
+So a payload the handler will refuse is screened with the handler's own
+predicate before the claim, and never claims at all. Release is
 guarded on the claim's own record, so a late release cannot evict a successor
 that legitimately re-claimed the id.
 


### PR DESCRIPTION
## Summary

Closes the SSR surface-review cluster rf2-fzbj.10 (two findings) plus its per-finding splits rf2-gwye.18, rf2-gwye.19 and rf2-gwye.20.

**1. `:rf.server/safe-redirect` let off-origin targets through `:relative-only?` and `:allow` (rf2-gwye.18, security, P1).** `java.net.URI` parses `///evil.example/path` with no scheme and no authority, so the gate called it a relative reference. Every WHATWG/browser URL parser skips the extra slashes and navigates to `https://evil.example/path`. Separately, `//evil_example/path` has an authority but no extractable host, and the allowlist arm only checked a host that was present, so it waved the target through.
- A raw `//` prefix now always makes a target non-relative.
- Under `:allow`, every non-relative target must name an allowlisted host. A host URI cannot extract names none.
- Rejections reuse the existing categories and reasons (`:relative-only-violation`, `:not-in-allowlist`), so the always-on record vocabulary is unchanged.
- Ordinary relative references, allowed https hosts, and the no-policy path are unchanged.

**2. A payload the `:rf/hydrate` handler refused still held the install claim (rf2-gwye.19).** `hydrate!` treated a still-live frame incarnation as proof the seed landed. But the handler refuses a malformed `:rf/app-db` or `:rf/runtime-db` partition and leaves the frame live. The refused payload kept its ledger claim, ran verification, and made the next valid payload for that frame throw `:rf.error/frame-payload-conflict` against data that was never installed.
- `hydrate!` now screens with the handler's own predicate (`malformed-hydration-payload-reason`, made public) before any claim. That is the bead's first suggested repair.
- A refused payload is still dispatched, so the handler emits its always-on `:rf.error/malformed-hydration-payload` record as before. It claims nothing, verifies nothing, and `hydrate!` returns nil, which is the client-only answer.
- Post-commit claim retention, conflict-after-seed, idempotence and destroyed-frame release are untouched, and their existing tests still pass.
- Spec 011 §Failed-root isolation gains one sentence: liveness is not acceptance.

**3. `streaming.client/install!`'s Usage example contradicted its own contract (rf2-gwye.20).** The example rendered into the streaming root immediately and suggested polling for `__rf_payload`. It is replaced with a readiness-driven recipe:
- the frame is created first;
- the container is bound before `install!`, because `:on-ready` can fire synchronously;
- `ssr/hydrate!` then `reagent2.dom.client/hydrate-root` run only from `:on-ready`.

## Tests

Each new test was shown RED against the pre-fix code, then green. The pre-fix run exited 1 with 35 FAIL/ERROR lines, all in the new tests.
- `re-frame.ssr-safe-redirect-production-test`:
  - `a-network-path-reference-cannot-satisfy-either-policy` covers `///`, `////` and `//evil_example` under both `:relative-only?` and `:allow`. Pre-fix, 5 of the 6 cases passed the gate; `//evil_example` under relative-only was already refused.
  - `each-policy-still-passes-its-legitimate-targets` is the control that the fix did not refuse everything. It is green before and after.
- `re-frame.ssr.failed-root-isolation-cljs-test`:
  - `a-refused-payload-leaves-no-claim-and-verifies-nothing`, which pre-fix errored with the conflict throw, installed-by the refused root.
  - `a-refused-root-cannot-block-a-corrected-sibling-sharing-its-frame`, which pre-fix read `[:hydrated :failed :hydrated]`.
- `re-frame.ssr.streaming-hydration-lifecycle-dom-cljs-test` has `the-install-recipe-boots-once-from-readiness-on-a-live-stream` and `the-install-recipe-boots-once-on-an-already-buffered-response`. The recipe is new, so there is no pre-fix red. Instead, a planted fault that fires `:on-ready` before `unwrap-mounts!` turned exactly those two tests red (4 assertions, captured runner exit 1) and nothing else. The restore was verified by blob hash against the committed object.

The Node 24 WHATWG `URL` parser, resolved against `https://trusted.example/login`, sends every refused corpus location off-origin and keeps every passing control same-origin.

## Quality gates

Every gate below ran on this branch rebased onto `8ff4be83c7`. Each number is the runner's own exit code, captured on the same command line as the run, never through a pipe.

| Gate | Local result | CI job |
|---|---|---|
| `clojure -M:test` from `implementation/ssr` | exit 0: 677 tests, 4524 assertions | `jvm-ssr` |
| `bash scripts/test-ssr-prod-gate.sh` | exit 0: 679 tests, 4358 assertions; its printed gate root is this worktree | `jvm-ssr-prod-gate` |
| `npm run test:browser` (own port) | exit 0: 1095 tests, 5978 assertions, 0 failures | `cljs-browser` |
| `npm run test:cljs` (node-test build; the new `.cljc` tests are confirmed in the compiled output) | exit 0: 11994 tests, 59601 assertions | `cljs` |
| `python scripts/check_doc_slugs.py`, nominated for `spec/011-SSR.md` | exit 0 | `verify-readme-links` |
| `python scripts/check_readme_links.py --ci` | exit 0 | `verify-readme-links` |
| The test.yml Python ratchets: retired spellings, thrown error messages, ambient durable reads, egress walker residue, inject-cofx residue, keyword catalogue drift, SSR prop-drop roster drift, escaped continuations, flattened lists, JVM lane rosters, test lane bijection | all exit 0 | their own test.yml jobs |
| clj-kondo on the changed files | 0 errors; 2 warnings, both present unchanged at the merge-base | `clj-kondo` (lint.yml; fails on errors only) |

**Base.** Main has since moved 4 commits, touching only `implementation/ssr-node` JavaScript and `.beads`. No file this PR touches or any of these gates reads changed, so the branch was not re-rebased; this relies on CI's run of the merge ref.

**Checked by hand.** The spec change is one prose sentence carrying one in-page anchor (`#the-rfhydrate-event`, which three existing links in the page already use). No table or fence was touched. Nothing validates prose, so it was read by hand. `mkdocs build --strict` relies on CI.

## Not done, deliberately

- **No new Ring `Location` test in `implementation/ssr-ring`.** A refusal leaves `:redirect` nil and `:status` 200 on the accumulator (asserted). `pipeline.clj` writes `Location` only from `:redirect`, so the accumulator assertion already covers the wire.
- **No hostless-network-path rejection when no policy is supplied.** An unrestricted safe-redirect already accepts any http(s) or protocol-relative target, and the finding is about the two restricting policies.
