### PR TITLE
fix(mcp-base): dedup ignores caller metadata, replaces record keys, keeps list/vector kinds (rf2-fzbj.9)

### DIFF
--- a/tools/mcp-base/spec/dedup.md
+++ b/tools/mcp-base/spec/dedup.md
@@ -96,6 +96,8 @@ No committed gate runs the whole `Clojure → Cheshire → Node` seam in one pro
 
 Compresses `form` into a flat cache map. Slot `cache-0` holds the root; every further slot is a subtree that occurred more than once, replaced at each occurrence by its cache-element symbol. Cache-id allocation is call-local, so the same input always yields the same slot ids.
 
+The encoder reads the value and nothing else. Metadata is not wire data, so the caller's metadata can neither name a slot nor replace a subtree; which slot a subtree occupies is tracked by the walk itself (rf2-gwye.30). A record rebuilds as itself with exactly its own entries: an extension key that the grammar escapes, or that is pooled into a reference, replaces its original spelling rather than landing beside it, in both directions (rf2-gwye.31).
+
 ### `expand cache` → value
 
 The exact inverse. This is the call an agent-side Clojure consumer makes on the value it reads out of `:rf.mcp/dedup-table`.
@@ -139,6 +141,8 @@ Applies structural dedup to `v` and wraps the result in the cross-MCP marker `{:
 #### Why equality, not identity
 
 Values reaching the wire boundary are equality-shared, not identity-shared: re-frame2-pair-mcp reconstructs CLJS values from EDN over bencode (no identity sharing survives the transport), and story-mcp synthesises assertion records and rendered hiccup fresh per call. Equality is what makes the cross-record share-pooling actually fire on the wire boundary.
+
+The equality is **wire** equality: Clojure `=` refined by collection kind. `=` and `hash` both treat `[1 2 3]` and `(1 2 3)` as the same value. The EDN on the wire does not: it prints them differently, reads them back differently, and they answer `vector?` differently. So a vector never shares a slot with a list or seq, at any depth. Two otherwise-equal maps whose children differ in kind stay in separate slots. The counting pass, the repeat check and slot lookup all use this one equivalence. Within a kind, pooling is plain equality, and sorted collections still lower to unsorted (rf2-gwye.32).
 
 ## The wrapper-aware helper stays consumer-side
 

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -48,6 +48,11 @@
   upstream identity-based variant was dropped rather than carried as a
   branch nothing takes.
 
+  It is WIRE equality: `=` refined by collection kind (`wire=`). Clojure
+  equality holds `[1 2 3]` and `(1 2 3)` equal, but the EDN on the wire
+  does not, so a vector never shares a slot with a list or seq — at any
+  depth — and each comes back as itself.
+
   ## Wire shape
 
   A deduped payload is wrapped in a top-level marker:
@@ -198,6 +203,16 @@
 ;;      taken as one pre-alpha cut across the codec, the spec and the Node
 ;;      decoder; the cache-element namespace, the `cache-N` key spelling and
 ;;      the `:rf.mcp/dedup-table` envelope are untouched.
+;;   6. Three places where `expand` was not the exact inverse (rf2-fzbj.9).
+;;      Upstream marked a pooled subtree with `:cache-id` METADATA and read
+;;      that key back off every subtree, so a caller's own `:cache-id`
+;;      replaced their data; the slot now travels through the walk as a
+;;      return value (rf2-gwye.30). Both walks conj-ed a record's rebuilt
+;;      entries onto the original, so a respelled extension key kept its old
+;;      spelling beside the new one (`rebuild-record`, rf2-gwye.31). And
+;;      pooling by `=` alone merged a vector with an equal list or seq
+;;      (`wire=`, rf2-gwye.32). Output changes only for inputs that hit one
+;;      of the three, and the wire shape does not change at all.
 ;;
 ;; ---------------------------------------------------------------------------
 
@@ -349,7 +364,7 @@
      :clj  (instance? clojure.lang.IRecord form)))
 
 (defn ^:private rebuild-into
-  "The empty collection `side-walk` rebuilds `form` into.
+  "The empty collection `walk` rebuilds `form` into.
 
   `(empty form)` for everything EXCEPT a sorted map or sorted set,
   which lower to their unsorted counterparts. Substitution replaces a
@@ -370,24 +385,45 @@
     (with-meta (if (map? form) {} #{}) (meta form))
     (empty form)))
 
-(defn ^:private side-walk
-  "Like `clojure.walk/walk`, but `outer` receives BOTH the original form
-  and the rebuilt one — which is what lets the encoder read the
-  `:cache-id` metadata `inner` attached before the rebuild dropped it.
-  Recognises every Clojure collection; consumes seqs as with `doall`.
-  Sorted maps/sets rebuild unsorted — see `rebuild-into`."
-  [inner outer form]
-  (cond
-    (list? form)       (outer form (apply list (doall (map inner form))))
-    (map-entry?* form) (outer form (vec (doall (map inner form))))
-    (seq? form)        (outer form (doall (map inner form)))
-    (record?* form)    (outer form (reduce (fn [r x] (conj r (inner x))) form form))
-    (coll? form)       (outer form (into (rebuild-into form) (doall (map inner form))))
-    :else              (outer form form)))
+(defn ^:private rebuild-record
+  "`record` with each entry replaced by `(f entry)`, the rebuilt `[k v]`.
 
-(defn ^:private side-prewalk
-  [inner outer form]
-  (side-walk (partial side-prewalk inner outer) outer (inner form)))
+  A record cannot be rebuilt from `empty` (it has none), so its entries
+  are written back into the original — which makes a RESPELLED key the
+  hazard: an extension key that `f` escapes, unescapes or pools into a
+  slot reference must REPLACE its original, or both spellings survive
+  and the record gains an entry (rf2-gwye.31). A fixed field's key is a
+  plain keyword that no transform respells, so the `dissoc` below only
+  ever meets extension keys and the record keeps its type. Every entry
+  is rebuilt before any is written, so a key whose new spelling is
+  another entry's old one cannot overwrite that entry before it is read."
+  [f record]
+  (let [rebuilt (mapv (fn [entry] [(key entry) (f entry)]) record)]
+    (reduce (fn [r [_ entry]] (conj r entry))
+            (reduce (fn [r [k [k' _]]] (if (= k k') r (dissoc r k)))
+                    record
+                    rebuilt)
+            rebuilt)))
+
+(defn ^:private walk
+  "`form` rebuilt with `f` applied to each of its children — as
+  `clojure.walk/walk` with an identity `outer`. Recognises every Clojure
+  collection; consumes seqs as with `doall`. Sorted maps/sets rebuild
+  unsorted (see `rebuild-into`); records rebuild as themselves (see
+  `rebuild-record`)."
+  [f form]
+  (cond
+    (list? form)       (apply list (doall (map f form)))
+    (map-entry?* form) (vec (doall (map f form)))
+    (seq? form)        (doall (map f form))
+    (record?* form)    (rebuild-record f form)
+    (coll? form)       (into (rebuild-into form) (doall (map f form)))
+    :else              form))
+
+(defn ^:private prewalk
+  "`f` applied to `form`, then to every child of the result, recursively."
+  [f form]
+  (walk (partial prewalk f) (f form)))
 
 (defn ^:private cacheable?
   "True for the forms worth pooling. Scalars are cheaper inline than as a
@@ -403,6 +439,39 @@
            (seq? element)
            (coll? element))))
 
+;; ---- The pooling equivalence ------------------------------------------------
+
+(defn ^:private same-kinds?
+  "Given `(= a b)`, true when `a` and `b` are also the same EDN.
+
+  Clojure equality — and `hash` — erase one distinction the wire keeps:
+  `(= [1 2 3] '(1 2 3))`, yet the two print, read back and answer
+  `vector?` differently. So a vector matches only a vector, and a list
+  or seq only a list or seq, at EVERY depth: two equal maps whose
+  children differ in kind are just as different on the wire. Map keys
+  and set elements are paired through `find` / `get`, which hand back
+  `b`'s own key or element for `a`'s equal one, querying in the same
+  direction `=` itself does (rf2-gwye.32)."
+  [a b]
+  (cond
+    (identical? a b) true
+    (sequential? a)  (and (= (vector? a) (vector? b))
+                          (every? true? (map same-kinds? a b)))
+    (map? a)         (every? (fn [[k v]]
+                               (let [[k' v'] (find b k)]
+                                 (and (same-kinds? k k') (same-kinds? v v'))))
+                             a)
+    (set? a)         (every? (fn [x] (same-kinds? (get a x) x)) b)
+    :else            true))
+
+(defn ^:private wire=
+  "The one equivalence the encoder pools by: `=`, refined by
+  `same-kinds?`. The counting pass, the repeat check and slot lookup all
+  use it, so they cannot disagree about what one slot may hold. It is
+  still EQUALITY, not identity — see the namespace docstring."
+  [a b]
+  (and (= a b) (same-kinds? a b)))
+
 ;; ---- Pass 1: count candidates ----------------------------------------------
 ;;
 ;; Only subtrees seen MORE THAN ONCE are worth a cache slot, so the encoder
