### PR TITLE
fix(schemas): redact across variable-width :cat sequences; reset print limits before memoising digest bytes

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -103,12 +103,19 @@
 (defn- compute-edn-print
   "The pure serialisation step behind `default-edn-print` — `pr-str`
   over a canonicalised EDN form with the digest pipeline's print-flag
-  bindings. Same `schema-value` always returns byte-identical bytes."
+  bindings. Same `schema-value` always returns byte-identical bytes.
+
+  `*print-length*` / `*print-level*` are reset too: an ambient REPL or tool
+  binding would otherwise truncate both the canonicaliser's `pr-str` key
+  comparator and the final bytes, and the memo would keep the truncated
+  string process-wide (rf2-gwye.14)."
   [schema-value]
   (binding [*print-meta*           false
             *print-readably*       true
             *print-dup*            false
-            *print-namespace-maps* false]
+            *print-namespace-maps* false
+            *print-length*         nil
+            *print-level*          nil]
     (pr-str (canonicalise-schema-form schema-value))))
 
 ;; The process-lifetime print cache is bounded by boot-time schema

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -66,7 +66,11 @@
   — `(conj c i)` in `re-frame.elision`), which matches a position-pinned
   declaration exactly. No elision-side change is required — the index fork
   is schema-agnostic (it walks the runtime value), so `:cat`/`:catn`/`:tuple`
-  all align through the same generic path."
+  all align through the same generic path.
+
+  `:tuple` is always positional. A `:cat` / `:catn` is positional only when
+  `fixed-width-sequence?` holds and it is not itself spliced into an
+  enclosing regex op; otherwise its elements descend index-free (rf2-gwye.11)."
   #{:tuple :cat :catn})
 
 (defn- schema-properties
@@ -85,6 +89,39 @@
     (if (and (seq schema-tail) (map? (first schema-tail)))
       (subvec schema-tail 1)
       schema-tail)))
+
+(def ^:private regex-ops
+  "Malli's sequence (regex) operators. As an element of an enclosing sequence
+  one of these is SPLICED into it and consumes zero, one or many input values,
+  so its input position cannot be read off its schema position (rf2-gwye.11)."
+  #{:cat :catn :alt :altn :? :* :+ :repeat})
+
+(defn- sequence-element-schema
+  "The element schema of a `:tuple` / `:cat` / `:catn` child: the bare child,
+  or a `:catn` entry's `[name props? schema]` schema part (nil if malformed)."
+  [op child]
+  (if (= op :catn)
+    (when (and (vector? child) (>= (count child) 2))
+      (if (map? (nth child 1))
+        (nth child 2 nil)
+        (nth child 1)))
+    child))
+
+(defn- fixed-width-sequence?
+  "True when input index `i` provably addresses element `i`: always for a
+  `:tuple`, and for a `:cat` / `:catn` only when every element consumes
+  exactly one value — a keyword, symbol, fn, or non-regex vector form. A
+  regex, malformed or compiled element makes the width unknowable from the
+  pure data (rf2-gwye.11), so the node falls back to a whole-node decision."
+  [op children]
+  (or (= op :tuple)
+      (every? (fn [child]
+                (let [element (sequence-element-schema op child)]
+                  (or (keyword? element) (symbol? element) (fn? element)
+                      (and (vector? element)
+                           (pos? (count element))
+                           (not (contains? regex-ops (nth element 0)))))))
+              children)))
 
 (defn- declaration-from-properties
   "Build a declaration map `{flag-key true :source :schema}` (plus
@@ -106,6 +143,8 @@
     (cond-> {flag-key true
              :source  :schema}
       (some? (:hint props)) (assoc :hint (:hint props)))))
