### PR TITLE
fix(examples-patterns): keep the correlated WebSocket outcome; leave Nine States success on an invalid submit (rf2-fzbj.34)

### DIFF
--- a/examples/patterns/nine_states/core.cljs
+++ b/examples/patterns/nine_states/core.cljs
@@ -458,10 +458,13 @@
       :correct
       ;; State 8 — the brief "nice, that worked" moment. It's transient: as
       ;; soon as the user edits again, an :edit drops the region back to
-      ;; :neutral.
+      ;; :neutral. And since a valid submit clears the draft while Add stays
+      ;; enabled, the very next press can fail validation — that lands in
+      ;; :incorrect, or "Todo added" would out-rank the new error.
       {:tags #{:form/success :form/transient}
-       :on   {:edit  :neutral
-              :reset :neutral}}}}
+       :on   {:submit-invalid :incorrect
+              :edit           :neutral
+              :reset          :neutral}}}}
 
     ;; ---- :mode region — Active / Done ----
     :mode

--- a/examples/patterns/websocket/messages.cljs
+++ b/examples/patterns/websocket/messages.cljs
@@ -495,8 +495,13 @@
     {:doc "Fold one inbound frame into app-db. UNTRUSTED INGRESS — the body
            is validated against the closed `InboundMessage` wire union, in
            every build, before this handler runs. It joins the
-           [:messages :received] log, and if it's a correlated reply it also
-           lands at [:messages :last-reply]. Each one gets a monotonic
+           [:messages :received] log, and that is ALL it does. A
+           `:request-id` on the frame is not correlation: the connection
+           machine decides that, and a reply it accepts reaches
+           [:messages :last-reply] through :ws.app/request-reply. A reply
+           it refused — answering a superseded registration, arriving after
+           a timeout, a duplicate — is logged here and moves no outcome.
+           Each one gets a monotonic
            `:rx-seq` stamp on the way in — that's the inbox's stable React
            `:key`. (Server pushes carry no `:request-id`, so we can't lean
            on identity from the wire, and list position shifts as new
@@ -509,9 +514,7 @@
             (update-in [:messages :received]
                        (fn [received]
                          (vec (cons (assoc body :rx-seq rx-seq) (or received [])))))
-            (assoc-in [:messages :rx-count] (inc rx-seq))
-            (cond-> (:request-id body)
-              (assoc-in [:messages :last-reply] body))))}))
+            (assoc-in [:messages :rx-count] (inc rx-seq))))}))
 
   ;; --- app-level events -------------------------------------------------
   (rf/reg-event :ws.app/send
@@ -580,7 +583,8 @@
            different questions: the machine's guards protect its own
            correlation state, this one protects app-db, and a boundary that
            only holds because something upstream is careful is not a
-           boundary. Either way the outcome files at [:messages :last-reply].
+           boundary. Either way the outcome files at [:messages :last-reply],
+           and this handler is that slot's only writer.
            See :ws.app/request for the correlation it completes."
      :schema       [:cat [:= :ws.app/request-reply] schema/RequestOutcome]
      :boundary?    true}

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -286,9 +286,11 @@
    [:draft    :string]
    ;; The inbox log, newest-first, so the view just renders top-down.
    [:received [:vector Message]]
-   ;; The most recent correlated reply. :ws/handle-message updates this only
-   ;; when the body has a :request-id, and :ws.app/request-reply records the
-   ;; same body for the registered callback. Server pushes stay in :received.
+   ;; The most recent correlated OUTCOME: a server reply the connection
+   ;; machine matched to its registration, or a locally minted failure.
+   ;; :ws.app/request-reply is its only writer. :ws/handle-message never
+   ;; touches it, so pushes and replies the machine refused to correlate
+   ;; stay in :received.
    [:last-reply [:maybe :any]]
    ;; The ticking source for each message's :rx-seq stamp.
    [:rx-count :int]])

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -283,6 +283,43 @@
           "the abandoned load's items never land"))))
 
 ;; ----------------------------------------------------------------------------
