### PR TITLE
fix(xray): pin the shown event on pause, route palette picks through focus, wire density, keep every emptied-sequence removal

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/diff/engine.cljc
@@ -291,9 +291,12 @@
           ;; `[] → [populated]`: per-index :+ at the AFTER indices.
           ;; `[populated] → []`: per-index :- at the BEFORE indices (each
           ;; flows through `project`'s `:vector-removals` channel).
-          ;; Indices descend for the removal so the renderer surfaces them
-          ;; in before order; `resolve-vector-removals` recovers the true
-          ;; before-index regardless.
+          ;; The removals are emitted in DESCENDING index order: `project`
+          ;; replays `:-` edits sequentially against the shrinking sequence
+          ;; (`replay-vector-edits`), and only a descending walk keeps each
+          ;; index naming its ORIGINAL element (rf2-gwye.10 — ascending
+          ;; indices dropped every other removal and invented shifts).
+          ;; `resolve-vector-removals` sorts them back into before order.
           (let [seq? (fn [v] (and (sequential? v) (not (map? v)) (not (set? v))))]
             (and (seq? before-at) (seq? after-at)
                  (or (empty? before-at) (empty? after-at))))
@@ -306,7 +309,7 @@
 
               (and (seq bvec) (empty? avec))
               (mapv (fn [i] [(conj (vec path) i) :-])
-                    (range (count bvec)))
+                    (range (dec (count bvec)) -1 -1))
 
               ;; both empty (shouldn't reach — `:r` implies a value change)
               :else [edit]))

--- a/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/palette/events.cljs
@@ -13,7 +13,7 @@
   Source items in `palette/sources` declare their action as one of:
 
     [:palette/select-panel id]
-    [:palette/select-event ev-id]
+    [:palette/select-event dispatch-id frame-id]
     [:palette/select-frame fid]
     [:palette/inspect-handler kind id]
     [:palette/cycle-density]
@@ -220,6 +220,15 @@
     :never   :os
     :os))
 
+;; ---- density cycle (rf2-gwye.9) -----------------------------------------
+
+(defn- next-density
+  "Pure helper. Flip the two shipped density tiers `:cosy ↔ :compact`.
+  Anything else (nil, a persisted `:comfy`) reads as `:cosy`, as the
+  `:rf.xray/density` sub does, and so flips to `:compact`."
+  [current]
+  (if (= :compact current) :cosy :compact))
+
 ;; ---- install --------------------------------------------------------------
 
 (defn install!
@@ -363,14 +372,17 @@
            :fx (conj base-fx [:dispatch [:rf.xray.static/select-tab (first args)]])}
 
           :palette/select-event
-          ;; Route to the Epoch tab with the event pre-selected. The
-          ;; Epoch panel is the canonical "what happened in this epoch"
-          ;; surface; `:rf.xray/selected-event-id` is the selected-event
-          ;; slot the panels read.
-          {:db (assoc close-db
-                      :selected-tab :epoch
-                      :selected-event-id (first args))
-           :fx base-fx}
+          ;; rf2-gwye.8 — a recent-event pick moves the SHARED spine focus
+          ;; through `:rf.xray/focus-event`, the path an L2 row click takes
+          ;; (frame reseed, epoch resolution, head-aware LIVE/RETRO), and
+          ;; lands on the Epoch tab, which reads that focus. The item names
+          ;; the row's dispatch id + frame: an event vector identifies
+          ;; neither a particular run nor a frame.
+          (let [[dispatch-id frame-id] args]
+            {:db (assoc close-db :selected-tab :epoch)
+             :fx (cond-> base-fx
+                   (some? dispatch-id)
+                   (conj [:dispatch [:rf.xray/focus-event dispatch-id frame-id]]))})
 
           :palette/select-frame
           ;; Drive the frame-picker selection event so the user's
@@ -400,11 +412,16 @@
              :fx base-fx})
 
           :palette/cycle-density
