### PR TITLE
fix(machines-viz): nest parallel regions in the frame; share fn delays and debug-named ids (rf2-fzbj.13)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1781,7 +1781,16 @@ encoder:
    a topology submap, is PRESERVED, rf2-07gg7h), and replaces any inline-fn
    slot with a names-only opaque label, so the payload is a viewer-safe
    topology with no source/paths/fns. The topology references (state ids,
-   transition targets, guard/action NAMES) survive.
+   transition targets, guard/action NAMES) survive. Both drops apply to
+   RECORD maps only (a state node, a transition candidate, a guard/action
+   entry): the KEYS of `:states`, `:regions`, `:on`, `:after`, `:guards` and
+   `:actions` are identifiers, so a state, event, region, guard or action
+   named `:source-code`, `:source-coords` or `:fn` survives (rf2-gwye.49).
+   A function-valued `:after` delay (Spec 005) is a map KEY, not a slot
+   value, so it becomes an inert `[<label> <n>]` vector key: a delay shape
+   the viewer projects but never runs, numbered so that two anonymous delay
+   functions keep two transitions. The delay function is never called
+   (rf2-fzbj.13).
 3. Canonicalises map / set ordering (per
    [Principles §Reproducible from the registry alone](./Principles.md)).
 4. Wraps in the versioned envelope.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -500,7 +500,11 @@
        region edges keep their ELK routes — the interior transpose moved
        their endpoints consistently, but ELK's absolute bend-points would
        now mismatch, so intra-region routes are cleared too and fall back to
-       the clean bezier through the transposed handles."
+       the clean bezier through the transposed handles.
+    4. GROW the regions' parent frame (the ROOT-CONTAINER) to enclose the
+       re-stacked column, keeping ELK's right/bottom inset and never
+       shrinking it — the regions are the frame's `parentId` children, so an
+       undersized frame would clamp them (rf2-fzbj.13)."
   [{:keys [positions edge-points edge-labels] :as layout} parsed]
   (if-not (:parallel? parsed)
     layout
@@ -593,9 +597,35 @@
                       (mapcat (fn [e] [(str (:id e) "__in") (str (:id e) "__out")])))
                 edges)
           pruned-points (apply dissoc edge-points stale-edge-ids)
-          pruned-labels (apply dissoc edge-labels stale-edge-ids)]
+          pruned-labels (apply dissoc edge-labels stale-edge-ids)
+          ;; 4 — rf2-fzbj.13: GROW the regions' frame to enclose the column.
+          ;; The region containers are children of the ROOT-CONTAINER frame
+          ;; (xyflow `parentId` + `:extent "parent"`), and ELK sized that
+          ;; frame for the side-by-side layout the re-stack just replaced.
+          ;; Left alone, the taller column overflows it and xyflow clamps the
+          ;; bands back inside, piling them up. Keep the right/bottom inset
+          ;; ELK left around the regions; never shrink (the header may need
+          ;; the width).
+          frame-id      (some :parent-id region-nodes)
+          frame         (get positions frame-id)
+          far-edge      (fn [ps axis size]
+                          (reduce max 0 (map (fn [r]
+                                               (let [p (get ps (:id r))]
+                                                 (+ (or (axis p) 0) (or (size p) 0))))
+                                             region-nodes)))
+          framed-positions
+          (if (and (:width frame) (:height frame))
+            (assoc new-positions frame-id
+                   (assoc frame
+                          :width  (max (:width frame)
+                                       (+ (far-edge new-positions :x :width)
+                                          (- (:width frame) (far-edge positions :x :width))))
+                          :height (max (:height frame)
+                                       (+ (far-edge new-positions :y :height)
+                                          (- (:height frame) (far-edge positions :y :height))))))
+            new-positions)]
       (assoc layout
-             :positions   new-positions
+             :positions   framed-positions
              :edge-points pruned-points
              :edge-labels pruned-labels))))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -1601,14 +1601,27 @@
                     ;; parent. Emit `:parentId` so xyflow's
                     ;; `adoptUserNodes` path adopts the child + uses
                     ;; the parent's absolute origin as the offset.