+;; SUCCESS THEN INVALID SUBMIT (rf2-gwye.56)
+;;
+;; A valid submit clears the draft and lands the :form region at :correct.
+;; Add stays enabled, so pressing it again submits the now-empty draft, which
+;; fails validation. The per-state fixtures above each start from a fresh frame
+;; and never make that :correct -> :submit-invalid step, which used to be
+;; unhandled: the form stayed :correct and "Todo added" out-ranked the new
+;; field error in the render-priority table.
+;; ----------------------------------------------------------------------------
+
+(deftest success-then-invalid-submit-selects-incorrect
+  (testing "a failing submit straight after a successful one leaves :correct for :incorrect"
+    (with-new-frame [f (new-frame)]
+      (let [items  #(rf/compute-sub [:todos/items] (rf/frame-state-value f))
+            errors #(get-in (rf/app-db-value f) [:new-todo :errors])]
+        (rf/dispatch-sync [:new-todo/edit-field :title "Buy milk"] {:frame f})
+        (rf/dispatch-sync [:new-todo/submit] {:frame f})
+        (is (= :correct (render-model f)) "precondition: the first submit succeeded")
+        (is (= 1 (count (items))))
+
+        ;; Add again, with the draft the success path just cleared.
+        (rf/dispatch-sync [:new-todo/submit] {:frame f})
+        (is (= 1 (count (items))) "the invalid submit adds nothing")
+        (is (seq (:title (errors))) "the title error is recorded")
+        (is (machine-has-tag? f :form/invalid) "the :form region is :incorrect")
+        (is (not (machine-has-tag? f :form/success)) "the success acknowledgement is gone")
+        (is (= :incorrect (render-model f))
+            "THE REGRESSION: the page renders the error, not \"Todo added\"")
+
+        ;; And the form still recovers to :correct on the next valid submit.
+        (rf/dispatch-sync [:new-todo/edit-field :title "Buy eggs"] {:frame f})
+        (rf/dispatch-sync [:new-todo/submit] {:frame f})
+        (is (= :correct (render-model f)) "a later valid submit returns to :correct")
+        (is (= ["Buy milk" "Buy eggs"] (mapv :title (items)))
+            "and adds exactly one further item")))))
+
+;; ----------------------------------------------------------------------------
 ;; STORY LIFECYCLE — :error variant
 ;;
 ;; The `:story.nine-states-lifecycle/error` variant in

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -925,6 +925,107 @@
                 (is (= {:type :request :tag "B"} (:echo outcome))
                     "B's caller gets B's OWN body, never the superseded request's")))))))))
 
