### PR TITLE
fix(realworld): own late replies by their page; admit optimistic comment ids; restale the feed on follow (rf2-fzbj.21)

### DIFF
--- a/examples/real-apps/realworld_http/article_editor.cljs
+++ b/examples/real-apps/realworld_http/article_editor.cljs
@@ -328,7 +328,14 @@
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug (get-in rt [:rf.runtime/routing :current :params :slug])]
       {:db (assoc db :editor (editor-slice slug blank-draft))
-       :fx [[:dispatch [:ui/article-editor [:use-edit]]]
+       ;; `:reset` first, so a NEW editing session starts the machine clean. A
+       ;; save or delete left pending by an earlier session holds the lifecycle
+       ;; at `:submitting`, and its late settle is refused (WRITE OWNERSHIP
+       ;; below); without the reset this session would stay busy — `:submitting`
+       ;; ignores `:fetch-started` and `:fetch-succeeded` — with every input
+       ;; locked.
+       :fx [[:dispatch [:ui/article-editor [:reset]]]
+            [:dispatch [:ui/article-editor [:use-edit]]]
             [:dispatch [:ui/article-editor [:fetch-started]]]
             [:rf.http/managed
              (rh/request {:method     :get
@@ -399,6 +406,7 @@
   ;; The machine snapshot lives in runtime-db.
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [{:keys [slug draft]} (:editor db)
+          nav-token   (rh/current-nav-token rt)
           mode        (get-in rt [:rf.runtime/machines :snapshots :ui/article-editor :state :mode])
           ;; Flow output — read as plain app-db data.
           can-submit? (get-in db [:editor :can-submit?])
@@ -435,29 +443,64 @@
                                           "/articles")
                             :body       (article-body draft)
                             :decode     schema/ArticleResponse
-                            :on-success [:editor/submit-success]
-                            :on-failure [:editor/submit-error]})]]}))))
+                            ;; The issuing navigation rides both targets
+                            ;; (WRITE OWNERSHIP, just below).
+                            :on-success [:editor/submit-success nav-token]
+                            :on-failure [:editor/submit-error nav-token]})]]}))))
+
+;; ---- WRITE OWNERSHIP ----
+;;
+;; A save or a delete is answered whenever the server says, and a clean draft
+;; (or one the reader chose to discard) leaves the editor freely in the
+;; meantime. The four settles below all write the ONE `[:editor]` slice, drive
+;; the ONE `:ui/article-editor` machine, and two of them navigate — so a
+;; departed session's reply would erase the newer draft the reader is typing,
+;; flip its lifecycle, banner its form with another session's error, or drag
+;; the reader off the page they chose. Each therefore acts only while the
+;; navigation that issued it is still current (`rh/same-navigation?`, REPLY
+;; OWNERSHIP in http.cljs).
+;;
+;; Why not the slug, as `still-editing?` does for the READ? Because a write's
+;; session is not named by one: a `/editor` create draft has no slug, and
+;; leaving `/editor/a` and coming back to it is a new session under the same
+;; slug. The nav-token names the session exactly.
+;;
+;; Refusing strands nothing. The server write stands either way, and a new
+;; editing session resets the slice AND the machine on entry (`:editor/reset`,
+;; `:editor/load-article`), so the busy lifecycle a departed write left behind
+;; is gone before its refused settle arrives.
 
 (rf/reg-event :editor/submit-success
-  (fn [{:keys [db]} [_ {:keys [value]}]]
-    (let [article (:article value)
-          draft   (draft-from-article article)]
-      {:db (assoc db :editor (editor-slice (:slug article) draft))
-       :fx [[:dispatch [:ui/article-editor [:use-edit]]]
-            [:dispatch [:ui/article-editor [:submit-succeeded]]]
-            [:dispatch [:rf.route/navigate {:to :realworld.article/show :params {:slug (:slug article)}}]]]})))
+  {:doc "The save's `:on-success`, carrying the nav-token it was issued under.
+         On the page that issued it, rebase the form onto the saved article and
+         open that article. Refused once the reader has navigated away (WRITE
+         OWNERSHIP above)."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [value]}]]
+    (when (rh/same-navigation? rt nav-token)
+      (let [article (:article value)
+            draft   (draft-from-article article)]
+        {:db (assoc db :editor (editor-slice (:slug article) draft))
+         :fx [[:dispatch [:ui/article-editor [:use-edit]]]
+              [:dispatch [:ui/article-editor [:submit-succeeded]]]
+              [:dispatch [:rf.route/navigate {:to :realworld.article/show :params {:slug (:slug article)}}]]]}))))
 
 (rf/reg-event :editor/submit-error
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    {:db (assoc-in db [:editor :submit-error] (rh/failure->message error))
-     :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
+  {:doc "The save's `:on-failure`, gated exactly as `:editor/submit-success`
+         is, so a departed save cannot banner a newer editor's form."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [error]}]]
+    (when (rh/same-navigation? rt nav-token)
+      {:db (assoc-in db [:editor :submit-error] (rh/failure->message error))
+       :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]})))
 
 (rf/reg-event :editor/delete
   {:doc "Delete the article. No retry — destructive, one click. Broadcasts
          `:submit-started` to push the lifecycle region into :submitting (which
-         flies the :editor/busy tag, so the form locks while it's working)."}
-  (fn [{:keys [db]} _]
-    (let [slug (get-in db [:editor :slug])]
+         flies the :editor/busy tag, so the form locks while it's working).
+         Both reply targets carry the nav-token it was issued under (WRITE
+         OWNERSHIP above)."}
+  (fn [{:keys [db] rt :rf.db/runtime} _]
+    (let [slug      (get-in db [:editor :slug])
+          nav-token (rh/current-nav-token rt)]
       {:fx [[:dispatch [:ui/article-editor [:submit-started]]]
             [:rf.http/managed
              (rh/request {:method     :delete
@@ -466,19 +509,28 @@
                           ;; `:auto` is the right call — it shrugs at an empty
                           ;; body instead of trying to parse one.
                           :decode     :auto
-                          :on-success [:editor/delete-success]
-                          :on-failure [:editor/delete-error]})]]})))
+                          :on-success [:editor/delete-success nav-token]
+                          :on-failure [:editor/delete-error nav-token]})]]})))
 
 (rf/reg-event :editor/delete-success
-  (fn [{:keys [db]} _]
-    {:db (assoc db :editor (editor-slice))
-     :fx [[:dispatch [:ui/article-editor [:reset]]]
-          [:dispatch [:rf.route/navigate {:to :realworld/home}]]]}))
+  {:doc "The DELETE's `:on-success`, carrying the nav-token it was issued
+         under. On the page that issued it, blank the editor and head home.
+         Once the reader has navigated away it is refused: the slice and the
+         machine now belong to whatever they did next — a new draft, say, which
+         this used to wipe before taking them home (WRITE OWNERSHIP above)."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token _reply]]
+    (when (rh/same-navigation? rt nav-token)
+      {:db (assoc db :editor (editor-slice))
+       :fx [[:dispatch [:ui/article-editor [:reset]]]
+            [:dispatch [:rf.route/navigate {:to :realworld/home}]]]})))
 
 (rf/reg-event :editor/delete-error
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    {:db (assoc-in db [:editor :submit-error] (rh/failure->message error))
-     :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]}))
+  {:doc "The DELETE's `:on-failure`, gated exactly as `:editor/delete-success`
+         is, so a departed delete cannot banner a newer editor's form."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [error]}]]
+    (when (rh/same-navigation? rt nav-token)
+      {:db (assoc-in db [:editor :submit-error] (rh/failure->message error))
+       :fx [[:dispatch [:ui/article-editor [:submit-failed]]]]})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/examples/real-apps/realworld_http/articles.cljs
+++ b/examples/real-apps/realworld_http/articles.cljs
@@ -235,7 +235,13 @@
 
          It also broadcasts `:fetch-started` into the home machine, nudging the
          `:data` region to `:loading` (or `:refreshing`, if a list is already
-         showing)."}
+         showing).
+
+         Supersession only fires between requests sharing one id, and Your
+         Feed's `:feed/load` is a different id feeding the SAME machine — so
+         both reply targets carry the nav-token this load was issued under,
+         and the settles refuse a reply whose navigation the reader has left
+         (REPLY OWNERSHIP, http.cljs)."}
   ;; The route lives in runtime-db. The 1-indexed `?page=` off the route query
   ;; becomes the wire's limit/offset window via `rh/paginate-path`, which also
   ;; URL-encodes the `:tag` filter. The active tag is a path param; the page is
@@ -247,7 +253,10 @@
           tag       (get-in current [:params :tag])
           page      (or (get-in current [:query :page]) 1)
           path      (rh/paginate-path "/articles" (when tag {:tag tag}) page)