+
+(declare ^:private walk-flags)
 
 (defn walk-flagged-schema
   "Walk a Malli EDN schema form at `base-path`, populating `acc` with
@@ -148,6 +187,14 @@
       literal-index fork (`fork-index-paths` — `(conj c i)`), which matches
       a position-pinned declaration exactly.
 
+      That precision needs a FIXED-WIDTH sequence (`fixed-width-sequence?`)
+      that is not itself spliced into an enclosing regex op. A `:cat` /
+      `:catn` with a regex element (`[:cat [:* :int] Payload]`) cannot map an
+      input index to an element, so it descends like `:sequential` — every
+      element at the SAME `base-path`, `:catn` entry flags claiming
+      `base-path` — and value-path alignment falls back to the whole node
+      (rf2-gwye.11).
+
     - Other positional / nameless container ops (`:vector`, `:set`,
       `:sequential`, `:maybe`, `:and`, `:or`, `:not`, …) descend into each
       child at the SAME `base-path` — these ops are homogeneous (one
@@ -163,6 +210,13 @@
   ([flag-key schema base-path]
    (walk-flagged-schema flag-key schema base-path {}))
   ([flag-key schema base-path acc]
+   (walk-flags flag-key schema base-path acc false)))
+
+(defn- walk-flags
+  "The recursion behind `walk-flagged-schema`. `spliced?` is true when
+  `schema` is an element of a regex op, where a `:cat` / `:catn` is spliced
+  into the enclosing sequence and owns no input positions (rf2-gwye.11)."
+  ([flag-key schema base-path acc spliced?]
    (cond
      ;; Keyword schema (`:string`, `:int`, `:any`, registry-name kw, …)
      ;; — no slot props on a bare keyword; nothing to nominate.
@@ -175,7 +229,12 @@
                                            flag-key (schema-properties schema))]
                       (assoc acc base-path declaration)
                       acc)
-           children (schema-children schema)]
+           children (schema-children schema)
+           ;; A regex op's elements are spliced into its own sequence.
+           splices? (contains? regex-ops op)
+           positional? (and (contains? position-bearing-ops op)
+                            (not (and spliced? splices?))
+                            (fixed-width-sequence? op children))]
        (cond
          (contains? name-bearing-ops op)
          (reduce
@@ -196,12 +255,16 @@
                                             (assoc acc slot-path declaration)
                                             acc)]
                  (if (some? child-schema)
-                   (walk-flagged-schema flag-key child-schema slot-path acc)
+                   (walk-flags flag-key child-schema slot-path acc false)
                    acc))))
            acc'
            children)
 
-         (contains? dispatch-bearing-ops op)
+         ;; A non-positional `:catn` is entry-shaped exactly like a
+         ;; dispatch-bearing op: entry flags and element schemas both claim
+         ;; the base-path (rf2-gwye.11).
+         (or (contains? dispatch-bearing-ops op)
+             (and (= op :catn) (not positional?)))
          (reduce
            (fn [acc child]
              (if-not (vector? child)
@@ -218,7 +281,7 @@
                                             (assoc acc base-path declaration)
                                             acc)]
                  (if (some? child-schema)
-                   (walk-flagged-schema flag-key child-schema base-path acc)
+                   (walk-flags flag-key child-schema base-path acc splices?)
                    acc))))
            acc'
            children)
@@ -235,8 +298,10 @@
          ;; `:catn` elements are NAME-bearing entries (`[name props? schema]`)
          ;; — the flag may live in the entry's own props OR the element
          ;; schema's props, both claiming `(conj base i)`. Either shape
-         ;; descends the element schema at the position-pinned path.
-         (contains? position-bearing-ops op)
+         ;; descends the element schema at the position-pinned path. A
+         ;; variable-width or spliced `:cat` is not `positional?` and takes
+         ;; the index-free `:else` descent instead (rf2-gwye.11).
+         positional?
          (first
            (reduce
              (fn [[acc i] child]
@@ -263,7 +328,7 @@
                            (assoc acc slot-path entry-declaration)
                            acc)]
                  [(if (some? element-schema)
-                    (walk-flagged-schema flag-key element-schema slot-path acc)
+                    (walk-flags flag-key element-schema slot-path acc splices?)
                     acc)
                   (inc i)]))
              [acc' 0]
@@ -271,7 +336,7 @@
 
          :else
          (reduce (fn [acc child]
-                   (walk-flagged-schema flag-key child base-path acc))
+                   (walk-flags flag-key child base-path acc splices?))
                  acc'
                  children)))
 