-                    (and (not region?) (:parent-id n))
+                    ;;
+                    ;; Region containers are no exception (rf2-fzbj.13).
+                    ;; Since the ROOT-CONTAINER frame (rf2-q129z8) every
+                    ;; region nests under it, ELK positions the region
+                    ;; RELATIVE to the frame, and the region's children
+                    ;; inherit the region's origin — so a region without
+                    ;; `parentId` drags its whole subtree off by the frame
+                    ;; origin while ELK's ROOT-coordinate routes stay put.
+                    (:parent-id n)
                     (assoc :parentId (:parent-id n)
                            :extent   "parent"))))
-              ;; the machine-root node leads (it is the source of a
+              ;; the ROOT-CONTAINER frame leads (every top-level node,
+              ;; region containers included, names it as `parentId`), then
+              ;; the machine-root node (it is the source of a
               ;; machine-level fallback's `__in` edge + event-node, and
               ;; xyflow wants a source-node before any edge that references
               ;; it), alongside region/compound parents.
-              (sort-by #(if (or (:machine-root? %) (:region? %) (:compound? %)) 0 1) nodes))
+              (sort-by #(cond (:root-container? %) 0
+                              (or (:machine-root? %) (:region? %) (:compound? %)) 1
+                              :else 2)
+                       nodes))
 
         ;; events-as-nodes paradigm. Each parsed transition emits ONE
         ;; event-node (xyflow `type "rf2-event"`) plus one or two edges:

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -204,7 +204,13 @@
 ;; and a live `:fn` value can make Transit encoding FAIL outright. We sanitise
 ;; the definition STRUCTURALLY before validation / Transit:
 ;;
-;;   - recursively DROP `:source-coords` / `:source-code` everywhere;
+;;   - recursively DROP `:source-coords` / `:source-code` on every RECORD map
+;;     (state node, transition candidate, guard/action entry) — never as the
+;;     KEY of an identifier-indexed map, where either spelling is a valid
+;;     state / event / region / guard / action id (rf2-gwye.49);
+;;   - replace a fn-valued map KEY (Spec 005's function-valued `:after` delay)
+;;     with an inert numbered `[<label> <n>]` vector (rf2-fzbj.13) — the fn is
+;;     never called, and distinct anonymous delays stay distinct transitions;
 ;;   - DROP executable `:fn` values (the `{<id> {:fn …}}` entry collapses to a
 ;;     names-only marker — the topology reference by id survives);
 ;;   - replace any remaining LIVE fn value (an inline `:guard` / `:action` /
@@ -215,7 +221,9 @@
 (def ^:private source-debug-keys
   "Reference-site debug fields the macro co-locates inside `:states` /
   `:guards` / `:actions` (Spec 005 §Source-coord
-  stamping). Stripped wholesale from a share payload."
+  stamping). Stripped from every RECORD map in a share payload — never as
+  the key of an identifier-indexed map (`identifier-indexed-slots`), where
+  they are valid topology ids."
   #{:source-coords :source-code})
 
 (def ^:private fn-label-marker
@@ -232,38 +240,74 @@
         (keyword "rf.machines-viz.share" (str "fn-" (name n))))
       fn-label-marker))
 
