### PR TITLE
fix(machines): fence exit-cascade writes/effects and post-resolution timer reserve to their incarnation (rf2-fzbj.1, rf2-gwye.21)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -231,11 +231,13 @@
   ride the exact owner token, and the timer cancel threads the same gate. For a
   genuinely eventless caller (`eventless-fence`) `owner-gone?` never fires and
   the token is nil — the tail runs exactly as it historically did."
-  [frame-id actor-id teardown-args emit-destroyed!-fn {:keys [owner-gone? owner-token]}]
+  [frame-id actor-id teardown-args emit-destroyed!-fn {:keys [owner-gone? owner-token] :as fence}]
   ;; (1) run the active configuration's `:exit` cascade — its `:exit` actions
   ;; are authored callbacks that may destroy A. An already-entered callback
-  ;; stands; recheck before every subsequent framework action.
-  (rf.machines.lifecycle-fx.exit-cascade/run-child-exit! frame-id actor-id)
+  ;; stands; recheck before every subsequent framework action. rf2-fzbj.1 — the
+  ;; helper takes the same `fence`, so its own post-exit snapshot write and
+  ;; nested exit-effect walk stop at A's loss instead of landing in B.
+  (rf.machines.lifecycle-fx.exit-cascade/run-child-exit! frame-id actor-id fence)
   ;; (2) abort in-flight HTTP — the late-bound `:http/abort-on-actor-destroy`
   ;; hook is callback-bearing. rf2-wjfm — frame-exact: an actor address is
   ;; frame-LOCAL, so the destroying frame is threaded through and a same-named

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -77,38 +77,66 @@
   Returns nil. Per Spec 005 §Final states §Composition with `:entry` /
   `:exit` — `:exit` runs BEFORE the auto-destroy teardown; per
   §Declarative `:spawn` §Composition — `:exit` reads the actor's