+(defn- late-uncorrelated-reply-cannot-overwrite-correlated-outcome-test []
+  ;; rf2-gwye.55 / rf2-fzbj.34 — the machine refusing to correlate a frame
+  ;; is only half the contract; the app-db slot the view labels "Last
+  ;; correlated reply" must honour that refusal too. `:ws/handle-message`
+  ;; used to write any `:request-id`-bearing frame to [:messages :last-reply],
+  ;; so a vetted but UNCORRELATED reply — an answer to a superseded
+  ;; registration, a reply arriving after its request timed out, a duplicate —
+  ;; replaced the correlated outcome with its own raw, unstamped body, even
+  ;; though the machine fired no callback. The previous test delivers A
+  ;; BEFORE B, which that write happened to paper over; this one delivers B
+  ;; first. Every outcome is recorded by the EXAMPLE's :ws.app/request-reply
+  ;; (the counting target forwards to it), so the slot under test is the
+  ;; shipped one.
+  (log-tb442-reply!)
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [live-id    (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
+              in-flight  #(get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                  [:data :in-flight])
+              log        #(get-in (rf/app-db-value f) [:messages :reply-log])
+              last-reply #(get-in (rf/app-db-value f) [:messages :last-reply])
+              inbox-tags #(set (keep (comp :tag :echo)
+                                     (get-in (rf/app-db-value f) [:messages :received])))
+              request!   (fn [rid tag]
+                           (rf/dispatch-sync
+                             [:ws/connection
+                              [:ws/request {:request-id rid
+                                            :body       {:type :silent-no-echo :tag tag}
+                                            :reply      [:ws.test/log-tb442-reply]
+                                            :timeout-ms 5000}]]
+                             {:frame f}))
+              reply!     (fn [rid token tag]
+                           (rf/dispatch-sync
+                             [:ws/connection
+                              [:ws/received {:source-socket-id live-id
+                                             :body {:type          :reply
+                                                    :request-id    rid
+                                                    :request-token token
+                                                    :ok            true
+                                                    :echo          {:type :request :tag tag}}}]]
+                             {:frame f}))]
+          ;; --- A/B reuse of one id, B's reply lands FIRST -------------------
+          (let [rid [:feature/load "delta"]]
+            (request! rid "A")
+            (let [tok-a (request-token f rid)]
+              (request! rid "B")
+              (let [tok-b (request-token f rid)]
+                (is (= 1 (count (log))) "A is settled once, as superseded")
+                (reply! rid tok-b "B")
+                (let [b-outcome (last-reply)]
+                  (is (= :ws/server (:origin b-outcome))
+                      "positive control: B's matching reply reaches the slot through its callback, server-stamped")
+                  (is (= tok-b (:request-token b-outcome)))
+                  (is (= {:type :request :tag "B"} (:echo b-outcome)))
+                  (is (= 2 (count (log))) "B's callback fired once")
+
+                  ;; --- A's late reply: valid, vetted, uncorrelated ----------
+                  (reply! rid tok-a "A")
+                  (is (= {} (in-flight)) "the machine correlates nothing")
+                  (is (= 2 (count (log))) "and fires no callback")
+                  (is (= b-outcome (last-reply))
+                      "THE REGRESSION: a superseded registration's late reply does not overwrite the correlated outcome")
+                  (is (= #{"A" "B"} (inbox-tags))
+                      "both vetted wire frames still reach the inbox")
+
+                  ;; --- a duplicate of B's own reply --------------------------
+                  (reply! rid tok-b "B")
+                  (is (= 2 (count (log))) "a duplicate fires no second callback")
+                  (is (= b-outcome (last-reply))
+                      "a duplicate reply does not replace the stamped outcome with its raw body")
+
+                  ;; --- a push only ever touches the inbox --------------------
+                  (messages/send-server-push! (rf/capture-frame f) {:type :push :note "p"})
+                  (is (= b-outcome (last-reply)) "a push leaves the correlated outcome alone")))))
+
+          ;; --- a reply arriving AFTER its request timed out -----------------
+          (let [rid [:feature/load "epsilon"]]
+            (request! rid "T")
+            (let [tok-t (request-token f rid)]
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/request-timeout {:request-id       rid
+                                                       :token            tok-t
+                                                       :source-socket-id live-id}]]
+                                {:frame f})
+              (let [timeout-outcome (last-reply)
+                    settled         (count (log))]
+                (is (= {:origin :ws/local :request-id rid :ok false :error :ws/timeout}
+                       timeout-outcome)
+                    "positive control: the local timeout is the correlated outcome")
+                (reply! rid tok-t "T")
+                (is (= settled (count (log))) "the late reply fires no callback")
+                (is (= timeout-outcome (last-reply))
+                    "THE REGRESSION: a reply arriving after its timeout does not overwrite the local outcome")
+                (is (contains? (inbox-tags) "T")
+                    "the late reply still joins the inbox")))))))))
+
 (defn- clean-disconnect-fails-in-flight-request-test []
   ;; rf2-b2jpr — a clean :ws/disconnect destroys the only socket capable of
   ;; replying, so leaving :active through the clean door must settle every
@@ -1872,6 +1973,13 @@
             token rides the wire and the reply must echo it back. The later
             registration still settles on the reply that actually answers it"
     (wire-reply-cannot-settle-a-later-same-id-registration-test)))