+(def ^:private identifier-indexed-slots
+  "rf2-gwye.49 — definition slots whose map KEYS are topology IDENTIFIERS
+  (state / region / event / guard / action ids, and `:after` delays) rather
+  than record fields. A key in one of these maps is a name the topology
+  references, so it survives sanitisation however it is spelled —
+  `:source-code`, `:source-coords` and `:fn` are all valid ids — and only its
+  VALUE is walked. The debug-field and executable-`:fn` drops apply to RECORD
+  maps alone: the state nodes, transition candidates and guard/action entries
+  the macro stamps."
+  #{:states :regions :on :after :guards :actions})
+
+(defn- fn-key-label
+  "rf2-fzbj.13 — the inert stand-in for a fn-valued map KEY (Spec 005's
+  function-valued `:after` delay): a `[<names-only label> <n>]` vector. The
+  share grammar accepts it as a subscription-vector-shaped delay, so the
+  viewer projects the timed transition without ever holding — or calling —
+  the fn. `n` numbers the fn keys of ONE map, so two anonymous delays, which
+  share a label, keep two transitions instead of merging into one."
+  [f n]
+  [(fn-name-label f) n])
+
 (defn- sanitise-definition
   "rf2-m285a — recursively rewrite a (possibly macro-stamped) machine
   definition into a viewer-safe topology payload: drop `:source-coords` /
   `:source-code`, drop executable `:fn` values, and replace any live fn slot
   with an opaque label. Preserves all topology references (state ids,
-  targets, guard/action NAMES via their map keys). Pure structural walk."
-  [x]
-  (cond
-    (fn? x) (fn-name-label x)
+  targets, guard/action NAMES via their map keys). Pure structural walk.
 
-    (map? x)
-    (into (empty x)
-          (keep (fn [[k v]]
-                  (cond
-                    ;; Drop reference-site source/debug fields entirely.
-                    (contains? source-debug-keys k) nil
-                    ;; rf2-07gg7h — drop the EXECUTABLE fn off a co-located
-                    ;; `{:fn <fn> …}` entry (the `:guards` / `:actions`
-                    ;; slot form): the entry's KEY already
-                    ;; carries the name the topology references; the body is
-                    ;; lossy by contract. Gate on `(fn? v)` so a topology key
-                    ;; that HAPPENS to be named `:fn` (a state id, event id,
-                    ;; or region id whose VALUE is a topology submap, never a
-                    ;; fn) is PRESERVED — only the executable slot is stripped.
-                    (and (= :fn k) (fn? v))          nil
-                    :else [k (sanitise-definition v)]))
-                x))
+  `identifiers?` is true while walking a map whose keys are topology ids
+  (`identifier-indexed-slots`, rf2-gwye.49): those keys are kept verbatim and
+  only the values are sanitised. A fn-valued KEY in any map becomes a
+  `fn-key-label` (rf2-fzbj.13), numbered in a stable order so the encoded
+  bytes do not depend on map iteration order."
+  ([x] (sanitise-definition x false))
+  ([x identifiers?]
+   (cond
+     (fn? x) (fn-name-label x)
 
-    (set? x)    (into #{} (map sanitise-definition x))
-    (vector? x) (mapv sanitise-definition x)
-    (seq? x)    (map sanitise-definition x)
-    :else       x))
+     (map? x)
+     (let [entries
+           (keep (fn [[k v]]
+                   (cond
+                     identifiers?                    [k (sanitise-definition v)]
+                     ;; Drop reference-site source/debug fields entirely.
+                     (contains? source-debug-keys k) nil
+                     ;; rf2-07gg7h — drop the EXECUTABLE fn off a co-located
+                     ;; `{:fn <fn> …}` entry (the `:guards` / `:actions`
+                     ;; slot form): the entry's KEY already
+                     ;; carries the name the topology references; the body is
+                     ;; lossy by contract. Gate on `(fn? v)` so a topology key
+                     ;; that HAPPENS to be named `:fn` (a state id, event id,
+                     ;; or region id whose VALUE is a topology submap, never a
+                     ;; fn) is PRESERVED — only the executable slot is stripped.
+                     (and (= :fn k) (fn? v))         nil
+                     :else [k (sanitise-definition
+                                v (contains? identifier-indexed-slots k))]))
+                 x)
+           {fn-keyed true plain false} (group-by #(fn? (first %)) entries)]
+       (into (empty x)
+             (concat plain
+                     (map-indexed (fn [n [f v]] [(fn-key-label f n) v])
+                                  (sort-by (fn [[f v]] (pr-str [(fn-name-label f) v]))
+                                           fn-keyed)))))
+
+     (set? x)    (into #{} (map sanitise-definition x))
+     (vector? x) (mapv sanitise-definition x)
+     (seq? x)    (map sanitise-definition x)
+     :else       x)))
 
 ;; ---------------------------------------------------------------------------
 ;; Schema validation — narrow allowlist

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -434,6 +434,47 @@
       (is (>= (:x (get np audio-rid)) root-x))
       (is (>= (:y (get np audio-rid)) root-y)))))
 