-  final snapshot before clearing."
-  [frame-id actor-id]
-  (when actor-id
-    (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
-          snapshot   (when runtime-db (get-in runtime-db (rf.machines.paths/snapshot-path actor-id)))
-          machine    (resolve-machine-spec actor-id snapshot)]
-      (when (and snapshot machine)
-        (let [r (rf.machines.parallel/run-active-exit-cascade machine snapshot)]
-          (if (rf.machines.result/fail? r)
-            ;; Match `apply-transition-once`'s exit-cascade failure
-            ;; trace shape — same category, with a destroy-time
-            ;; discriminator so consumers can disambiguate. Shared with
-            ;; `finalize-machine`'s final-state auto-destroy via
-            ;; `rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure!`.
-            (rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure! actor-id frame-id (rf.machines.result/info r))
-            (rf.machines.result/with-ok [new-snap exit-fx] r
-              ;; (4) Write the post-exit snapshot back to runtime-db. The
-              ;; write is transient — the unified teardown projection runs
-              ;; immediately after this and dissocs `[:rf.runtime/machines :snapshots
-              ;; actor-id]`. Tools that observe runtime-db between
-              ;; `:exit` and teardown see the `:exit`-time `:data`
-              ;; writes; the production-runtime cost is one extra
-              ;; swap-runtime-db! per destroy. Machine snapshots are
-              ;; durable runtime-db state.
-              (when (not= snapshot new-snap)
-                (rf.frame/swap-runtime-db! frame-id
-                                        (fn [rt] (assoc-in rt (rf.machines.paths/snapshot-path actor-id) new-snap))))
-              ;; (5) Fire the `:exit`-emitted fx via the standard fx
-              ;; interpreter. Use the frame's `:platform` (defaults to
-              ;; :client) so platform-gated fx behave consistently with
-              ;; transition-time fx fires.
-              (when (seq exit-fx)
-                (let [platform (or (:platform (rf.frame/frame-meta frame-id)) :client)]
-                  (rf.fx/do-fx frame-id (vec exit-fx) platform))))))))
-    nil))
+  final snapshot before clearing.
+
+  rf2-fzbj.1 — the 3-arity takes the destroy EFFECT's exact-incarnation
+  `fence` (`{:owner-gone? :owner-token}`, captured once at the effect entry by
+  `lifecycle-fx.destroy`). The helper crosses three callback-bearing
+  boundaries — the pure cascade (each `:exit` action emits a synchronous
+  `:rf.machine/action-ran`), the snapshot write (the container's watches) and
+  every exit effect — any of which can destroy A and publish a same-id B. So
+  ownership is rechecked after the cascade and again after the write, the write
+  rides the exact owner token, and the nested `do-fx` walk carries the same
+  token, so a loss inside one exit effect stops the rest and the terminal
+  marker. Work completed in A while A existed stands. The 2-arity is the
+  eventless frame-destroy entry: no owner, full authority, as before."
+  ([frame-id actor-id]
+   (run-child-exit! frame-id actor-id {:owner-gone? (constantly false) :owner-token nil}))
+  ([frame-id actor-id {:keys [owner-gone? owner-token]}]
+   (when actor-id
+     (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
+           snapshot   (when runtime-db (get-in runtime-db (rf.machines.paths/snapshot-path actor-id)))
+           machine    (resolve-machine-spec actor-id snapshot)]
+       (when (and snapshot machine)
+         (let [r (rf.machines.parallel/run-active-exit-cascade machine snapshot)]
+           (cond
+             (rf.machines.result/fail? r)
+             ;; Match `apply-transition-once`'s exit-cascade failure
+             ;; trace shape — same category, with a destroy-time
+             ;; discriminator so consumers can disambiguate. Shared with
+             ;; `finalize-machine`'s final-state auto-destroy via
+             ;; `rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure!`.
+             (rf.machines.lifecycle-fx.traces/emit-destroy-exit-failure! actor-id frame-id (rf.machines.result/info r))
+
+             ;; The cascade's `:rf.machine/action-ran` listeners may have lost
+             ;; A: nothing of A's may be written into, or run against, B.
+             (owner-gone?)
+             nil
+
+             :else
+             (rf.machines.result/with-ok [new-snap exit-fx] r
+               ;; (4) Write the post-exit snapshot back to runtime-db. The
+               ;; write is transient — the unified teardown projection runs
+               ;; immediately after this and dissocs `[:rf.runtime/machines :snapshots
+               ;; actor-id]`. Tools that observe runtime-db between
+               ;; `:exit` and teardown see the `:exit`-time `:data`
+               ;; writes; the production-runtime cost is one extra
+               ;; swap-runtime-db! per destroy. Machine snapshots are
+               ;; durable runtime-db state. With an owner token the write
+               ;; binds to A's own container and is not attributed to a
+               ;; same-id B if a watch loses A mid-install.
+               (when (not= snapshot new-snap)
+                 (let [write (fn [rt] (assoc-in rt (rf.machines.paths/snapshot-path actor-id) new-snap))]
+                   (if owner-token
+                     (rf.frame/swap-runtime-db-exact! frame-id owner-token write)
+                     (rf.frame/swap-runtime-db! frame-id write))))
+               ;; (5) Fire the `:exit`-emitted fx via the standard fx
+               ;; interpreter. Use the frame's `:platform` (defaults to
+               ;; :client) so platform-gated fx behave consistently with
+               ;; transition-time fx fires. Rechecked after the write's
+               ;; watches; the owner token fences each entry of the walk.
+               (when (and (seq exit-fx) (not (owner-gone?)))
+                 (let [platform (or (:platform (rf.frame/frame-meta frame-id)) :client)]
+                   (rf.fx/do-fx frame-id (vec exit-fx) platform
+                                {:frame-incarnation-token owner-token}))))))))
+     nil)))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -679,6 +679,19 @@
       :else
       (let [[resolved-ms reaction] (resolve-delay-ms frame-id delay-key snapshot)]
         (cond
+          ;; rf2-gwye.21 — delay resolution is itself callback-bearing: a
+          ;; fn-form delay reading a sub through `compute-sub` emits a
+          ;; synchronous `:rf.sub/run`, and a subscription-vector delay
+          ;; subscribes and derefs. A listener there can destroy A and publish
+          ;; same-id B, which may arm its own timer at this very key. Recheck
+          ;; the SAME predicate captured above (a fresh capture would name B)
+          ;; before touching the table. On loss, stop: no reservation over B's
+          ;; slot, and no bare-id `unsubscribe`, which would decrement a ref B
+          ;; holds — A's own sub-cache went with A (see the post-emit abort
+          ;; below for the same rule).
+          (owner-gone?)
+          nil
+
           (or (not (number? resolved-ms))
               (not (pos? resolved-ms)))
           ;; Bad delay resolution — emit advisory and skip.

--- a/implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc
@@ -1,0 +1,142 @@
+(ns re-frame.machine-after-delay-resolution-fence-cljs-test
+  "rf2-gwye.21 — an `:after` arm rechecks its captured frame incarnation
+  immediately after resolving the delay, before reserving its timer-table slot.
+
+  Delay resolution is callback-bearing even when the delay is pure: a fn-form
+  delay that reads a subscription through `compute-sub` emits a synchronous
+  `:rf.sub/run` trace, and a listener there can destroy frame A and publish a
+  same-id B that arms its own timer at the identical key. The A continuation
+  used to reserve its slot unconditionally at `[frame-id k]`, overwriting B's
+  entry, and then — its later owner check correctly noticing A's loss — reclaim
+  that reservation, leaving B with no entry: B's host handle orphaned, its
+  timeout never dispatched, and its teardown unable to cancel it.
+
+  Deterministic and single-threaded on both runtimes; the host clock is the
+  only stub. Per Spec 005 §Delayed `:after` transitions."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.late-bind :as rf.late-bind]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.machines.timer :as rf.machines.timer]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact rf.machines/machine-transition)
+
+(use-fixtures :each
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
+
+(def ^:private frame-id :rf2-gwye-21/frame)
+(def ^:private actor :rf2-gwye-21/actor)
+(def ^:private snapshot-path [:rf.runtime/machines :snapshots actor])
+
+(defn- fresh-handle
+  "A process-unique opaque host handle, distinguishable by `identical?`."
+  []
+  #?(:clj (Object.) :cljs #js {}))
+
+(defn- delay-fn
+  "A PURE fn-form delay: it only computes a sub from its supplied snapshot."
+  [{:keys [snapshot]}]
+  (rf/compute-sub [:rf2-gwye-21/delay] (:data snapshot)))
+
+(def ^:private args
+  {:rf/parent-id actor :rf/invoke-id [:waiting] :state :waiting
+   :delay-key delay-fn :epoch 1 :server? false})
+
+(def ^:private timer-key {:parent actor :spawn [:waiting] :delay delay-fn})
+
+(defn- entry [] (get-in @rf.machines.timer/after-timers [frame-id timer-key]))
+
+(defn- seed! [ms]
+  (rf.frame/swap-runtime-db! frame-id assoc-in snapshot-path
+                             {:state :waiting :data {:ms ms :rf/after-epoch {[:waiting] 1}}}))
+
+(defn- arm-a!
+  "Arm A's `:after` with the host clock stubbed. When `replace?`, a once-only
+  `:rf.sub/run` observer on the delay's own resolution destroys A, publishes
+  same-id B with a 7000 ms delay, and arms B at the identical key. Calls `then`
+  with the observations while the host-clock stubs are still installed."
+  [replace? then]
+  (let [fired?  (atom false)
+        b-entry (atom nil)
+        arms    (atom [])
+        cancels (atom [])]
+    (rf/reg-sub :rf2-gwye-21/delay (fn [db _] (:ms db)))
+    (rf/make-frame {:id frame-id})
+    (seed! 5000)
+    (rf.trace.tooling/register-listener!
+      ::replace
+      (fn [ev]
+        (when (and replace?
+                   (= :rf.sub/run (:operation ev))
+                   (= :rf2-gwye-21/delay (get-in ev [:tags :rf.sub/id]))
+                   (compare-and-set! fired? false true))
+          (rf.frame/destroy-frame! frame-id)
+          (rf/make-frame {:id frame-id})
+          (seed! 7000)
+          (rf.machines.timer/after-schedule-fx {:frame frame-id} args)
+          (reset! b-entry (entry)))))
+    (try
+      (with-redefs [rf.interop/schedule-after!   (fn [thunk ms]
+                                                   (let [h (fresh-handle)]
+                                                     (swap! arms conj {:handle h :thunk thunk :ms ms})
+                                                     h))
+                    rf.interop/cancel-scheduled! (fn [h] (swap! cancels conj h) nil)]
+        (rf.machines.timer/after-schedule-fx {:frame frame-id} args)
+        (then {:fired? @fired? :b-entry @b-entry :arms @arms :cancels cancels}))
+      (finally
+        (rf.trace.tooling/unregister-listener! ::replace)
+        (swap! rf.machines.timer/after-timers dissoc frame-id)))))
+
+(deftest delay-resolution-loss-preserves-successor-timer
+  (testing "a :rf.sub/run observer replaces A with B during A's delay
+            resolution: A's stale continuation reserves nothing, so B's entry,
+            token and handle survive and B's timeout still dispatches once"
+    (arm-a! true
+      (fn [{:keys [fired? b-entry arms cancels]}]
+        (is (true? fired?) "the :rf.sub/run observer ran (seam exercised)")
+        (is (some? (:handle b-entry)) "B armed and published its own timer")
+        (is (= b-entry (entry))
+            "B's entry — token, handle, resolved delay — is exactly as B published it")
+        (is (= [7000] (mapv :ms arms))
+            "only B armed a host timer; A's stale continuation armed nothing")
+        (is (not-any? #(identical? (:handle b-entry) %) @cancels)
+            "B's host handle was not cancelled")
+        (let [dispatched (atom [])
+              orig       (rf.late-bind/get-fn :router/dispatch!)]
+          (rf.late-bind/set-fn! :router/dispatch! (fn [ev _opts] (swap! dispatched conj ev)))
+          (try
+            ((:thunk (first arms)))
+            (finally
+              (rf.late-bind/set-fn! :router/dispatch! orig)))
+          (is (= [[actor [:rf.machine.timer/after-elapsed delay-fn 1 [:waiting]]]]
+                 @dispatched)
+              "B's host callback claims B's slot and dispatches its timeout once"))))))
+
+(deftest successor-teardown-cancels-its-own-timer
+  (testing "after A's stale arm stops, B's own teardown still finds its entry
+            and cancels B's host handle"
+    (arm-a! true
+      (fn [{:keys [b-entry cancels]}]
+        (rf.machines.timer/cancel-actor-timers! frame-id actor)
+        (is (some #(identical? (:handle b-entry) %) @cancels)
+            "B's teardown cancelled B's own host handle")
+        (is (nil? (entry)) "B's slot is released")))))
+
+(deftest live-owner-arms-exactly-once
+  (testing "control: with no replacement, A resolves its delay, reserves, arms
+            once and publishes"
+    (arm-a! false
+      (fn [{:keys [fired? arms]}]
+        (is (false? fired?))
+        (is (= [5000] (mapv :ms arms)) "A armed exactly one host timer at its resolved delay")
+        (is (= 5000 (:resolved-ms (entry))) "A's entry is published")
+        (is (identical? (:handle (first arms)) (:handle (entry)))
+            "the published handle is the one armed")))))

--- a/implementation/machines/test/re_frame/machine_exit_cascade_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_exit_cascade_incarnation_fence_cljs_test.cljc
@@ -1,0 +1,201 @@
+(ns re-frame.machine-exit-cascade-incarnation-fence-cljs-test
+  "rf2-fzbj.1 — the destroy-time `:exit` helper (`run-child-exit!`) keeps its
+  post-exit snapshot write and its nested `:fx` walk bound to the exact frame
+  incarnation that entered teardown.
+
+  The outer destroy tail was already fenced (rf2-i4aj9c,
+  `machine_destroy_tail_incarnation_fence_test.clj`), but that suite's `:exit`
+  returns `(:data ctx)` with no `{:data ...}` rider and no `:fx`, so the helper's
+  own write + effect tail never ran there. Here the `:exit` returns a CHANGED
+  `:data` and two real custom effects, and ownership is lost at each of the
+  helper's three boundaries:
+
+    1. the `:rf.machine/action-ran` trace the pure cascade emits (a listener is
+       a reachable replacement boundary even when the authored action is pure)
+       destroys A and publishes a same-id B;
+    2. the FIRST exit effect destroys A — the second effect and the walk's
+       terminal `:rf.fx/do-fx` marker must not run. (A successor cannot be
+       published from inside an effect: EP-0027 refuses frame construction
+       while `*handler-scope*` is bound, so loss is the reachable case there.);
+    3. a container watch on the post-exit write destroys A and publishes B — no
+       commit-epoch bump may be attributed to B, and no effect may follow.
+
+  Where B exists it must stay byte-identical with zero A-derived effects. The
+  live-owner and eventless controls keep the intended write-before-effects
+  ordering and full teardown. Per Spec 005 §Declarative `:spawn` §Composition
+  with explicit `:entry` / `:exit`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.machines.lifecycle-fx.destroy :as rf.machines.lifecycle-fx.destroy]
+            [re-frame.machines.test-support :as rf.machines.test-support]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
+
+;; Touch the artefact so the machines registration hooks are wired even when
+;; this ns runs in isolation.
+(def ^:private _artefact rf.machines/machine-transition)
+
+(use-fixtures :each
+  (rf.machines.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
+
+(def ^:private actor :rf2-fzbj-1/actor)
+(def ^:private snapshot-path [:rf.runtime/machines :snapshots actor])
+
+(defn- runtime-db [frame-id] (rf.frame/frame-runtime-db-value frame-id))
+(defn- snapshot [frame-id] (get-in (runtime-db frame-id) snapshot-path))
+
+(defn- run-destroy
+  "Seed `actor` live in frame A, whose `:exit` returns a changed `:data` and two
+  effects, then tear it down.
+
+  `mode` picks the driver and the loss boundary:
+    :live         — `:rf.machine/destroy` under A's event owner, no loss;
+    :eventless    — `destroy-single-actor!` with NO event owner bound (the
+                    frame-destroy cascade's entry), no loss;
+    :action-ran   — replace A with B on the destroy-exit `:rf.machine/action-ran`;
+    :first-effect — destroy A inside the first exit effect;
+    :exit-write   — replace A with B from a container watch on A's post-exit write.
+
+  The loss fires once. Every effect run is recorded with whether it ran in B
+  and whether the post-exit write was visible when it ran; effects and terminal
+  markers that run after the first-effect loss are recorded separately."
+  [frame-id mode]
+  (let [effects          (atom [])
+        after-loss       (atom [])
+        do-fx-in-b       (atom 0)
+        do-fx-after-loss (atom 0)
+        fired?           (atom false)
+        lost?            (atom false)
+        b-token          (atom nil)
+        b-birth          (atom nil)
+        b-commit         (atom nil)
+        in-b?            (fn []
+                           (and (some? @b-token)
+                                (identical? @b-token (rf.frame/frame-incarnation-token frame-id))))
+        replace!         (fn []
+                           (when (compare-and-set! fired? false true)
+                             (rf.frame/destroy-frame! frame-id)
+                             (rf/make-frame {:id frame-id})
+                             (rf.frame/swap-runtime-db! frame-id assoc-in snapshot-path
+                                                        {:state :running :data {:owner :b}})
+                             (reset! b-token (rf.frame/frame-incarnation-token frame-id))
+                             (reset! b-birth (runtime-db frame-id))
+                             (reset! b-commit (rf.frame/frame-commit-epoch frame-id))))]
+    (rf/reg-fx :rf2-fzbj-1/effect
+      (fn [_ctx value]
+        (when @lost? (swap! after-loss conj value))
+        (swap! effects conj {:value       value
+                             :in-b?       (in-b?)
+                             :exit-marker (get-in (snapshot frame-id) [:data :exit-marker])})
+        (when (and (= :first-effect mode) (= 1 value) (compare-and-set! fired? false true))
+          (rf.frame/destroy-frame! frame-id)
+          (reset! lost? true))))
+    (rf/reg-machine actor
+      {:initial :running
+       :states  {:running {:exit (fn [_]
+                                   {:data {:exit-marker :from-a}
+                                    :fx   [[:rf2-fzbj-1/effect 1]
+                                           [:rf2-fzbj-1/effect 2]]})}}})
+    (rf/make-frame {:id frame-id})
+    (rf.frame/swap-runtime-db! frame-id assoc-in snapshot-path
+                               {:state :running :data {:owner :a}})
+    (let [token-a     (rf.frame/frame-incarnation-token frame-id)
+          container-a (rf.frame/frame-state-container frame-id)]
+      (rf.trace.tooling/register-listener!
+        ::observer
+        (fn [ev]
+          (case (:operation ev)
+            :rf.machine/action-ran
+            (when (and (= :action-ran mode)
+                       (= :destroy-exit (get-in ev [:tags :phase])))
+              (replace!))
+
+            :rf.fx/do-fx
+            (do (when (in-b?) (swap! do-fx-in-b inc))
+                (when @lost? (swap! do-fx-after-loss inc)))
+
+            nil)))
+      (when (= :exit-write mode)
+        (add-watch container-a ::exit-write
+                   (fn [_ _ _ after]
+                     (when (= :from-a (get-in after (into [:rf.db/runtime] (conj snapshot-path :data :exit-marker))))
+                       (replace!)))))
+      (try
+        (if (= :eventless mode)
+          (rf.machines.lifecycle-fx.destroy/destroy-single-actor! frame-id actor)
+          (rf.frame/call-with-event-owner-token frame-id token-a
+            (fn [] (rf.machines.lifecycle-fx.destroy/destroy-machine-fx {:frame frame-id} actor))))
+        {:fired?           @fired?
+         :b-birth          @b-birth
+         :b-runtime        (runtime-db frame-id)
+         :b-commit         @b-commit
+         :commit           (rf.frame/frame-commit-epoch frame-id)
+         :snapshot         (snapshot frame-id)
+         :effects          @effects
+         :after-loss       @after-loss
+         :do-fx-in-b       @do-fx-in-b
+         :do-fx-after-loss @do-fx-after-loss}
+        (finally
+          (rf.trace.tooling/unregister-listener! ::observer)
+          (remove-watch container-a ::exit-write))))))
+
+(defn- assert-b-untouched [{:keys [fired? b-birth b-runtime b-commit commit effects do-fx-in-b]}]
+  (is (true? fired?) "the replacement boundary ran (fence exercised)")
+  (is (some? b-birth) "same-id successor B was published")
+  (is (= b-birth b-runtime)
+      "B's runtime-db is byte-identical to its birth value — A's post-exit snapshot write did not land in B")
+  (is (= b-commit commit)
+      "no commit-epoch bump was attributed to B")
+  (is (empty? (filter :in-b? effects))
+      "zero A-derived exit effects ran in B")
+  (is (zero? do-fx-in-b)
+      "A's exit walk emitted no terminal :rf.fx/do-fx marker against B"))
+
+(deftest action-ran-loss-fences-exit-write-and-effects
+  (testing "a destroy-exit :rf.machine/action-ran listener replaces A with B:
+            the helper rechecks ownership after the pure cascade, so A's
+            changed :data never reaches B and A's exit effects never run in B"
+    (assert-b-untouched (run-destroy :rf2-fzbj-1/action-ran-frame :action-ran))))
+
+(deftest first-effect-loss-fences-remaining-exit-effects
+  (testing "the first exit effect destroys A: the nested walk carries A's exact
+            token, so the second effect and the terminal marker do not run"
+    (let [{:keys [fired? effects after-loss do-fx-after-loss]}
+          (run-destroy :rf2-fzbj-1/effect-frame :first-effect)]
+      (is (true? fired?) "the first effect destroyed A (fence exercised)")
+      (is (= {:value 1 :in-b? false :exit-marker :from-a} (first effects))
+          "the first effect ran in A after A's exit write, before the loss")
+      (is (empty? after-loss)
+          "no exit effect of the lost walk ran after A was destroyed")
+      (is (zero? do-fx-after-loss)
+          "the lost walk emitted no terminal :rf.fx/do-fx marker"))))
+
+(deftest exit-write-watch-loss-fences-epoch-and-effects
+  (testing "a container watch on A's post-exit write replaces A with B: the
+            write binds to A's own container, the epoch bump is not attributed
+            to B, and no exit effect follows"
+    (assert-b-untouched (run-destroy :rf2-fzbj-1/write-frame :exit-write))))
+
+(deftest live-owner-exit-writes-then-fires-then-tears-down
+  (testing "control: with no loss, the exit write lands before both effects
+            run (in order, once each) and the snapshot is removed"
+    (let [{:keys [fired? snapshot effects]} (run-destroy :rf2-fzbj-1/live-frame :live)]
+      (is (false? fired?))
+      (is (= [{:value 1 :in-b? false :exit-marker :from-a}
+              {:value 2 :in-b? false :exit-marker :from-a}]
+             effects)
+          "both exit effects ran once, in order, each seeing the post-exit write")
+      (is (nil? snapshot) "the teardown removed the actor's snapshot"))))
+
+(deftest eventless-destroy-keeps-full-exit-authority
+  (testing "control: the eventless frame-destroy entry has no owner token, so
+            the exit write and both effects run exactly as before"
+    (let [{:keys [snapshot effects]} (run-destroy :rf2-fzbj-1/eventless-frame :eventless)]
+      (is (= [{:value 1 :in-b? false :exit-marker :from-a}
+              {:value 2 :in-b? false :exit-marker :from-a}]
+             effects)
+          "both exit effects ran once, in order, each seeing the post-exit write")
+      (is (nil? snapshot) "the teardown removed the actor's snapshot"))))


### PR DESCRIPTION
## Summary

Two same-id frame-replacement defects in `implementation/machines`, both re-verified at tip before fixing (the review ran against an older trunk).

**rf2-fzbj.1 (P1) — the destroy-time `:exit` helper wrote into, and fired effects in, a successor frame.** `run-child-exit!` ran its post-exit snapshot write through the bare `swap-runtime-db!` and its exit effects through the tokenless 3-arity `do-fx`. A synchronous callback during teardown (a `:rf.machine/action-ran` listener on the pure cascade, a container watch on the write, or an exit effect) could destroy frame A and publish same-id B; the helper then wrote A's snapshot into B, bumped B's commit epoch, and ran A's exit effects in B. The outer destroy tail was already fenced (rf2-i4aj9c), but it only rechecks *after* this helper returns.

Fix: `run-child-exit!` gains a 3-arity taking the destroy effect's exact-incarnation fence (`{:owner-gone? :owner-token}`). `teardown-live-actor!` passes its fence through. The helper:

- rechecks ownership after the pure cascade;
- writes through `swap-runtime-db-exact!` when an owner token is bound;
- rechecks again before the effects;
- hands the same token to the nested `do-fx` walk as `:frame-incarnation-token`, so a loss inside one exit effect stops the remaining effects and the terminal marker.

The 2-arity keeps the eventless frame-destroy entry's full authority, unchanged. Every destroy variant routes through the one helper: ordinary, tracked, per-child `:spawn-all`, and occupied-address replacement.

**rf2-gwye.21 (P2) — an `:after` arm overwrote a successor's timer after delay resolution lost its frame.** `schedule-after-timer!` checked its captured `owner-gone?` before `resolve-delay-ms` but not after. A pure fn-form delay reading a sub through `compute-sub` emits a synchronous `:rf.sub/run`, and a listener there can replace A with B and arm B's timer at the identical key. A's continuation then reserved over B's slot and later reclaimed its own reservation. That left B with no entry, an orphaned host handle, and a timeout that never dispatched. Fix: one recheck of the same captured predicate immediately after resolution, before either the bad-delay `unsubscribe` or the reservation. On loss it stops, touching neither B's table nor B's sub refs.

No public API, grammar or spec change. Both fixes enforce contracts that Spec 005 already states.

## Differences from the beads

- rf2-fzbj.1's acceptance asks for a case where the first exit effect *replaces* A with B. B cannot be constructed from inside an effect: EP-0027 refuses frame construction while `*handler-scope*` is bound (`:rf.error/frame-construction-in-handler`). The reachable case there is *loss*, so that test has the first effect destroy A, and asserts that the second effect and the terminal `:rf.fx/do-fx` marker do not run. Publishing B is covered by the action-ran and container-watch cases.
- The destroy-exit *failure* trace (`emit-destroy-exit-failure!`) is left unfenced. It reports a failure that really happened in A; it is neither a write nor an effect.
- rf2-gwye.21's optional extra coverage through a subscription-vector delay is not added. That path goes through the same single recheck the fn-form test pins.

## Tests

Two new `.cljc` namespaces run on both hosts: the JVM runner matches `-test$`, and `:node-test` matches `cljs-test$`.

- `re-frame.machine-exit-cascade-incarnation-fence-cljs-test`: loss at action-ran, at the first effect, and at a container watch on the exit write. It asserts that B is byte-identical to its birth value, that B's commit epoch is unmoved, and that no A-derived effect or terminal marker ran against B. Two controls: live-owner (write lands before both effects, in order, and the snapshot is removed) and eventless (full authority).
- `re-frame.machine-after-delay-resolution-fence-cljs-test`: the reviewer's pure delay-fn plus `compute-sub` plus observer scenario. It asserts that B's entry, token and handle are unchanged, that only B armed a host timer, that B's callback still dispatches exactly once, and that B's own teardown cancels B's handle. The live-owner control arms once.

Every loss test asserts that its seam actually fired, so a green result cannot be vacuous.

## Quality gates

| Gate | Run | Result |
|---|---|---|
| New namespaces, JVM, **before the fix** | `clojure -M:test -n <both new ns>` | exit 1: 8 tests, 33 assertions, **12 failures** (every loss case red; the three controls green) |
| New namespaces, JVM, after the fix | same | exit 0: 8 tests, 33 assertions, 0 failures |
| New namespaces, CLJS | `node out/node-test.js --test=<both new ns>` on the compiled `:node-test` build | exit 0: 8 tests, 33 assertions, 0 failures |
| `jvm-machines` (`JVM machines (clojure -M:test)`) | `clojure -M:test` in `implementation/machines` | exit 0 on the final base (`origin/main` at `e9a6e3dd54`): 1257 tests, 4627 assertions. Same result as the pre-rebase run |
| `cljs` (`CLJS (shadow-cljs :node-test)`) | `npm run test:cljs` in `implementation` | exit 0 on the final base: 11998 tests, 59613 assertions. Same result as the pre-rebase run |
| Per-namespace isolation (step of `cljs`) | `node scripts/check-per-ns-isolation.cjs` | exit 0 |
| clj-kondo | lint of the 5 changed files | 0 errors. The 2 warnings (`with-ok` bindings unresolved) reproduce identically on the pre-fix blob |
| splint | `clojure -M:splint --fail-on-errors machines` | exit 0. Nothing on changed lines or new files |
| require-alias-dialect, test-lane bijection, retired-vocab and residue scans | `python scripts/check_*.py` | exit 0 each |
| Review probes, re-run after the fix | both reviewer witnesses | each now fails its own defect assertion: B keeps `{:owner :b}`; B's timer entry is preserved |

**CI coverage relied on:** the classifier also arms `jvm-tools-machines-viz` and `cljs-tools-machines-viz` for a change under `implementation/machines/**`. I did not run them locally; they are CI coverage for this PR.

No spec or doc page was touched, so no link gate applies.