-          ;; Phase 1: density toggle is wired through the existing
-          ;; density-sub once the density-runtime bead lands. The
-          ;; palette event records the user intent so the follow-on
-          ;; bead has the data point.
-          {:db (assoc close-db :density-cycle-requested? true)}
+          ;; rf2-gwye.9 — flip the Settings density control (:cosy ↔
+          ;; :compact) through `:rf.xray/settings-update`, the path the
+          ;; Settings radio takes, so persistence and the font-size apply
+          ;; come with it. Reads the live atom, as `:palette/toggle-theme`
+          ;; does, so no Settings-open prerequisite.
+          {:db close-db
+           :fx (conj base-fx
+                     [:dispatch
+                      [:rf.xray/settings-update :general :density
+                       (next-density (config/get-setting :general :density))]])}
 
           :palette/clear-trace-buffer
           (do

--- a/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/palette/sources.cljc
@@ -106,7 +106,11 @@
   Recency rank rises with index from the end (the most-recently-
   pushed event is rank 0). Caps at 30 rows by default — beyond that
   the recency bonus is zero anyway, and the palette result list
-  itself is finite."
+  itself is finite.
+
+  The action names the row's dispatch id and frame (rf2-gwye.8) — the
+  identity `:rf.xray/focus-event` selects by. The event vector is only
+  the label: two runs of one event are two different selections."
   ([buffer]
    (recent-event-items buffer 30))
   ([buffer max-rows]
@@ -139,7 +143,9 @@
               :icon         (icon-table :recent-event)
               :recency-rank rank
               :boost        (boost-table :recent-event)
-              :action       [:palette/select-event ev-id]
+              :action       [:palette/select-event
+                             (get-in t [:tags :rf.trace/dispatch-id])
+                             (get-in t [:tags :frame])]
               :modes        #{:dynamic}
               :popout?      true}))
          taken)))))
@@ -212,7 +218,7 @@
   [{:source :setting
     :id     :density-toggle
     :label  "Cycle display density"
-    :hint   "compact / cosy / comfy"
+    :hint   "compact / cosy"
     :icon   (icon-table :setting)
     :boost  (boost-table :setting)
     :action [:palette/cycle-density]

--- a/tools/xray/src/day8/re_frame2_xray/spine.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/spine.cljs
@@ -750,11 +750,36 @@
   continues collecting; only auto-scrolling stops. When already in
   `:retro`, toggling is a no-op (the Space key has no meaning when
   the user has already pinned an older row — they would press `L` to
-  resume LIVE in that case)."
-  [db]
-  (if (= :retro (get-in db [:focus :mode]))
-    db
-    (update-in db [:focus :paused?] not)))
+  resume LIVE in that case).
+
+  ## rf2-fzbj.2 — pausing pins what LIVE is SHOWING
+
+  Unpaused LIVE composes the displayed event from the HEAD, ignoring the
+  stored slot, which is routinely empty (fresh mount, after Follow head)
+  or lags a newer head (a click on the then-head). Paused LIVE composes
+  FROM the stored slot. Flipping the flag alone therefore made Space drop
+  the displayed epoch, keep following new arrivals, or jump back to a
+  stale pin. The 2-arity takes `composed` — `compose-focus` of the
+  pre-toggle state, resolved by the event handler from the same sources
+  `:rf.xray/focus` reads — and stores its `:dispatch-id`, `:epoch-id` and
+  `:frame` with `:paused? true` in one write. Resuming only clears
+  `:paused?`: unpaused LIVE ignores the stored pin and follows head again.
+  The 1-arity (no composition to hand) flips the flag alone."
+  ([db]
+   (toggle-live-pause-reducer db nil))
+  ([db composed]
+   (let [focus (:focus db)]
+     (cond
+       (= :retro (or (:mode composed) (:mode focus))) db
+       (:paused? focus) (assoc-in db [:focus :paused?] false)
+       (nil? composed)  (assoc-in db [:focus :paused?] true)
+       :else
+       (update db :focus (fnil merge {})
+               (cond-> {:dispatch-id (:dispatch-id composed)
+                        :epoch-id    (:epoch-id composed)
+                        :mode        :live
+                        :paused?     true}
+                 (:frame composed) (assoc :frame (:frame composed))))))))
 
 (defn set-frame-reducer
   "Pure reducer for `:rf.xray/set-frame <frame-id>`. Writes `:frame`
@@ -1144,9 +1169,14 @@
     (fn [{:keys [db]} _event]
       {:db (follow-head-reducer db)}))
 