-          has-data? (seq (get-in db [:articles :data]))]
+          has-data? (seq (get-in db [:articles :data]))
+          ;; Which navigation this load serves; both reply targets carry it
+          ;; (REPLY OWNERSHIP, http.cljs).
+          nav-token (rh/current-nav-token rt)]
       {:db (-> db
                (assoc-in [:articles :status] (if has-data? :fetching :loading))
                (assoc-in [:articles :error] nil)
@@ -259,45 +268,58 @@
                           :decode     schema/ArticlesResponse
                           :retry      rh/data-fetch-retry
                           :request-id :articles/load
-                          :on-success [:articles/loaded]
-                          :on-failure [:articles/load-failed]})]]})))
+                          :on-success [:articles/loaded nav-token]
+                          :on-failure [:articles/load-failed nav-token]})]]})))
 
 (rf/reg-event :articles/loaded
   {:doc "The fetch came back happy. Swap in the new list and clear any stale
          error. It arrives as `{:status :ok :value <ArticlesResponse>}` —
-         the same uniform reply shape every managed request returns. Folds the
-         fresh count into the home machine via `:fetch-succeeded`, and the
-         `:data` region's `:resolving` `:always` cascade takes it from there,
-         choosing `:empty` or `:some`."
+         the same uniform reply shape every managed request returns — after
+         the nav-token the request was issued under. Folds the fresh count into
+         the home machine via `:fetch-succeeded`, and the `:data` region's
+         `:resolving` `:always` cascade takes it from there, choosing `:empty`
+         or `:some`.
+
+         Gated on that nav-token first (`rh/same-navigation?`): a reply for a
+         navigation the reader has since left writes nothing and signals
+         nothing. The home machine is shared with Your Feed (favorites.cljs),
+         and its `:empty` / `:some` / `:error` states take no
+         `:fetch-succeeded` — so a departed reply that settled it first would
+         get the CURRENT reply ignored, and leave the page rendering the feed
+         the reader left."
    :rf.cofx/requires [:rf/time-ms]}
-  (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
-    (let [items (vec (:articles value))
-          ;; `articlesCount` is the GRAND total across all matching articles,
-          ;; not the size of this page — it's what the page count is computed
-          ;; from. If the server leaves it out, fall back to this page's size.
-          total (or (:articlesCount value) (count items))]
-      {:db (-> db
-               (assoc-in [:articles :status] :loaded)
-               (assoc-in [:articles :data] items)
-               (assoc-in [:articles :articles-count] total)
-               (assoc-in [:articles :error] nil)
-               (assoc-in [:articles :loaded-at] time-ms))
-       :fx [[:dispatch [:realworld/articles-home
-                        [:fetch-succeeded {:items items}]]]]})))
+  (fn [{:keys [db rf/time-ms] rt :rf.db/runtime} [_ nav-token {:keys [value]}]]
+    (when (rh/same-navigation? rt nav-token)
+      (let [items (vec (:articles value))
+            ;; `articlesCount` is the GRAND total across all matching articles,
+            ;; not the size of this page — it's what the page count is computed
+            ;; from. If the server leaves it out, fall back to this page's size.
+            total (or (:articlesCount value) (count items))]
+        {:db (-> db
+                 (assoc-in [:articles :status] :loaded)
+                 (assoc-in [:articles :data] items)
+                 (assoc-in [:articles :articles-count] total)
+                 (assoc-in [:articles :error] nil)
+                 (assoc-in [:articles :loaded-at] time-ms))
+         :fx [[:dispatch [:realworld/articles-home
+                          [:fetch-succeeded {:items items}]]]]}))))
 
 (rf/reg-event :articles/load-failed
   {:doc "The fetch failed. Hold on to whatever list was already showing (no
          point blanking the page over a hiccup) and surface a readable error
          message, projected from the failure map. Folds the failure into the
          home machine via `:fetch-failed`, sending the `:data` region to
-         `:error`."}
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    (let [message (rh/failure->message error)]
-      {:db (-> db
-               (assoc-in [:articles :status] :error)
-               (assoc-in [:articles :error] message))
-       :fx [[:dispatch [:realworld/articles-home
-                        [:fetch-failed {:failure message}]]]]})))
+         `:error`. Gated on the nav-token exactly as `:articles/loaded` is: a
+         departed failure would otherwise strand the shared machine in
+         `:error`, which ignores the current reply's `:fetch-succeeded`."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [error]}]]
+    (when (rh/same-navigation? rt nav-token)
+      (let [message (rh/failure->message error)]
+        {:db (-> db
+                 (assoc-in [:articles :status] :error)
+                 (assoc-in [:articles :error] message))
+         :fx [[:dispatch [:realworld/articles-home
+                          [:fetch-failed {:failure message}]]]]}))))
 
 (rf/reg-event :articles/cancel
   {:doc "Abort an in-flight :articles/load — say the user wanders off the home

--- a/examples/real-apps/realworld_http/favorites.cljs
+++ b/examples/real-apps/realworld_http/favorites.cljs
@@ -64,8 +64,11 @@
          via `rh/paginate-path` — the very same pagination the global feed
          uses."}
   (fn [{:keys [db] rt :rf.db/runtime} _]
-    (let [page (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
-          path (rh/paginate-path "/articles/feed" nil page)]
+    (let [page      (or (get-in rt [:rf.runtime/routing :current :query :page]) 1)
+          path      (rh/paginate-path "/articles/feed" nil page)
+          ;; Which navigation this load serves; both reply targets carry it
+          ;; (REPLY OWNERSHIP, http.cljs).
+          nav-token (rh/current-nav-token rt)]
       {:db (-> db
                (assoc-in [:feed :status]
                          (if (seq (get-in db [:feed :data])) :fetching :loading))
@@ -78,8 +81,8 @@
                           :decode     schema/ArticlesResponse
                           :retry      rh/data-fetch-retry
                           :request-id :feed/load
-                          :on-success [:feed/loaded]
-                          :on-failure [:feed/load-failed]})]]})))
+                          :on-success [:feed/loaded nav-token]
+                          :on-failure [:feed/load-failed nav-token]})]]})))
 
 (rf/reg-event :feed/cancel
   {:doc "Abort an in-flight :feed/load — say the user leaves before it lands.
@@ -92,29 +95,36 @@
 (rf/reg-event :feed/loaded
   {:doc "The user-feed fetch came back happy. Folds the new count into the home
          machine via `:fetch-succeeded`, and the `:data` region's `:resolving`
-         `:always` cascade takes it from there — `:empty` or `:some`."
+         `:always` cascade takes it from there — `:empty` or `:some`. Gated on
+         the nav-token the request was issued under, exactly as
+         `:articles/loaded` is and for the same reason: the two families settle
+         ONE home machine, so a reply for the feed the reader left must not
+         settle it for the feed they chose."
    :rf.cofx/requires [:rf/time-ms]}
-  (fn [{:keys [db rf/time-ms]} [_ {:keys [value]}]]
-    (let [items (vec (:articles value))
-          total (or (:articlesCount value) (count items))]
-      {:db (-> db
-               (assoc-in [:feed :status] :loaded)
-               (assoc-in [:feed :data] items)
-               (assoc-in [:feed :articles-count] total)
-               (assoc-in [:feed :loaded-at] time-ms))
-       :fx [[:dispatch [:realworld/articles-home
-                        [:fetch-succeeded {:items items}]]]]})))
+  (fn [{:keys [db rf/time-ms] rt :rf.db/runtime} [_ nav-token {:keys [value]}]]
+    (when (rh/same-navigation? rt nav-token)
+      (let [items (vec (:articles value))
+            total (or (:articlesCount value) (count items))]
+        {:db (-> db
+                 (assoc-in [:feed :status] :loaded)
+                 (assoc-in [:feed :data] items)
+                 (assoc-in [:feed :articles-count] total)
+                 (assoc-in [:feed :loaded-at] time-ms))
+         :fx [[:dispatch [:realworld/articles-home
+                          [:fetch-succeeded {:items items}]]]]}))))
 
 (rf/reg-event :feed/load-failed
   {:doc "The user-feed fetch didn't make it. Folds the failure into the home
-         machine via `:fetch-failed`, sending the `:data` region to `:error`."}
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    (let [message (rh/failure->message error)]
-      {:db (-> db
-               (assoc-in [:feed :status] :error)
-               (assoc-in [:feed :error] message))
-       :fx [[:dispatch [:realworld/articles-home
-                        [:fetch-failed {:failure message}]]]]})))
+         machine via `:fetch-failed`, sending the `:data` region to `:error`.
+         Gated on the nav-token exactly as `:feed/loaded` is."}
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [error]}]]
+    (when (rh/same-navigation? rt nav-token)
+      (let [message (rh/failure->message error)]
+        {:db (-> db
+                 (assoc-in [:feed :status] :error)
+                 (assoc-in [:feed :error] message))
+         :fx [[:dispatch [:realworld/articles-home
+                          [:fetch-failed {:failure message}]]]]}))))
 
 ;; ============================================================================
 ;; FAVORITES

--- a/examples/real-apps/realworld_http/http.cljs
+++ b/examples/real-apps/realworld_http/http.cljs
@@ -164,6 +164,35 @@
     out))
 
 ;; ============================================================================
+;; REPLY OWNERSHIP — which navigation issued this request?
+;; ============================================================================
+;;
+;; A managed request outlives the screen that sent it: the reply lands whenever
+;; the network says, and by then the reader may be somewhere else. The article
+;; page answers that with ROUTE identity (`reply-for-current-slug?` /
+;; `article-route-for-slug?`, comments.cljs), because its slices are keyed by
+;; the slug. Two surfaces have no such key. On the home page, Your Feed and the
+;; Global Feed are DIFFERENT request families settling ONE machine, so a reply
+;; from the feed the reader left can settle it for the feed they chose. In the
+;; editor, a fresh `/editor` draft has no slug at all, and returning to the same
+;; article is a new editing session. For those two the identity is the
+;; NAVIGATION itself — the committed route's `:nav-token`, which routing mints
+;; afresh on every navigation. The request captures it, the reply target
+;; carries it, and the settle acts only while it is still the current one.
+
+(defn current-nav-token
+  "The committed navigation's token, read off RUNTIME-db (handlers get it as the
+   `:rf.db/runtime` coeffect). Nil before the first navigation."
+  [rt]
+  (get-in rt [:rf.runtime/routing :current :nav-token]))
+
+(defn same-navigation?
+  "Was a reply's request issued under the navigation that is still current?
+   `nav-token` is what `current-nav-token` read when the request went out."
+  [rt nav-token]
+  (= nav-token (current-nav-token rt)))
+
+;; ============================================================================
 ;; CLOCK — the framework's recordable time fact (:rf/time-ms)
 ;; ============================================================================
 ;;

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -195,6 +195,36 @@
    [:can-submit? {:optional true} :boolean]
    [:submit-error [:maybe :string]]])
 
