### PR TITLE
fix(mcp-conformance): keep own __proto__ keys, close the dedup wrapper, read every reader-conditional arm, integer overflow counts (rf2-fzbj.14)

### DIFF
--- a/tools/mcp-conformance/lib/dedup-envelope.cjs
+++ b/tools/mcp-conformance/lib/dedup-envelope.cjs
@@ -91,7 +91,9 @@
 // `decodeDedupEnvelope(structuredContent)` — return the expanded
 // payload if `structuredContent` carries the marker, otherwise return
 // the input unchanged. Throws if the marker is present but the cache
-// has no `cache-0` entry (a malformed envelope).
+// has no `cache-0` entry, or the wrapper carries any sibling key (a
+// malformed envelope). Every decoded key is an own data property, so the
+// JSON projection survives exactly — `"__proto__"` included.
 
 'use strict';
 
@@ -165,7 +167,17 @@ function expandCache(cache) {
           typeof expandedKey === 'string' || typeof expandedKey === 'number'
             ? expandedKey
             : JSON.stringify(expandedKey);
-        out[jsKey] = expandValue(v[k]);
+        // DEFINE, never assign (rf2-gwye.36). `out['__proto__'] = …` runs
+        // the inherited `Object.prototype.__proto__` setter instead of
+        // creating the key — the payload entry vanishes and its value
+        // becomes the rebuilt object's prototype. `JSON.parse` keeps that
+        // key as an own data property, so the decoded object must too.
+        Object.defineProperty(out, jsKey, {
+          value: expandValue(v[k]),
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       }
       return out;
     }
@@ -233,6 +245,23 @@ function decodeDedupEnvelope(structuredContent) {
     !Object.prototype.hasOwnProperty.call(structuredContent, DEDUP_TABLE_KEY)
   ) {
     return structuredContent;
+  }
+  // The wrapper is CLOSED and SINGLE-KEY (rf2-gwye.38), held exactly as
+  // `unwrapClosedOverflow` in `overflow-marker.cjs` holds the overflow
+  // wrapper: the JVM contract pins `DedupTable` as
+  // `[:map {:closed true} [:rf.mcp/dedup-table …]]`. Expansion returns the
+  // cache root and so would ERASE a sibling — a sibling `ok? false` beside
+  // an inner `ok? true` was then graded on the sanitised value. Neither side
+  // has precedence; the envelope is malformed, so reject it here.
+  const siblings = Object.keys(structuredContent).filter((k) => k !== DEDUP_TABLE_KEY);
+  if (siblings.length > 0) {
+    throw new Error(
+      'dedup-envelope: the ' + DEDUP_TABLE_KEY + ' wrapper MUST be the CLOSED ' +
+        'single-key map {"' + DEDUP_TABLE_KEY + '": <cache-map>}; got sibling ' +
+        'key(s) ' + JSON.stringify(siblings) + '. The JVM contract pins ' +
+        '`DedupTable` = [:map {:closed true} [:rf.mcp/dedup-table ...]], and ' +
+        'expanding the cache would silently erase them.',
+    );
   }
   const cache = structuredContent[DEDUP_TABLE_KEY];
   if (!cache || typeof cache !== 'object' || Array.isArray(cache)) {

--- a/tools/mcp-conformance/lib/overflow-marker.cjs
+++ b/tools/mcp-conformance/lib/overflow-marker.cjs
@@ -62,11 +62,12 @@ const EDN_PARSE_OPTS = { mapAs: 'object', keywordAs: 'string', setAs: 'array' };
 // cross-encoding grep gate (`js-assertOverflowBody-pins-every-re-frame2-pair-
 // overflow-required-field`) reads THIS data table by name (it slurps this
 // file — see `live-re-frame2-pair-overflow-js-rel`) so a drift in either
-// direction trips the JVM-side test.
+// direction trips the JVM-side test. `int` means an INTEGER, as Malli's
+// `:int` does — `typeof === 'number'` let 5000.5 through (rf2-gwye.41).
 const REQUIRED_FIELDS = [
   ['limit',       (v) => v === 'reached',          'enum :reached'],
-  ['cap-tokens',  (v) => typeof v === 'number',    'int'],
-  ['token-count', (v) => typeof v === 'number',    'int'],
+  ['cap-tokens',  (v) => Number.isInteger(v),      'int'],
+  ['token-count', (v) => Number.isInteger(v),      'int'],
   ['tool',        (v) => typeof v === 'string',    'string|keyword'],
   ['hint',        (v) => typeof v === 'string',    'string|keyword'],
 ];

--- a/tools/mcp-conformance/test/dedup-envelope.test.cjs
+++ b/tools/mcp-conformance/test/dedup-envelope.test.cjs
@@ -415,6 +415,87 @@ test('symbol, keyword and string payloads collapse to ONE JSON token — all thr
   assert.deepEqual(out.a, { big: ['repeat', 'me'] });
 });
 
+// ---------------------------------------------------------------------
+// rf2-gwye.36 (rf2-fzbj.14 F1): an own `__proto__` payload key survives.
+//
+// `JSON.parse` keeps `"__proto__"` as an ordinary own data property, and
+// the codec promises encode-then-decode is the identity on the JSON
+// projection (`tools/mcp-base/spec/dedup.md`). Plain assignment
+// `out['__proto__'] = v` does not create that property: it runs the
+// inherited `Object.prototype.__proto__` setter, so the key vanished and
+// its object value became the rebuilt object's PROTOTYPE — the payload's
+// fields then read back as inherited values.
+//
+// The wire is transcribed from a real encode: `dedup-value` (enabled)
+// over the payload below, serialised with Cheshire. Both strings go
+// through JSON.parse, as the SDK does — an object literal spelling
+// `__proto__:` would set the prototype itself and never carry the key.
+// ---------------------------------------------------------------------
+
+const PROTO_KEY_ORIGINAL =
+  '{"__proto__":{"marker":"root-payload"},' +
+  '"nested":{"__proto__":{"marker":"nested-payload"}},' +
+  '"a":{"items":["repeat","the","subtree"]},' +
+  '"b":{"items":["repeat","the","subtree"]}}';
+
+const PROTO_KEY_WIRE =
+  '{"rf.mcp/dedup-table":{' +
+  '"de-dupe.cache/cache-2":["repeat","the","subtree"],' +
+  '"de-dupe.cache/cache-1":{"items":"de-dupe.cache/cache-2"},' +
+  '"de-dupe.cache/cache-0":{"__proto__":{"marker":"root-payload"},' +
+  '"nested":{"__proto__":{"marker":"nested-payload"}},' +
+  '"a":"de-dupe.cache/cache-1","b":"de-dupe.cache/cache-1"}}}';
+
+test('an own "__proto__" payload key survives expansion, at the root and nested (rf2-gwye.36)', () => {
+  const original = JSON.parse(PROTO_KEY_ORIGINAL);
+  const out = decodeDedupEnvelope(JSON.parse(PROTO_KEY_WIRE));
+  // Strict deep equality compares own keys AND prototypes, so this is the
+  // JSON-projection identity the codec promises.
+  assert.deepEqual(out, original);
+  for (const [where, obj] of [['root', out], ['nested', out.nested]]) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(obj, '__proto__'),
+      where + ': "__proto__" is an own key',
+    );
+    assert.equal(Object.getPrototypeOf(obj), Object.prototype, where + ': ordinary prototype');
+    assert.equal(obj.marker, undefined, where + ': no payload value is inherited');
+  }
+  assert.equal(out.a, out.b, 'the shared subtree is still pooled');
+});
+
+// ---------------------------------------------------------------------
+// rf2-gwye.38 (rf2-fzbj.14 F2): the dedup wrapper is CLOSED.
+//
+// The JVM contract pins `DedupTable` as `[:map {:closed true}
+// [:rf.mcp/dedup-table …]]`. The decoder used to check only that the
+// marker was present, then return the expanded cache — erasing any
+// sibling, so a response the JVM schema rejects was graded on a
+// sanitised value. Neither the inner nor a sibling `ok?` wins: the
+// envelope is malformed.
+// ---------------------------------------------------------------------
+
+test('a dedup wrapper carrying a sibling key is rejected, harmless or conflicting (rf2-gwye.38)', () => {
+  const cache = { [cacheId(0)]: { 'ok?': true, value: 42 } };
+  for (const siblings of [{ meta: 'harmless' }, { 'ok?': false, reason: 'failure' }]) {
+    assert.throws(
+      () => decodeDedupEnvelope(Object.assign(envelope(cache), siblings)),
+      (err) => {
+        assert.match(err.message, /CLOSED single-key map/);
+        for (const k of Object.keys(siblings)) {
+          assert.ok(err.message.includes(JSON.stringify(k)), 'names sibling ' + k);
+        }
+        return true;
+      },
+    );
+  }
+  // Still accepted: the same wrapper alone, with arbitrary fields in the
+  // decoded ROOT — the wrapper is closed, the payload is not.
+  const open = { [cacheId(0)]: { 'ok?': true, value: 42, meta: 'additive', reason: 'x' } };
+  assert.deepEqual(decodeDedupEnvelope(envelope(open)), {
+    'ok?': true, value: 42, meta: 'additive', reason: 'x',
+  });
+});
+
 test('POSITIVE CONTROL: the keyword rule did not disable resolution either (rf2-kjv05)', () => {
   // Same shape as the keyword value test, `cache-1` deleted. Widening
   // the escape set must not have turned a dangling genuine reference

--- a/tools/mcp-conformance/test/is-error-matches-ok.test.cjs
+++ b/tools/mcp-conformance/test/is-error-matches-ok.test.cjs
@@ -34,7 +34,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { assertIsErrorMatchesOk } = require('./_runner.cjs');
+const { assertIsErrorMatchesOk, structured } = require('./_runner.cjs');
 const { DEDUP_TABLE_KEY, ROOT_CACHE_ID } = require('../lib/dedup-envelope.cjs');
 
 function dedupWrapped(payload) {
@@ -91,6 +91,24 @@ test('assertIsErrorMatchesOk: a non-dedup (plain) envelope still cross-checks as
       structuredContent: { 'ok?': true },
     }),
   );
+});
+
+test('assertIsErrorMatchesOk: a dedup wrapper with siblings is rejected, not graded on its sanitised inner value (rf2-gwye.38)', () => {
+  // The review reproduction: the sibling `ok? false` used to be erased by
+  // expansion, leaving the inner `ok? true` to pass beside isError:false.
+  const resp = {
+    isError: false,
+    structuredContent: Object.assign(dedupWrapped({ 'ok?': true, value: 42 }), {
+      'ok?': false,
+      reason: 'failure',
+    }),
+  };
+  assert.throws(() => structured(resp), /CLOSED single-key map/);
+  assert.throws(() => assertIsErrorMatchesOk('probe', resp), /CLOSED single-key map/);
+  // Control: the same wrapper without siblings is still decoded and graded.
+  const ok = { isError: false, structuredContent: dedupWrapped({ 'ok?': true, value: 42 }) };
+  assert.deepEqual(structured(ok), { 'ok?': true, value: 42 });
+  assert.doesNotThrow(() => assertIsErrorMatchesOk('probe', ok));
 });
 
 test('assertIsErrorMatchesOk: a non-:ok?-shaped result is out of scope (no throw)', () => {

--- a/tools/mcp-conformance/test/overflow-marker.test.cjs
+++ b/tools/mcp-conformance/test/overflow-marker.test.cjs
@@ -145,6 +145,35 @@ test('assertOverflowBody: rejects a wrong :limit enum and non-numeric token fiel
   assert.throws(() => assertOverflowBody(validBody({ 'token-count': null }), 'test'), /:token-count MUST be/);
 });
 
+test('fractional :cap-tokens / :token-count are rejected through BOTH slots (rf2-gwye.41)', () => {
+  // Malli pins both fields as `:int`; a `typeof === 'number'` check let
+  // 5000.5 through both validators and the agreement check. Each field is
+  // fractional alone, then both (cap-tokens is checked first).
+  for (const [cap, count, field] of [
+    [5000.5, 6250, 'cap-tokens'],
+    [5000, 6250.5, 'token-count'],
+    [5000.5, 6250.5, 'cap-tokens'],
+  ]) {
+    const text =
+      '{:rf.mcp/overflow {:limit :reached :cap-tokens ' + cap + ' :token-count ' +
+      count + ' :tool "eval-cljs" :hint "raise the cap"}}';
+    const wrapper = { 'rf.mcp/overflow': validBody({ 'cap-tokens': cap, 'token-count': count }) };
+    const want = new RegExp(':' + field + ' MUST be int');
+    assert.throws(() => validateOverflowText(text, 'text-slot'), want, 'text ' + cap + '/' + count);
+    assert.throws(() => validateOverflowWrapper(wrapper, 'structured'), want, 'structured ' + cap + '/' + count);
+  }
+  // Still accepted: the integer body, through both slots, in agreement.
+  const text =
+    '{:rf.mcp/overflow {:limit :reached :cap-tokens 5000 :token-count 6250 ' +
+    ':tool "eval-cljs" :hint "raise the cap"}}';
+  const fromText = validateOverflowText(text, 'text-slot');
+  const fromStructured = validateOverflowWrapper(
+    { 'rf.mcp/overflow': validBody({ hint: 'raise the cap' }) },
+    'structured',
+  );
+  assert.doesNotThrow(() => assertBodiesAgree(fromText, fromStructured, 'dual-slot'));
+});
+
 test('assertOverflowBody: rejects token-count <= cap-tokens (degenerate tripped cap)', () => {
   // Equal is a violation: a tripped cap MUST strictly exceed the budget.
   assert.throws(

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/trace_catalogue_lint_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/trace_catalogue_lint_test.clj
@@ -57,15 +57,20 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Read a `.cljc` / `.clj` source file as a sequence of top-level forms.
-;; `:read-cond :allow` keeps reader-conditionals as data rather than choosing
-;; a platform branch; `:eof ::eof` terminates the read loop cleanly. We swallow
-;; NOTHING — a read error means a malformed source file and MUST surface.
+;; `:read-cond :preserve` keeps every reader conditional as a
+;; `ReaderConditional` VALUE, all arms intact, and `duplicate-hits` inspects
+;; every arm. (`:allow` picks the JVM arm at read time, so a `:cljs`-only or
+;; spliced emitter never reached the detector — rf2-gwye.40.) Preserve mode
+;; cannot read a SPLICING conditional placed directly inside a map literal
+;; (`{:k v #?@(:cljs [...])}`): such a file fails this gate at read time,
+;; loudly, rather than being skipped. `:eof ::eof` terminates the read loop
+;; cleanly. We swallow NOTHING — a read error MUST surface.
 ;; ---------------------------------------------------------------------------
 
 (defn- read-all-forms [source-text]
   (let [rdr (java.io.PushbackReader. (java.io.StringReader. source-text))
         eof ::eof
-        opts {:eof eof :read-cond :allow}]
+        opts {:eof eof :read-cond :preserve}]
     (loop [forms []]
       (let [form (read opts rdr)]
         (if (= form eof)
@@ -75,19 +80,29 @@
 ;; ---------------------------------------------------------------------------
 ;; Walk every sub-form of the parsed source; collect the map literals that
 ;; carry BOTH a canonical namespaced reply-envelope key AND its bare duplicate.
-;; A hit is [canonical-key bare-key the-offending-map].
+;; A hit is [canonical-key bare-key the-offending-map]. A preserved reader
+;; conditional is not a collection the walk can enter, so each is first
+;; replaced by the vector of ALL its arms — `#?` and splicing `#?@` alike, and
+;; nested ones as the walk reaches them. Each arm is inspected on its own, so
+;; two valid alternatives never combine into a false duplicate.
 ;; ---------------------------------------------------------------------------
+
+(defn- conditional-arms [node]
+  (if (reader-conditional? node)
+    (vec (take-nth 2 (rest (:form node))))
+    node))
 
 (defn- duplicate-hits [forms]
   (let [hits (volatile! [])]
-    (walk/postwalk
+    (walk/prewalk
       (fn [node]
-        (when (map? node)
-          (doseq [[canonical bare] duplicate-key-pairs]
-            (when (and (contains? node canonical)
-                       (contains? node bare))
-              (vswap! hits conj [canonical bare node]))))
-        node)
+        (let [node (conditional-arms node)]
+          (when (map? node)
+            (doseq [[canonical bare] duplicate-key-pairs]
+              (when (and (contains? node canonical)
+                         (contains? node bare))
+                (vswap! hits conj [canonical bare node]))))
+          node))
       forms)
     @hits))
 
@@ -148,3 +163,39 @@
                                 :rf.reply/current {:work/id other :generation 2}})]]
       (is (empty? (duplicate-hits nested))
           "the carried/current correlation gate legitimately nests :work/id"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) The READ boundary — every reader-conditional arm reaches the detector
+;;     (rf2-gwye.40, rf2-fzbj.14 F3). (2) hands `duplicate-hits` an
+;;     already-read literal, so it proves the walk and not the read; these
+;;     go through `read-all-forms` on source TEXT, the path (1) takes.
+;; ---------------------------------------------------------------------------
+
+(defn- hit-pairs [source]
+  (mapv (fn [[canonical bare _m]] [canonical bare])
+        (duplicate-hits (read-all-forms source))))
+
+(deftest every-reader-conditional-arm-is-inspected
+  (let [work-id   [[:rf.reply/work-id :work/id]]
+        completed [[:rf.reply/completed-at :completed-at]]]
+    (testing "a duplicate is reported whichever arm, splice or nesting carries it"
+      (doseq [[label source expected]
+              [["unconditional" "{:rf.reply/work-id w :work/id w}" work-id]
+               ["CLJ-only" "#?(:clj {:rf.reply/work-id w :work/id w})" work-id]
+               ["CLJS-only" "#?(:cljs {:rf.reply/work-id w :work/id w})" work-id]
+               ["CLJS arm beside a valid CLJ arm"
+                "#?(:clj {:rf.reply/work-id w} :cljs {:rf.reply/work-id w :work/id w})"
+                work-id]
+               ["CLJS splice" "[#?@(:clj [] :cljs [{:rf.reply/work-id w :work/id w}])]" work-id]
+               ["nested conditional"
+                "#?(:clj nil :cljs (emit! #?(:cljs {:rf.reply/completed-at t :completed-at t})))"
+                completed]]]
+        (is (= expected (hit-pairs source)) label)))
+    (testing "valid alternatives, a lone :work/id and carried/current maps stay accepted in every arm"
+      (doseq [[label source]
+              [["valid alternatives"
+                "#?(:clj {:rf.reply/work-id w} :cljs {:rf.reply/work-id w})"]
+               ["lone :work/id" "#?(:cljs {:work/id w :generation 1})"]
+               ["carried/current"
+                "#?(:cljs {:rf.reply/work-id w :rf.reply/carried {:work/id w} :rf.reply/current {:work/id o}})"]]]
+        (is (= [] (hit-pairs source)) label)))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -980,9 +980,9 @@
    [":limit :reached"
     "['limit',       (v) => v === 'reached',          'enum :reached']"]
    [":cap-tokens : int"
-    "['cap-tokens',  (v) => typeof v === 'number',    'int']"]
+    "['cap-tokens',  (v) => Number.isInteger(v),      'int']"]
    [":token-count : int"
-    "['token-count', (v) => typeof v === 'number',    'int']"]
+    "['token-count', (v) => Number.isInteger(v),      'int']"]
    [":tool : string|keyword"
     "['tool',        (v) => typeof v === 'string',    'string|keyword']"]
    [":hint : string|keyword"


### PR DESCRIPTION
## Summary

Closes the rf2-fzbj.14 finding set on `tools/mcp-conformance/**` together with its per-finding children rf2-gwye.36, .38, .40 and .41. Each finding was re-verified at the tip before it was fixed, by re-running the review's own probes; all four reproduced. No other surface is touched, and no spec change is needed: `tools/mcp-base/spec/dedup.md` already states that encode-then-decode is the identity on the JSON projection.

- **rf2-gwye.36 (F1): an own `__proto__` key survives dedup expansion.** `lib/dedup-envelope.cjs` rebuilt each object with `out[jsKey] = ...`. For the key `"__proto__"` that runs the inherited `Object.prototype.__proto__` setter instead of creating the key, so the entry vanished and its value became the rebuilt object's prototype. Decoded keys are now created with `Object.defineProperty`. The regression fixture is transcribed from a real `dedup-value` encode serialised with Cheshire, re-run after #9752 merged; the wire is byte-identical.
- **rf2-gwye.38 (F2): the dedup wrapper is closed.** `decodeDedupEnvelope` now rejects a `rf.mcp/dedup-table` wrapper carrying any sibling key before expansion erases it, and names the siblings in the error. This mirrors `unwrapClosedOverflow` and the JVM `DedupTable` schema. The review's reproduction is tested through `structured` and `assertIsErrorMatchesOk`.
- **rf2-gwye.40 (F3): the trace-catalogue lint reads every reader-conditional arm.** `read-all-forms` used `:read-cond :allow`, which picks the JVM arm at read time, so CLJS-only, spliced and nested duplicates never reached the detector. It now reads with `:preserve`, and `duplicate-hits` replaces each preserved conditional with the vector of all its arms before walking. A new test drives source TEXT through `read-all-forms` and then `duplicate-hits`, the path the gate actually takes.
- **rf2-gwye.41: overflow counts and caps are integers.** `REQUIRED_FIELDS` checked `typeof v === 'number'` and now checks `Number.isInteger`, matching Malli `:int`. The two JVM source pins in `wire_vocab_test.clj` move with it. The live path already emits integers (`token-estimate` is `(quot (count s) 4)`), so no live lane can newly fail.

### Still accepted: one well-formed value per new rejection

- **F2:** `{"rf.mcp/dedup-table": {"de-dupe.cache/cache-0": {"ok?": true, "value": 42, "meta": "additive", "reason": "x"}}}` still decodes, keeping every root field. Unwrapped payloads still pass through untouched.
- **F3:** `#?(:clj {:rf.reply/work-id w} :cljs {:rf.reply/work-id w})`, a lone `:work/id`, and nested carried/current maps still report zero hits. All 10 production emitter files still read and pass under `:preserve`.
- **gwye.41:** `{:rf.mcp/overflow {:limit :reached :cap-tokens 5000 :token-count 6250 ...}}` still passes both slots and the agreement check.
- **F1** adds no rejection. The repeated-subtree sharing, escaped-token, missing-reference and cycle controls are unchanged and green.

### Known residual (F3)

In preserve mode, Clojure's reader cannot read a splicing conditional placed directly inside a map literal (`{:k v #?@(:cljs [...])}`). Such a file now fails the lint LOUDLY at read time rather than being skipped. None of the 10 emitters contains one: their `#?@` sites are all in `let` binding vectors and `ns` requires.

## Red, then green

- **Node, the three changed test files.** Against the pre-fix libs, 4 of 47 tests fail, exactly the four new ones. After the fix, 47 of 47 pass.
- **JVM wire-vocab.** Against the pre-fix lint there are 4 failures: CLJS-only, a CLJS arm beside a valid CLJ arm, a CLJS splice, and a nested conditional. After the fix: 92 tests, 1038 assertions, 0 failures.
- **Mutation "`:preserve` alone, no arm traversal".** Planted after commit on the single line that calls `conditional-arms`, it produces 5 failures. The restore was verified against the committed blob hash, and `git diff --quiet` exits 0.

## Quality gates

| Gate | CI job | Local result |
|---|---|---|
| Node unit cluster, `npm run test:unit` | `mcp-conformance-re-frame2-pair`, step "Run mcp-conformance Node unit-regression cluster" | exit 0: 153 tests, 144 pass, 9 skipped, 0 fail (baseline 149 / 140 / 9) |
| JVM wire-vocab, `clojure -M:test` | `mcp-conformance-wire-vocab` | exit 0: 92 tests, 1038 assertions, 0 failures (baseline 91 / 1029) |
| story-mcp e2e and CLI flag gates, `npm run test:story` then `npm run test:flag-gates` | `mcp-conformance-story` | exit 0: STORY-MCP MCP-CLIENT CONFORMANCE, PROJECT-STORIES GOLDEN PATH and CLI FLAG-VOCABULARY all GREEN (the runner loads `lib/` relative to itself, so these graded the changed decoder against real story-mcp responses) |
| pair-mcp e2e and the hermetic live suite | `mcp-conformance-re-frame2-pair` | relying on CI: both need a compiled pair-mcp server, and the hermetic suite needs Chromium |
| fast-PR spine, `scripts/test-fast-pr.sh` | local only | exit 0, `PASS fast PR spine`, with the printed gate root naming this worktree. The classifier armed no docs, JVM or node tier for this diff (`docs=false jvm=false node=false`), so only the always-on static and ratchet block ran. |

No markdown is touched, so `scripts/check_readme_links.py --ci` is not nominated.