+(deftest transpose-grows-the-frame-to-enclose-the-stacked-column
+  ;; rf2-fzbj.13 — the region containers are the ROOT-CONTAINER frame's
+  ;; `parentId` children (xyflow `:extent "parent"`), so after the re-stack
+  ;; the frame must enclose every band, or xyflow clamps them back inside the
+  ;; box ELK sized for the side-by-side layout. Region positions are
+  ;; frame-relative, as `elk-result->positions` records them.
+  (let [parsed    (layout/project-definition parallel-machine)
+        desc      (post-elk/region-descendant-ids parsed)
+        audio-rid (layout/region-node-id :audio)
+        video-rid (layout/region-node-id :video)
+        child-col (fn [ids]
+                    (into {} (map-indexed
+                               (fn [i id] [id {:x 20 :y (+ 40 (* 80 i))
+                                               :width 120 :height 50}])
+                               ids)))
+        ;; the frame HUGS the side-by-side regions with a 20px right/bottom inset
+        frame     {:x 12 :y 12 :width 680 :height 540}
+        positions (merge
+                    {layout/root-container-id frame
+                     audio-rid {:x 60  :y 120 :width 200 :height 400}
+                     video-rid {:x 460 :y 120 :width 200 :height 400}}
+                    (child-col (sort (get desc audio-rid)))
+                    (child-col (sort (get desc video-rid))))
+        out       (post-elk/transpose-parallel-regions
+                    {:positions positions :edge-points {} :edge-labels {}} parsed)
+        np        (:positions out)
+        new-frame (get np layout/root-container-id)
+        bands     (map #(get np %) [audio-rid video-rid])
+        right     (reduce max (map #(+ (:x %) (:width %)) bands))
+        bottom    (reduce max (map #(+ (:y %) (:height %)) bands))]
+    (testing "sanity: the stacked column outgrows the side-by-side frame"
+      (is (> right (:width frame))))
+    (testing "every stacked band sits inside the frame"
+      (is (<= right (:width new-frame)))
+      (is (<= bottom (:height new-frame))))
+    (testing "the frame keeps its origin and ELK's 20px right inset, and never shrinks"
+      (is (= [12 12] [(:x new-frame) (:y new-frame)]))
+      (is (= (+ right 20) (:width new-frame)))
+      (is (= (:height frame) (:height new-frame))
+          "the column is shorter than the frame, so the height stays"))))
+
 (defn- x-overlap?
   "Do two boxes `{:x :width}` overlap along the x-axis (open intervals)? Pure."
   [a b]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -393,16 +393,81 @@
 (deftest xyflow-graph-region-children-wire-parent-id
   (testing "rf2-lkwev + rf2-xh1lm — every state inside a region carries
             `:parentId` (the region container id) + `:extent \"parent\"`
-            so xyflow v12's sub-flow nests + clamps it; the region
-            container itself carries NEITHER"
+            so xyflow v12's sub-flow nests + clamps it; rf2-fzbj.13 — the
+            region container ITSELF nests the same way under the
+            ROOT-CONTAINER frame ELK lays it out in"
     (let [parsed (layout/project-definition parallel-machine)
           graph  (projection/xyflow-graph parsed {} {})
           region (node-by-id graph (layout/region-node-id :audio))
           muted  (node-by-id graph (layout/region-scoped-id :audio [:muted]))]
       (is (= (layout/region-node-id :audio) (:parentId muted)))
       (is (= "parent" (:extent muted)))
-      (is (nil? (:parentId region)) "region container is not nested")
-      (is (nil? (:extent region))))))
+      (is (= layout/root-container-id (:parentId region))
+          "the region container nests under the root-container frame")
+      (is (= "parent" (:extent region))))))
+
+(defn- elk-parent-of
+  "`{child-id parent-id}` read off the NESTED `->elk-children` tree — ELK's
+  own ancestry, independent of the xyflow projection under test."
+  ([children] (elk-parent-of children nil))
+  ([children parent]
+   (reduce (fn [acc c]
+             (cond-> (merge acc (elk-parent-of (:children c) (:id c)))
+               parent (assoc (:id c) parent)))
+           {}
+           children)))
+
+(defn- chain-sum
+  "The absolute `{:x :y}` of `id`: its own position plus every ancestor's,
+  walking `parent-of` out to the root — ELK's frame arithmetic, and xyflow's
+  `adoptUserNodes` arithmetic over a `parentId` chain."
+  [pos-of parent-of id]
+  (loop [id id acc {:x 0 :y 0}]
+    (if (nil? id)
+      acc
+      (let [p (pos-of id)]
+        (recur (parent-of id) {:x (+ (:x acc) (:x p)) :y (+ (:y acc) (:y p))})))))
+
+(deftest xyflow-graph-parallel-absolute-positions-match-elk-ancestry
+  (testing "rf2-fzbj.13 — with the frame at a NON-ZERO origin, the absolute
+            position xyflow derives from each projected node's `parentId`
+            chain equals the sum of its ELK ancestry, for region containers,
+            leaves, event-nodes and initial markers alike. Pre-fix every
+            region dropped its frame parent, so each region subtree landed
+            short by exactly the frame origin."
+    (let [parsed    (layout/project-definition parallel-machine)
+          elk-par   (elk-parent-of (projection/->elk-children parsed))
+          elk-ids   (into (set (keys elk-par)) (vals elk-par))
+          ;; parent-relative positions, distinct per node; the frame sits at
+          ;; (100, 200) so a lost frame parent cannot hide in a zero.
+          positions (into {}
+                          (map-indexed (fn [i id]
+                                         [id (if (= id layout/root-container-id)
+                                               {:x 100 :y 200 :width 900 :height 700}
+                                               {:x (+ 10 i) :y (+ 20 i)
+                                                :width 152 :height 58})]))
+                          (sort elk-ids))
+          graph     (projection/xyflow-graph parsed positions {})
+          by-id     (into {} (map (juxt :id identity)) (:nodes graph))
+          xy-abs    (fn [id] (chain-sum (comp :position by-id) (comp :parentId by-id) id))
+          elk-abs   (fn [id] (chain-sum positions elk-par id))
+          markers   (filter #(= "initial-marker" (:type %)) (:nodes graph))]
+      (testing "every region nests under the frame in ELK AND in xyflow"
+        (doseq [r (filter :region? (:nodes parsed))]
+          (is (= layout/root-container-id (get elk-par (:id r))))
+          (is (= layout/root-container-id (:parentId (by-id (:id r)))))))
+      (testing "every ELK-laid node: frame, regions, leaves, event-nodes"
+        (is (some #(str/starts-with? % "__rf2_event_") elk-ids)
+            "sanity: the fixture lays out event-nodes too")
+        (doseq [id elk-ids]
+          (is (= (elk-abs id) (xy-abs id))
+              (str id " — xyflow's absolute position disagrees with ELK's"))))
+      (testing "every initial marker sits in its container's ELK frame"
+        (is (seq markers) "sanity: the regions project initial markers")
+        (doseq [m markers]
+          (is (= (merge-with + (:position m) (elk-abs (:parentId m)))
+                 (xy-abs (:id m)))
+              (str (:id m) " — marker offset from its container's ELK frame")))))))
 
 (deftest xyflow-graph-region-children-do-not-emit-pre-v12-parent-node
   (testing "rf2-xh1lm — the projector emits the v12 `:parentId` shape

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -26,6 +26,7 @@
             [clojure.string :as str]
             [clojure.walk]
             [cognitect.transit :as transit]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.grammar :as grammar]
             [day8.re-frame2-machines-viz.share :as share]))
 
@@ -599,6 +600,122 @@
           "the executable :fn slot is still dropped")
       (is (contains? (:guards dfn) :ready?)
           "the guard NAME (its key) survives, names-only"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-fzbj.13 / rf2-gwye.48 — a function-valued `:after` delay (Spec 005) is a
+;; map KEY, so the value-side fn handling never reached it: the fn survived
+;; sanitisation and Transit refused to write it. It now shares as an inert
+;; numbered vector label, and the delay fn is never called.
+
+(defn- round-trip-definition
+  "Encode definition `d` as a share-URL and return the decoded `:definition`."
+  [d]
+  (-> (encode (assoc chart-state :definition d))
+      share/decode-share-url
+      :rf.machines-viz.share/chart
+      :definition))
+
+(deftest fn-valued-after-delay-shares-as-an-inert-label
+  (testing "rf2-fzbj.13 — a fn delay key encodes (Transit writes no fn),
+            decodes to a projectable definition, keeps its timed transition,
+            and the fn is never invoked"
+    (let [calls    (atom 0)
+          delay-fn (fn [_ctx] (swap! calls inc) 1000)
+          d        {:initial :idle
+                    :states  {:idle {:after {delay-fn :done}}
+                              :done {}}}
+          dfn      (round-trip-definition d)
+          after    (get-in dfn [:states :idle :after])]
+      (is (= 1 (count after)) "the one delayed transition survives")
+      (is (vector? (key (first after))) "its key became an inert vector label")
+      (is (= :done (val (first after))) "its target is intact")
+      (is (grammar/valid-definition? (grammar/desugar-grammar dfn))
+          "the decoded definition is a valid, projectable machine")
+      (is (= (layout/semantic-counts d) (layout/semantic-counts dfn))
+          "the same states and transitions as the original")
+      (is (zero? @calls) "the delay fn was never called"))))
+
+(deftest distinct-anonymous-fn-delays-keep-distinct-transitions
+  (testing "rf2-fzbj.13 — two anonymous delay fns share a label, so the
+            numbering is what keeps them from merging into one key"
+    (let [d   {:initial :idle
+               :states  {:idle {:after {(fn [_] 100) :a
+                                        (fn [_] 200) :b}}
+                         :a {} :b {}}}
+          dfn (round-trip-definition d)]
+      (is (= 2 (count (get-in dfn [:states :idle :after]))))
+      (is (= #{:a :b} (set (vals (get-in dfn [:states :idle :after])))))
+      (is (= (layout/semantic-counts d) (layout/semantic-counts dfn))))))
+
+(deftest literal-and-subscription-delays-round-trip-unchanged
+  (testing "rf2-fzbj.13 — the fn-key rewrite leaves literal ms and
+            subscription-vector delay keys exactly as authored"
+    (let [d {:initial :idle
+             :states  {:idle {:after {1000              :a
+                                      [:timeouts/retry] :b}}
+                       :a {} :b {}}}]
+      (is (= d (round-trip-definition d))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-gwye.49 — `:source-code` / `:source-coords` are debug fields on a RECORD
+;; (a state node, transition candidate or guard/action entry), but they are
+;; also valid topology ids. The pre-fix walk dropped the key wherever it
+;; appeared, so a state, event, region, guard or action with either name
+;; vanished while validation still passed.
+
+(def debug-named-topology
+  "Every id spelled like a debug field, beside GENUINE debug fields on the
+  same records that must still go."
+  {:initial :source-code
+   :guards  {:source-coords {:fn          (fn [_] true)
+                             :source-code "(fn [_] true)"}}
+   :actions {:source-code   {:fn            (fn [_] nil)
+                             :source-coords {:file "/Users/mike/proj/x.cljs" :line 9}}}
+   :states  {:source-code   {:on            {:source-code   {:target        :source-coords
+                                                             :guard         :source-coords
+                                                             :action        :source-code
+                                                             :source-coords {:file "/Users/mike/proj/x.cljs"
+                                                                             :line 12}}
+                                             :source-coords :source-code}
+                             :source-coords {:file "/Users/mike/proj/x.cljs" :line 10}}
+             :source-coords {:on {:go :source-code}}}})
+
+(deftest debug-named-topology-ids-survive-sharing
+  (testing "rf2-gwye.49 — state, event, guard and action ids spelled
+            `:source-code` / `:source-coords` survive; genuine annotations on
+            the same records are still stripped"
+    (let [url (encode (assoc chart-state :definition debug-named-topology))
+          dfn (:definition (:rf.machines-viz.share/chart (share/decode-share-url url)))]
+      (is (= #{:source-code :source-coords} (set (keys (:states dfn))))
+          "both STATE ids survive")
+      (is (= :source-code (:initial dfn)))
+      (is (= #{:source-code :source-coords}
+             (set (keys (get-in dfn [:states :source-code :on]))))
+          "both EVENT ids survive")
+      (is (= :source-coords (get-in dfn [:states :source-code :on :source-code :target])))
+      (is (= :source-code (get-in dfn [:states :source-code :on :source-coords])))
+      (is (contains? (:guards dfn) :source-coords) "the GUARD id survives")
+      (is (contains? (:actions dfn) :source-code) "the ACTION id survives")
+      (is (= (layout/semantic-counts debug-named-topology) (layout/semantic-counts dfn))
+          "no state or transition is lost")
+      (testing "the genuine annotations on those same records are gone"
+        (is (not (str/includes? url "Users")) "no local path in the URL bytes")
+        (is (not (contains? (get-in dfn [:states :source-code]) :source-coords)))
+        (is (not (contains? (get-in dfn [:states :source-code :on :source-code])
+                            :source-coords)))
+        (is (= {} (get-in dfn [:guards :source-coords]))
+            "the guard keeps its name and loses :fn and :source-code")
+        (is (= {} (get-in dfn [:actions :source-code]))
+            "the action keeps its name and loses :fn and :source-coords")))))
+
+(deftest debug-named-region-ids-survive-sharing
+  (testing "rf2-gwye.49 — parallel REGION ids spelled like debug fields survive"
+    (let [d   {:type    :parallel
+               :regions {:source-code   {:initial :a :states {:a {:on {:go :b}} :b {}}}
+                         :source-coords {:initial :p :states {:p {}}}}}
+          dfn (round-trip-definition d)]
+      (is (= d dfn))
+      (is (= (layout/semantic-counts d) (layout/semantic-counts dfn))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Versioning + failure modes


### PR DESCRIPTION
## Summary

Fixes the machines-viz findings from the 2026-09-12/13 surface review. rf2-gwye.46 and rf2-gwye.48 split out rf2-fzbj.13's two findings; rf2-gwye.49 is a third, standalone finding on the same surface.

- **rf2-gwye.46 (rf2-fzbj.13 finding 1): parallel regions nest in the root frame again.** `chart/projection.cljc` skipped `parentId` for region containers. The guard dates from before rf2-q129z8 added the root-container frame, when regions had no parent at all. ELK lays each region out relative to that frame, so xyflow read the region position as absolute and shifted every region subtree by the frame origin, while ELK's ROOT-coordinate edge routes stayed put. Regions now carry `parentId` and `:extent "parent"` like every other nested node, and the frame leads the parent-first sort. The opt-in `:auto` re-stack in `chart/post_elk.cljc` now grows the frame to enclose its vertical column. Without that, the restored `:extent "parent"` would clamp the bands into a frame ELK sized for the side-by-side layout. The stale "region container is not nested" assertion is replaced, as the bead directs.
- **rf2-gwye.48 (rf2-fzbj.13 finding 2): fn-valued `:after` delays share.** A Spec 005 delay fn is a map KEY, and the sanitiser in `share.cljs` rewrote only values, so Transit refused to encode the fn and `encode-share-url` threw. A fn key now becomes an inert `[<label> <n>]` vector. The share grammar already accepts that as a delay, so the grammar is unchanged. The fn is never called, and two anonymous delays keep two transitions.
- **rf2-gwye.49: debug-named topology ids survive sharing.** `:source-code` and `:source-coords` were dropped wherever they appeared as a map key. That deleted any state, event, region, guard or action with either name, and validation still passed, so the recipient got an incomplete chart without an error. The drops now apply to record maps only. The keys of `:states`, `:regions`, `:on`, `:after`, `:guards` and `:actions` are kept as identifiers. Genuine annotations are still stripped, including on those same records.
- `tools/machines-viz/spec/API.md` §Share-URL encoding, step 2, records the record-only drops and the delay-key label shape.

No spec change: the fn-valued delay contract in `spec/005-StateMachines.md` is unchanged, and the share payload shape is this tool's own contract.

## Quality gates

Each exit code below is the runner's own, redirected to a log and echoed on the same command line. None is read off a pipeline or taken from a harness report.

| Gate (run from this branch's worktree) | Local result on the rebased tip | CI job |
|---|---|---|
| `clojure -M:test` in `tools/machines-viz` | exit 0: 654 tests, 2862 assertions, 0 failures | `jvm-tools-machines-viz` |
| `npm run test:tools-machines-viz` (from `implementation/`) | exit 0: 862 tests, 3848 assertions, 0 failures | `cljs-tools-machines-viz` |
| `python scripts/check_doc_slugs.py` (covers `tools/*/spec`) | exit 0 | `verify-readme-links` (test.yml), `build` (docs.yml) |
| `sh scripts/check-no-hardcoded-paths.sh` | exit 0 | portability ratchet |
| `python scripts/check_thrown_error_messages.py` | exit 0 | thrown-error ratchet |

Both lanes passed on the pre-rebase tip too (JVM exit 0, 654 tests; CLJS exit 0, 862 tests, 3848 assertions). The rebase brought in changes to `implementation/machines` and `implementation/core`, so both lanes were re-run on the rebased tip.

**CI coverage only, not run locally:**
- `machines-viz-viewer-page`, the viewer page build, which compiles `share.cljs`;
- the consolidated `cljs` job (`:node-test`), which also runs the three `*_cljs_test` suites touched here;
- `cljs-browser`, the DOM suites, including `chart_dom_cljs_test`'s check that region containers render as xyflow parents.

**RED controls.**
- **Plant.** I restored the three pre-fix source files from the merge base and kept the new tests. The plant was verified by blob hash: each working file matched its merge-base blob.
- **JVM lane on the planted tree:** 654 tests, 18 failures.
- **CLJS lane on the planted tree:** 862 tests, 18 failures and 4 errors.
- **Where they fell:** every failure and error was in a new or updated test. Those are the region-parent and ELK-ancestry projection tests, the post-ELK frame-enclosure test, and the four share tests, which error because the pre-fix encode throws.
- **Control and tree check:** the literal and subscription-vector delay test is a control and stayed green. The CLJS build recompiled 25 files from the planted tree, which confirms the lane read this branch's checkout.
- **Restore.** Verified against the committed objects by blob hash, and `git diff --quiet HEAD` exited 0.

**The reviewer's probes, re-run against this branch's source.**
- **Pre-fix:** both regions had no xyflow parent, and every region subtree came out offset (-12,-12) from ELK's absolute positions through the installed `@xyflow/system` `adoptUserNodes`. The transit probe reproduced the fn-delay writer error, and the `:source-code` event and state losses (1 transition to 0, and 2 states to 1).
- **Post-fix:** every adoption delta is (0,0), the fn delay encodes, and both the event and the state keep their original semantic counts.

**Hand checks:** nothing validates prose. The API.md addition continues a numbered list item at the same 3-space indent and adds no links, tables or fenced blocks. I read it as rendered markdown by hand.

## Skipped suggestion

rf2-fzbj.13 and rf2-gwye.46 acceptance item 3 asks for a rendered browser fixture: edge/node alignment and frame containment with a context band, under `:tb` and `:auto`. I did not add it. The coordinate contract is pinned at the pure layer instead:
- a projection test asserts, with a non-zero frame origin, that xyflow's `parentId`-chain arithmetic equals ELK's ancestry for regions, leaves, event nodes and initial markers;
- a post-ELK test asserts the frame encloses the `:auto` re-stack.

The reviewer's probe confirmed the same result end to end through real elkjs and `@xyflow/system`. A Playwright fixture would re-assert it at many times the cost.
