### PR TITLE
fix(reagent-slim): keep sequence render output a seq; make MetaFn props JS-callable (rf2-fzbj.30)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -367,9 +367,14 @@
             (set! (.-cljsRenderFn c) inner)
             (apply inner args))
 
-          ;; Seq-as-fragment shape — coerce to a vector for React's
-          ;; children-of-a-fragment handling.
-          (seq? out) (vec out)
+          ;; A sequence is SIBLING children and must reach `as-element`
+          ;; still a seq: a vector there means ONE hiccup form, so the
+          ;; `(vec out)` this arm used to do made the first child a head —
+          ;; `:rf.error/template-bad-tag` for keyed elements, an empty-vector
+          ;; error for `()`, and `("a" "b")` rendered as `<a>b</a>`
+          ;; (rf2-fzbj.30). `doall` keeps the realization inside the render
+          ;; Reaction, where `vec` had it, without changing the shape.
+          (seq? out) (doall out)
 
           ;; Anything else (a React element, a primitive) flows
           ;; through unchanged.

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -486,6 +486,23 @@
 (defn- ^boolean js-val? [x]
   (not (identical? "object" (goog/typeOf x))))
 
+(def ^:private js-callables
+  "Per-input cache for `js-callable`. Weakly keyed, so a handler that is
+  dropped takes its shim with it."
+  (js/WeakMap.))
+
+(defn- js-callable
+  "A plain JS function forwarding every call to the object-backed callable
+  `f` (a `cljs.core/MetaFn`, or a `deftype`/`reify` implementing `IFn`)
+  and returning its value. The same `f` always yields the same function,
+  so a converted callback prop keeps one identity across renders
+  (rf2-fzbj.30)."
+  [f]
+  (or (.get js-callables f)
+      (let [shim (fn [& args] (apply f args))]
+        (.set js-callables f shim)
+        shim)))
+
 (declare convert-prop-value)
 
 (defn- add-converted-nested-prop!
@@ -579,25 +596,25 @@
       through. This is the arm a PLAIN JS function takes: `goog/typeOf`
       of a function is \"function\", so an ordinary event handler is
       returned here, with its identity intact, and never reaches the
-      `fn?` arm below.
+      `ifn?` arm below.
     - Maps recursively convert (style maps + custom-component prop maps).
     - Coll? values become JS arrays via clj->js (children, vector classes).
-    - `fn?` values pass through verbatim — referentially stable across
-      renders. Since plain functions already left at `js-val?`, the
-      values that REACH this arm are the object-backed ones satisfying
-      `Fn`: chiefly `cljs.core/MetaFn`, what `(with-meta some-fn …)`
-      returns. Those must keep their identity too, so `React.memo` /
-      `shouldComponentUpdate` bail-outs work on a metadata-bearing
-      handler; wrapping one in a fresh closure per render would silently
-      defeat memoisation.
-    - Non-fn `IFn` values are wrapped in a variadic shim so the React
-      side can invoke them as plain JS functions. NOTE that keywords,
-      maps, sets and vectors — the usual \"used as a function\" examples —
-      never get here: keywords and symbols are taken by `named?`, maps by
-      `map?`, and sets and vectors by `coll?`. What reaches this arm is
-      an object-backed callable that satisfies `IFn` without satisfying
-      `Fn`, `named?`, `map?` or `coll?` — a `deftype`/`reify` the caller
-      passes as a prop meaning \"React may call this\".
+    - Any other `IFn` value becomes a real JS function via `js-callable`.
+      Since plain functions already left at `js-val?`, what REACHES this
+      arm is object-backed: chiefly `cljs.core/MetaFn`, what
+      `(with-meta some-fn …)` returns, plus any `deftype`/`reify` the
+      caller passes as a prop meaning \"React may call this\". Such a
+      value is callable through CLJS's invoke protocol (and its own
+      `.call`), but its `typeof` is \"object\", so JavaScript's `f(...)`
+      syntax cannot invoke it: React DOM refuses it as a listener, treats
+      it as an OBJECT ref, and a foreign component calling the prop
+      throws (rf2-fzbj.30 — this arm used to hand a MetaFn back
+      unchanged). The shim is cached per input, so converting the same
+      handler on every render yields the SAME function and `React.memo` /
+      `shouldComponentUpdate` / callback-ref identity hold. NOTE that
+      keywords, maps, sets and vectors — the usual \"used as a function\"
+      examples — never get here: keywords and symbols are taken by
+      `named?`, maps by `map?`, and sets and vectors by `coll?`.
     - Everything else passes through unchanged.
 
   HOT PATH — this runs once per prop on every render, and the ordering