@@ -672,10 +737,14 @@
             ;; failure — the rf2-4q681i fix. `:tuple`/`:cat` element `segment` is
             ;; `children[segment]` (bare schema); `:catn` element `segment` is a
             ;; NAME-bearing entry (`[name props? schema]`) so we descend into
-            ;; its schema part.
+            ;; its schema part. A VARIABLE-WIDTH `:cat` / `:catn` (a regex
+            ;; element) cannot say which element input index `segment`
+            ;; addresses — `children[segment]` may be a different child — so
+            ;; it falls back to the whole node (rf2-gwye.11).
             (contains? position-bearing-ops op)
             (if-let [child (when (and (int? segment)
-                                      (< segment (count children)))
+                                      (< segment (count children))
+                                      (fixed-width-sequence? op children))
                              (nth children segment))]
               (let [element-schema (if (= op :catn)
                                      (if (and (vector? child) (>= (count child) 2))
@@ -793,6 +862,9 @@
       failure reports the CALLER-SUPPLIED extra key itself as the segment —
       user data, possibly a credential — so the key-not-found branch fails
       closed INCLUDING the current segment.
+    - A VARIABLE-WIDTH `:cat` / `:catn` (a regex element such as `:*` /
+      `:?`, rf2-gwye.11) cannot say which element an index addresses, so it
+      takes the FAIL-CLOSED tail below.
     - Transparent wrappers contribute NO `:in` segment — descend without
       consuming. `:maybe` is genuinely single-child (`[:maybe inner]`) so
       the lockstep walk continues precisely. `:and` / `:or` are MULTI-child
@@ -920,6 +992,13 @@
                 (recur value-schema
                        (subvec remaining-path 1)
                        (conj sanitized-path sanitized-segment)))
+
+              ;; A VARIABLE-WIDTH `:cat` / `:catn` (rf2-gwye.11) — the input
+              ;; index does not identify the element, so the lockstep walk
+              ;; cannot continue. Fail CLOSED like any ambiguous op.
+              (and (contains? position-bearing-ops op)
+                   (not (fixed-width-sequence? op children)))
+              (fail-closed-tail sanitized-path remaining-path)
 
               ;; Other index-bearing ops — the segment is a navigable index
               ;; (`:vector` / `:sequential` / `:tuple` / `:cat` / `:catn`);

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_cljs_test.cljs
@@ -62,3 +62,18 @@
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))
+
+;; ---- ambient printer limits (rf2-gwye.14) ---------------------------------
+
+(deftest cljs-printer-limits-never-reach-digest-bytes
+  (testing "rf2-gwye.14 — a bounded *print-length* / *print-level* in the
+            calling context changes neither the bytes and digests computed
+            under it nor what the memo serves once the binding ends"
+    (let [{:keys [baseline results]} (rf.schemas.digest-parity-fixtures/printer-limit-observations)]
+      (is (apply distinct? (:digests baseline))
+          "the unbounded baseline keeps every schema form distinct")
+      (doseq [{:keys [label inside after]} results]
+        (is (= baseline inside)
+            (str (pr-str label) " — bytes and digests inside the binding"))
+        (is (= baseline after)
+            (str (pr-str label) " — memoised bytes and digests read after it"))))))

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_fixtures.cljc
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_fixtures.cljc
@@ -32,7 +32,8 @@
   were repinned when the path-key encoding moved to `canonical-bytes`; the
   empty-set literal (`sha256:e3b0c44298fc1c14`) is unchanged because the
   empty schema set emits no path-key line."
-  (:require [re-frame.schemas.digest]))
+  (:require [re-frame.schemas.digest]
+            [re-frame.schemas.validator]))
 
 ;; ---- the parity test entry point ------------------------------------------
 ;;