+
+(deftest websocket-late-uncorrelated-reply-cannot-overwrite-correlated-outcome
+  (testing "rf2-gwye.55 — :ws.app/request-reply is the sole writer of
+            [:messages :last-reply]: a vetted reply the machine refused to
+            correlate (superseded, post-timeout, duplicate) joins the inbox
+            but cannot replace the correlated outcome"
+    (late-uncorrelated-reply-cannot-overwrite-correlated-outcome-test)))
 
 (deftest websocket-clean-disconnect-fails-in-flight-request
   (testing "rf2-b2jpr — a clean :ws/disconnect settles every in-flight request


### PR DESCRIPTION
## Summary

Fixes the two findings of rf2-fzbj.34 (examples-patterns surface review), each also filed as its own per-finding bead:

- **rf2-gwye.55 (P2): WebSocket.** `:ws/handle-message` wrote any `:request-id`-bearing frame to `[:messages :last-reply]`. A vetted reply that the connection machine had refused to correlate therefore replaced the correlated outcome with its own raw, unstamped body. That covers an answer to a superseded registration arriving after its successor's, a reply after a timeout, and a duplicate. The machine fired no callback for these, but the inbox still wrote the slot. The inbox now only logs. `:ws.app/request-reply`, which is reached only through the machine's correlation or local settlement, is the slot's sole writer. The `:doc` of both handlers and the `MessagesSlice` comment now say so.
- **rf2-gwye.56 (P3): Nine States.** A valid submit clears the draft, and Add stays enabled. Pressing Add again fails validation and dispatches `:submit-invalid`, which `:form`/`:correct` did not handle. The form stayed `:correct`, and "Todo added" out-ranked the new field error in the render-priority table. `:correct` now takes `:submit-invalid` to `:incorrect`.

Boot and long-running-work, the bead's other two patterns, carried no actionable finding.

Both findings were re-verified at the dispatch tip before fixing. The unconditional `cond->` write and the missing `:correct` transition were both still present.

## Regression tests

Both are in the framework-owned adapter tests. Examples stay test-free.

- `websocket_cljs_test.cljs`, `websocket-late-uncorrelated-reply-cannot-overwrite-correlated-outcome`: registers A and B under one reusable id through the shipped registrations, then delivers B's reply first and A's last.
  - It asserts that B's stamped outcome survives A's late reply and a duplicate B reply, that a push leaves it alone, that both frames reach the inbox, and that callbacks stay at one per registration.
  - It also covers a reply arriving after its request timed out, which leaves the local `:ws/timeout` outcome in place.
- `nine_states_cljs_test.cljs`, `success-then-invalid-submit-selects-incorrect`: initialise, then valid submit, then submit again with the cleared draft.
  - After the second submit it asserts one item, the title error, `:form/invalid` present, `:form/success` absent, and `:ui/render` = `:incorrect`.
  - It then checks that the next valid submit recovers to `:correct` and adds exactly one further item.

The tests were committed separately and ahead of the fix, so each commit is its own control. At the tests-only commit, the two namespaces ran 38 tests with 326 assertions and **7 failures**, all in the two new tests (3 nine-states, 4 websocket). The run's captured exit code was 1.

## Quality gates

All local gates were run at the fix commit. The worktree guard ran and exited 0, and each gate's recorded root was checked against that worktree.

- **`npm run test:cljs`** (from `implementation/`): **exit 0**. `Build completed ... 0 warnings`, `Ran 12007 tests containing 59687 assertions. 0 failures, 0 errors.`
  - CI job: `CLJS (shadow-cljs :node-test)`, key `cljs`.
- **The two namespaces alone, against that same fix-commit bundle**: **exit 0**, 38 tests, 326 assertions, **0 failures**. These are the same 38 tests and 326 assertions as the RED run, so the new tests ran in both. Compare this with the RED run above.
- **`node implementation/scripts/check-examples-compile.cjs`**: **exit 0**. All 58 swept builds compiled with zero warnings, `examples/websocket`, `examples/nine-states`, `examples/nine-states-with-stories`, `examples/boot` and `examples/long-running-work` among them.
  - CI job: `CLJS (compile every standalone example build, coverage gate)`, key `cljs-examples-compile`.
  - The job is armed by the `examples_compile` surface, which covers `examples/*`.
- **`scripts/check_retired_spellings.py`** (the ratchet over `examples/`): **exit 0**.

Not applicable:
- `check_readme_links.py --ci`: no README was touched.
- `check_doc_slugs.py`: no spec page was touched.

Nothing validates prose inside docstrings or comments. I read the changed `:doc` strings and comments by hand.

## Not built

- No new schema discriminator, epoch or callback policy. The bead says none is needed: the machine already makes the correlation decision, and the fix only stops a second writer from overriding it.
- No README edit. `nine_states/README.md` describes `:correct` leaving on `:edit`, which is still true, so `check_readme_links.py` is not nominated.
- No spec, skill or hot-zone file touched.
