### PR TITLE
fix(core): release the exact one-shot reaction; extract cache-clear batches atomically (rf2-fzbj.5)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1918,13 +1918,23 @@
 
 (defn- subscribe-once-in-frame
   "INTERNAL worker for `subscribe-once`. `target` may be a frame-id
-  keyword or a live frame value; `subscribe-in-frame` / `unsubscribe` each
-  normalize it to its runnable-id ADDRESS, so subscribe-then-unsubscribe
-  here target the same frame for every supported spelling."
+  keyword or a live frame value; `subscribe-in-frame` /
+  `unsubscribe-if-reaction` each normalize it to its runnable-id ADDRESS, so
+  subscribe-then-release here target the same frame for every supported
+  spelling.
+
+  The release is IDENTITY-GUARDED (rf2-gwye.3): it returns the reference this
+  read took on `reaction`, never whatever sits at the address once the deref
+  returns. On the JVM an eviction (`clear-sub-cache!`, hot reload, a
+  generation change) can land mid-deref and another consumer can rebuild the
+  slot; the eviction already took this read's reference, so an address-only
+  release would decrement, and dispose, the successor under its owner. A nil
+  `reaction` (missing-frame recovery) acquired nothing and releases nothing."
   [target query-v]
   (let [reaction (subscribe-in-frame target query-v)
         v        (when reaction @reaction)]
-    (unsubscribe target query-v)
+    (when reaction
+      (unsubscribe-if-reaction target query-v reaction))
     v))
 
 (defn subscribe-once
@@ -2515,8 +2525,9 @@
   still holds `reaction`**, then take the ordinary 1 → 0 in-tick disposal.
 
   Not public API and not an alternative teardown: it exists for holders
-  whose reference can outlive its slot. Two of the three are the React-hook
-  spine's; the third is this namespace's own layer-2+ input release
+  whose reference can outlive its slot. Two of the four are the React-hook
+  spine's; `subscribe-once`'s release is another (rf2-gwye.3: an eviction can
+  land while it derefs); the fourth is this namespace's own layer-2+ input release
   (`release-input-ref!`, rf2-1frc), which outlives its slot for the same
   reason case 2 does — an eviction batch is removed from the cache before it
   is disposed, so an eagerly reacquiring holder can repopulate a slot mid-walk

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -472,10 +472,13 @@
                           {:where 're-frame.subs.cache/clear-sub-cache!})))
   ([frame-id]
    (when-let [cache (:sub-cache (rf.frame/frame frame-id))]
-     (let [snapshot @cache]
-       ;; Evict the whole cache BEFORE any dispose! call — see the
-       ;; rf2-awhtpc note above.
-       (reset! cache {})
+     ;; Evict the whole cache BEFORE any dispose! call — see the rf2-awhtpc
+     ;; note above — and do it in ONE atomic take, disposing exactly the map
+     ;; it removed (rf2-gwye.4). A separate `@cache` read and `reset!` left a
+     ;; JVM window in which an entry acquired between them was erased without
+     ;; being in the batch, so it was never disposed, and two overlapping
+     ;; clears could each condemn the same entry.
+     (let [[snapshot _] (reset-vals! cache {})]
        ;; Tag the observation port's synchronous node-disposed notifications
        ;; with the INTRINSIC :cache-clear cause (→ :disposed) so an explicit
        ;; teardown is never mislabelled :hmr by a co-pending HMR drain
@@ -555,8 +558,9 @@
   deterministically reasoned `:frame-destroy`. Returns nil."
   [cache frame-id]
   (when cache
-    (let [snapshot @cache]
-      (reset! cache {})
+    ;; One atomic take, as in `clear-sub-cache!` (rf2-gwye.4): the batch
+    ;; disposed is exactly the map this call removed.
+    (let [[snapshot _] (reset-vals! cache {})]
       ;; Tag the observation port's synchronous node-disposed notifications with
       ;; the INTRINSIC :frame-destroy cause (→ :disposed) so a frame teardown is
       ;; never mislabelled :hmr by a co-pending HMR drain (rf2-r8jmdb).

--- a/implementation/core/test/re_frame/sub_ownership_race_test.clj
+++ b/implementation/core/test/re_frame/sub_ownership_race_test.clj
@@ -1,0 +1,288 @@
+(ns re-frame.sub-ownership-race-test
+  "JVM-only regressions for two sub-cache OWNERSHIP races (rf2-fzbj.5, split
+  as rf2-gwye.3 and rf2-gwye.4). In both, a release or a disposal batch acted
+  on the cache as it stood at that moment rather than on what its own caller
+  had acquired or removed.
+
+  1. `subscribe-once` released by ADDRESS. If a `clear-sub-cache!` evicted
+     the one-shot's reaction A while it was mid-deref, and another consumer
+     then rebuilt the slot as B, the one-shot's release decremented B and
+     disposed it under its owner. The eviction had already taken A's
+     reference, so the release must be a no-op.
+  2. `clear-sub-cache!` and `dispose-all-for-frame-destroy!` read the cache
+     and emptied it in two steps. An entry acquired between the two was
+     erased by the reset without being in the batch, so it was never
+     disposed; and two overlapping batches could each condemn one entry.
+
+  ## Determinism
+
+  No sleeps and no reliance on scheduler luck: every interleaving is pinned
+  with promises at a named point.
+
+  - Race 1 holds the one-shot INSIDE its deref, in the sub body itself.
+  - Race 2 holds the batch at the moment it empties the cache, through a
+    `with-redefs` over `reset!` and `reset-vals!` that matches ONLY this
+    frame's cache atom being set to `{}`, holds only the first such call,
+    and otherwise delegates unchanged. It covers both primitives so it pins
+    the same point whichever one the batch uses: with a read-then-reset
+    extraction the hold lands AFTER the batch has taken its snapshot, and
+    with a single atomic extraction it lands before it.
+
+  Every wait is bounded, and a timeout fails the test instead of hanging it.
+
+  ## Posture
+
+  Ref-counts, cache identity and dispose counts only, with no trace
+  observation, so every assertion holds under `-Dre-frame.debug=false` and
+  this namespace runs in the production-gate lane by default."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.interop :as rf.interop]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.schemas :as rf.schemas]
+            [re-frame.subs :as rf.subs]
+            [re-frame.subs.cache :as rf.subs.cache]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
+
+(defn- reset-runtime [test-fn]
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (rf.flows/reset-flows!)
+  (rf.schemas/clear-schemas-by-frame!)
+  (rf/destroy-adapter!)
+  (rf/init! rf.substrate.plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(def ^:private wait-ms 10000)
+
+(defn- await!
+  "Deref `p`, bounded. A timeout throws, so a broken interleaving fails the
+  test rather than hanging the lane."
+  [p what]
+  (let [v (deref p wait-ms ::timeout)]
+    (when (= ::timeout v)
+      (throw (ex-info (str "timed out waiting for " what) {:waiting-for what})))
+    v))
+
+(defn- entry [frame-id query-v]
+  (get @(:sub-cache (rf.frame/frame frame-id)) query-v))
+
+(defn- counting-dispose
+  "A `rf.interop/dispose!` stand-in that counts calls per reaction in `counts`
+  and then delegates. It counts the CALL rather than the on-dispose callbacks
+  because a plain-atom reaction's `-dispose` is idempotent, which would hide
+  a second disposal."
+  [counts]
+  (let [real-dispose! rf.interop/dispose!]
+    (fn [r]
+      (swap! counts update r (fnil inc 0))
+      (real-dispose! r))))
+
+(defn- run-batch-held-at-extraction
+  "Run `batch!` on a worker thread and hold it at the moment it empties
+  `cache`, call `in-window` on this thread while it is held, then release it
+  and wait for it to return. See the namespace docstring for the seam."
+  [cache batch! in-window]
+  (let [held             (promise)
+        release          (promise)
+        armed            (atom true)
+        real-reset!      clojure.core/reset!
+        real-reset-vals! clojure.core/reset-vals!
+        hold!            (fn [a v]
+                           (when (and (identical? a cache)
+                                      (= {} v)
+                                      (compare-and-set! armed true false))
+                             (deliver held true)
+                             (await! release "the test to release the batch")))]
+    (with-redefs [clojure.core/reset!      (fn [a v] (hold! a v) (real-reset! a v))
+                  clojure.core/reset-vals! (fn [a v] (hold! a v) (real-reset-vals! a v))]
+      (let [job (future (batch!))]
+        (try
+          (await! held "the batch to reach its extraction")
+          (in-window)
+          (deliver release true)
+          (await! job "the batch to return")
+          (finally
+            (deliver release true)
+            (future-cancel job)))))))
+
+;; ---- 1. subscribe-once releases the reaction it acquired ------------------
+
+(deftest one-shot-release-does-not-steal-a-successor-reaction
+  (testing "an eviction during the one-shot's deref ends its reference, so the
+            release that follows must not decrement a successor another
+            consumer owns"
+    (let [frame-id :own/once
+          q        [:own/value]
+          entered  (promise)
+          resume   (promise)
+          disposed (atom 0)]
+      (rf/reg-sub :own/value
+                  (fn [_db _q]
+                    (deliver entered true)
+                    (await! resume "the test to resume the one-shot deref")
+                    :value))
+      (rf/make-frame {:id frame-id})
+      (let [job (future (rf.subs/subscribe-once q {:frame frame-id}))]
+        (try
+          (await! entered "the one-shot to enter its deref")
+          (let [a (:reaction (entry frame-id q))]
+            (is (some? a) "premise: the one-shot's reaction A is cached while it derefs")
+            (rf.subs.cache/clear-sub-cache! frame-id)
+            (let [b (rf.subs/subscribe q {:frame frame-id})]
+              (rf.interop/add-on-dispose! b #(swap! disposed inc))
+              (is (not (identical? a b)) "premise: the clear evicted A and B is its successor")
+              (deliver resume true)
+              (is (= :value (await! job "the one-shot to return"))
+                  "the one-shot still returns the value it read")
+              (is (identical? b (:reaction (entry frame-id q)))
+                  "THE BUG (rf2-gwye.3): pre-fix the one-shot's address-only release
+                   found B at the address, drove it 1 -> 0 and evicted it")
+              (is (= 1 (:ref-count (entry frame-id q)))
+                  "B keeps exactly its owner's reference")
+              (is (zero? @disposed) "B's on-dispose never ran")
+              (rf.subs/unsubscribe frame-id q)
+              (is (nil? (entry frame-id q)) "B's owner still releases it normally")
+              (is (= 1 @disposed) "and that release disposes B exactly once")))
+          (finally
+            (deliver resume true)
+            (future-cancel job)))))))
+
+(deftest one-shot-read-beside-a-live-holder-leaves-the-holder-intact
+  (testing "no eviction: the one-shot takes and returns only its own reference"
+    (let [frame-id :own/control
+          q        [:own/value]
+          disposed (atom 0)]
+      (rf/reg-sub :own/value (fn [_db _q] :value))
+      (rf/make-frame {:id frame-id})
+      (let [held (rf.subs/subscribe q {:frame frame-id})]
+        (rf.interop/add-on-dispose! held #(swap! disposed inc))
+        (is (= :value (rf.subs/subscribe-once q {:frame frame-id})))
+        (is (identical? held (:reaction (entry frame-id q)))
+            "the holder's reaction is still the cached one")
+        (is (= 1 (:ref-count (entry frame-id q)))
+            "the one-shot released exactly the reference it took")
+        (is (zero? @disposed))
+        (rf.subs/unsubscribe frame-id q)
+        (is (nil? (entry frame-id q)))
+        (is (= 1 @disposed) "the holder's own release disposes exactly once")))))
+
+(deftest one-shot-read-as-the-only-owner-disposes-in-tick
+  (testing "the one-shot owned the last reference, so its release evicts and
+            disposes before it returns"
+    (let [frame-id :own/final
+          q        [:own/value]
+          seen     (atom nil)
+          counts   (atom {})]
+      (rf/reg-sub :own/value (fn [_db _q] :value))
+      (rf/make-frame {:id frame-id})
+      (let [cache (:sub-cache (rf.frame/frame frame-id))]
+        (add-watch cache ::seen
+                   (fn [_ _ _ m]
+                     (when-let [r (get-in m [q :reaction])]
+                       (compare-and-set! seen nil r))))
+        (with-redefs [rf.interop/dispose! (counting-dispose counts)]
+          (is (= :value (rf.subs/subscribe-once q {:frame frame-id}))))
+        (remove-watch cache ::seen))
+      (is (some? @seen) "premise: the one-shot's reaction was cached")
+      (is (nil? (entry frame-id q)) "the slot is evicted before subscribe-once returns")
+      (is (= 1 (get @counts @seen 0)) "its reaction is disposed exactly once")))
+  (testing "a missing frame is still a nil read, not a throw"
+    (is (nil? (rf.subs/subscribe-once [:own/value] {:frame :own/never-made})))))
+
+;; ---- 2. batch disposal disposes exactly what it removes ------------------
+
+(def ^:private batches
+  "The two whole-cache disposal paths, each as `frame-id -> thunk`."
+  [["clear-sub-cache!"
+    (fn [frame-id] #(rf.subs.cache/clear-sub-cache! frame-id))]
+   ["dispose-all-for-frame-destroy!"
+    (fn [frame-id]
+      (let [cache (:sub-cache (rf.frame/frame frame-id))]
+        #(rf.subs.cache/dispose-all-for-frame-destroy! cache frame-id)))]])
+
+(defn- fresh-frame! [scenario i]
+  (let [frame-id (keyword "own" (str scenario "-" i))]
+    (rf/make-frame {:id frame-id})
+    frame-id))
+
+(defn- owned-exactly-once?
+  "An entry is either still cached and never disposed (it was acquired after
+  the extraction), or gone and disposed exactly once (it was in the batch).
+  Erased but never disposed, and disposed twice, are both ownership leaks."
+  [{:keys [cached? disposes]}]
+  (if cached? (zero? disposes) (= 1 disposes)))
+
+(deftest a-concurrent-acquisition-is-never-erased-undisposed
+  (rf/reg-sub :own/old (fn [_db _q] :old))
+  (rf/reg-sub :own/late (fn [_db _q] :late))
+  (doseq [[i [label batch-for]] (map-indexed vector batches)]
+    (testing (str label ": an entry acquired while the batch empties the cache
+                   is either left live or disposed with the batch")
+      (let [frame-id (fresh-frame! "acquire" i)
+            cache    (:sub-cache (rf.frame/frame frame-id))
+            counts   (atom {})
+            old      (rf.subs/subscribe [:own/old] {:frame frame-id})
+            late     (promise)]
+        (with-redefs [rf.interop/dispose! (counting-dispose counts)]
+          (run-batch-held-at-extraction
+            cache (batch-for frame-id)
+            (fn []
+              (let [r (rf.subs/subscribe [:own/late] {:frame frame-id})]
+                (deliver late r)
+                (is (identical? r (:reaction (get @cache [:own/late])))
+                    "premise: B is cached inside the batch's window")))))
+        (let [late (await! late "B")
+              fate (fn [r q] {:cached?  (identical? r (:reaction (get @cache q)))
+                              :disposes (get @counts r 0)})]
+          (is (= {:cached? false :disposes 1} (fate old [:own/old]))
+              "A, cached when the batch began, is removed and disposed exactly once")
+          (is (owned-exactly-once? (fate late [:own/late]))
+              (str "THE BUG (rf2-gwye.4): pre-fix B was erased by the reset but was "
+                   "absent from the batch's snapshot, so it was never disposed; got "
+                   (fate late [:own/late]))))))))
+
+(deftest overlapping-batches-condemn-each-entry-once
+  (rf/reg-sub :own/old (fn [_db _q] :old))
+  (doseq [[i [label batch-for]] (map-indexed vector batches)]
+    (testing (str label ": a batch that runs to completion while another is held
+                   at its extraction leaves each entry in exactly one of them")
+      (let [frame-id (fresh-frame! "overlap" i)
+            cache    (:sub-cache (rf.frame/frame frame-id))
+            counts   (atom {})
+            old      (rf.subs/subscribe [:own/old] {:frame frame-id})
+            batch!   (batch-for frame-id)]
+        (with-redefs [rf.interop/dispose! (counting-dispose counts)]
+          (run-batch-held-at-extraction cache batch! batch!))
+        (is (= {} @cache))
+        (is (= 1 (get @counts old 0))
+            "THE BUG (rf2-gwye.4): pre-fix both batches had already snapshotted
+             the entry, so each of them disposed it")))))
+
+(deftest an-acquisition-after-extraction-stays-live
+  (rf/reg-sub :own/old (fn [_db _q] :old))
+  (rf/reg-sub :own/late (fn [_db _q] :late))
+  (doseq [[i [label batch-for]] (map-indexed vector batches)]
+    (testing (str label ": an entry acquired while the batch disposes its
+                   members, after it emptied the cache, is not the batch's")
+      (let [frame-id (fresh-frame! "after" i)
+            cache    (:sub-cache (rf.frame/frame frame-id))
+            counts   (atom {})
+            old      (rf.subs/subscribe [:own/old] {:frame frame-id})
+            late     (atom nil)]
+        ;; Acquire from inside A's disposal, i.e. strictly after the extraction:
+        ;; the eager-reacquisition shape the React-hook spine uses.
+        (rf.interop/add-on-dispose!
+          old #(reset! late (rf.subs/subscribe [:own/late] {:frame frame-id})))
+        (with-redefs [rf.interop/dispose! (counting-dispose counts)]
+          ((batch-for frame-id)))
+        (is (some? @late) "premise: A's disposal acquired B")
+        (is (identical? @late (:reaction (get @cache [:own/late]))) "B stays cached")
+        (is (= 1 (:ref-count (get @cache [:own/late]))) "with its owner's reference")
+        (is (zero? (get @counts @late 0)) "and the batch never disposes it")))))


### PR DESCRIPTION
## Summary

Fixes the two confirmed sub-cache ownership defects in rf2-fzbj.5 (split per finding as rf2-gwye.3 and rf2-gwye.4). Both re-verified at tip before fixing: the new regression namespace is RED against the unfixed source.

**rf2-gwye.3: `subscribe-once` released by address.** If a `clear-sub-cache!` evicted the one-shot's reaction A while it was mid-deref, and another consumer then rebuilt the slot as B, the one-shot's `(unsubscribe target query-v)` decremented B and disposed it under its owner. `subscribe-once-in-frame` now releases the reaction it acquired, through the existing identity-guarded `unsubscribe-if-reaction`. A nil reaction (missing-frame recovery) releases nothing. Arities, return value, missing-frame recovery and synchronous final-reference disposal are unchanged.

**rf2-gwye.4: whole-cache batches extracted in two steps.** `clear-sub-cache!` and `dispose-all-for-frame-destroy!` read `@cache` and then `reset!` it. An entry acquired between the two was erased without being in the batch, so it was never disposed, and two overlapping batches could each dispose one entry. Both now take and empty the cache in one `reset-vals!` and dispose exactly the map removed. Remove-before-dispose ordering (rf2-awhtpc), the disposal-cause binding, per-key trace reasons and best-effort per-entry disposal are all unchanged. The destroy path gets the same one-line change so the two batch paths don't diverge; the review did not reproduce a destroy-admission race, and none is claimed.

No public API, no new ownership API, no spec edit.

## Files

- `implementation/core/src/re_frame/subs.cljc`: the one-shot release, plus the caller count in `unsubscribe-if-reaction`'s docstring.
- `implementation/core/src/re_frame/subs/cache.cljc`: atomic extraction in both batch paths.
- `implementation/core/test/re_frame/sub_ownership_race_test.clj`: new JVM-only namespace.

## Regression test (deterministic, no sleeps)

`re-frame.sub-ownership-race-test`:

- The one-shot race is pinned with promises inside the sub body: pause the deref, clear, subscribe the successor, resume. Its controls are a no-eviction shared owner, a final-owner one-shot that disposes in-tick, and missing frame returning nil.
- The batch races run over BOTH batch paths. The seam is a `with-redefs` over `reset!` / `reset-vals!` that matches only this frame's cache atom being set to `{}`, holds only the first such call, and delegates unchanged.
  - Concurrent acquisition: an entry is either left live, or disposed exactly once with the batch.
  - Overlapping batches: each entry is condemned once.
  - Acquisition after extraction, from inside a member's disposal: the entry stays live. This is a control that passes both before and after the fix.

RED against the pre-fix source, which was byte-identical to its parent (`git diff --quiet HEAD` exit 0): captured exit 1, 6 tests, 37 assertions, 7 failures, every one on a discriminating assertion. The one-shot's successor was disposed and evicted. On both batch paths the late entry came back `{:cached? false, :disposes 0}`, and the overlapping batches disposed the entry twice. GREEN after the fix in both postures (see gates).

## Quality gates

Every number below is the runner's own exit code, captured on the same command line as the run. Local runs were on merge base `891ad4274f`. `origin/main` has since moved 20 commits, none of them touching these three files; the three-dot diff contains only this change. I relied on CI's merge-ref build for the combined tree instead of rebasing and re-running.

| Gate | Result | CI job |
|---|---|---|
| New namespace, dev posture, pre-fix source | exit 1, 7 failures (the RED) | `jvm-core` |
| New namespace + `sub-cache-test`, `sub-cache-concurrency-test`, `subs-evicted-input-release-cljs-test`, dev posture | exit 0, 49 tests / 246 assertions | `jvm-core` |
| New namespace under `clojure -M:test:prod-gate`, pre-fix source planted from the parent commit | exit 1, same 7 failures (the RED) | `jvm-core-prod-gate` |
| Same run, post-fix, with `prod-gate-lane-pin-test` | exit 0, 11 tests / 56 assertions | `jvm-core-prod-gate` |
| Full `clojure -M:test` (implementation/core) | exit 0, 2313 tests / 11971 assertions | `jvm-core` — JVM core (clojure -M:test) |
| `bash scripts/test-core-prod-gate.sh` (gate root printed as this worktree) | exit 0, 194 namespaces / 2034 tests / 8739 assertions; the new namespace is on its `--plan` roster | `jvm-core-prod-gate` |
| `npm run test:cljs` | exit 0, 11996 tests / 59625 assertions | `cljs` — CLJS (shadow-cljs :node-test) |
| `check_test_lane_bijection.py`, `check_retired_spellings.py`, `check_thrown_error_messages.py`, `check_keyword_catalogue_drift.py`, `check_ambient_durable_reads.py`, `check_require_alias_dialect.py` | all exit 0 | test.yml / lint.yml ratchet jobs |
| clj-kondo on the 3 changed files (local v2025.10.23, not CI's pin) | 0 errors. One pre-existing warning at `subs.cljc:52`, in the ns form, outside the diff | `clj-kondo` |
| Splint `--fail-on-errors` on the 3 changed files | exit 0. Two pre-existing style warnings at `subs.cljc:221` and `:2171`, outside the diff | `splint` |

The pre-fix plant was restored and checked two ways: each file's `git hash-object` blob hash equals `HEAD:<path>`, and `git diff --quiet HEAD` exits 0.

I did not run the fast-PR spine locally. For this change its coverage is the `jvm-core`, `jvm-core-prod-gate` and `cljs` jobs above, and I rely on CI for them on the merge ref. No spec or doc page is touched, so no link gate applies.

## Spec note (hot zone, not edited)

`spec/006-ReactiveSubstrate.md` §`subscribe-once` spells the release in its pseudocode as `unsubscribe(frame-id, query-v)`. The MUSTs beside it ("a concurrent reactive subscriber keeps the slot alive; `subscribe-once`'s decrement only triggers disposal when it owned the last reference") are what this fix makes true. The pseudocode reads as address-only, though. Suggested refinement for whoever next holds that file: have the pseudocode line release `r` itself, i.e. "release THIS read's reference on r; a no-op if an eviction already took it". No contract changes.

## Skipped suggestions

None of the review's suggestions were extras; each acceptance bullet is met above. The existing eager-reacquisition assertions in `subs_evicted_input_release_cljs_test.cljc` still pass, unmodified. Its prose still mentions `(reset! cache {})` when describing the clear; that is still true in meaning, and it's outside this change's file fence.