@@ -191,3 +192,44 @@
    props-order-pair
    metadata-stripped-pair
    metadata-stripped-inner-pair])
+
+;; ---- ambient printer limits (rf2-gwye.14) ---------------------------------
+;;
+;; A REPL or tool that binds `*print-length*` / `*print-level*` must neither
+;; reach the digest bytes nor leave a truncated serialisation in the
+;; process-wide `default-edn-print` memo. The first two forms collapse to one
+;; string under either bound; the third also sends collection-valued map keys
+;; and set members through the canonicaliser's `pr-str` comparator, where a
+;; bound makes distinct members compare equal and merge.
+
+(def printer-limit-schemas
+  [[:map [:a :int]]
+   [:map [:a :string]]
+   [:map {:doc-keys {[:k 1] :x [:k 2] :y} :doc-set #{[:m 1] [:m 2]}} [:a :int]]])
+
+(def printer-limit-bindings
+  "`[label *print-length* *print-level*]` — each bound alone, then both."
+  [[:print-length 1 nil]
+   [:print-level nil 1]
+   [:both 1 1]])
+
+(defn printer-limit-observations
+  "For each of `printer-limit-bindings`, starting from an EMPTY print memo: the
+  printer bytes and digests of `printer-limit-schemas` computed INSIDE the
+  binding (`:inside`), then re-read after it WITHOUT clearing (`:after`). Both
+  must equal the unbounded `:baseline`. Leaves the memo empty."
+  []
+  (let [observe  (fn []
+                   {:bytes   (mapv re-frame.schemas.validator/run-printer printer-limit-schemas)
+                    :digests (mapv #(compute-digest {[:s] %}) printer-limit-schemas)})
+        _        (re-frame.schemas.validator/clear-edn-print-cache!)
+        baseline (observe)
+        results  (mapv (fn [[label length level]]
+                         (re-frame.schemas.validator/clear-edn-print-cache!)
+                         (let [inside (binding [*print-length* length
+                                                *print-level*  level]
+                                        (observe))]
+                           {:label label :inside inside :after (observe)}))
+                       printer-limit-bindings)]
+    (re-frame.schemas.validator/clear-edn-print-cache!)
+    {:baseline baseline :results results}))

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
@@ -128,3 +128,18 @@
       (is (= (Integer/signum (compare-utf8-bytes a b))
              (Integer/signum (compare a b)))
           (str "ASCII order coincides for " (pr-str [a b]))))))
+
+;; ---- ambient printer limits (rf2-gwye.14) ---------------------------------
+
+(deftest jvm-printer-limits-never-reach-digest-bytes
+  (testing "rf2-gwye.14 — a bounded *print-length* / *print-level* in the
+            calling context changes neither the bytes and digests computed
+            under it nor what the memo serves once the binding ends"
+    (let [{:keys [baseline results]} (rf.schemas.digest-parity-fixtures/printer-limit-observations)]
+      (is (apply distinct? (:digests baseline))
+          "the unbounded baseline keeps every schema form distinct")
+      (doseq [{:keys [label inside after]} results]
+        (is (= baseline inside)
+            (str (pr-str label) " — bytes and digests inside the binding"))
+        (is (= baseline after)
+            (str (pr-str label) " — memoised bytes and digests read after it"))))))

--- a/implementation/schemas/test/re_frame/schemas/sequence_width_fixtures.cljc
+++ b/implementation/schemas/test/re_frame/schemas/sequence_width_fixtures.cljc
@@ -1,0 +1,72 @@
+(ns re-frame.schemas.sequence-width-fixtures
+  "Shared, host-agnostic corpus for sensitive-value redaction across
+  VARIABLE-WIDTH `:cat` / `:catn` sequences (rf2-gwye.11 / rf2-fzbj.25).
+  Both the JVM test (`re-frame.schemas-sensitive-test`) and the CLJS test
+  (`re-frame.schemas-sequence-width-cljs-test`) register each schema at
+  `[:items]`, validate `{:items value}` through `validate-app-schema!` and
+  read the real trace recorder, so the redaction cannot diverge by host.
+
+  The defect: the walker read a `:cat` / `:catn` input index as its schema
+  child index. A regex element (`:*`, `:?`, a nested `:cat`) consumes zero or
+  many values, so the failing input element could belong to a DIFFERENT child
+  than the one the index named, and a sensitive payload's value — or a
+  sensitive `:map-of` key riding `:path` — shipped verbatim.
+
+  Every case is pure vector-form data, so the corpus loads identically on the
+  JVM and under `:node-test`.")
+
+(def secret
+  "The value that must appear in NO slot of a `leak-cases` trace."
+  "SEQ-WIDTH-SECRET-gwye11")
+
+(def ^:private sensitive-map
+  [:map [:token {:sensitive? true} :int]])
+
+(def leak-cases
+  "Each `{:desc :schema :value}` must reject, stamp `:sensitive?`, redact
+  `:value`, and carry `secret` in no trace slot."
+  [{:desc   "zero-width :* prefix in a :cat"
+    :schema [:cat [:* :int] sensitive-map]
+    :value  [{:token secret}]}
+
+   {:desc   "zero-width :* prefix in a :catn"
+    :schema [:catn [:prefix [:* :int]] [:payload sensitive-map]]
+    :value  [{:token secret}]}
+
+   {:desc   "empty :? optional prefix"
+    :schema [:cat [:? :int] sensitive-map]
+    :value  [{:token secret}]}
+
+   {:desc   "nonzero :* repetition shifts the payload onto a later schema child"
+    :schema [:cat [:* :int] sensitive-map [:* :int]]
+    :value  [1 2 {:token secret}]}
+
+   {:desc   "a nested :cat expands to two values, shifting the payload"
+    :schema [:cat [:cat :int :int] sensitive-map :string]
+    :value  [1 2 {:token secret} "x"]}
+
+   {:desc   "a sensitive :map-of KEY after a nested :cat — the key would ride
+             :path and :reason"
+    :schema [:cat [:cat :int :int]
+             [:map-of [:string {:sensitive? true}] :int]
+             :string :string]
+    :value  [1 2 {secret "not-an-int"} "a" "b"]}])
+
+(def precise-cases
+  "Controls: each `{:desc :schema :value :expected}` must reject and report
+  `:expected` VERBATIM in `:value` — the fix is scoped to the ambiguous node
+  and does not blank ordinary failures."
+  [{:desc     "a variable-width :cat declaring nothing sensitive reports its value"
+    :schema   [:cat [:* :int] [:map [:name :string]]]
+    :value    [{:name 5}]
+    :expected {:name 5}}
+
+   {:desc     "a fixed-width :cat keeps sibling precision beside a sensitive element"
+    :schema   [:cat :int sensitive-map]
+    :value    ["not-an-int" {:token 1}]
+    :expected "not-an-int"}
+
+   {:desc     "a slot outside a variable-width sequence stays precise"
+    :schema   [:map [:seq [:cat [:* :int] sensitive-map]] [:label :string]]
+    :value    {:seq [{:token 1}] :label 42}
+    :expected 42}])

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -50,6 +50,8 @@
             ;; half (re-frame.schemas-sensitive-path-cljs-test) asserts the
             ;; SAME cases so privacy behaviour cannot diverge by host.
             [re-frame.schemas.walker-sanitize-path-fixtures :as rf.schemas.walker-sanitize-path-fixtures]
+            ;; Shared cross-host variable-width sequence corpus (rf2-gwye.11).
+            [re-frame.schemas.sequence-width-fixtures :as rf.schemas.sequence-width-fixtures]
             [re-frame.schemas.test-fixture :as rf.schemas.test-fixture]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
@@ -2287,3 +2289,26 @@
           "no :sensitive? stamp — nothing in the schema is sensitive")
       (is (= [:plain "extra-key"] (-> v :tags :path))
           "the extra key rides verbatim in :path — precise diagnostics kept"))))
+
+;; ---- variable-width :cat / :catn (rf2-gwye.11 / rf2-fzbj.25) --------------
+;; A regex element consumes zero or many values, so a :cat input index is not
+;; its schema child index. The shared corpus pins the leak shapes and the
+;; non-sensitive controls; the CLJS half asserts the same corpus.
+
+(deftest app-db-validation-variable-width-sequence-never-leaks-sensitive-value
+  (testing "rf2-gwye.11 — a regex element before a sensitive payload no longer
+            misaligns the redaction decision"
+    (doseq [{:keys [desc schema value]} rf.schemas.sequence-width-fixtures/leak-cases]
+      (let [v (app-db-failure-trace [:items] schema {:items value} :items/bad)]
+        (is (some? v) (str desc " — a trace fired"))
+        (is (true? (:sensitive? v)) (str desc " — :sensitive? stamped"))
+        (is (= :rf/redacted (-> v :tags :value)) (str desc " — :value redacted"))
+        (is (not (str/includes? (pr-str v) rf.schemas.sequence-width-fixtures/secret))
+            (str desc " — the secret is in no trace slot"))))))
+
+(deftest app-db-validation-variable-width-fix-keeps-non-sensitive-values
+  (testing "rf2-gwye.11 control — non-sensitive failures still report their value"
+    (doseq [{:keys [desc schema value expected]} rf.schemas.sequence-width-fixtures/precise-cases]
+      (let [v (app-db-failure-trace [:items] schema {:items value} :items/bad)]
+        (is (some? v) (str desc " — a trace fired"))
+        (is (= expected (-> v :tags :value)) desc)))))

--- a/implementation/schemas/test/re_frame/schemas_sequence_width_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_sequence_width_cljs_test.cljs
@@ -1,0 +1,48 @@
+(ns re-frame.schemas-sequence-width-cljs-test
+  "CLJS host half of the variable-width `:cat` / `:catn` redaction pins
+  (rf2-gwye.11 / rf2-fzbj.25). Asserts the SAME shared corpus
+  (`re-frame.schemas.sequence-width-fixtures`) end to end through
+  `validate-app-schema!` and the real trace recorder; the JVM half lives in
+  `re-frame.schemas-sensitive-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.schemas.sequence-width-fixtures :as rf.schemas.sequence-width-fixtures]
+            [re-frame.test-support :as rf.test-support])
+  (:require-macros [re-frame.test-support :refer [with-trace-recorder!]]))
+
+;; Adapter-less, as in the security redaction suites: `validate-app-schema!`
+;; is called directly, so a clean app-schema slate plus a carried
+;; `:rf/default` scope is all the harness needs.
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture {:clear-app-schemas? true})
+  (fn [test-fn]
+    (binding [rf.frame/*current-frame* :rf/default]
+      (test-fn))))
+
+(defn- failure-trace [schema value]
+  (rf/reg-app-schema [:items] schema)
+  (with-trace-recorder! [traces]
+    (rf.schemas/validate-app-schema! {:items value} :items/bad)
+    (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                   @traces))))
+
+(deftest cljs-variable-width-sequence-never-leaks-sensitive-value
+  (testing "rf2-gwye.11 — a regex element before a sensitive payload no longer
+            misaligns the redaction decision"
+    (doseq [{:keys [desc schema value]} rf.schemas.sequence-width-fixtures/leak-cases]
+      (let [v (failure-trace schema value)]
+        (is (some? v) (str desc " — a trace fired"))
+        (is (true? (:sensitive? v)) (str desc " — :sensitive? stamped"))
+        (is (= :rf/redacted (-> v :tags :value)) (str desc " — :value redacted"))
+        (is (not (str/includes? (pr-str v) rf.schemas.sequence-width-fixtures/secret))
+            (str desc " — the secret is in no trace slot"))))))
+
+(deftest cljs-variable-width-fix-keeps-non-sensitive-values
+  (testing "rf2-gwye.11 control — non-sensitive failures still report their value"
+    (doseq [{:keys [desc schema value expected]} rf.schemas.sequence-width-fixtures/precise-cases]
+      (let [v (failure-trace schema value)]
+        (is (some? v) (str desc " — a trace fired"))
+        (is (= expected (-> v :tags :value)) desc)))))

--- a/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
@@ -115,6 +115,25 @@
               [:tail :string]]
              [:row])))))
 
+(deftest variable-width-sequence-descends-index-free
+  (testing "rf2-gwye.11 — a :cat / :catn whose width is not fixed cannot pin a
+            flag to a position; its elements descend at the SHARED base-path,
+            like :sequential"
+    (is (= {[:ev :tok] {:sensitive? true :source :schema}}
+           (rf.schemas/extract-sensitive-paths-from-schema
+             [:cat [:* :int] [:map [:tok {:sensitive? true} :string]]]
+             [:ev])))
+    (is (= {[:row] {:sensitive? true :source :schema}}
+           (rf.schemas/extract-sensitive-paths-from-schema
+             [:catn [:head [:? :int]] [:tail {:sensitive? true} :string]]
+             [:row]))
+        "a :catn entry flag claims the base-path")
+    (is (= {[:ev] {:sensitive? true :source :schema}}
+           (rf.schemas/extract-sensitive-paths-from-schema
+             [:* [:cat :int [:string {:sensitive? true}]]]
+             [:ev]))
+        "a fixed-width :cat spliced into a regex op owns no positions")))
+
 (deftest and-descends-at-parent-path
   (testing ":and — every child descends at the parent path"
     (is (= {[:slot] {:sensitive? true :source :schema}}


### PR DESCRIPTION
Remediates rf2-fzbj.25 (both findings), rf2-gwye.11 (finding 1) and rf2-gwye.14 (finding 2). Both findings were re-verified at tip before fixing: the reviewer's probe, re-pointed at this worktree, still reproduced every leak shape and every digest collision.

## Finding 1 (P1, privacy): sensitive redaction across variable-width `:cat` / `:catn`

The walker read a `:cat` / `:catn` input index as its schema child index. A regex element (`:*`, `:?`, a nested `:cat`) consumes zero or many values, so the failing input element could belong to a different child. The failing child's sensitivity was then misjudged: `[:cat [:* :int] [:map [:token {:sensitive? true} :int]]]` against `[{:token "…secret…"}]` shipped the secret in `:value`, and a sensitive `:map-of` key could ride `:path` / `:reason`.

Fix (`walker.cljc` only): a `:tuple`, or a `:cat` / `:catn` whose every element provably consumes one value and which is not itself spliced into an enclosing regex op, stays positional exactly as before (rf2-4q681i / rf2-ss06u.4 precision kept). Any other sequence:
- descends its elements index-free at the shared base-path, like `:sequential`, with `:catn` entry flags claiming the base-path;
- falls back to the whole-node sensitivity/opacity decision in `align-in-path`;
- takes the fail-closed tail in `sanitize-sensitive-path`.

There is no second regex parser and no new dependency.

## Finding 2 (P2): ambient `*print-length*` / `*print-level*` poisoned the digest memo

`compute-edn-print` now binds both to nil alongside its existing print flags, around canonicalisation and the final `pr-str`. The memo key, the digest algorithm, the public API and the custom-printer contract are unchanged. `implementation/ssr/src/re_frame/ssr/hydrate.cljc` consumes the digest only through the late-bind hook, so it needed no edit.

## Tests

- `test/re_frame/schemas/sequence_width_fixtures.cljc`: a new shared CLJ/CLJS corpus.
  - Six leak cases: zero-width `:*` in a `:cat` and in a `:catn`, an empty `:?`, a nonzero `:*` repetition, a nested `:cat` expansion, and a sensitive `:map-of` key on the path.
  - Three non-sensitive controls that must still report their value verbatim.
  - Asserted end to end through `validate-app-schema!` and the real trace recorder by `schemas_sensitive_test.clj` (JVM) and the new `schemas_sequence_width_cljs_test.cljs` (CLJS).
- `schemas_walker_operators_test.clj`: pins the index-free declaration shape, including a fixed-width `:cat` spliced into a regex op.
- `digest_parity_fixtures.cljc`, `digest_parity_test.clj`, `digest_parity_cljs_test.cljs`: a shared printer-limit observation.
  - Bounded `*print-length*`, bounded `*print-level*`, and both, each starting from an empty memo.
  - Bytes and digests are read inside the binding and re-read after it without clearing.
  - Each read must equal the unbounded baseline.
  - Includes a form whose collection-valued map keys and set members exercise the canonicaliser's comparator.

## Quality gates

Every exit code below is the one captured from the runner itself, not a pipeline's.

- **`jvm-schemas`**, CI job *JVM schemas (clojure -M:test)*.
  - Fixed tree, final rebased base: exit 0, 394 tests / 19352 assertions. Pre-change baseline: 390 / 19312.
  - RED: I planted the pre-fix `walker.cljc` and `validator.cljc` (their `origin/main` blobs, verified by blob hash) and ran the suite: exit 1, 21 failures, every one in the new tests. That is 6 leak cases × 2 assertions (`:value` redacted, secret absent), 3 printer bindings × 2 (inside, after), and 3 walker declaration pins.
  - Restore verified by blob hash against the committed objects.
- **CLJS `:node-test`**, CI job *CLJS (shadow-cljs :node-test)*.
  - Fixed tree: exit 0, 11993 tests / 59617 assertions.
  - RED on the same plant: exit 1, 18 failures, all in the two new CLJS deftests.
  - Run on the pre-rebase base. The rebase changed nothing under `implementation/schemas`; relying on CI for the final-base run.
- **`jvm-security`**, CI job *JVM security (clojure -M:test)*: exit 0, 92 tests / 725 assertions. The security suites consume the walker. Pre-rebase base.
- **`npm run test:security`**: exit 0, 93 tests / 732 assertions, final base. No workflow schedules this script; `jvm-security` is the CI arm for the same CLJC suites.
- **`cljs-schemas-bundle`**, CI job *CLJS schemas bundle cost*: exit 0, `PASS` with a margin of 39.9 KB inside the 20.0–44.0 KB band. Final base.
- **`cljs-browser-schemas-boundary-prod`**: not run locally, since it needs a Playwright release build; relying on CI.
- **Ratchets**: all 46 `scripts/check_*.py` checkers exit 0 on this change. Pre-rebase base.
- **Classifier**: these paths arm `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod`, `bundle_isolation` and `skills_structural`. The jobs behind the browser, examples, prod and bundle-isolation surfaces are relying on CI.
- **Docs**: no spec or doc page changed, so no link gate applies.

## Findings recorded rather than built

- Keyword or symbol registry references inside a `:cat` are treated as single-value. The walker cannot tell a registry ref that resolves to a regex from a primitive without calling into the validator, which is the same documented opaque-schema boundary under which keyword refs are already flag-invisible. Register the vector form.
- A fixed-width prefix before a regex element (`[:cat :int [:* :int] X]`) could in principle keep position precision for element 0. It was not built: the whole-node fallback is sufficient.
- No spec page changed. `spec/010-Schemas.md` does not describe `:cat` / `:catn` position precision, and the conservative fallback is recorded in the walker's docstrings.