+  ;; rf2-fzbj.2 — compose the displayed focus from the same sources the
+  ;; `:rf.xray/focus` sub reads, so pausing pins exactly what LIVE shows.
   (rf/reg-event :rf.xray/toggle-live-pause
     (fn [{:keys [db]} _event]
-      {:db (toggle-live-pause-reducer db)}))
+      {:db (toggle-live-pause-reducer
+             db
+             (compose-focus (:focus db) (db->event-bundles db)
+                            (db->show-ungrouped? db) (db->epoch-history db)))}))
 
   (rf/reg-event :rf.xray/set-frame
     (fn [{:keys [db]} [_ frame-id]]

--- a/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/diff/engine_cljs_test.cljc
@@ -883,6 +883,33 @@
       (is (= :added (engine/op-at p [:a 0])))
       (is (contains? (:wholly-changed-roots p) [:a])))))
 
+(deftest gwye-10-multi-element-sequential-emptied-reports-every-removal
+  (testing "rf2-gwye.10 — emptying a MULTI-element vector or list reports
+            every removed element exactly once and no surviving shift.
+            Editscript emits one whole-value `:r` for these, which the
+            engine expands into per-index `:-` edits; those are replayed
+            against the SHRINKING sequence, so ascending indices named the
+            wrong elements (only `:one`/`:three` of four survived, plus
+            phantom shifts). One-element cases never saw it."
+    (doseq [[before after parent]
+            [[{:a [:one :two]}          {:a []}        [:a]]
+             [{:a '(:one :two :three)}  {:a '()}       [:a]]
+             [{:a {:b [1 2 3 4]}}       {:a {:b []}}   [:a :b]]
+             [[:one :two :three :four]  []             []]
+             ['(:w :x :y :z)            '()            []]]]
+      (let [p        (engine/project before after)
+            removed  (vec (get-in before parent))
+            expected (vec (map-indexed (fn [i v] {:before-index i :before-value v})
+                                       removed))]
+        (is (= expected (get-in p [:vector-removals parent]))
+            (str "every removal reported for " (pr-str before)))
+        (is (= (count removed)
+               (count (filter :rf.xray.diff/vector-removal? (:flat-rows p))))
+            (str "one flat removed row per element for " (pr-str before)))
+        (is (empty? (:shift-suffix p))
+            (str "an emptied collection has no surviving shift for "
+                 (pr-str before)))))))
+
 (deftest yucxn-root-vector-empty-edges
   (testing "rf2-yucxn BUG A — the empty edge at the ROOT (a bare vector):
             `[1] → []` member-removes index 0; `[] → [1]` member-adds it.

--- a/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/events_cljs_test.cljs
@@ -22,6 +22,7 @@
             [re-frame.frame :as rf.frame]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.palette.recents :as recents]
+            [day8.re-frame2-xray.palette.sources :as sources]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
@@ -151,25 +152,57 @@
   (is (= :trace (:selected-tab (xray-db))))
   (is (false? (boolean (:palette-open? (xray-db))))))
 