@@ -413,7 +482,7 @@
   (let [h      (hash element)
         bucket (or (bucket-get store h) [])]
     (if-let [entry (some (fn [entry]
-                           (when (= (:element entry) element) entry))
+                           (when (wire= (:element entry) element) entry))
                          bucket)]
       (bucket-set! store h (mapv (fn [bucket-entry]
                                    (if (identical? bucket-entry entry)
@@ -425,13 +494,12 @@
 (defn ^:private count-cacheable-elements
   [form]
   (let [store (new-bucket-store)]
-    (side-prewalk (fn [element]
-                    (when (and (not (identical? element form))
-                               (cacheable? element))
-                      (count-cacheable-element! store element))
-                    element)
-                  (fn [_org-element element] element)
-                  form)
+    (prewalk (fn [element]
+               (when (and (not (identical? element form))
+                          (cacheable? element))
+                 (count-cacheable-element! store element))
+               element)
+             form)
     store))
 
 (defn ^:private repeated-cacheable?
@@ -441,7 +509,7 @@
     (boolean
       (some (fn [{candidate :element :keys [count]}]
               (and (< 1 count)
-                   (= element candidate)))
+                   (wire= element candidate)))
             bucket))))
 
 ;; ---- Pass 2: substitute -----------------------------------------------------
@@ -453,21 +521,19 @@
     (vswap! counter inc)
     cache-id))
 