@@ -616,8 +633,7 @@
      (map? prop-value)    (reduce-kv add-converted-nested-prop!
                                      #js {} prop-value)
      (coll? prop-value)   (clj->js prop-value)
-     (fn? prop-value)     prop-value ; pass through — preserves identity
-     (ifn? prop-value)    (fn [& args] (apply prop-value args))
+     (ifn? prop-value)    (js-callable prop-value) ; stable per input
      :else                prop-value))
   ([prop-key prop-value]
    ;; 2-arg form: CUSTOM/INTEROP semantics (the `:>` path + the public
@@ -634,8 +650,7 @@
      (map? prop-value)    (reduce-kv add-converted-nested-prop!
                                      #js {} prop-value)
      (coll? prop-value)   (clj->js prop-value)
-     (fn? prop-value)     prop-value ; pass through — preserves identity
-     (ifn? prop-value)    (fn [& args] (apply prop-value args))
+     (ifn? prop-value)    (js-callable prop-value) ; stable per input
      :else                prop-value))
   ([prop-key prop-value dom-element?]
    ;; 3-arg form: TARGET-AWARE. For a native DOM tag every prop is an
@@ -1168,11 +1183,11 @@
   React accepts `key`, `ref` and `children` on a Fragment and nothing
   else. `:ref` therefore already crosses here and needs no arm of its
   own: the whole map goes through `convert-prop-value`'s `map?` branch,
-  which camelCases the key to `ref` via `cached-prop-name` and answers a
-  function value from the `fn?` arm BY IDENTITY — which is the part that
-  matters, because React detaches and reattaches on a changed ref
-  identity. An object ref falls to the `:else` arm and is likewise
-  untouched. React answers either with a `FragmentInstance` rather than a
+  which camelCases the key to `ref` via `cached-prop-name` and hands a
+  plain function back BY IDENTITY (a metadata-bearing one as its single
+  cached `js-callable` shim) — which is the part that matters, because
+  React detaches and reattaches on a changed ref identity. An object ref
+  falls to the `:else` arm and is likewise untouched. React answers either with a `FragmentInstance` rather than a
   DOM node. This docstring previously said only `:key` was meaningful
   here; that was true before React 19.3 and is no longer."
   [argv]

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/sibling_output_and_callable_props_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/sibling_output_and_callable_props_dom_cljs_test.cljs
@@ -1,0 +1,90 @@
+(ns reagent2.impl.sibling-output-and-callable-props-dom-cljs-test
+  "rf2-fzbj.30 (rf2-gwye.51, rf2-gwye.52) — two reagent-slim render-boundary
+  contracts, witnessed through a real `react-dom/client` root.
+
+  1. A component whose render returns a SEQUENCE commits sibling children:
+     no wrapper element and no `:rf.error/template-bad-tag`. Before the fix,
+     `wrap-render`'s untagged arm coerced the seq with `vec`, so
+     `as-element` read the first child as a hiccup HEAD.
+  2. A metadata-bearing callback (`cljs.core/MetaFn`, what `with-meta`
+     returns for a fn) reaches React DOM as a real JS function, so a click
+     runs it and a callback ref is called with the node. Before the fix the
+     MetaFn object passed through unchanged; its `typeof` is \"object\", so
+     React DOM refused it as a listener and treated it as an object ref.
+
+  TEST-ONLY. The ns ends in `-dom-cljs-test`, so `:browser-test` runs the
+  live bodies; `:node-test` also loads it (`cljs-test$` matches), where they
+  gate on `(browser?)` and no-op. The node-lane counterparts live in
+  `template_cljs_test.cljs`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.dom.client :as rdc]
+            ["react-dom" :as react-dom]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- with-attached-root
+  "Mount a fresh root on a node attached to the document (so a real click
+  bubbles to React's root listener), call `(f root node)`, and always
+  unmount and detach."
+  [f]
+  (let [node (.createElement js/document "div")
+        root (rdc/create-root node)]
+    (.appendChild (.-body js/document) node)
+    (try
+      (f root node)
+      (finally
+        (try (rdc/unmount root) (catch :default _ nil))
+        (.remove node)))))
+
+(defn- host-html [^js node]
+  (some-> (.querySelector node ".host") .-innerHTML))
+
+(defn- keyed-rows [] (list ^{:key "a"} [:span "a"] ^{:key "b"} [:span "b"]))
+(defn- empty-rows [] (list))
+(defn- text-rows [] (list "a" "b"))
+
+(deftest sequence-output-commits-sibling-children
+  (testing "reagent-slim — an untagged component returning a sequence commits its items as siblings (rf2-fzbj.30)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (with-attached-root
+        (fn [root node]
+          (react-dom/flushSync (fn [] (rdc/render root [:div.host [keyed-rows]])))
+          (is (= "<span>a</span><span>b</span>" (host-html node))
+              "two keyed sibling spans, with no wrapper element")
+
+          (react-dom/flushSync (fn [] (rdc/render root [:div.host [empty-rows]])))
+          (is (= "" (host-html node))
+              "an empty sequence commits nothing")
+
+          (react-dom/flushSync (fn [] (rdc/render root [:div.host [text-rows]])))
+          (is (= "ab" (some-> (.querySelector node ".host") .-textContent))
+              "text siblings commit as text")
+          (is (= 0 (some-> (.querySelector node ".host") .-children .-length))
+              "…and not as an `<a>` element holding the second item"))))))
+
+(deftest metafn-click-handler-and-callback-ref-reach-react-dom
+  (testing "reagent-slim — a metadata-bearing on-click and :ref are called by React DOM (rf2-fzbj.30)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [clicks   (atom 0)
+            seen     (atom nil)
+            on-click (with-meta (fn [_e] (swap! clicks inc)) {:rf/probe true})
+            ref-fn   (with-meta (fn [el] (when el (reset! seen el))) {:rf/probe true})]
+        (with-attached-root
+          (fn [root node]
+            (react-dom/flushSync
+              (fn []
+                (rdc/render root [:button {:id       "metafn-probe"
+                                           :on-click on-click
+                                           :ref      ref-fn}
+                                  "Click"])))
+            (let [button (.querySelector node "#metafn-probe")]
+              (is (some? button) "the button committed")
+              (is (and (some? button) (identical? button @seen))
+                  "the metadata-bearing callback ref was CALLED with the committed node")
+              (when button (.click button))
+              (is (= 1 @clicks)
+                  "a real click ran the metadata-bearing handler"))))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -196,7 +196,7 @@
 
 ;; rf2-6r9j.30 — a fixture that actually REACHES `convert-prop-value`'s
 ;; `ifn?` arm: object-backed, satisfies IFn, and satisfies none of the
-;; arms that come first (`js-val?`, `named?`, `map?`, `coll?`, `fn?`).
+;; arms that come first (`js-val?`, `named?`, `map?`, `coll?`).
 ;; A deftype implementing IFn does NOT satisfy the `Fn` marker protocol,
 ;; which is what separates it from a function. Each -invoke records its
 ;; own arguments so a call through the wrapper can be proven to have
@@ -207,38 +207,55 @@
   (-invoke [_ a]   (swap! calls conj [a])      [:called-1 a])
   (-invoke [_ a b] (swap! calls conj [a b])    [:called-2 a b]))
 