-(deftest invoke-select-event-routes-to-epoch-tab
-  ;; rf2-qy0nu — :palette/select-event writes :selected-tab to the
-  ;; canonical "what happened in this epoch" L3 tab. rf2-5gl5r retired
-  ;; the Event/Handler tab; the routing target is now `:epoch` (the
-  ;; Epoch panel supersedes it).
-  (setup!)
+;; rf2-gwye.8 — a recent-event pick drives the SHARED spine focus
+;; (`:rf.xray/focus-event`), which the Epoch panel reads; the palette keeps
+;; no selection of its own. Items are built by the real source fn from
+;; producer-shaped trace rows.
+
+(defn- dispatched-row [id dispatch-id frame ev]
+  {:id id :op-type :rf.event :operation :rf.event/dispatched
+   :tags {:rf.trace/dispatch-id dispatch-id :frame frame :rf.event/v ev}})
+
+(defn- invoke-item! [item]
   (rf/with-frame :rf/xray
     (rf/dispatch-sync [:rf.xray/palette-open])
-    (rf/dispatch-sync
-      [:rf.xray/palette-invoke
-       {:source :recent-event
-        :id     [:foo/bar 1]
-        :label  "[:foo/bar]"
-        :action [:palette/select-event [:foo/bar]]
-        :popout? true}
-       false]))
-  (is (= :epoch (:selected-tab (xray-db))))
-  (is (= [:foo/bar]    (:selected-event-id (xray-db))))
-  (is (false? (boolean (:palette-open? (xray-db))))))
+    (rf/dispatch-sync [:rf.xray/palette-invoke item false])))
+
+(defn- xray-sub [query]
+  (rf/with-frame :rf/xray @(rf/subscribe query)))
+
+(deftest invoke-select-event-focuses-the-chosen-dispatch-rf2-gwye-8
+  (testing "choosing the OLDER of two identical event vectors focuses that
+            dispatch and its epoch, and lands on the Epoch tab"
+    (setup!)
+    (let [rows  [(dispatched-row 1 1 :rf/default [:counter/inc])
+                 (dispatched-row 2 2 :rf/default [:counter/inc])]
+          older (first (sources/recent-event-items rows))]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/sync-trace-buffer rows])
+        (rf/dispatch-sync [:rf.xray/sync-epoch-history
+                           [{:epoch-id 101 :dispatch-id 1 :frame :rf/default}
+                            {:epoch-id 102 :dispatch-id 2 :frame :rf/default}]]))
+      (is (= [2 102] ((juxt :dispatch-id :epoch-id) (xray-sub [:rf.xray/focus])))
+          "precondition: focus is on the latest event")
+      (invoke-item! older)
+      (is (= [1 101 :rf/default]
+             ((juxt :dispatch-id :epoch-id :frame) (xray-sub [:rf.xray/focus]))))
+      (is (= 101 (get-in (xray-sub [:rf.xray/epoch-pipeline]) [:record :epoch-id]))
+          "the Epoch panel's record is the chosen event's")
+      (is (= :epoch (:selected-tab (xray-db))))
+      (is (false? (boolean (:palette-open? (xray-db))))))))
+
+(deftest invoke-select-event-selects-the-rows-own-frame-rf2-gwye-8
+  (testing "two frames reuse dispatch id 1 — the chosen row's frame wins"
+    (setup!)
+    (let [rows   [(dispatched-row 1 1 :app/a [:counter/inc])
+                  (dispatched-row 2 1 :app/b [:counter/inc])]
+          a-item (first (sources/recent-event-items rows))]
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/sync-trace-buffer rows]))
+      (is (= :app/b (:frame (xray-sub [:rf.xray/focus])))
+          "precondition: focus is on the head frame")
+      (invoke-item! a-item)
+      (is (= [1 :app/a] ((juxt :dispatch-id :frame) (xray-sub [:rf.xray/focus])))))))
 
 (deftest invoke-clear-trace-buffer-empties-buffer
   (setup!)
@@ -198,7 +231,7 @@
        {:source :recent-event
         :id     [:foo/bar 1]
         :label  "[:foo/bar]"
-        :action [:palette/select-event [:foo/bar]]
+        :action [:palette/select-event 1 :rf/default]
         :popout? true}
        true]))
   (is (= 1 @popout-calls)
@@ -313,6 +346,26 @@
        false]))
   (is (= :never (config/get-setting :general :reduced-motion-override))
       "second cycle: :always → :never"))