-(defn ^:private check-in-cache
-  "First sighting of `element`: record it and return the element tagged
-  with its freshly allocated `:cache-id` (the rebuild reads that tag off
-  the original). Later sightings: return the cache-element symbol, which
-  IS the substitution."
-  [element store counter]
-  (let [h      (hash element)
-        bucket (or (bucket-get store h) [])]
-    (if-let [cache-id (some (fn [[cached-element cache-id]]
-                              (when (= cached-element element) cache-id))
-                            bucket)]
-      cache-id
-      (let [cache-id (next-cache-id! counter)]
-        (bucket-set! store h (conj bucket [element cache-id]))
-        (with-meta element {:cache-id cache-id})))))
+(defn ^:private pooled-id
+  "The cache-element symbol already allocated for `element` in `store`,
+  or nil on its first sighting."
+  [store element]
+  (some (fn [[cached-element cache-id]]
+          (when (wire= cached-element element) cache-id))
+        (bucket-get store (hash element))))
+
+(defn ^:private pool!
+  "Record `cache-id` as the slot for `element` in `store`."
+  [store element cache-id]
+  (let [h (hash element)]
+    (bucket-set! store h (conj (or (bucket-get store h) []) [element cache-id]))))
 
 (defn ^:private escape-literals
   "`escape-token` applied throughout `form`.
@@ -477,7 +543,7 @@
   hashing different values for any subtree holding a colliding literal,
   and the pooling would quietly stop firing for exactly those subtrees."
   [form]
-  (side-prewalk escape-token (fn [_org-element element] element) form))
+  (prewalk escape-token form))
 
 (defn de-dupe-eq
   "Compress `form` into a flat cache map keyed by `de-dupe.cache/cache-N`
@@ -499,27 +565,35 @@
         counter          (volatile! 1)
         compressed-cache (volatile! {})
         candidate-counts (count-cacheable-elements form)
-        values-store     (new-bucket-store)
-        process-element  (fn [element]
-                           ;; The root itself is slot 0, never a substitution;
-                           ;; map entries and scalars are not cacheable; and a
-                           ;; subtree seen once is cheaper inline.
-                           (if (or (identical? element form)
-                                   (not (cacheable? element))
-                                   (not (repeated-cacheable? candidate-counts element)))
-                             element
-                             (check-in-cache element values-store counter)))
-        outer-fn         (fn [org-element element]
-                           (if (and (cacheable? org-element)
-                                    (not (identical? org-element form)))
-                             (if-let [id (:cache-id (meta org-element))]
-                               (do (vswap! compressed-cache assoc id element)
-                                   id)
-                               element)
-                             element))
-        cache-0          (side-prewalk process-element outer-fn form)]
-    (vswap! compressed-cache assoc (make-cache-element 0) cache-0)
-    @compressed-cache))
+        values-store     (new-bucket-store)]
+    ;; The slot a subtree occupies travels through the walk as a return
+    ;; value, never on the subtree: upstream tagged first sightings with
+    ;; `:cache-id` METADATA and read that key back off every subtree, so a
+    ;; caller's own `:cache-id` replaced their data (rf2-gwye.30).
+    ;;
+    ;; Each rebuilt value is BOUND before it is stored: `vswap!` reads the
+    ;; cache before evaluating its arguments, so storing the result of a
+    ;; descent inline would write back a snapshot taken before the descent
+    ;; stored the slots nested inside it.
+    (letfn [(substitute [element]
+              ;; Map entries and scalars are not cacheable, and a subtree
+              ;; seen once is cheaper inline: rebuild those in place.
+              (if-not (and (cacheable? element)
+                           (repeated-cacheable? candidate-counts element))
+                (walk substitute element)
+                (or (pooled-id values-store element)
+                    ;; First sighting. The id is allocated BEFORE the
+                    ;; descent, so a parent's slot numbers ahead of its
+                    ;; children's.
+                    (let [cache-id (next-cache-id! counter)
+                          _        (pool! values-store element cache-id)
+                          rebuilt  (walk substitute element)]
+                      (vswap! compressed-cache assoc cache-id rebuilt)
+                      cache-id))))]
+      ;; The root itself is slot 0, never a substitution.
+      (let [cache-0 (walk substitute form)]
+        (vswap! compressed-cache assoc (make-cache-element 0) cache-0))
+      @compressed-cache)))
 
 ;; ---- The inverse ------------------------------------------------------------
 