-(deftest convert-prop-value-fn-preserves-identity-rf2-wyocr
-  (testing "rf2-wyocr: an object-backed Fn prop — a fn carrying metadata,
-            i.e. cljs.core/MetaFn — passes through the `fn?` arm with ===
-            identity preserved, so React.memo / shouldComponentUpdate
-            bail-outs work on a metadata-bearing handler.
+(deftest convert-prop-value-fn-yields-stable-callable-js-fn-rf2-fzbj-30
+  (testing "rf2-fzbj.30 / rf2-gwye.52: an object-backed Fn prop — a fn
+            carrying metadata, i.e. cljs.core/MetaFn — converts to a REAL
+            JavaScript function, and converting the same handler again
+            returns that SAME function, so the host can invoke it AND
+            React.memo / shouldComponentUpdate / callback-ref identity
+            still hold.
 
-            rf2-6r9j.30: this test used to pass a PLAIN fn, which
-            `goog/typeOf`s as \"function\" and therefore returns from the
-            earlier `js-val?` arm — so it would have stayed green with
-            both `fn?` arms deleted. MetaFn is the ordinary value shape
-            that actually reaches the arm this regression names."
-    (let [handler (with-meta (fn [_e] :clicked) {:rf/probe true})]
+            History: rf2-wyocr passed the MetaFn through unchanged and
+            rf2-6r9j.30 pinned that input identity here. But `goog/typeOf`
+            a MetaFn is \"object\": JavaScript's `f(...)` syntax cannot
+            invoke it, React DOM refuses it as a listener, and a foreign
+            component calling the prop throws. So the witness below is a
+            NATIVE call (`Reflect.apply`), never CLJS invocation or
+            `.call` — MetaFn implements both, which is how the pinned
+            identity looked healthy."
+    (let [calls   (atom [])
+          handler (with-meta (fn [& args]
+                               (swap! calls conj (vec args))
+                               [:handled (vec args)])
+                    {:rf/probe true})]
       ;; Preconditions, asserted rather than assumed — these are what
-      ;; route the value past the earlier arms and INTO `fn?`.
+      ;; route the value past `js-val?` and make the defect real.
       (is (= "object" (goog/typeOf handler))
           "precondition: a metadata-bearing fn is object-backed, so js-val? declines it")
       (is (fn? handler)
-          "precondition: MetaFn satisfies Fn, so the fn? arm takes it")
-      ;; 2-arg form — the production path through `add-converted-nested-prop!`.
-      (let [a (template/convert-prop-value :on-click handler)
-            b (template/convert-prop-value :on-click handler)]
-        (is (identical? handler a)
-            "2-arg: fn returned is the SAME reference passed in (=== check)")
-        (is (identical? a b)
-            "2-arg: two conversions of the same fn produce the same reference"))
-      ;; 1-arg form — used for nested map values.
-      (let [a (template/convert-prop-value handler)
-            b (template/convert-prop-value handler)]
-        (is (identical? handler a)
-            "1-arg form preserves identity too")
-        (is (identical? a b)
-            "1-arg form: repeat conversions return the same reference")))
+          "precondition: MetaFn satisfies Fn")
+      (is (thrown? js/TypeError (js/Reflect.apply handler nil #js []))
+          "precondition: the MetaFn itself is NOT natively callable")
+      (let [one-a   (template/convert-prop-value handler)
+            one-b   (template/convert-prop-value handler)
+            two-a   (template/convert-prop-value :on-click handler)
+            two-b   (template/convert-prop-value :on-click handler)
+            three-a (template/convert-prop-value :on-click handler true)
+            three-b (template/convert-prop-value :on-click handler true)]
+        (doseq [[label out] [["1-arg" one-a] ["2-arg" two-a] ["3-arg" three-a]]]
+          (is (= "function" (goog/typeOf out))
+              (str label ": converts to a real JS function")))
+        (is (identical? one-a one-b)
+            "1-arg: repeated conversion returns the SAME function")
+        (is (identical? two-a two-b)
+            "2-arg: repeated conversion returns the SAME function")
+        (is (identical? three-a three-b)
+            "3-arg: repeated conversion returns the SAME function")
+        ;; Invoke it the way a host does — natively.
+        (is (= [:handled [:x :y]] (js/Reflect.apply two-a nil #js [:x :y]))
+            "a native call forwards the arguments and returns the handler's value")
+        (is (= [[:x :y]] @calls)
+            "the handler itself ran, exactly once")))
     ;; A plain JS fn still passes through unchanged — by the js-val? arm.
     (let [plain (fn [_e] :plain)]
       (is (identical? plain (template/convert-prop-value :on-click plain))
@@ -266,7 +283,7 @@
       (is (not (map? probe))  "precondition: not a map")
       (is (not (coll? probe)) "precondition: not a coll")
       (is (not (fn? probe))
-          "precondition: does NOT satisfy Fn, so the fn? arm declines it")
+          "precondition: does NOT satisfy Fn — the non-MetaFn shape of this arm")
       (is (ifn? probe)
           "precondition: satisfies IFn — this is the arm under test")
       (let [out (template/convert-prop-value :on-select probe)]
@@ -274,6 +291,8 @@
             "the ifn? arm returns a real JS function React can call")
         (is (not (identical? probe out))
             "the wrapper is a distinct value — this arm allocates, by design")
+        (is (identical? out (template/convert-prop-value :on-select probe))
+            "…once per input: repeated conversion returns the SAME function (rf2-fzbj.30)")
         ;; Invoke it the way React would: as a plain JS function.
         (is (= [:called-1 :a] (.call out nil :a))
             "1-arg JS call forwards to the fixture and returns its value")
@@ -287,6 +306,89 @@
             "1-arg form also wraps into a JS function")
         (is (= :called-0 (.call out1 nil))
             "0-arg JS call forwards")))))
+
+(defn- CallsOnSelect
+  "A foreign React function component that calls its callback prop the
+  way third-party JavaScript does — natively, as `props.onSelect(...)`."
+  [^js props]
+  (react/createElement "span" nil (.onSelect props "picked")))
+
+(deftest metafn-callback-prop-is-callable-by-a-foreign-react-component-rf2-fzbj-30
+  (testing "rf2-fzbj.30 / rf2-gwye.52: a real React render of a foreign
+            component that invokes its callback prop natively. Pre-fix the
+            MetaFn object reached `props.onSelect` unchanged and the render
+            threw `props.onSelect is not a function`."
+    (let [meta-handler  (with-meta (fn [v] (str "meta-" v)) {:rf/probe true})
+          plain-handler (fn [v] (str "plain-" v))]
+      (is (= "<span>plain-picked</span>"
+             (rds/renderToStaticMarkup
+               (template/as-element [:> CallsOnSelect {:on-select plain-handler}])))
+          "control: a plain fn prop is called by the foreign component")
+      (is (= "<span>meta-picked</span>"
+             (rds/renderToStaticMarkup
+               (template/as-element [:> CallsOnSelect {:on-select meta-handler}])))
+          "a metadata-bearing fn prop is called by the foreign component too"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-fzbj.30 / rf2-gwye.51 — a component whose render returns a SEQUENCE
+;; renders it as sibling children, whatever its Form classification. Driven
+;; through the real generated class (`as-element` → `fn-to-class` → render
+;; → `wrap-render` → `as-element`), because a `wrap-render`-only `=`
+;; assertion cannot see this bug: a list and the vector it was coerced to
+;; compare equal, yet `as-element` reads the vector as ONE hiccup form.
+;; ---------------------------------------------------------------------------
+
+(defn- seq-rows [] (list ^{:key "a"} [:span "a"] ^{:key "b"} [:span "b"]))
+(defn- seq-empty [] (list))
+(defn- seq-text [] (list "a" "b"))
+
+(defn- static-markup [hiccup]
+  (rds/renderToStaticMarkup (template/as-element hiccup)))
+
+(defn- class-render-output
+  "Instantiate the class `as-element` generates for the component vector
+  `hiccup` and run its React `render` method, returning what React would
+  receive. Unmounts the instance so its render Reaction is disposed."
+  [hiccup]
+  (let [^js el   (template/as-element hiccup)
+        klass    (.-type el)
+        ^js inst (new klass (.-props el))]
+    (try
+      (.render inst)
+      (finally
+        (.componentWillUnmount inst)))))
+
+(deftest untagged-component-sequence-output-renders-siblings-rf2-fzbj-30
+  (testing "an untagged component returning a list renders sibling
+            children through the runtime classification path — keyed
+            elements, an empty sequence and text siblings alike"
+    (is (= "<span>a</span><span>b</span>" (static-markup [seq-rows]))
+        "keyed element siblings, with no wrapper element")
+    (is (= "<div></div>" (static-markup [:div [seq-empty]]))
+        "an empty sequence renders nothing (not an empty hiccup vector)")
+    (is (= "<div>ab</div>" (static-markup [:div [seq-text]]))
+        "text siblings stay text (not misread as an `<a>` tag with a child)")
+    (let [out (class-render-output [seq-rows])]
+      (is (array? out)
+          "the class render hands React an array of children, not one element")
+      (is (= ["a" "b"] (when (array? out) (mapv #(.-key ^js %) out)))
+          "each child keeps its :key"))))
+
+(deftest sequence-output-agrees-across-form-shapes-rf2-fzbj-30
+  (testing "controls: a tagged Form-1, a Form-2 inner renderer and a direct
+            as-element of the same sequence render the same siblings, and a
+            hiccup vector still means ONE element"
+    (let [tagged-form-1 (with-meta (fn [] (seq-rows)) {:reagent2/form :reagent2/form-1})
+          form-2        (fn [] (fn [] (seq-rows)))
+          vector-form-1 (fn [] [:span "one"])]
+      (is (= "<span>a</span><span>b</span>" (static-markup [tagged-form-1]))
+          "compile-time-tagged Form-1")
+      (is (= "<span>a</span><span>b</span>" (static-markup [form-2]))
+          "Form-2 inner renderer")
+      (is (= "<span>a</span><span>b</span>" (static-markup (seq-rows)))
+          "direct as-element of the sequence")
+      (is (= "<span>one</span>" (static-markup [vector-form-1]))
+          "an untagged component returning a hiccup vector still renders one element"))))
 
 (deftest nested-style-keyword-value-stringifies-on-live-path-rf2-fdm4rm
   (testing "rf2-fdm4rm: a nested style-map keyword value reaches React as


### PR DESCRIPTION
## Summary

Two reagent-slim render-boundary repairs from the surface review. Closes rf2-fzbj.30 and its per-finding splits rf2-gwye.51 and rf2-gwye.52. Both findings were re-verified at tip before being fixed; both still held.

**1. Sequence-valued component output (rf2-fzbj.30 finding 1, rf2-gwye.51).**
`wrap-render`'s untagged runtime arm coerced a sequence result with `vec`. `as-element` then read the first child as a hiccup HEAD, so an ordinary component returning a list broke three ways: keyed siblings threw `:rf.error/template-bad-tag`, `()` threw `:rf.error/template-empty-vector`, and `("a" "b")` rendered as `<a>b</a>`. The arm now uses `doall`, which keeps the realization inside the render Reaction where `vec` had it, while leaving the value a seq so `as-element`'s sequence arm takes it. Tagged Form-1, Form-2 and direct `as-element` already produced siblings; all four shapes now agree, and a hiccup vector still means one element.

**2. MetaFn callback props (rf2-fzbj.30 finding 2, rf2-gwye.52).**
`convert-prop-value` handed a `cljs.core/MetaFn` back unchanged. MetaFn is what `with-meta` returns for a fn, and its `typeof` is `"object"` — so React DOM refused it as a listener, treated it as an OBJECT ref, and a foreign component calling the prop threw. The `fn?` and `ifn?` arms are now one `ifn?` arm routed through `js-callable`: a JS shim cached per input in a `WeakMap`. Output is natively callable and keeps one identity across renders, so `React.memo` / `shouldComponentUpdate` / callback-ref identity still hold. Plain JS functions are untouched — they leave earlier at `js-val?` with their input identity, as before.

Collapsing the two arms is a net simplification: every object-backed `IFn` now takes one path, and the non-Fn `IFn` case gains the same stable identity instead of allocating a fresh wrapper per render.

## Tests — each shown RED before the fix, then green

Node lane, `implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs`:
- `convert-prop-value-fn-yields-stable-callable-js-fn-rf2-fzbj-30` replaces the old identity-only regression. It witnesses conversion with a NATIVE call (`Reflect.apply`), never CLJS invocation or `.call` — MetaFn implements both, which is exactly how the old pinned identity looked healthy. Asserts `typeof function` and stable output identity in all three arities.
- `metafn-callback-prop-is-callable-by-a-foreign-react-component-rf2-fzbj-30` — a real `react-dom/server` render of a foreign component calling `props.onSelect(...)`, with a plain-fn control.
- `untagged-component-sequence-output-renders-siblings-rf2-fzbj-30` — keyed, empty and text siblings driven through the real generated class, plus keys surviving on the class's render output. A `wrap-render`-only `=` assertion cannot see this bug, since a list and the vector it was coerced to compare equal.
- `sequence-output-agrees-across-form-shapes-rf2-fzbj-30` — tagged Form-1, Form-2 inner renderer and direct `as-element` controls, and a hiccup vector still rendering as one element.
- The non-Fn `IFn` regression keeps its existing assertions and gains one pinning stable output identity.

Browser lane, new `test/reagent2/impl/sibling_output_and_callable_props_dom_cljs_test.cljs`: sibling output committed through a real `react-dom/client` root, a real click running a metadata-bearing handler, and a metadata-bearing callback ref called with the committed node.

RED evidence (pre-fix code, same assertions):
- node lane, template namespace: `5 failures, 5 errors` — `typeof` read `"object"`; `Reflect.apply` threw `TypeError: ... is an object and not a function`; the foreign component threw `props.onSelect is not a function`; the sequence cases threw `template-bad-tag` and `template-empty-vector` and rendered `<div><a>b</a></div>`.
- browser lane, restoring the two source files at the pre-fix commit: `Ran 2 tests containing 7 assertions. 6 failures` — React DOM's own `Expected \`onClick\` listener to be a function, instead got a value of \`object\` type`, and the callback ref never called. The restore was verified by blob hash against the committed object, and the same 7 assertions then passed.

## Quality gates

Every exit code below was captured on the command line that ran the gate and is quoted from that capture, on the final rebased base (`b7d9ce9169`).

| Gate | Command | Exit | Result | CI job |
|---|---|---|---|---|
| Fast PR spine (node tier, JVM tier, always-on static/ratchet checks) | `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine`; node lane `Ran 12027 tests containing 59826 assertions. 0 failures, 0 errors.` | `cljs` + many |
| CLJS node lane (focused re-run) | `node out/node-test.js --test=reagent2.impl.template-cljs-test,reagent2.impl.sibling-output-and-callable-props-dom-cljs-test` | 0 | `Ran 104 tests containing 325 assertions. 0 failures, 0 errors.` | `cljs` — CLJS (shadow-cljs :node-test) |
| Browser DOM lane (focused on the new namespace) | `shadow-cljs compile browser-test --config-merge …` then `scripts/serve-and-run-browser-tests.cjs` | 0 | `Ran 2 tests containing 7 assertions. 0 failures, 0 errors.` | `cljs-browser` — CLJS (shadow-cljs :browser-test, headless Chromium) |
| reagent-slim client-runtime smoke | `npm run test:reagent-slim:smoke` | 0 | `Ran 1 reagent-slim client-runtime smoke. 0 failures.` | `cljs-reagent-slim-bundle-isolation` |
| reagent-slim bundle isolation | `npm run test:reagent-slim:bundle-isolation` | 0 | `PASS reagent-slim-bundle-isolation: 8 contracts passed; 41 sentinel checks + 2 entrypoint checks` | `cljs-reagent-slim-bundle-isolation` |

Each gate was confirmed to have read THIS worktree: the spine, node, smoke and bundle-isolation runs each print the worktree's own `shadow-cljs.edn` or `out/` path, and the browser lane is discriminated by the planted fault going red there and only there.

Relied on CI: `cljs-examples-compile` (the examples/testbeds compile sweep — not run locally; the bundle-isolation gate did release-compile `examples/counter`, `examples/counter-slim-and-fast` and the slim SSR isolation fixture, all clean), and the lint/docs rollups.

No `spec/` or docs page is touched, so `check_doc_slugs.py` and `mkdocs build --strict` are not nominated for this change; the only prose edited is source docstrings inside the two files.

## Not built, and why

- **Slim regression coverage for the shared derived-container activation defect.** rf2-fzbj.30 cross-references it, but it belongs to rf2-fzbj.29's shared-spine repair (the Reagent surface, a later wave). Nothing here touches `implementation/adapters/reagent/**`.
- **Reactive derefs inside lazy sequences.** The review investigated and deliberately declined to file it: stock Reagent documents the same `doall` constraint. `doall` here preserves the existing realization point rather than extending that contract.