+;; ----------------------------------------------------------------------------
+;; DURABLE COMMENT — the wire Comment, plus the optimistic card's temp id
+;; ----------------------------------------------------------------------------
+
+(def TempCommentId
+  "The id an optimistically-posted comment wears until the server answers: the
+   `temp-<uuid>` string the recordable `:realworld/temp-comment-id` coeffect
+   mints (comments.cljs). A string by construction, so it can never collide
+   with a real Conduit comment id, which is an `:int`."
+  [:re #"^temp-"])
+
+(def DurableComment
+  "A comment as `[:comments :data]` STORES it: the wire `ws/Comment` with its
+   `:id` widened to admit the optimistic card's `TempCommentId` beside the
+   server's integer.
+
+   Wire and durable part here for the same kind of reason `ws/User` and
+   `ws/SessionUser` do. `:comment-form/submit` conjes the temp card into the
+   slice BEFORE the POST goes out, so validating the durable list against the
+   wire shape rejects that commit — and with the candidate discarded its `:fx`
+   go too, so the POST never leaves either. The decode schemas
+   (`ws/CommentResponse` / `ws/CommentsResponse`) stay strict: a server that
+   answers with a string id is still a broken reply.
+
+   Derived from `ws/Comment` rather than restated, so a field added to the wire
+   shape reaches this one too; the result is still plain vector-form Malli."
+  (into [:map [:id [:or :int TempCommentId]]]
+        (remove (fn [[k]] (= :id k)))
+        (rest ws/Comment)))
+
 ;; ============================================================================
 ;; SCHEMA REGISTRATION
 ;; ============================================================================
@@ -255,7 +285,9 @@
    ;; this one (profile.cljs, SERIALISING THE TOGGLE).
    [:profile.follow-pending]        [:maybe [:set :string]]
    [:comments]                      [:maybe RequestSlice]
-   [:comments :data]                [:maybe [:vector ws/Comment]]
+   ;; The DURABLE comment, not the wire one: the list holds the optimistic
+   ;; card under its temp id while the POST is out (see `DurableComment`).
+   [:comments :data]                [:maybe [:vector DurableComment]]
    [:feed]                          [:maybe RequestSlice]
    [:feed :data]                    [:maybe [:vector ws/Article]]
    [:comment-form]                  [:maybe FormSlice]

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -34,11 +34,13 @@
    Both continuations this page needs are call-site `:reply-to` targets — the
    very idiom settings.cljs uses — so the view has no off-render reactions at all.
    The save / delete success continuation (navigate to the saved article, or home
-   on a delete) is the mutation's `:reply-to [:editor/replied]`; the runtime
-   dispatches `[:editor/replied reply]` once, AFTER `:invalidates` staled the lists
-   and feed and the instance settled, and the continuation branches save-vs-delete
-   on the reply value (save and delete share one instance, so they share one
-   continuation). The seed-on-load continuation is the `:realworld/article`
+   on a delete) is the mutation's `:reply-to [:editor/replied nav-token]`; the
+   runtime dispatches `[:editor/replied nav-token reply]` once, AFTER
+   `:invalidates` staled the lists and feed and the instance settled, and the
+   continuation branches save-vs-delete on the reply value (save and delete share
+   one instance, so they share one continuation). The nav-token names the
+   navigation the write was issued under, so a reply that lands after the reader
+   has left the editor is refused rather than dragging them back. The seed-on-load continuation is the `:realworld/article`
    ensure's `:reply-to [:editor/article-loaded slug]`, the resource-read
    counterpart of a mutation completion continuation: a cache-hit fires it
    immediately, a fetch fires it on settle. The reply carries the slug it was for,
@@ -378,13 +380,39 @@
   (fn [{:keys [db]} [_ field]]
     {:db (update-in db [:editor :touched] (fnil conj #{}) field)}))
 
+;; ---- WRITE OWNERSHIP ----
+;;
+;; The mutation runs to completion wherever the reader goes. Releasing the
+;; route-owned article read on the way out does not retire an independent
+;; write, and a clean draft leaves the editor freely — so a save or delete can
+;; answer after the reader has moved on to a profile, or anywhere else. Its
+;; continuation writes the ONE `[:editor]` slice and navigates, so it acts only
+;; while the navigation that issued it is still the current one: the route's
+;; `:nav-token` rides the `:reply-to` target and is compared on the way back.
+;; A slug would not do — a `/editor` create draft has none, and returning to an
+;; article is a new session under the same slug.
+;;
+;; Entering another editor already covers the other half: `:editor/initialise`
+;; and `:editor/load-article` clear the shared `save-instance`, and the runtime
+;; suppresses a late result for a cleared instance, so the new session starts
+;; with usable controls and no continuation ever arrives for it. What remains is
+;; the detour to a page with no editor on it, and that is what the gate refuses.
+;; A refused reply touches nothing — not even the instance, which the next
+;; editor entry clears.
+
+(defn- current-nav-token
+  "The committed navigation's token, read off RUNTIME-db. Nil before the first
+   navigation."
+  [rt]
+  (get-in rt [:rf.runtime/routing :current :nav-token]))
+
 (rf/reg-event :editor/submit
   {:doc "Save the article. Reads the `:editor/can-submit?` FLOW output straight off
          app-db — a materialised derived value, consumed as plain data, no
          subscribe ceremony required. Valid-and-dirty fires the save mutation; an
          invalid draft re-runs validation to fill in the per-field error map; and
          valid-but-unchanged is a no-op."}
-  (fn [{:keys [db]} _]
+  (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [{:keys [slug draft]} (:editor db)
           can-submit? (get-in db [:editor :can-submit?])
           errors      (validate-draft draft)]
@@ -418,15 +446,18 @@
                            ;; delete share one instance, so they share one
                            ;; continuation that branches on the reply — `:value`
                            ;; carries the saved Article for a save; a delete comes
-                           ;; back with no body.
-                           :reply-to [:editor/replied]
+                           ;; back with no body. The target also carries the
+                           ;; issuing navigation's token (WRITE OWNERSHIP below).
+                           :reply-to [:editor/replied (current-nav-token rt)]
                            :cause    [:submit :editor/save]}]]]}))))
 
 (rf/reg-event :editor/replied
   {:doc "The save / delete completion continuation (the `:reply-to` target). It
-         receives the canonical reply map as its final arg, observed AFTER the
-         mutation's `:invalidates` staled the lists and feed and the instance
-         settled. On a successful SAVE (`:value` carries the saved `{:article …}`),
+         receives the nav-token the write was issued under, then the canonical
+         reply map as its final arg, observed AFTER the mutation's
+         `:invalidates` staled the lists and feed and the instance settled. A
+         reply for a navigation the reader has since left is refused whole
+         (WRITE OWNERSHIP above). On a successful SAVE (`:value` carries the saved `{:article …}`),
          re-seed the editor from the saved article so the draft reads as clean —
          that way the `:can-leave` guard won't block — clear the instance, and
          navigate to the article detail. On a successful DELETE (no `:article` in
@@ -436,9 +467,13 @@
          owner by hand (there is none; the route owns the read, routing.cljs). On
          `:error` there's nothing to do here; the form already shows it off the
          instance state."}
-  (fn [{:keys [db]} [_ {:keys [status value]}]]
+  (fn [{:keys [db] rt :rf.db/runtime} [_ nav-token {:keys [status value]}]]
     (cond
       (not= :ok status) {}
+
+      ;; Issued under a navigation the reader has since left: not this page's
+      ;; to act on (WRITE OWNERSHIP above).
+      (not= nav-token (current-nav-token rt)) {}
 
       (:article value)
       (let [article (:article value)]
@@ -459,13 +494,13 @@
   {:doc "Delete the article (edit mode only). Fires the delete mutation under the
          same instance the save uses, with the same `:reply-to [:editor/replied]`
          continuation — which branches save-vs-delete on the reply value."}
-  (fn [{:keys [db]} _]
+  (fn [{:keys [db] rt :rf.db/runtime} _]
     (when-let [slug (get-in db [:editor :slug])]
       {:fx [[:dispatch [:rf.mutation/execute
                         {:mutation :realworld/delete-article
                          :params   {:slug slug}
                          :instance save-instance
-                         :reply-to [:editor/replied]
+                         :reply-to [:editor/replied (current-nav-token rt)]
                          :cause    [:click :editor/delete slug]}]]]})))
 
 ;; ============================================================================

--- a/examples/real-apps/realworld_resources/article_editor.cljs
+++ b/examples/real-apps/realworld_resources/article_editor.cljs
@@ -40,8 +40,8 @@
    continuation branches save-vs-delete on the reply value (save and delete share
    one instance, so they share one continuation). The nav-token names the
    navigation the write was issued under, so a reply that lands after the reader
-   has left the editor is refused rather than dragging them back. The seed-on-load continuation is the `:realworld/article`
-   ensure's `:reply-to [:editor/article-loaded slug]`, the resource-read
+   has left the editor is refused rather than dragging them back. The
+   seed-on-load continuation is the `:realworld/article` ensure's `:reply-to [:editor/article-loaded slug]`, the resource-read
    counterpart of a mutation completion continuation: a cache-hit fires it
    immediately, a fetch fires it on settle. The reply carries the slug it was for,
    because per-slug reads are distinct cache entries with independent generations
@@ -457,8 +457,9 @@
          reply map as its final arg, observed AFTER the mutation's
          `:invalidates` staled the lists and feed and the instance settled. A
          reply for a navigation the reader has since left is refused whole
-         (WRITE OWNERSHIP above). On a successful SAVE (`:value` carries the saved `{:article …}`),
-         re-seed the editor from the saved article so the draft reads as clean —
+         (WRITE OWNERSHIP above). On a successful SAVE (`:value` carries the
+         saved `{:article …}`), re-seed the editor from the saved article so the
+         draft reads as clean —
          that way the `:can-leave` guard won't block — clear the instance, and
          navigate to the article detail. On a successful DELETE (no `:article` in
          the reply value), clear the slice and instance and head home. Both
@@ -492,8 +493,9 @@
 
 (rf/reg-event :editor/delete
   {:doc "Delete the article (edit mode only). Fires the delete mutation under the
-         same instance the save uses, with the same `:reply-to [:editor/replied]`
-         continuation — which branches save-vs-delete on the reply value."}
+         same instance the save uses, with the same
+         `:reply-to [:editor/replied nav-token]` continuation — which branches
+         save-vs-delete on the reply value."}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (when-let [slug (get-in db [:editor :slug])]
       {:fx [[:dispatch [:rf.mutation/execute

--- a/examples/real-apps/realworld_resources/mutations.cljs
+++ b/examples/real-apps/realworld_resources/mutations.cljs
@@ -209,7 +209,23 @@
 ;; read. The reply comes back as a full Profile, so `:populates` can seed the
 ;; banner right away rather than waiting for the refetch. The profile read is
 ;; viewer-scoped (its `:following` is relative to the acting viewer), so both the
-;; populate target and the invalidation descriptor name `{:from-db :realworld/viewer}`.
+;; populate target and the profile descriptor name `{:from-db :realworld/viewer}`.
+;;
+;; It ALSO changes who is in the acting user's Your Feed — that feed is exactly
+;; the articles of the authors they follow — so both writes stale the session
+;; `[:feed]` too, the same cross-scope reach favorite/unfavorite already have.
+;; Without it a feed visited within its freshness window is a cache-hit on
+;; re-entry, and still shows the old membership after the follow succeeded.
+
+(defn- follow-invalidates
+  "Invalidation targets for a follow / unfollow of `username`: the acting
+   viewer's `[:profile username]` read, and the session `[:feed]` whose
+   membership the follow set decides."
+  [username]
+  [{:scope {:from-db :realworld/viewer}
+    :tags  #{[:profile username]}}
+   {:scope {:from-db :realworld/session}
+    :tags  #{[:feed]}}])
 
 (rf/reg-mutation :realworld/follow
   {:doc           "Follow a user. POST /profiles/:username/follow."
@@ -219,8 +235,7 @@
    ;; flips immediately, on the acting viewer's own profile entry.
    :populates     (fn [{:keys [username]} result]
                     {{:resource :realworld/profile :params {:username username} :scope {:from-db :realworld/viewer}} result})
-   :invalidates   (fn [{:keys [username]} _result]
-                    [{:scope {:from-db :realworld/viewer} :tags #{[:profile username]}}])}
+   :invalidates   (fn [{:keys [username]} _result] (follow-invalidates username))}
   (fn [{:keys [username]} _ctx]
     {:request {:method :post :url (rh/full-url (str "/profiles/" username "/follow"))}
      :decode  schema/ProfileResponse}))
@@ -230,8 +245,7 @@
    :params-schema [:map [:username :string]]
    :populates     (fn [{:keys [username]} result]
                     {{:resource :realworld/profile :params {:username username} :scope {:from-db :realworld/viewer}} result})
-   :invalidates   (fn [{:keys [username]} _result]
-                    [{:scope {:from-db :realworld/viewer} :tags #{[:profile username]}}])}
+   :invalidates   (fn [{:keys [username]} _result] (follow-invalidates username))}
   (fn [{:keys [username]} _ctx]
     {:request {:method :delete :url (rh/full-url (str "/profiles/" username "/follow"))}
      :decode  schema/ProfileResponse}))

--- a/examples/real-apps/realworld_resources/views.cljs
+++ b/examples/real-apps/realworld_resources/views.cljs
@@ -185,10 +185,22 @@
                          :cause [:follow-author-detail-sync slug]}]]]}
       {})))
 
+(defn- article-route-for-slug?
+  "Is the ACTIVE ROUTE still the detail page for `slug`? True exactly when the
+   committed route is `:realworld.article/show` and its `:slug` param is this
+   one. Reads RUNTIME-db, where the route slice lives. The HTTP twin carries
+   the same predicate (realworld_http/comments.cljs)."
+  [rt slug]
+  (let [{:keys [route-id params]} (get-in rt [:rf.runtime/routing :current])]
+    (and (= :realworld.article/show route-id)
+         (= slug (:slug params)))))
+
 (rf/reg-event :ui/delete-article
   {:doc "Delete the current article from the detail page (author only). Fires the
          `:realworld/delete-article` mutation with a `:reply-to
-         [:ui/article-deleted]` continuation that navigates home on success."}
+         [:ui/article-deleted slug]` continuation that navigates home on success.
+         The target carries the slug the delete was issued on, so the
+         continuation can tell whether the reader is still on that article."}
   (fn [{:keys [db]} [_ slug]]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
@@ -196,19 +208,29 @@
                         {:mutation :realworld/delete-article
                          :params   {:slug slug}
                          :instance [:delete-article slug]
-                         :reply-to [:ui/article-deleted]
+                         :reply-to [:ui/article-deleted slug]
                          :cause    [:click :ui/delete-article slug]}]]]})))
 
 (rf/reg-event :ui/article-deleted
-  {:doc "Delete-article completion continuation (the `:reply-to` target). On `:ok`,
-         clear the delete instance and head home — by the time this fires, the
-         mutation's `:invalidates` has already staled the lists, the feed, and the
-         now-vanished article's detail. The reply carries the `:instance` to
-         clear."}
-  (fn [_ [_ {:keys [status instance]}]]
+  {:doc "Delete-article completion continuation (the `:reply-to` target), carrying
+         the slug the delete was issued on. On `:ok`, clear the delete instance —
+         by the time this fires, the mutation's `:invalidates` has already staled
+         the lists, the feed, and the now-vanished article's detail — and head
+         home, but ONLY while the reader is still on that article's page.
+
+         The mutation runs to completion wherever the reader goes: releasing the
+         article read on the way out does not retire an independent write. So a
+         delete answered after the reader moved to another article or a profile
+         still lands here, and taking them home would throw away the page they
+         chose. Asking the ROUTE rather than a cached slug is what makes a walk
+         to a non-article page visible. The clear stays unconditional: the
+         instance is this delete's own (`[:delete-article slug]`), and nothing
+         else will ever clear it."}
+  (fn [{rt :rf.db/runtime} [_ slug {:keys [status instance]}]]
     (if (= :ok status)
-      {:fx [[:dispatch [:rf.mutation/clear {:instance instance}]]
-            [:dispatch [:rf.route/navigate {:to :realworld/home}]]]}
+      {:fx (cond-> [[:dispatch [:rf.mutation/clear {:instance instance}]]]
+             (article-route-for-slug? rt slug)
+             (conj [:dispatch [:rf.route/navigate {:to :realworld/home}]]))}
       {})))
 
 ;; ============================================================================
@@ -485,8 +507,9 @@
 (reg-view ^{:doc "The article-detail page — a pure function of subs that never
                   dispatches out of band. The two settle continuations it needs are
                   the mutations' own `:reply-to` targets: deleting fires
-                  `:ui/delete-article` → `:reply-to [:ui/article-deleted]`
-                  (navigate home), and following the author fires
+                  `:ui/delete-article` → `:reply-to [:ui/article-deleted slug]`
+                  (navigate home, while still on this article), and following
+                  the author fires
                   `:ui/follow-author` → `:reply-to [:ui/follow-author-replied slug]`
                   (re-stale `[:article slug]` so the embedded author flag
                   refetches). No Form-3 wrapper, no off-render reaction."}

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -558,7 +558,9 @@
     ;; Authenticate first so this test exercises the optimistic-rollback
     ;; path it is here to cover.
     (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
-    (rf/dispatch-sync [:articles/loaded
+    ;; `nil` is the nav-token the reply carries: this frame never navigated,
+    ;; so nil IS the current navigation and the ownership gate admits it.
+    (rf/dispatch-sync [:articles/loaded nil
                        {:kind :success
                         :value {:articles [{:slug "hello"
                                             :title "Hello"
@@ -2815,7 +2817,9 @@
                         :fx-overrides {:rf.http/managed :realworld.test/favorite-ok}})]
     (rf/dispatch-sync [:articles/initialise] {:frame f})
     (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c" :token "jwt" :bio nil :image nil}] {:frame f})
-    (rf/dispatch-sync [:articles/loaded
+    ;; `nil` is the nav-token the reply carries: this frame never navigated,
+    ;; so nil IS the current navigation and the ownership gate admits it.
+    (rf/dispatch-sync [:articles/loaded nil
                        {:kind :success
                         :value {:articles [{:slug "hello" :title "Hello" :description "Short"
                                             :body "Body" :tagList [] :createdAt "x" :updatedAt "x"
@@ -3541,6 +3545,311 @@
             be latched at once, and an older settle — success or rollback —
             releases its own username alone (rf2-8icg)"
     (profile-follow-latch-does-not-leak-to-a-bystander-test)))
+
+;; ============================================================================
+;; comment schema, home-feed ownership, editor write ownership (rf2-fzbj.21)
+;; ============================================================================
+;;
+;; Three findings of one review, each a place where a candidate or a reply was
+;; judged against the wrong owner.
+;;
+;;   - COMMENT SCHEMA (rf2-gwye.33). Every comment row above runs on an anon
+;;     frame that registers no app schema, so none of them could see that the
+;;     optimistic card — `:id "temp-<uuid>"` — failed the wire `ws/Comment` the
+;;     app registered at `[:comments :data]`. In a development build that
+;;     rejects the whole `:comment-form/submit` candidate, fx included: no card,
+;;     and no POST. The row below registers the app's REAL schema registry on
+;;     its frame (the AuthSlice row explains why that is the only honest way)
+;;     and drives the real submit with its real temp-id supplier.
+;;
+;;   - HOME FEED OWNERSHIP (rf2-gwye.34). Your Feed (`:feed/load`) and the
+;;     Global Feed (`:articles/load`) carry DIFFERENT request ids, so neither
+;;     supersedes the other, and both settle the ONE `:realworld/articles-home`
+;;     machine. Its `:empty` / `:some` / `:error` states take no
+;;     `:fetch-succeeded`, so whichever reply landed first won — including one
+;;     for the feed the reader had already left.
+;;
+;;   - EDITOR WRITE OWNERSHIP (rf2-gwye.37). A clean editor leaves freely with a
+;;     save or delete still out, and the settle then wrote the ONE `[:editor]`
+;;     slice and navigated, whatever the reader had moved on to.
+;;
+;; All of it reuses `with-held-comment-fx`, the article page's held-request
+;; harness — comment-flavoured only in its name.
+
+(defn- comment-ids* [f]
+  (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+
+(defn- comment-posts
+  "Every captured comment POST to `slug`, in order."
+  [lowered slug]
+  (filterv #(and (= :post (get-in % [:request :method]))
+                 (str/ends-with? (get-in % [:request :url])
+                                 (str "/articles/" slug "/comments")))
+           lowered))
+
+(defn- app-db-rejections [traces]
+  (filter #(and (= :rf.error/schema-validation-failure (:operation %))
+                (= :app-db (-> % :tags :where)))
+          traces))
+
+(defn- comment-optimistic-card-under-app-schemas-test []
+  (with-held-comment-fx :realworld.test/comment-app-schemas
+    (fn [f lowered]
+      ;; The app's REAL registry on THIS frame — the very value schema.cljs
+      ;; binds to `:rf/default`.
+      (rf/reg-app-schemas app-schema/app-db-schemas {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-ok! f (:on-success (req-by-id @lowered [:comments/load "alpha"]))
+                  {:comments [(saved-comment 1 "First!")]})
+      (is (= [1] (comment-ids* f)) "alpha's one existing comment loaded under the app schemas")
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:comment-form/edit-field :body "Great read"] {:frame f})
+        (rf/dispatch-sync [:comment-form/submit] {:frame f})
+        (is (empty? (app-db-rejections @traces))
+            "the optimistic candidate passes the app's own schema — no :app-db rejection"))
+      (is (= 2 (count (comment-ids* f)))
+          "ONE optimistic card is on the list (rf2-gwye.33)")
+      (is (str/starts-with? (str (second (comment-ids* f))) "temp-")
+          "…under the real supplier's temp id, not one the test chose")
+      (is (= 1 (count (comment-posts @lowered "alpha")))
+          "…and exactly ONE POST went out — a rejected candidate took its fx with it")
+      (settle-ok! f (:on-success (first (comment-posts @lowered "alpha")))
+                  {:comment (saved-comment 7 "Great read")})
+      (is (= [1 7] (comment-ids* f))
+          "the saved comment replaces the temp card in place, under the server's id")
+      (is (= :idle (:status (comment-form* f))) "the form is released on success")
+      ;; A failed post takes its card back out and leaves the form usable.
+      (rf/dispatch-sync [:comment-form/edit-field :body "Second thoughts"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (is (= 3 (count (comment-ids* f))) "a second optimistic card is on the list")
+      (settle-fail! f (:on-failure (second (comment-posts @lowered "alpha"))))
+      (is (= [1 7] (comment-ids* f)) "a failed post removes its temp card")
+      (is (= :idle (:status (comment-form* f)))
+          "…the form is back at :idle, so the textarea and Post button are enabled")
+      (is (some? (:submit-error (comment-form* f))) "…with the failure surfaced")
+      (rf/dispatch-sync [:comment-form/edit-field :body "Try again"] {:frame f})
+      (is (= "Try again" (get-in (comment-form* f) [:draft :body]))
+          "…and typing still lands"))))
+
+(defn- comment-wire-schema-stays-strict-test []
+  (let [wire (saved-comment 1 "x")]
+    (is (true? (m/validate ws/Comment wire)) "an integer-id comment is a good wire comment")
+    (is (false? (m/validate ws/Comment (assoc wire :id "temp-1")))
+        "the WIRE Comment still rejects a string id — decode stays strict")
+    (is (false? (m/validate ws/CommentsResponse {:comments [(assoc wire :id "c-1")]}))
+        "…and so does the list envelope the GET decodes against")
+    (is (true? (m/validate app-schema/DurableComment (assoc wire :id "temp-1")))
+        "the DURABLE comment admits the optimistic card's temp id")
+    (is (false? (m/validate app-schema/DurableComment (assoc wire :id "c-1")))
+        "…and only a temp id: any other string is still refused")))
+
+(defn- home-render* [f] (rf/compute-sub [:articles.home/render] (rf/frame-state-value f)))
+
+(defn- home-state* [f]
+  (get-in (:rf.db/runtime (rf/frame-state-value f))
+          [:rf.runtime/machines :snapshots :realworld/articles-home :state]))
+
+(defn- home-slugs* [f]
+  (mapv :slug (rf/compute-sub [:articles.home/active-articles] (rf/frame-state-value f))))
+
+(defn- last-req-by-id
+  "The most recent captured request carrying `:request-id` id. A re-issued read
+   (same id, new page) is the LAST one, not the first."
+  [lowered id]
+  (last (filter #(= id (:request-id %)) lowered)))
+
+(defn- articles-of [& slugs]
+  {:articles (mapv #(full-article % (str "Title " %)) slugs) :articlesCount (count slugs)})
+
+(defn- walk-home! [f from to]
+  (rf/dispatch-sync [:rf.route/handle-url-change from] {:frame f})
+  (rf/dispatch-sync [:rf.route/handle-url-change to] {:frame f}))
+
+(defn- home-feed-departed-reply-is-refused-test []
+  (testing "Your Feed → Global Feed: the departed EMPTY feed reply lands first"
+    (with-held-comment-fx :realworld.test/home-feed-to-global
+      (fn [f lowered]
+        (walk-home! f "/?feed=following" "/")
+        (is (= :global (:feed (home-state* f))) "the reader is on the Global Feed")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :feed/load)) (articles-of))
+        (is (= :loading (:data (home-state* f)))
+            "the departed Your Feed reply does not settle the shared machine (rf2-gwye.34)")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :articles/load))
+                    (articles-of "hello-conduit"))
+        (is (= :some (home-render* f))
+            "the Global Feed settles from its OWN reply and renders its articles")
+        (is (= ["hello-conduit"] (home-slugs* f))))))
+  (testing "Global Feed → Your Feed: the departed EMPTY global reply lands first"
+    (with-held-comment-fx :realworld.test/home-global-to-feed
+      (fn [f lowered]
+        (walk-home! f "/" "/?feed=following")
+        (is (= :user-feed (:feed (home-state* f))) "the reader is on Your Feed")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :articles/load)) (articles-of))
+        (settle-ok! f (:on-success (last-req-by-id @lowered :feed/load))
+                    (articles-of "followed-article"))
+        (is (= :some (home-render* f)) "Your Feed renders its own articles")
+        (is (= ["followed-article"] (home-slugs* f))))))
+  (testing "a departed FAILURE landing first does not strand the machine in :error"
+    (with-held-comment-fx :realworld.test/home-feed-fail-first
+      (fn [f lowered]
+        (walk-home! f "/?feed=following" "/")
+        (settle-fail! f (:on-failure (last-req-by-id @lowered :feed/load)))
+        (is (not= :error (:data (home-state* f))) "the departed failure is refused")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :articles/load))
+                    (articles-of "hello-conduit"))
+        (is (= :some (home-render* f)) "the current reply still settles and renders"))))
+  (testing "a departed reply landing AFTER the current one changes nothing"
+    (with-held-comment-fx :realworld.test/home-feed-late-after
+      (fn [f lowered]
+        (walk-home! f "/?feed=following" "/")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :articles/load))
+                    (articles-of "hello-conduit"))
+        (settle-ok! f (:on-success (last-req-by-id @lowered :feed/load)) (articles-of))
+        (settle-fail! f (:on-failure (last-req-by-id @lowered :feed/load)))
+        (is (= :some (home-render* f)) "the Global Feed is still what renders")
+        (is (= ["hello-conduit"] (home-slugs* f))))))
+  (testing "control: a same-feed page change — the current page's reply renders"
+    (with-held-comment-fx :realworld.test/home-feed-page-change
+      (fn [f lowered]
+        (walk-home! f "/" "/?page=2")
+        (settle-ok! f (:on-success (last-req-by-id @lowered :articles/load))
+                    (articles-of "page-two"))
+        (is (= :some (home-render* f)) "the current page's reply settles the machine")
+        (is (= ["page-two"] (home-slugs* f)) "…and its articles are the ones on screen")))))
+
+(defn- editor-slice* [f] (rf/compute-sub [:editor/slice] (rf/frame-state-value f)))
+(defn- route-id* [f] (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+
+(defn- open-clean-editor!
+  "Open /editor/<slug> and settle its held GET, leaving a clean edit draft."
+  [f lowered slug]
+  (rf/dispatch-sync [:rf.route/handle-url-change (str "/editor/" slug)] {:frame f})
+  (settle-ok! f (:on-success (last-req-by-id @lowered [:editor/load-article slug]))
+              {:article (full-article slug (str "Title " slug))})
+  (is (= slug (:slug (editor-slice* f))) (str "the editor holds " slug))
+  (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f)))
+      "…as a clean draft, so leaving needs no confirmation"))
+
+(defn- editor-delete! [f lowered slug]
+  (rf/dispatch-sync [:editor/delete] {:frame f})
+  (let [del (req-by-method+url @lowered :delete (str "/articles/" slug))]
+    (is (some? del) (str slug "'s DELETE went out and is held"))
+    (is (true? (ed-has-tag? f :editor/busy)) "the editor is busy while it is out")
+    del))
+
+(defn- editor-late-delete-keeps-a-newer-draft-test []
+  (with-held-comment-fx :realworld.test/editor-late-delete-new-draft
+    (fn [f lowered]
+      (open-clean-editor! f lowered "alpha")
+      (let [del (editor-delete! f lowered "alpha")]
+        ;; The reader gives up waiting and starts a new article.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/editor"] {:frame f})
+        (rf/dispatch-sync [:editor/edit-field :title "New unsaved draft"] {:frame f})
+        (settle-ok! f (:on-success del) nil)
+        (is (= :realworld.editor/new (route-id* f))
+            "a LATE delete success does not take the reader home (rf2-gwye.37)")
+        (is (= "New unsaved draft" (get-in (editor-slice* f) [:draft :title]))
+            "…and does not wipe the new draft they are typing")
+        (is (false? (ed-has-tag? f :editor/busy))
+            "…and the new session's controls stay usable")))))
+
+(defn- editor-late-delete-after-a-profile-detour-test []
+  (with-held-comment-fx :realworld.test/editor-late-delete-profile
+    (fn [f lowered]
+      (open-clean-editor! f lowered "alpha")
+      (let [del (editor-delete! f lowered "alpha")]
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+        (settle-ok! f (:on-success del) nil)
+        (is (= :realworld.profile/show (route-id* f))
+            "a LATE delete success does not yank the reader off the profile they chose")
+        (is (= {:username "eve"} (route-params* f)) "…their own route stands")
+        ;; The strand control: the refused settle never reset the machine, so
+        ;; the next editing session has to start clean on its own.
+        (open-clean-editor! f lowered "beta")
+        (is (false? (ed-has-tag? f :editor/busy))
+            "a new editing session is not left busy by the departed delete")
+        (is (true? (ed-has-tag? f :lifecycle/idle)) "…its own load settled it to :idle")))))
+
+(defn- editor-late-failure-and-save-are-refused-test []
+  (testing "a departed DELETE's failure does not banner a newer editor"
+    (with-held-comment-fx :realworld.test/editor-late-delete-fail
+      (fn [f lowered]
+        (open-clean-editor! f lowered "alpha")
+        (let [del (editor-delete! f lowered "alpha")]
+          (rf/dispatch-sync [:rf.route/handle-url-change "/editor"] {:frame f})
+          (rf/dispatch-sync [:editor/edit-field :title "New unsaved draft"] {:frame f})
+          (settle-fail! f (:on-failure del))
+          (is (nil? (:submit-error (editor-slice* f)))
+              "alpha's late DELETE failure does not banner the new draft's form")
+          (is (true? (ed-has-tag? f :lifecycle/idle)) "…nor move its lifecycle")
+          (is (= "New unsaved draft" (get-in (editor-slice* f) [:draft :title])))))))
+  (testing "a departed SAVE's success neither re-seeds the editor nor navigates"
+    (with-held-comment-fx :realworld.test/editor-late-save
+      (fn [f lowered]
+        (open-clean-editor! f lowered "alpha")
+        (rf/dispatch-sync [:editor/edit-field :title "Alpha, edited"] {:frame f})
+        (rf/dispatch-sync [:editor/submit] {:frame f})
+        (let [put (req-by-method+url @lowered :put "/articles/alpha")]
+          (is (some? put) "alpha's PUT went out and is held")
+          ;; The draft is still dirty while the save is out, so leaving asks
+          ;; first; the reader confirms, as the shell's dialog would.
+          (rf/dispatch-sync [:rf.route/navigate {:to :realworld.profile/show
+                                                 :params {:username "eve"}}]
+                            {:frame f})
+          (let [pending (rf/compute-sub [:rf/pending-navigation] (rf/frame-state-value f))]
+            (is (some? pending) "the dirty draft's :can-leave guard held the navigation")
+            (rf/dispatch-sync [:rf.route/continue (:id pending)] {:frame f}))
+          (is (= :realworld.profile/show (route-id* f)) "the reader confirmed and left")
+          (settle-ok! f (:on-success put) {:article (full-article "alpha" "Alpha, edited")})
+          (is (= :realworld.profile/show (route-id* f))
+              "a LATE save success does not drag the reader to the article (rf2-gwye.37)")
+          (is (= {:username "eve"} (route-params* f)) "…their own route stands"))))))
+
+(defn- editor-current-owner-settles-still-land-test []
+  (testing "on the issuing page a DELETE failure still banners and frees the form"
+    (with-held-comment-fx :realworld.test/editor-current-delete-fail
+      (fn [f lowered]
+        (open-clean-editor! f lowered "alpha")
+        (settle-fail! f (:on-failure (editor-delete! f lowered "alpha")))
+        (is (some? (:submit-error (editor-slice* f))) "the failure is surfaced on the form")
+        (is (false? (ed-has-tag? f :editor/busy)) "…and the form is usable again"))))
+  (testing "on the issuing page a held DELETE success still blanks the editor and goes home"
+    (with-held-comment-fx :realworld.test/editor-current-delete-ok
+      (fn [f lowered]
+        (open-clean-editor! f lowered "alpha")
+        (settle-ok! f (:on-success (editor-delete! f lowered "alpha")) nil)
+        (is (= :realworld/home (route-id* f)) "the gate is not vacuous — the delete goes home")
+        (is (nil? (:slug (editor-slice* f))) "…with the editor blanked"))))
+  (testing "on the issuing page a held SAVE success still opens the saved article"
+    (with-held-comment-fx :realworld.test/editor-current-save-ok
+      (fn [f lowered]
+        (open-clean-editor! f lowered "alpha")
+        (rf/dispatch-sync [:editor/edit-field :title "Alpha, edited"] {:frame f})
+        (rf/dispatch-sync [:editor/submit] {:frame f})
+        (settle-ok! f (:on-success (req-by-method+url @lowered :put "/articles/alpha"))
+                    {:article (full-article "alpha" "Alpha, edited")})
+        (is (= :realworld.article/show (route-id* f)) "the save opens the saved article")
+        (is (= {:slug "alpha"} (route-params* f)))))))
+
+(deftest realworld-comment-feed-and-editor-ownership
+  (testing "the optimistic comment passes the PRODUCTION app schemas: one card, one
+            POST, then the server's id; a failure removes the card and frees the form
+            (rf2-gwye.33)"
+    (comment-optimistic-card-under-app-schemas-test))
+  (testing "the wire Comment stays strict; only the durable shape admits a temp id"
+    (comment-wire-schema-stays-strict-test))
+  (testing "a departed home-feed reply cannot settle the machine for the current
+            feed, in either direction (rf2-gwye.34)"
+    (home-feed-departed-reply-is-refused-test))
+  (testing "a late editor DELETE keeps the newer draft and its route (rf2-gwye.37)"
+    (editor-late-delete-keeps-a-newer-draft-test))
+  (testing "a late editor DELETE leaves a profile detour alone, and the next session
+            is not left busy"
+    (editor-late-delete-after-a-profile-detour-test))
+  (testing "a departed failure or save cannot reach a newer page"
+    (editor-late-failure-and-save-are-refused-test))
+  (testing "on the issuing page, save and delete settles still land"
+    (editor-current-owner-settles-still-land-test)))
 
 ;; ============================================================================
 ;; http — failure->message + pure pagination/query helpers

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -3632,15 +3632,18 @@
           "…and typing still lands"))))
 
 (defn- comment-wire-schema-stays-strict-test []
-  (let [wire (saved-comment 1 "x")]
+  (let [wire    (saved-comment 1 "x")
+        ;; Whatever the app registers for the durable list — asked by PATH, so
+        ;; this reads the registry the validator reads, not a name for it.
+        durable (get app-schema/app-db-schemas [:comments :data])]
     (is (true? (m/validate ws/Comment wire)) "an integer-id comment is a good wire comment")
     (is (false? (m/validate ws/Comment (assoc wire :id "temp-1")))
         "the WIRE Comment still rejects a string id — decode stays strict")
     (is (false? (m/validate ws/CommentsResponse {:comments [(assoc wire :id "c-1")]}))
         "…and so does the list envelope the GET decodes against")
-    (is (true? (m/validate app-schema/DurableComment (assoc wire :id "temp-1")))
-        "the DURABLE comment admits the optimistic card's temp id")
-    (is (false? (m/validate app-schema/DurableComment (assoc wire :id "c-1")))
+    (is (true? (m/validate durable [wire (assoc wire :id "temp-1")]))
+        "the DURABLE [:comments :data] admits the optimistic card's temp id")
+    (is (false? (m/validate durable [(assoc wire :id "c-1")]))
         "…and only a temp id: any other string is still refused")))
 
 (defn- home-render* [f] (rf/compute-sub [:articles.home/render] (rf/frame-state-value f)))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -648,7 +648,11 @@
         (is (true? (rf/compute-sub [:editor/can-leave?] (state-value f)))
             "after the save reply re-seeds the baseline, the draft is clean → can leave")
         (is (false? (rf/compute-sub [:editor/dirty?] (state-value f)))
-            "the saved draft is no longer dirty")))))
+            "the saved draft is no longer dirty")
+        ;; The ownership control for rf2-gwye.39: this save was issued and
+        ;; answered under ONE navigation, so its continuation still navigates.
+        (is (= :realworld.article/show (route-id f))
+            "on its own page the save continuation still opens the saved article")))))
 
 (defn- saved-tag-list
   "The `:tagList` the save actually put on the wire — read off the lowered
@@ -1844,22 +1848,236 @@
         (is (or (contains? #{:loading :fetching} (:status ae)) (some? (:invalidated-at ae)))
             ":ui/follow-author-replied re-staled [:article slug] → the detail refetches")))))
 
+;; ----------------------------------------------------------------------------
+;; A write outlives the page that issued it (rf2-fzbj.21)
+;; ----------------------------------------------------------------------------
+;;
+;; A mutation runs to completion wherever the reader goes: leaving a page
+;; releases the reads the ROUTE owns, never an independent write. So every
+;; continuation that navigates or writes page-local state has to ask whether
+;; the reader is still on the page that issued it. The detail-page delete asks
+;; the route (`[:ui/article-deleted slug]`, rf2-gwye.42); the editor asks the
+;; navigation (`[:editor/replied nav-token]`, rf2-gwye.39), because a create
+;; draft has no slug to ask about.
+
+(defn- delete-alpha-then-walk-to!
+  "Open /article/alpha, click Delete (the write is held open), then — when a
+   `detour` route request is given — walk there before the server answers.
+   Returns the held delete request."
+  [f detour]
+  (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug "alpha"}}]
+                    {:frame f})
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:ui/delete-article "alpha"] {:frame f})
+  (let [del @last-managed-args]
+    (is (= :delete (get-in del [:request :method])) "alpha's delete write went out and is held")
+    (when detour
+      (rf/dispatch-sync [:rf.route/navigate detour] {:frame f}))
+    del))
+
+(defn- alpha-delete-status [f]
+  (:status (rf/compute-sub [:rf/mutation {:instance [:delete-article "alpha"]}] (state-value f))))
+
 (deftest delete-article-continuation-navigates-home
   (testing "examples/real-apps/realworld_resources — :ui/delete-article fires the
-            :realworld/delete-article mutation with :reply-to [:ui/article-deleted];
-            the continuation clears the instance and navigates home on :ok"
-    (with-new-frame [f (rf.frame/make-anon-frame-record! {:url-bound? true
-                                       :fx-overrides {:rf.nav/push-url :rf/no-op}})]
+            :realworld/delete-article mutation with :reply-to [:ui/article-deleted slug];
+            settled while the reader is still ON that article, the continuation
+            clears the instance and navigates home"
+    (with-new-frame [f (guarded-frame!)]
       (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
-      ;; Land somewhere other than home so the navigate-home is observable.
-      (rf/dispatch-sync [:rf.route/navigate {:to :realworld.auth/register}] {:frame f})
-      (is (= :realworld.auth/register (route-id f)))
+      (let [del (delete-alpha-then-walk-to! f nil)]
+        (is (= :realworld.article/show (route-id f)) "still on alpha while the write is out")
+        (reply-success! del {} f)
+        (is (= :realworld/home (route-id f))
+            ":ui/article-deleted navigates home on a successful delete from its own page")
+        (is (not= :success (alpha-delete-status f))
+            "…and clears the completed delete instance")))))
+
+(deftest delete-article-continuation-leaves-a-departed-reader-where-they-are
+  (testing "examples/real-apps/realworld_resources — walk from alpha to another
+            article or to a profile before the server answers, and the late
+            success leaves the reader on the page they chose (rf2-gwye.42); the
+            completed instance is still cleared"
+    (doseq [[label detour expect-id expect-params]
+            [["alpha → beta" {:to :realworld.article/show :params {:slug "beta"}}
+              :realworld.article/show {:slug "beta"}]
+             ["alpha → profile/eve" {:to :realworld.profile/show :params {:username "eve"}}
+              :realworld.profile/show {:username "eve"}]]]
+      (testing label
+        (with-new-frame [f (guarded-frame!)]
+          (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+          (let [del (delete-alpha-then-walk-to! f detour)]
+            (is (= expect-id (route-id f)) "the reader has left alpha")
+            (reply-success! del {} f)
+            (is (= expect-id (route-id f))
+                "a LATE delete success does not take the reader home")
+            (is (= expect-params (route-params f)) "…their own newer route stands")
+            (is (not= :success (alpha-delete-status f))
+                "…and the completed delete's instance is still cleared"))))))
+  (testing "a failed delete navigates nowhere, and navigation still works after it"
+    (with-new-frame [f (guarded-frame!)]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (let [del (delete-alpha-then-walk-to! f nil)]
+        (rf/dispatch-sync (conj (:on-failure del)
+                                {:status :error :error {:kind :rf.http/http-5xx :status 500}})
+                          {:frame f})
+        (is (= {:slug "alpha"} (route-params f)) "a failed delete stays on alpha")
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug "beta"}}]
+                          {:frame f})
+        (is (= {:slug "beta"} (route-params f)) "…and the reader can still move on")))))
+
+(deftest editor-write-continuations-stay-with-the-page-that-issued-them
+  (testing "examples/real-apps/realworld_resources — a DELETE answered after a detour
+            to a profile leaves the reader there and the editor slice alone
+            (rf2-gwye.39)"
+    (with-new-frame [f (guarded-frame!)]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/edit :params {:slug "doomed"}}]
+                        {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "doomed" :title "Doomed" :description "d"
+                                 :body "b" :tagList []}}
+                      f)
       (reset! last-managed-args nil)
-      (rf/dispatch-sync [:ui/delete-article "hello-conduit"] {:frame f})
-      (is (some? @last-managed-args) "the delete mutation lowered a write")
-      (reply-success! @last-managed-args {} f)
-      (is (= :realworld/home (route-id f))
-          ":ui/article-deleted navigates home on a successful delete"))))
+      (rf/dispatch-sync [:editor/delete] {:frame f})
+      (let [del @last-managed-args]
+        (is (= :delete (get-in del [:request :method])) "the delete write went out and is held")
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld.profile/show
+                                               :params {:username "eve"}}]
+                          {:frame f})
+        (is (= :realworld.profile/show (route-id f)) "the clean editor let the reader leave")
+        (reply-success! del {} f)
+        (is (= :realworld.profile/show (route-id f))
+            "the late delete continuation does not take the reader home")
+        (is (= {:username "eve"} (route-params f)) "…their own route stands")
+        (is (= "doomed" (rf/compute-sub [:editor/slug] (state-value f)))
+            "…and the editor slice it no longer owns is not rewritten"))))
+  (testing "a SAVE answered after a confirmed leave neither re-seeds the editor nor
+            navigates"
+    (with-new-frame [f (guarded-frame!)]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:editor/register-flow] {:frame f})
+      (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/new}] {:frame f})
+      (rf/dispatch-sync [:editor/edit-field :title "New Title"] {:frame f})
+      (rf/dispatch-sync [:editor/edit-field :description "A desc"] {:frame f})
+      (rf/dispatch-sync [:editor/edit-field :body "Some body"] {:frame f})
+      (reset! last-managed-args nil)
+      (rf/dispatch-sync [:editor/submit] {:frame f})
+      (let [save @last-managed-args]
+        (is (= :post (get-in save [:request :method])) "the create write went out and is held")
+        ;; Still dirty while the save is out, so leaving asks first; the reader
+        ;; confirms, as the shell's dialog would.
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld.profile/show
+                                               :params {:username "eve"}}]
+                          {:frame f})
+        (let [pending (rf/compute-sub [:rf/pending-navigation] (state-value f))]
+          (is (some? pending) "the dirty draft's :can-leave guard held the navigation")
+          (rf/dispatch-sync [:rf.route/continue (:id pending)] {:frame f}))
+        (is (= :realworld.profile/show (route-id f)) "the reader confirmed the leave")
+        (reply-success! save {:article {:slug "new-title" :title "New Title"
+                                        :description "A desc" :body "Some body"
+                                        :tagList []}}
+                        f)
+        (is (= :realworld.profile/show (route-id f))
+            "a LATE save continuation does not drag the reader to the saved article")
+        (is (nil? (rf/compute-sub [:editor/slug] (state-value f)))
+            "…nor re-seed the editor slice with the saved article"))))
+  (testing "control: entering a NEW editor clears the shared instance, so the old
+            delete's reply never lands and the new session's controls are usable"
+    (with-new-frame [f (guarded-frame!)]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/edit :params {:slug "doomed"}}]
+                        {:frame f})
+      (reply-success! @last-managed-args
+                      {:article {:slug "doomed" :title "Doomed" :description "d"
+                                 :body "b" :tagList []}}
+                      f)
+      (reset! last-managed-args nil)
+      (rf/dispatch-sync [:editor/delete] {:frame f})
+      (let [del  @last-managed-args
+            save #(rf/compute-sub [:rf/mutation {:instance :editor/save}] (state-value f))]
+        (is (true? (:pending? (save))) "the delete is in flight")
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld.editor/new}] {:frame f})
+        (is (not (:pending? (save))) "the new session's save control is not busy")
+        (reply-success! del {} f)
+        (is (= :realworld.editor/new (route-id f))
+            "the late delete does not take the new draft's reader home")))))
+
+(defn- feed-requests
+  "Every logged managed-HTTP request for the session feed, in order."
+  []
+  (filterv #(str/includes? (str (get-in % [:request :url])) "/articles/feed")
+           @managed-args-log))
+
+(defn- feed-article [slug author]
+  {:slug slug :title (str "Title " slug) :description "d" :body "b" :tagList []
+   :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+   :author {:username author :bio nil :image nil :following true}})
+
+(defn- follow-then-reenter-feed!
+  "Visit Your Feed and settle it with `before`, walk to `detour`, fire
+   `follow-event` and settle its write with `profile`, then come straight back
+   to Your Feed — well inside its freshness window. Returns how many NEW feed
+   requests the re-entry lowered."
+  [f before detour follow-event profile]
+  (rf/dispatch-sync [:rf.route/navigate {:to :realworld/home :query {:feed "following"}}]
+                    {:frame f})
+  (reply-success! (last (feed-requests)) before f)
+  (is (= :loaded (:status (entry f (feed-key "alice" 1)))) "Your Feed is loaded and cached")
+  (rf/dispatch-sync [:rf.route/navigate detour] {:frame f})
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync follow-event {:frame f})
+  (let [write @last-managed-args]
+    (is (str/includes? (str (get-in write [:request :url])) "/profiles/eve/follow")
+        "the follow write went out")
+    (reply-success! write {:profile profile} f))
+  (let [seen (count (feed-requests))]
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld/home :query {:feed "following"}}]
+                      {:frame f})
+    (- (count (feed-requests)) seen)))
+
+(deftest follow-and-unfollow-restale-the-session-feed
+  (testing "examples/real-apps/realworld_resources — Your Feed is exactly the
+            articles of the authors you follow, so a follow or unfollow stales the
+            session [:feed] alongside the viewer's [:profile username]
+            (rf2-gwye.35). Without it a feed visited in the last minute is a
+            cache-hit on re-entry, still showing the old membership"
+    (testing "follow from the PROFILE page: an empty cached feed refetches and shows the author"
+      (with-new-frame [f (guarded-frame!)]
+        (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+        (is (= 1 (follow-then-reenter-feed!
+                   f {:articles [] :articlesCount 0}
+                   {:to :realworld.profile/show :params {:username "eve"}}
+                   [:ui/follow "eve" false]
+                   {:username "eve" :bio "" :image "" :following true}))
+            "re-entering Your Feed FETCHES — the follow staled it")
+        (is (true? (-> (entry f (profile-key "eve")) :data :profile :following))
+            "control: the banner was still populated straight from the reply")
+        (reply-success! (last (feed-requests))
+                        {:articles [(feed-article "eve-post" "eve")] :articlesCount 1} f)
+        (is (= ["eve-post"] (mapv :slug (-> (entry f (feed-key "alice" 1)) :data :articles)))
+            "…and the feed now shows the newly followed author's article")))
+    (testing "follow from the ARTICLE page reaches the feed too"
+      (with-new-frame [f (guarded-frame!)]
+        (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+        (is (= 1 (follow-then-reenter-feed!
+                   f {:articles [] :articlesCount 0}
+                   {:to :realworld.article/show :params {:slug "hello-conduit"}}
+                   [:ui/follow-author "hello-conduit" "eve" false]
+                   {:username "eve" :bio "" :image "" :following true}))
+            "re-entering Your Feed FETCHES after a follow from the article page")))
+    (testing "unfollow: a populated cached feed refetches and drops the author"
+      (with-new-frame [f (guarded-frame!)]
+        (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+        (is (= 1 (follow-then-reenter-feed!
+                   f {:articles [(feed-article "eve-post" "eve")] :articlesCount 1}
+                   {:to :realworld.profile/show :params {:username "eve"}}
+                   [:ui/follow "eve" true]
+                   {:username "eve" :bio "" :image "" :following false}))
+            "re-entering Your Feed FETCHES — the unfollow staled it")
+        (reply-success! (last (feed-requests)) {:articles [] :articlesCount 0} f)
+        (is (empty? (-> (entry f (feed-key "alice" 1)) :data :articles))
+            "…and the unfollowed author's article is gone")))))
 
 (deftest auth-guard-return-to-preserves-full-address
   ;; rf2-78x8j (twin of rf2-k5zty in realworld_http) — the return-to stash is the


### PR DESCRIPTION
## Summary

Fixes the four confirmed RealWorld defects of rf2-fzbj.21, one per rf2-gwye child. Examples stay test-free; the regression rows live in the adapter-level harnesses.

- **rf2-gwye.33 (HTTP): the optimistic comment failed the app's own schema.** `[:comments :data]` was registered as `[:vector ws/Comment]`, whose `:id` is `:int`. The optimistic card's `temp-<uuid>` id failed it, and in a development build the rejected candidate took its POST with it. A new `DurableComment` (the wire `Comment` with `:id [:or :int [:re #"^temp-"]]`, derived from it rather than restated) is registered there instead. The decode schemas `ws/Comment`, `ws/CommentResponse` and `ws/CommentsResponse` stay strict.
- **rf2-gwye.34 (HTTP): a departed feed reply settled the home machine for the current feed.** Your Feed (`:feed/load`) and the Global Feed (`:articles/load`) settle one machine under different request ids, so neither supersedes the other, and the machine's `:empty` / `:some` / `:error` states take no `:fetch-succeeded`. Both families now carry the issuing navigation's `:nav-token` on their reply targets, and `loaded` / `load-failed` refuse a reply whose navigation the reader has left (`rh/same-navigation?`).
- **rf2-gwye.35 (Resources): follow/unfollow left a fresh Your Feed unchanged.** Both mutations now invalidate `{:from-db :realworld/session} #{[:feed]}` beside the viewer's `[:profile username]`, the same cross-scope reach favorite/unfavorite already had.
- **rf2-gwye.37 (HTTP editor) and rf2-gwye.39 (Resources editor): late save/delete settles erased newer drafts and navigated.** Their reply targets carry the issuing nav-token and every settle is gated on it. A slug cannot name the session: a `/editor` create draft has none, and returning to an article is a new session under the same slug. The HTTP `/editor/:slug` entry now also resets the editor machine, so a refused settle cannot leave the next session busy with its inputs locked.
- **rf2-gwye.42 (Resources detail delete): a late delete navigated home unconditionally.** `:ui/delete-article` carries its slug; the continuation clears its own instance on `:ok` and navigates home only while the route is still that article's `:realworld.article/show`, mirroring the HTTP twin's `article-route-for-slug?`.

Two existing rows changed as a consequence, both in the test tree:
- Resources `delete-article-continuation-navigates-home` issued its delete from `/register` and expected home — exactly the departed-page case gwye.42 says must be refused. It now issues the delete from the article page, and the departed cases are a new test beside it.
- Two HTTP rows that dispatch `[:articles/loaded …]` directly now pass the nav-token (`nil` on a frame that never navigated).

Nothing else from the review was built: rf2-gwye.34's optional "shared request identity / cancel" is not added (the ownership gate alone closes the defect, and a cancellation scheme is the machinery these examples exist to stay clear of), and rf2-gwye.39's "scope any cleanup to the completed operation" is met by a refused reply touching nothing at all, rather than by a new incarnation id.

## Quality gates

Run from the worktree on the final rebased base (`origin/main` at the time of the run), each exit code captured to a file and quoted from it:

- `npm run test:cljs` — **captured exit 0**, 12026 tests / 59924 assertions, 0 failures, 0 errors. CI job: `CLJS (shadow-cljs :node-test)` (`test.yml`, job key `cljs`), step "Compile and run node-test build (core + reagent)".
- `node scripts/check-examples-compile.cjs` (the derived examples sweep, 58 builds including `examples/realworld` and `examples/realworld-resources`) — **captured exit 0 — all 58 swept builds compiled with zero warnings, `examples/realworld` (332 files) and `examples/realworld-resources` (324 files) among them**. CI job: `cljs-examples-compile` (`test.yml`), step "Compile every declared standalone example build (coverage gate)", which runs `npm run test:examples-compile`.

**The regression rows were shown RED before the fix and green after.** With the eight example source files checked out at the merge base and the test tree left as committed, the focused run (`node out/node-test.js --test=re-frame.realworld-cljs-test,re-frame.realworld-resources-cljs-test`) gave **captured exit 1: 39 failures across the same 63 tests / 907 assertions** as the green run — so no namespace dropped out. The failures covered every finding: the combined HTTP deftest (comment schema, both home-feed directions, the departed failure, late delete/save/failure), `follow-and-unfollow-restale-the-session-feed`, `editor-write-continuations-stay-with-the-page-that-issued-them`, and `delete-article-continuation-leaves-a-departed-reader-where-they-are`. The same run green after restore: 0 failures. The restore was verified by content hash — each of the eight files' `git hash-object` matched its committed blob id, and `git diff --quiet HEAD` exited 0.

A first red attempt did not run at all: the compile gate refuses warnings, and the wire-schema control named `app-schema/DurableComment`, a var the pre-fix tree does not have, so the compile failed (captured exit 1) rather than the test failing. The control now asks the registry by path (`(get app-db-schemas [:comments :data])`), which both compiles on the pre-fix tree and fails there.

No gate for `scripts/check_readme_links.py` or `scripts/check_doc_slugs.py` is nominated: this change touches no markdown and no spec page. Nothing here validates prose — the docstrings and comments added to the example sources were checked by hand.

Trunk is currently red on `docs.yml` (the retired-image-key gate flagging a `::replace` listener id in a machines test from PR #9748; a fix is in flight as rf2-yvmc). That failure is not caused by this change — it touches no machines test and no docs — so a red MkDocs build / Docs required check here is that known trunk failure.