@@ -534,7 +608,7 @@
                 (list? value)          (apply list (map expand-value value))
                 (map-entry?* value)    (vec (map expand-value value))
                 (seq? value)           (doall (map expand-value value))
-                (record?* value)       (reduce (fn [r x] (conj r (expand-value x))) value value)
+                (record?* value)       (rebuild-record expand-value value)
                 (coll? value)          (into (empty value) (map expand-value value))
                 ;; Scalars — and the one scalar shape that is not simply
                 ;; itself: an escaped literal, which sheds one marker

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
@@ -493,3 +493,141 @@
         "the repeated element really was pooled")
     (is (= payload (rf.mcp-base.dedup/expand cache))
         "expand is equal to the input")))
+
+;; ---- Caller metadata is not encoder bookkeeping (rf2-gwye.30) ---------------
+;;
+;; The encoder used to tell a first-sighted pooled subtree apart by tagging it
+;; with `:cache-id` METADATA — and then trusted that key on ANY subtree, so a
+;; unique map carrying the caller's own `:cache-id` was replaced by the
+;; caller's value, and that value became a slot key outside the allocator's
+;; grammar. Metadata is not wire data; it must not move the output at all.
+
+(defn- allocator-keys?
+  "True when `cache` is keyed by exactly `cache-0` … `cache-(n-1)` — the
+  allocator's own slots and nothing else."
+  [cache]
+  (= (set (keys cache))
+     (set (map rf.mcp-base.dedup/make-cache-element (range (count cache))))))
+
+(deftest caller-cache-id-metadata-on-a-unique-subtree-changes-nothing
+  (let [payload {:user (with-meta {:x 1} {:cache-id 7})}]
+    (is (identical? payload (rf.mcp-base.dedup/dedup-value payload true))
+        "no subtree repeats ⇒ verbatim passthrough, whatever the metadata says")
+    (is (= {(rf.mcp-base.dedup/make-cache-element 0) payload}
+           (rf.mcp-base.dedup/de-dupe-eq payload))
+        "the raw cache is root-only: no slot was invented for the metadata")
+    (is (identical? payload (rf.mcp-base.dedup/dedup-value payload false))
+        "opting out stays a strict passthrough")))
+
+(deftest caller-cache-id-metadata-beside-a-real-repeat-expands-exactly
+  (let [shared  (with-meta {:v [1 2 3]} {:cache-id 'other/id})
+        payload {:user  (with-meta {:x 1} {:cache-id 7})
+                 :other (with-meta {:y 2} {:cache-id 'other/id})
+                 :a     shared
+                 :b     shared}
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        cache   (get out rf.mcp-base.vocab/dedup-table-key)]
+    (is (contains? out rf.mcp-base.vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (is (< 1 (count cache)) "the repeated subtree really was pooled")
+    (is (allocator-keys? cache)
+        "every slot key is the allocator's — no caller metadata value became one")
+    (is (= payload (rf.mcp-base.dedup/expand cache)))))
+
+;; ---- Record extension keys are REPLACED, not added beside (rf2-gwye.31) ----
+;;
+;; Both walks rebuilt a record by conj-ing each transformed entry back into the
+;; ORIGINAL record. A fixed field's key never changes, but an extension key can
+;; — escaped on the way out, unescaped on the way back, or replaced by a slot
+;; reference — and conj kept the old spelling beside the new one.
+
+(defrecord KeyedRecord [x])
+
+(deftest record-extension-keys-are-replaced-not-duplicated
+  (let [shared  [7 8 9]
+        rec     (assoc (->KeyedRecord shared)
+                       :de-dupe.cache/cache-1  :kw
+                       'de-dupe.cache/cache-1  :sym
+                       "de-dupe.cache/cache-1" :str
+                       ;; escapes to `!!cache-1` while `cache-1` escapes to THIS
+                       ;; spelling: pins that every original entry is read
+                       ;; before any rebuilt one is written over it.
+                       :de-dupe.cache/!cache-1 :already-escaped
+                       [4 5 6]                 :pooled-key)
+        payload {:record rec :again shared :also [4 5 6]}
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        cache   (get out rf.mcp-base.vocab/dedup-table-key)
+        slot-of (fn [v] (some (fn [[k cv]] (when (= v cv) k)) cache))
+        encoded (:record (get cache (rf.mcp-base.dedup/make-cache-element 0)))
+        back    (rf.mcp-base.dedup/expand cache)]
+    (is (contains? out rf.mcp-base.vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (testing "the encoded record carries each key ONCE, in its wire spelling"
+      (is (instance? KeyedRecord encoded))
+      (is (= #{:x
+               :de-dupe.cache/!cache-1 'de-dupe.cache/!cache-1 "de-dupe.cache/!cache-1"
+               :de-dupe.cache/!!cache-1
+               (slot-of [4 5 6])}
+             (set (keys encoded)))
+          "no original spelling survives beside its escaped or pooled replacement")
+      (is (= :kw (get encoded :de-dupe.cache/!cache-1)))
+      (is (= :already-escaped (get encoded :de-dupe.cache/!!cache-1))))
+    (testing "expansion restores exactly the original entries, and the type"
+      (is (= payload back))
+      (is (instance? KeyedRecord (:record back)))
+      (is (= (set (keys rec)) (set (keys (:record back))))
+          "no escaped spelling survives beside its restored original"))
+    (testing "controls"
+      (let [control (assoc payload :record (into {} rec))]
+        (is (= control (rf.mcp-base.dedup/expand
+                         (get (rf.mcp-base.dedup/dedup-value control true)
+                              rf.mcp-base.vocab/dedup-table-key)))
+            "the same entries in an ordinary map round-trip"))
+      (is (identical? payload (rf.mcp-base.dedup/dedup-value payload false))))))
+
+;; ---- Lists and vectors are different EDN (rf2-gwye.32) ----------------------
+;;
+;; `(= '(1 2 3) [1 2 3])` and their hashes agree, so pooling by `=` alone put
+;; a list and a vector in ONE slot and both came back as whichever was seen
+;; first. The wire prints them differently, so pooling must not merge them —
+;; at any depth, including inside containers that are otherwise equal.
+
+(deftest equal-lists-and-vectors-keep-their-kind
+  (let [shared {:big [:repeat :me]}]
+    (doseq [payload [(array-map :list '(1 2 3) :vector [1 2 3] :a shared :b shared)
+                     (array-map :vector [1 2 3] :list '(1 2 3) :a shared :b shared)]]
+      (let [out  (rf.mcp-base.dedup/dedup-value payload true)
+            back (rf.mcp-base.dedup/expand (get out rf.mcp-base.vocab/dedup-table-key))]
+        (is (contains? out rf.mcp-base.vocab/dedup-table-key) "non-vacuity: a real wrap")
+        (is (= payload back))
+        (is (list? (:list back)) "the list comes back a list, in either order")
+        (is (vector? (:vector back)) "the vector comes back a vector, in either order")))))
+
+(deftest same-kind-repeats-still-pool-one-slot-per-kind
+  (let [payload (array-map :l1 '(1 2 3) :v1 [1 2 3] :l2 '(1 2 3) :v2 [1 2 3])
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        cache   (get out rf.mcp-base.vocab/dedup-table-key)
+        root    (get cache (rf.mcp-base.dedup/make-cache-element 0))
+        back    (rf.mcp-base.dedup/expand cache)]
+    (is (= 3 (count cache)) "the root plus ONE slot per kind")
+    (is (= (:l1 root) (:l2 root)) "the two lists share a slot")
+    (is (= (:v1 root) (:v2 root)) "the two vectors share a slot")
+    (is (not= (:l1 root) (:v1 root)) "and the list slot is not the vector slot")
+    (is (= payload back))
+    (is (every? list? [(:l1 back) (:l2 back)]))
+    (is (every? vector? [(:v1 back) (:v2 back)]))))
+
+(deftest equal-containers-with-differently-kinded-children-keep-their-kinds
+  (let [shared  {:big [:repeat :me]}
+        payload (array-map :in-val-l {:child '(1 2 3)}  :in-val-v {:child [1 2 3]}
+                           :in-key-l {'(1 2 3) :child}  :in-key-v {[1 2 3] :child}
+                           :in-set-l #{'(1 2 3)}        :in-set-v #{[1 2 3]}
+                           :a shared :b shared)
+        out     (rf.mcp-base.dedup/dedup-value payload true)
+        back    (rf.mcp-base.dedup/expand (get out rf.mcp-base.vocab/dedup-table-key))]
+    (is (contains? out rf.mcp-base.vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (is (= payload back))
+    (is (list?   (get-in back [:in-val-l :child])))
+    (is (vector? (get-in back [:in-val-v :child])))
+    (is (list?   (first (keys (:in-key-l back)))) "a key keeps its kind")
+    (is (vector? (first (keys (:in-key-v back)))))
+    (is (list?   (first (:in-set-l back))) "a set element keeps its kind")
+    (is (vector? (first (:in-set-v back))))))


### PR DESCRIPTION
## Summary

Fixes the three confirmed findings of **rf2-fzbj.9** in the shared dedup codec (`tools/mcp-base/src/re_frame/mcp_base/dedup.cljc`), one per per-finding child:

- **rf2-gwye.30 (P2): caller `:cache-id` metadata replaced data.** The encoder tagged a first-sighted pooled subtree with `:cache-id` METADATA and then trusted that key on *every* subtree. So `{:user (with-meta {:x 1} {:cache-id 7})}`, which has no repeats at all, was wrapped as `{7 {:x 1}, de-dupe.cache/cache-0 {:user 7}}` and expanded to `{:user 7}`. The slot id now travels through the substitution walk as a return value, and metadata is never read.
- **rf2-gwye.31 (P2): record extension keys doubled.** Both walks conj-ed each rebuilt entry onto the ORIGINAL record. An extension key that was escaped, unescaped or pooled into a reference therefore kept its old spelling beside the new one, and the record gained an entry. The new `rebuild-record` rebuilds every entry first, dissocs each original key whose spelling changed, then writes the rebuilt entries. The forward walk and `expand` both use it.
- **rf2-gwye.32 (P3): equal lists and vectors merged.** Pooling by `=`/`hash` alone put `(1 2 3)` and `[1 2 3]` in one slot, and both came back as whichever was seen first. Counting, the repeat check and slot lookup now all use `wire=`: `=` refined by `same-kinds?`. `same-kinds?` separates vector from list/seq at every depth, covering values, map keys and set elements. Pooling within a kind is plain equality as before, and sorted collections still lower to unsorted.

A consequence of the first fix: once no walk needs the original form, the `outer` argument of `side-walk`/`side-prewalk` is dead. The two collapse to a plain private `walk`/`prewalk`.

`tools/mcp-base/spec/dedup.md` gains two paragraphs. One says the encoder reads only the value and records rebuild with exactly their own entries. The other defines the pooling equality as wire equality.

## Wire shape: UNCHANGED

The `:rf.mcp/dedup-table` envelope, the reference grammar (`cache-<digits>` reference, `!` escape), the `de-dupe.cache/cache-N` slot spelling and the slot-allocation order are all unchanged. Every pre-existing wire-spelling pin passes unmodified, including `colliding-payload-tokens-are-escaped-on-the-wire` and `cache-ids-are-allocated-per-call-not-globally`. Output changes only for inputs that hit one of the three defects, and in each case it changes from wrong to right:

- a unique subtree carrying caller `:cache-id` metadata now passes through verbatim;
- a record whose extension keys get respelled now carries each key once;
- equal-but-differently-kinded sequences now occupy separate slots.

Readers of this wire, found and checked:

- `tools/mcp-conformance/lib/dedup-envelope.cjs`, the Node oracle. It is a type-blind JSON decoder: lists, vectors and records all arrive as arrays and objects, so none of the three changes reaches it. **Not edited.** Its own queued findings (rf2-fzbj.14 and its rf2-gwye children) are untouched.
- The `tools/mcp-conformance/wire-vocab` `DedupTable` schema. Slot keys stay allocator `cache-N` symbols.
- re-frame2-pair-mcp (`tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs`, `snapshot_pipeline.cljs`) and story-mcp (`tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc`, `apply-dedup`). Both call `dedup-value`, and both suites pass unchanged (below).

## Quality gates

All rows below were run locally on the final base `e95e89d528` after rebasing. Each exit code is the runner's own captured exit, not a pipeline's.

| Gate | CI job | Local result |
| --- | --- | --- |
| mcp-base JVM, `clojure -M:test` | `jvm-tools-mcp-base` | 291 tests / 1035 assertions, 0 failures, exit 0 |
| mcp-base CLJS, `npm run test:cljs` | `jvm-tools-mcp-base` (CLJS step) | 55 tests / 332 assertions, 0 failures, 0 warnings, exit 0 |
| re-frame2-pair-mcp, `npm test` (`:server-test`) | `node-test-tools-re-frame2-pair-mcp` | 1178 tests / 4366 assertions, 0 failures, 0 warnings, exit 0 |
| story-mcp JVM, `clojure -M:test` | `jvm-tools-story-mcp` | 296 tests / 1630 assertions, 0 failures, exit 0 |
| story-mcp stdio roundtrip | `node-test-tools-story-mcp` | green, exit 0 |
| mcp-conformance Node unit cluster, `npm run test:unit` (includes `dedup-envelope.test.cjs`) | `mcp-conformance-re-frame2-pair` (unit-cluster step) | 149 tests: 140 pass, 0 fail, 9 skipped (symlink branches soft-skip on Windows), exit 0 |
| mcp-conformance story end-to-end, `npm run test:story` | `mcp-conformance-story` | both scripts green (`end-to-end-story`, `end-to-end-project-stories`), exit 0 |
| mcp-conformance pair end-to-end, `npm run test:re-frame2-pair` (against a fresh `npm run build` server bundle) | `mcp-conformance-re-frame2-pair` | client conformance green, exit 0 |
| `python scripts/check_doc_slugs.py` | `verify-readme-links` | exit 0 |

**Red, then green.** The regression tests were committed first (`f3fe037d05`) and run against the unmodified codec. The JVM dedup namespace ran 33 tests / 146 assertions with **15 failures**, exit 1. The CLJS lane ran 55 / 332 with **15 failures**, exit 1. Every one of the six new tests failed at least once, and every control passed. After the fix (`9136625872`) both hosts read 0 failures on the same test and assertion counts. The six tests are:

- `caller-cache-id-metadata-on-a-unique-subtree-changes-nothing`
- `caller-cache-id-metadata-beside-a-real-repeat-expands-exactly`
- `record-extension-keys-are-replaced-not-duplicated`
- `equal-lists-and-vectors-keep-their-kind`
- `same-kind-repeats-still-pool-one-slot-per-kind`
- `equal-containers-with-differently-kinded-children-keep-their-kinds`

**The doc-slug gate read this tree.** It prints no root, so a broken anchor was appended to `tools/mcp-base/spec/dedup.md`. The gate went red (exit 1, naming that file and line). The file was then restored, and its blob hash matches the committed blob.

**Checked by hand, because no gate validates it:** the prose of the two new spec paragraphs. No table, fence, heading, link or anchor was added or changed in any committed document.

**Relying on CI for:** `mcp-conformance-wire-vocab`, and the tool-descriptor drift checks inside the two consumer jobs. None of them reads the codec's output.

## Skipped suggestion (recorded on rf2-gwye.31)

- **rf2-gwye.31's "focused Story `apply-dedup` integration pin" was not built.** `apply-dedup` is `dedup-value` plus `pr-edn` of that same value, and story-mcp's existing `apply-dedup-rewrites-both-slots-consistently` already pins that the two slots stay consistent. The defect and its fix live entirely in the codec, whose new cross-host tests pin them. The pin would also sit outside this dispatch's `tools/mcp-base/**` surface.

## Scope

- No hot-zone file touched.
- No other rf2-fzbj or rf2-gwye finding touched.
- No AI-attribution trailers, per CLAUDE.md.