+
+(deftest invoke-cycle-density-drives-the-settings-control-rf2-gwye-9
+  (testing "rf2-gwye.9 — the palette's density command flips the SAME
+            setting the Settings radio writes (:cosy ↔ :compact), so the
+            config value and the density sub agree, and closes the palette"
+    (setup!)
+    (config/update-setting! :general :density :cosy)
+    (let [item    (first (filter #(= :density-toggle (:id %))
+                                 (sources/setting-items)))
+          density #(xray-sub [:rf.xray/density])]
+      (invoke-item! item)
+      (is (= [:compact :compact]
+             [(config/get-setting :general :density) (density)]))
+      (is (not (contains? (xray-db) :density-cycle-requested?))
+          "no orphan request flag")
+      (is (false? (boolean (:palette-open? (xray-db)))))
+      (invoke-item! item)
+      (is (= [:cosy :cosy]
+             [(config/get-setting :general :density) (density)])
+          "a second invocation cycles back"))))
 
 (deftest invoke-jump-to-settings-opens-popup
   (setup!)

--- a/tools/xray/test/day8/re_frame2_xray/palette/sources_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/palette/sources_cljs_test.cljc
@@ -65,6 +65,25 @@
     (is (every? #(true? (:popout? %)) items)
         "recent events should pop out into event-detail when Ctrl+Enter")))
 
+(deftest recent-event-action-carries-dispatch-and-frame-rf2-gwye-8
+  (testing "rf2-gwye.8 — the action names the DISPATCH and its FRAME, so two
+            runs of the same event vector (or the same dispatch id in two
+            frames) are distinct selections rather than one event value"
+    (let [row   (fn [id dispatch-id frame]
+                  {:id id :op-type :rf.event :operation :rf.event/dispatched
+                   :tags {:rf.trace/dispatch-id dispatch-id
+                          :frame                frame
+                          :rf.event/v           [:counter/inc]}})
+          items (sources/recent-event-items [(row 10 1 :rf/default)
+                                             (row 11 2 :rf/default)
+                                             (row 12 2 :app/other)])]
+      (is (= [[:palette/select-event 1 :rf/default]
+              [:palette/select-event 2 :rf/default]
+              [:palette/select-event 2 :app/other]]
+             (mapv :action items)))
+      (is (every? #(= "[:counter/inc]" (:label %)) items)
+          "the label still shows the event vector"))))
+
 (deftest recent-event-recency-rank-puts-latest-first
   (let [items (sources/recent-event-items sample-trace-buffer)
         latest (first (filter #(zero? (:recency-rank %)) items))]

--- a/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/spine_cljs_test.cljs
@@ -930,6 +930,83 @@
           "paused LIVE pins focus through arrivals")
       (is (true? (:paused? r))))))
 
+;; rf2-fzbj.2 — Space must freeze the event LIVE is SHOWING. The test above
+;; primes a stored pin equal to head before pausing; these start from the
+;; two ordinary states that do not: no pin at all (fresh / after Follow
+;; head) and a LIVE pin that lags a newer head. The epoch history is seeded
+;; once, up front, because `:rf.xray/sync-epoch-history` also stamps
+;; `[:focus :epoch-id]` (its mount-seed contract) and a re-seed mid-test
+;; would overwrite the very pin under test.
+
+(defn- event-bundle-count []
+  (rf/with-frame :rf/xray
+    (count @(rf/subscribe [:rf.xray/event-bundles]))))
+
+(deftest pause-with-no-stored-pin-freezes-the-shown-event-rf2-fzbj-2
+  (doseq [[label prime!]
+          [["fresh LIVE" (fn [] nil)]
+           ["after Follow head"
+            (fn []
+              (rf/with-frame :rf/xray
+                (rf/dispatch-sync [:rf.xray/focus-event :c1 :rf/default])
+                (rf/dispatch-sync [:rf.xray/follow-head])))]]]
+    (testing label
+      (setup-xray-frame!)
+      (seed-cascades! fixture-cascades)
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/sync-epoch-history
+                           [(epoch :e1 :c1) (epoch :e2 :c2)
+                            (epoch :e3 :c3) (epoch :e4 :c4)]]))
+      (prime!)
+      (is (= [:c3 :e3] ((juxt :dispatch-id :epoch-id) (focus-sub)))
+          "precondition: LIVE shows head c3 / e3")
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/toggle-live-pause]))
+      (let [r (focus-sub)]
+        (is (= [:c3 :e3 :rf/default true]
+               ((juxt :dispatch-id :epoch-id :frame :paused?) r))
+            "pausing pins the shown dispatch AND its epoch"))
+      (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+      (is (= 4 (event-bundle-count)) "the buffer keeps collecting while paused")
+      (let [r (focus-sub)]
+        (is (= [:c3 :e3 :rf/default]
+               ((juxt :dispatch-id :epoch-id :frame) r))
+            "a new arrival does not move the paused inspection"))
+      (rf/with-frame :rf/xray
+        (rf/dispatch-sync [:rf.xray/toggle-live-pause]))
+      (let [r (focus-sub)]
+        (is (= [:c4 :e4 false] ((juxt :dispatch-id :epoch-id :paused?) r))
+            "resuming follows the newest event and epoch again")))))
+
+(deftest pause-with-lagging-live-pin-keeps-the-newer-head-rf2-fzbj-2
+  (testing "clicking the then-head stores a LIVE pin; once a newer event
+            lands LIVE shows the newer one, and pausing must freeze THAT
+            rather than jump back to the stale pin"
+    (setup-xray-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2)
+                          (epoch :e3 :c3) (epoch :e4 :c4)]])
+      (rf/dispatch-sync [:rf.xray/focus-event :c3 :rf/default]))
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (is (= [:c4 :e4 :live] ((juxt :dispatch-id :epoch-id :mode) (focus-sub)))
+        "precondition: LIVE has moved on to c4 / e4")
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/toggle-live-pause]))
+    (is (= [:c4 :e4 :live true]
+           ((juxt :dispatch-id :epoch-id :mode :paused?) (focus-sub)))
+        "pause freezes the displayed c4 / e4 — no backward jump to c3")))
+
+(deftest pause-is-a-no-op-in-retro-through-the-registered-event-rf2-fzbj-2
+  (setup-xray-frame!)
+  (seed-cascades! fixture-cascades)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/focus-event :c1 :rf/default])
+    (rf/dispatch-sync [:rf.xray/toggle-live-pause]))
+  (is (= [:c1 :retro false] ((juxt :dispatch-id :mode :paused?) (focus-sub)))
+      "Space has no meaning once an older row is pinned"))
+
 (deftest preview-event-handler-does-not-persist-cross-frame-rekey-rf2-uo0rc5
   (testing "rf2-uo0rc.5 — the :rf.xray/preview-event HANDLER must not
             persist a cross-frame :target-frame / :epoch-history re-key


### PR DESCRIPTION
Four Xray correctness fixes from the 2026-09-12/13 surface review. They all sit on one surface (`tools/xray/**`), and each carries a regression test shown red against the pre-fix code.

## What changed

- **rf2-fzbj.2 — Space pins the event LIVE is showing.**
  - `:rf.xray/toggle-live-pause` now composes the displayed focus from the same sources `:rf.xray/focus` reads. It stores that focus's dispatch id, epoch id and frame with `:paused? true` in one write.
  - Before, it only flipped the flag. From a fresh LIVE, or after Follow head, the pause dropped the epoch and kept following new arrivals. From a LIVE pin lagging a newer head, it jumped back to the stale pin.
  - Resume still follows head, and RETRO Space stays a no-op.
  - Storing the frame scopes a later resume to that frame, the same as a row click or step already does.
- **rf2-gwye.8 — palette recent-event picks move the shared focus.**
  - Recent-event items now carry the row's `:rf.trace/dispatch-id` and frame.
  - Selecting one dispatches `:rf.xray/focus-event` plus the Epoch tab. That is the L2 row-click path: frame reseed, epoch resolution, head-aware LIVE/RETRO.
  - The unread `:selected-event-id` write is gone.
- **rf2-gwye.9 — "Cycle display density" works.**
  - It flips `:cosy`/`:compact` through `:rf.xray/settings-update`, the Settings radio's own path. Before, it set an unread `:density-cycle-requested?` flag.
  - The item hint now lists only the two shipped tiers.
- **rf2-gwye.10 — emptying a multi-element vector or list keeps every removal.**
  - The whole-value `:r` expansion now emits delete indices in descending order, so the sequential replay keeps naming the original elements.
  - Before, every other removal was lost and phantom shifts appeared.

## Regression tests (red before, green after)

- **`spine_cljs_test.cljs`**:
  - Pause with no stored pin, from fresh LIVE and after Follow head. Dispatch and epoch stay put across a new arrival while the buffer grows, and resume follows head.
  - Pause with a lagging LIVE pin keeps the newer head.
  - RETRO Space is a no-op through the registered event.
- **`palette/events_cljs_test.cljs`**:
  - Selecting the older of two identical event vectors focuses that dispatch, its epoch, and the Epoch pipeline record.
  - When two frames share a dispatch id, the pick selects the row's own frame.
  - The density command cycles both the config value and the density sub.
- **`palette/sources_cljs_test.cljc`**: recent-event actions carry the dispatch id and frame.
- **`diff/engine_cljs_test.cljc`**: root and nested vectors and lists of 2 to 4 elements, emptied, report every removal once, give one flat removed row each, and have no shift.

## Quality gates

All gates ran from the worker worktree, after the worktree guard exited 0. Each exit code below is the value captured on the same command line, not a harness summary.

| Gate | Result | CI job |
|---|---|---|
| **Red control:** the four touched suites on a bundle compiled from the pre-fix source (compile exit 0, 0 warnings) | exit 1 — 246 tests, 26 failures, every failure in a new test, 0 errors | `cljs` — CLJS (shadow-cljs :node-test) |
| The same four suites after the fix (compile exit 0, 0 warnings) | exit 0 — 246 tests / 819 assertions, 0 failures | `cljs` |
| Whole Xray CLJS lane, all 232 `day8.re-frame2-xray.*` namespaces | exit 0 — 3755 tests / 15540 assertions, 0 failures | `cljs` |
| **Red control:** JVM engine test before the fix | exit 1 — 78 tests, 15 failures | `jvm-tools-xray` — JVM tools/xray (clojure -M:test) |
| JVM `tools/xray` full lane after the fix | exit 0 — 1282 tests / 6162 assertions, 0 failures | `jvm-tools-xray` |
| `npm run test:xray-feature-gate` (full, nightly sweep); it served this worktree's `out/` | exit 0 — 16 scenarios, 0 failures, 13 matrix rows | `story-xray-browser` runs the smoke tier per PR; the full sweep runs nightly in `expensive-tests.yml` |
| `node implementation/scripts/check-examples-compile.cjs` (the derived sweep, all 58 builds from `--list`) | exit 0 — all 58 builds, zero warnings | `cljs-examples-compile` |
| `clj-kondo --fail-level error` on the 8 changed files | exit 0 — 0 errors, 0 warnings | `clj-kondo` in `lint.yml` |
| Ratchets: `check_retired_spellings`, `check_ambient_durable_reads`, `check_thrown_error_messages`, `check_keyword_catalogue_drift`, `check_inject_cofx_residue`, `check_egress_walker_residue`, `check_skill_xray_tab_inventory_drift` | all exit 0 | `verify-skill-mcp-drift` — Repo invariant checks |

A few gates were not applicable or not re-run:

- **`xray-spec-check` and `check_doc_slugs.py`**: no spec page, and no `tools/xray/spec/API.md`, is touched.
- **Base drift**: the gates ran on merge-base `8ff4be83c7`. The seven trunk commits since then touch only `implementation/resources`, `implementation/ssr-node`, `spec/016` and the tracker, never `tools/xray`. So this branch is not rebased, and CI grades the merge ref.
- **Revert check**: the three-dot diff against the merge base shows only the eight intended files, and no revert of a sibling landing.

## Skipped suggestions (recorded on the beads)

- **rf2-fzbj.2 — browser keyboard witness for Space.** The registered-event and sub tests already exercise the exact event the key maps to.
- **rf2-gwye.8 — browser Cmd/Ctrl+K witness.** Same reasoning: the invocation event is tested end to end.
- **rf2-gwye.10 — EDN-inspector renderer assertion.** The renderer reads `vector-removals-at` verbatim, and the engine regression pins that channel.

## Fleet notes

- The fix does not open `panels/routing.cljs`, so the rf2-u68x trigger has not fired.
- No file outside `tools/xray/**` is touched.
