### PR TITLE
fix(story-mcp): isolate the stdio lifecycle and preserve valid run results (rf2-fzbj.31, rf2-gwye.57-.60)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -264,7 +264,8 @@ tools/story-mcp/
         └── write.cljc                            ; gated: register-variant, unregister-variant
 └── test/
     ├── fixtures/tool-names.json                  ; canonical tool-name list (shared JVM + Node fixture)
-    ├── stdio-roundtrip.js                        ; Node stdio JSON-RPC roundtrip (initialize → tools/list → tools/call)
+    ├── fixtures/stdio_prelude.clj                ; preloaded story + printing handlers for the stdio roundtrip
+    ├── stdio-roundtrip.js                        ; Node stdio JSON-RPC roundtrip (initialize → tools/list → tools/call → run-variant → stdin EOF)
     └── re_frame/story_mcp/
         ├── protocol_test.clj                     ; wire-format coverage
         ├── tools_test.clj                        ; per-tool semantics + dispatcher + run-loop

--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -10,8 +10,25 @@
 - Each frame is one JSON object on one line; the server reads from
   stdin, writes to stdout. stderr is reserved for diagnostics
   (failure traces; never used for protocol traffic).
+- **Application output is a diagnostic, not a frame** (rf2-gwye.57). A
+  `tools/call` runs the author's own code, and an ordinary `println` in
+  a Story event handler writes to `*out*` — which in the CLI is stdout,
+  where it is not a frame and breaks the client's line parser over a run
+  that SUCCEEDED. So `server/handle-frame!` binds `*out*` to stderr for
+  the duration of a dispatch: such a line lands with the diagnostics and
+  stdout keeps carrying frames only. The JSON reply never travels
+  through `*out*` — the loop holds its writer explicitly. The redirect
+  is scoped to the dispatch (never `System/setOut`), and does not cover
+  LOAD-TIME printing by a namespace `clojure.main` required before
+  `-main` ran; that caveat stands as documented in the README
+  §Loading your project's stories.
 - The server's main loop terminates on stdin EOF; the `shutdown`
-  method is also honoured.
+  method is also honoured. At EOF `-main` also RELEASES what the CLI
+  acquired — Clojure's non-daemon future executor, which every variant
+  run uses — so a session that ran a story exits promptly instead of
+  idling out that pool's 60-second keep-alive (rf2-gwye.59). `run-loop!`
+  never does this: it is the embeddable half, and a library caller's
+  futures must outlive it.
 - **Frame-length cap** (rf2-g9fje): each inbound frame is bounded at
   `re-frame.story-mcp.protocol/max-frame-bytes` (4 MB — well above
   the largest legitimate MCP payload). A frame exceeding the cap is

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -141,6 +141,19 @@ summary an agent sees the inline `:rf/redacted` sentinels / vanished
 assertions but no signal that the payload was filtered, or by how much —
 the canonical silent-swallow failure mode this MUST closes.
 
+The drop applies to **every** assertion-record copy the projection emits,
+not only the top-level `:assertions` vec. `preview-variant` /
+`run-variant` also group those records under `:checks[*][:assertions]`
+(one check record per named `reg-check`), and a group holds the SAME
+maps the top level does — so dropping a stamped record from one slot
+while shipping it in the other is precisely the silent-swallow mode
+above, with the indicator count asserting the omission that did not
+happen (rf2-gwye.60). Two things are deliberately left alone: each check
+keeps its own authoritative `:status` (hiding a failing record must not
+recompute its check as a vacuous pass), and `:dropped-sensitive` stays
+the count of UNIQUE top-level records, since one record can appear in
+several groups and a per-group count would report a multiple of it.
+
 [conv]: ../../../spec/Conventions.md#cross-mcp-indicator-field-vocabulary-suppression-counters
 [s009]: ../../../spec/009-Instrumentation.md#size-elision-in-traces
 
@@ -397,7 +410,12 @@ The descriptor declares an `:outputSchema`; the official MCP SDK's
 high-level `callTool` rejects an outputSchema-declaring tool that
 returns no `structuredContent` (JSON-RPC -32600), so the structured
 slot rides alongside. The text slot stays the byte-stable source of
-truth for round-tripping.
+truth for round-tripping — for DATA. A supported
+`[:assert-db path :pred fn-or-sym]` assertion can leave a live function
+in an author's body; it crosses as the bounded
+`{:rf.story-mcp/unencodable "<class name>"}` marker in both slots, so
+the text stays readable EDN and the callable is named rather than
+reconstructible (rf2-gwye.58). See [`API.md`](API.md) §`variant->edn`.
 
 ### `get-docs-markdown` (rf2-i0kyy)
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -363,6 +363,16 @@ returns no `structuredContent` (JSON-RPC -32600), so the structured
 slot is emitted alongside the text. The text slot remains the
 byte-stable source of truth for round-tripping.
 
+A value that is not DATA does not round-trip, and no longer pretends to.
+A supported `[:assert-db path :pred fn-or-sym]` assertion
+([`tools/story/spec/001-Authoring.md`](../../story/spec/001-Authoring.md))
+may put a live function in an author's body, and it crosses both slots as
+the bounded `{:rf.story-mcp/unencodable "<class name>"}` marker
+(rf2-gwye.58) — the text stays readable EDN, and the callable is NAMED
+rather than reconstructible. Before that projection the raw function
+reached the JSON encoder and took the whole response down as a `-32603`
+server fault, body and run verdict with it.
+
 **Errors.** `isError: true` when `:variant-id` is not registered.
 
 ### `explain-variant` (rf2-ba86n.17)

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -13,7 +13,15 @@
   3. Client sends `notifications/initialized` (no response). Accepted
      but NOT required — see the relaxation note.
   4. Client sends `tools/list`, `tools/call`, etc.; we dispatch.
-  5. Shutdown: client closes stdin → readLine returns nil → we exit.
+  5. Shutdown: client closes stdin → readLine returns nil → we exit,
+     releasing the execution resources `-main` acquired (see `-main`).
+
+  ## stdout belongs to the protocol
+
+  stdout carries frames and nothing else, so `handle-frame!` binds
+  application `*out*` to stderr for the duration of a dispatch: a `println`
+  inside a Story event handler is a diagnostic, not a frame. See
+  `handle-frame!`.
 
   ## Pre-initialize state enforcement
 
@@ -280,7 +288,30 @@
   Public for tests."
   [state ^java.io.Writer writer message]
   (try
-    (when-let [resp (dispatch state message)]
+    ;; APPLICATION OUTPUT IS NOT PROTOCOL TRAFFIC (rf2-gwye.57).
+    ;;
+    ;; stdout carries one JSON frame per line (spec/001-Wire-Protocol.md
+    ;; §Transport). But a tool call runs the USER's code — a Story variant's
+    ;; event handlers — and an ordinary `println` in a handler writes to
+    ;; `*out*`, which in the CLI is stdout. One such line is not a frame, so
+    ;; the client's line parser rejects it and the session breaks, over a run
+    ;; that SUCCEEDED. Requiring every event handler to know it might be
+    ;; running under MCP is the wrong contract.
+    ;;
+    ;; So at this boundary — the server's own dispatch, the one place that
+    ;; knows the difference — application output is bound to stderr, which the
+    ;; transport reserves for diagnostics. The JSON reply does not travel
+    ;; through `*out*` at all: `writer` is held explicitly and written below,
+    ;; so redirecting the dynamic var cannot touch it. `future` conveys
+    ;; dynamic bindings, so the redirect reaches `run-variant-blocking`'s
+    ;; worker thread with it.
+    ;;
+    ;; Scoped to dispatch, never process-wide: no `System/setOut`, nothing an
+    ;; embedding caller of `run-loop!` keeps after the call returns. The
+    ;; separate LOAD-TIME caveat stands as documented (README §Loading your
+    ;; project's stories) — code `clojure.main` ran before `-main` printed
+    ;; before this boundary existed to redirect it.
+    (when-let [resp (binding [*out* *err*] (dispatch state message))]
       (rf.story-mcp.protocol/write-frame! writer resp))
     (catch Throwable e
       (log! "handler threw:" (ex-message e))
@@ -402,7 +433,27 @@
 (defn -main
   "Entry point. Boots, then runs the stdio JSON-RPC loop until stdin
   closes. The agent host launches this as a subprocess and terminates it
-  by closing stdin (or sending SIGTERM after a timeout)."
+  by closing stdin (or sending SIGTERM after a timeout).
+
+  ## Releasing the executor at EOF (rf2-gwye.59)
+
+  `-main` OWNS this process, so it releases what the process acquired.
+  `tools.lifecycle/run-variant-blocking` runs every variant on a `future`,
+  which is Clojure's cached send-off pool: NON-DAEMON threads with a
+  60-second keep-alive. So after a session that actually ran a story, the
+  read loop returns at EOF, `-main` returns, and the JVM then sits there for
+  the rest of that minute with nothing to do — measured at 60,021 ms
+  stdin-to-exit against 71 ms for a session that ran nothing. A host
+  restarting its MCP servers collects a pile of idle JVMs.
+
+  `shutdown-agents` is in a `finally` so an abnormal exit releases it too.
+  It is HERE and not in `run-loop!` deliberately: `run-loop!` is the
+  embeddable half, and shutting the pool down inside it would break the next
+  session — and every future — of a library caller that never asked this
+  server to end its process."
   [& argv]
-  (boot! (parse-args argv))
-  (run-stdio!))
+  (try
+    (boot! (parse-args argv))
+    (run-stdio!)
+    (finally
+      (shutdown-agents))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -171,7 +171,9 @@
                             :elapsed-ms   (:elapsed-ms outcome)
                             :app-db       (rf.story-mcp.tools.egress/elide-app-db raw-db vk incl?)
                             :assertions   assertions
-                            :checks       (vec (:checks outcome))
+                            ;; Same filter as `:assertions` — the check groups
+                            ;; carry the same records (rf2-gwye.60).
+                            :checks       (rf.story-mcp.tools.egress/scrub-checks (:checks outcome) incl?)
                             ;; Derived trees are PATH-projected through scrub-rendered:
                             ;; a value AT a classified path redacts, a re-keyed copy
                             ;; ships raw (EP-0025 fail-open). `run-variant` produces

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -235,6 +235,37 @@
     (nil? records) [[] 0]
     :else          (rf.mcp-base.sensitive/strip-sensitive records false)))
 
+(defn scrub-checks
+  "Apply the SAME sensitive-record drop to the assertion group nested inside
+  each named check record (rf2-gwye.60).
+
+  A check record (`re-frame.story.result/check-record`) groups the very
+  assertion-record MAPS that also ride the top-level `:assertions` vec — the
+  producer collects them by id + payload, it does not copy them into some
+  other shape. So a record `scrub-assertions+count` drops at the top level is
+  still sitting in `:checks[*][:assertions]`, carrying its `:actual` /
+  `:reason`, and a response that says `:dropped-sensitive 1` ships it anyway.
+  Adding a named check to a variant must not defeat the filter.
+
+  What is deliberately NOT done here:
+
+  - the check's own `:status` is left alone. It is the authoritative verdict
+    over the records that RAN; recomputing it after hiding its only failure
+    would turn a failed check into a vacuous pass, which is the worse lie.
+  - the drops are NOT counted. One source record can appear in several
+    groups (two checks expanding to the same assertion atom), so counting per
+    group would report a multiple of the truth. The `:dropped-sensitive`
+    indicator stays the caller's UNIQUE top-level count.
+
+  `include?` is the same opt-out the rest of the egress honours — when true
+  `scrub-assertions+count` returns the group unchanged."
+  [checks include?]
+  (mapv (fn [check]
+          (cond-> check
+            (contains? check :assertions)
+            (update :assertions #(first (scrub-assertions+count % include?)))))
+        checks))
+
 ;; ---------------------------------------------------------------------------
 ;; Derived-tree path-based projection (EP-0025 fail-open)
 ;; ---------------------------------------------------------------------------

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -16,16 +16,30 @@
   It is TOTAL: whatever a handler threw, the projection's output can be
   JSON-encoded.
 
+  `wire-safe-success` is its counterpart for ordinary SUCCESS data, and
+  `edn-result` — the envelope every data-returning handler builds — applies
+  it. Success data is not exception data and the two projections are not
+  interchangeable: see `wire-safe-success`.
+
   No story-mcp ns deps — `cap` / `cursor` / `args` / `egress`
-  / every category ns reaches here. `malli.error` is the sole library
-  require, reached transitively through `re-frame.story` (whose registrar
-  hard-requires `malli.core`), exactly as `re-frame.error` is."
-  (:require [malli.error :as me]))
+  / every category ns reaches here. `malli.error` is the sole third-party
+  require (`clojure.walk` is stdlib), reached transitively through
+  `re-frame.story` (whose registrar hard-requires `malli.core`), exactly as
+  `re-frame.error` is."
+  (:require [clojure.walk :as walk]
+            [malli.error :as me]))
 
 (defn pr-edn
   "Serialise a value to a stable, EDN-round-trippable string. Used to
   embed Story data inside an MCP text content item. Uses `pr-str` —
-  keywords stay keywords, sets stay sets, no JSON lossiness."
+  keywords stay keywords, sets stay sets, no JSON lossiness.
+
+  Round-trippable because `edn-result` projects the payload through
+  `wire-safe-success` FIRST. Given a raw callable — which a supported
+  `:pred` assertion puts in an author's body — `pr-str` emits an
+  `#object[…]` form that is not readable EDN at all; the projection has
+  already replaced it with the readable `{:rf.story-mcp/unencodable …}`
+  marker. The string round-trips; the callable, honestly, does not."
   [v]
   (binding [*print-readably* true]
     (pr-str v)))
@@ -47,14 +61,24 @@
   #?(:clj  (.getName (class v))
      :cljs (pr-str (type v))))
 
+(defn- edn-scalar?
+  "Is `v` one of the EDN scalars — nil, a boolean, a number, a string, a
+  keyword, a symbol, a character, a UUID or an instant (the last two being
+  EDN's built-in tagged literals)?
+
+  The closed set the two projections below share, so they cannot drift on
+  what counts as data. Everything outside it that is not a collection is a
+  live object the JSON encoder cannot write."
+  [v]
+  (or (nil? v) (boolean? v) (number? v) (string? v)
+      (keyword? v) (symbol? v) (char? v) (uuid? v) (inst? v)))
+
 (defn- wire-safe-value
   "Project any value into the EDN value space, which is the shape the JSON
   encoder can write.
 
-  A value survives when it IS data: nil, a boolean, a number, a string, a
-  keyword, a symbol, a character, a UUID or an instant — the closed set of
-  EDN scalars, the last two being EDN's two built-in tagged literals — or a
-  collection of values that survive. Everything else is a live object: a
+  A value survives when it IS data: an `edn-scalar?`, or a collection of
+  values that survive. Everything else is a live object: a
   reified Malli schema, a `Throwable`, an atom, a regex, a function, a bare
   `Object`. Those become `{:rf.story-mcp/unencodable \"<class name>\"}`,
   which says both that a value was there and what kind it was.
@@ -74,9 +98,7 @@
   one."
   [v]
   (cond
-    (or (nil? v) (boolean? v) (number? v) (string? v)
-        (keyword? v) (symbol? v) (char? v) (uuid? v) (inst? v))
-    v
+    (edn-scalar? v) v
 
     (map? v)        (reduce-kv (fn [m k x]
                                  (assoc m (wire-safe-value k) (wire-safe-value x)))
@@ -84,6 +106,57 @@
     (set? v)        (into #{} (map wire-safe-value) v)
     (sequential? v) (mapv wire-safe-value v)
     :else           {unencodable-key (type-name v)}))
+
+(defn wire-safe-success
+  "Project ORDINARY SUCCESS data so the JSON encoder can write it, leaving
+  everything that already IS data exactly as it was.
+
+  ## Why success data needs its own projection at all (rf2-gwye.58)
+
+  `[:assert-db path :pred fn-or-sym]` is a SUPPORTED Story authoring form
+  (`tools/story/spec/001-Authoring.md` §Script steps), so a live function
+  legitimately sits in a registered variant body — and from there in the
+  body `get-variant` returns, the plan `explain-variant` returns, and the
+  assertion evidence a RUN returns. None of that is exception data, so the
+  `wire-safe-ex-data` path never saw it, and a function reaching Cheshire
+  throws PAST the tool handler into `server/handle-frame!`, which answers
+  `-32603 Server fault: Cannot JSON encode object of class: class
+  clojure.core$pos_QMARK_`. Four tools failed that way on a variant Story
+  itself runs `:pass` — the verdict, the evidence and the whole surrounding
+  body discarded over one slot.
+
+  ## The rule: mark the value, keep everything around it
+
+  A callable cannot be reconstructed from JSON or from printed EDN, and
+  pretending otherwise is the lie this replaces: `pr-str` of a function
+  emits `#object[clojure.core$pos_QMARK_ 0x4d1b0d2a …]`, which is neither
+  readable EDN nor free of a build-local address. So the value is replaced —
+  in place — by the same bounded `{:rf.story-mcp/unencodable \"<class
+  name>\"}` marker `wire-safe-value` already uses: it says a value was
+  there, and what kind it was, without an identity hash. Everything else in
+  the payload survives untouched.
+
+  ## Not `wire-safe-ex-data`, and not a reshaping walk
+
+  Two differences, both deliberate:
+
+  - `wire-safe-ex-data` RENAMES `:explain` and `:rf.error/id`. Those are
+    exception vocabulary; on author data they are ordinary keys somebody
+    wrote, and rewriting them would corrupt the very body the author asked
+    to read back.
+  - this walk is TYPE-PRESERVING. `wire-safe-value` rebuilds every
+    collection through `{}` / `#{}` / `mapv`, which is right for an
+    `ex-data` blob but would quietly turn a list into a vector, a sorted map
+    into a hash map, and a record into a plain map — in a payload whose text
+    slot is the byte-stable EDN an agent DIFFS. `clojure.walk/postwalk`
+    rebuilds each collection as its own type (and visits map keys), so a
+    payload carrying no callable comes back equal to what went in."
+  [v]
+  (walk/postwalk (fn [x]
+                   (if (or (edn-scalar? x) (coll? x))
+                     x
+                     {unencodable-key (type-name x)}))
+                 v))
 
 (defn wire-safe-ex-data
   "Project a caught exception's `ex-data` into something the JSON encoder
@@ -182,9 +255,19 @@
 
   The two slots are dual-coded on purpose (per `wire-pipeline`): the
   text slot serves agent hosts that read EDN; the structured slot
-  serves hosts that prefer JSON data — and the cap pipeline sizes both."
+  serves hosts that prefer JSON data — and the cap pipeline sizes both.
+
+  ## The one success projection (rf2-gwye.58)
+
+  `wire-safe-success` runs HERE, once, before either slot is built — so the
+  two slots cannot disagree about a value, and the projection lands ahead of
+  the wire-boundary transforms (dedup, then the token cap) which run after
+  the handler returns. This is the chokepoint every data-returning handler
+  already shares, which is why the projection needs no per-handler opt-in
+  and no roster of which tools might carry a callable."
   [payload]
-  (text-result (pr-edn payload) payload))
+  (let [payload (wire-safe-success payload)]
+    (text-result (pr-edn payload) payload)))
 
 (defn error-result
   "Build a tool-execution error result. Per MCP §Error Handling these

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -130,7 +130,12 @@
                                   :frame              (:frame outcome vk)
                                   :app-db             (rf.story-mcp.tools.egress/elide-app-db raw-db vk incl?)
                                   :assertions         assertions
-                                  :checks             (vec (:checks outcome))
+                                  ;; The check groups carry the SAME records as
+                                  ;; `:assertions` above, so they take the same
+                                  ;; sensitive-record filter — otherwise a named
+                                  ;; check ships back the record this response
+                                  ;; reports as dropped (rf2-gwye.60).
+                                  :checks             (rf.story-mcp.tools.egress/scrub-checks (:checks outcome) incl?)
                                   :consumed-selectors (:consumed-selectors outcome #{})
                                   ;; Evidence-slot projections (.4 — one tape, one
                                   ;; projection). Every value-bearing slot is

--- a/tools/story-mcp/test/fixtures/stdio_prelude.clj
+++ b/tools/story-mcp/test/fixtures/stdio_prelude.clj
@@ -1,0 +1,53 @@
+(ns fixtures.stdio-prelude
+  "Preloaded by test/stdio-roundtrip.js:
+
+    clojure -M -i test/fixtures/stdio_prelude.clj -m re-frame.story-mcp.server
+
+  The README's \"Loading your project's stories\" launch shape, pointed at a
+  fixture. It is a script clojure.main loads before `-m`, not a test: the
+  namespace spells its own path (the test-quiet discovery rule, rf2-vruo9)
+  and does not end in `-test`, so the JVM suite discovers it but never loads
+  it.
+
+  The handlers that print do so AFTER the server is up, under the server's
+  own dispatch (rf2-gwye.57): the round-trip asserts those lines reach stderr
+  and never stdout. Nothing here prints at load time — that is the README's
+  separate \"stdout is the wire\" caveat, not this contract."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(rf/init! plain-atom/adapter)
+
+(story/reg-story :story.stdio-fixture {:doc "stdio-roundtrip fixture"})
+
+(rf/reg-event :stdio-fixture/quiet
+  (fn [{:keys [db]} _]
+    {:db (assoc db :ran :quiet)}))
+
+(rf/reg-event :stdio-fixture/print-in-setup
+  (fn [{:keys [db]} _]
+    (println "STDIO-FIXTURE-SETUP-PRINT")
+    {:db (assoc db :ran :setup)}))
+
+(rf/reg-event :stdio-fixture/print-in-script
+  (fn [{:keys [db]} _]
+    (println "STDIO-FIXTURE-SCRIPT-PRINT")
+    {:db (assoc db :ran :script)}))
+
+(rf/reg-event :stdio-fixture/print-then-throw
+  (fn [_ _]
+    (println "STDIO-FIXTURE-THROW-PRINT")
+    (throw (ex-info "stdio fixture: handler failed on purpose" {}))))
+
+(story/reg-variant :story.stdio-fixture/quiet
+  {:setup [[:stdio-fixture/quiet]]})
+
+(story/reg-variant :story.stdio-fixture/setup-print
+  {:setup [[:stdio-fixture/print-in-setup]]})
+
+(story/reg-variant :story.stdio-fixture/script-print
+  {:script [[:dispatch-sync [:stdio-fixture/print-in-script]]]})
+
+(story/reg-variant :story.stdio-fixture/throw-print
+  {:setup [[:stdio-fixture/print-then-throw]]})

--- a/tools/story-mcp/test/fixtures/stdio_prelude.clj
+++ b/tools/story-mcp/test/fixtures/stdio_prelude.clj
@@ -14,12 +14,12 @@
   and never stdout. Nothing here prints at load time — that is the README's
   separate \"stdout is the wire\" caveat, not this contract."
   (:require [re-frame.core :as rf]
-            [re-frame.story :as story]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.story :as rf.story]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]))
 
-(rf/init! plain-atom/adapter)
+(rf/init! rf.substrate.plain-atom/adapter)
 
-(story/reg-story :story.stdio-fixture {:doc "stdio-roundtrip fixture"})
+(rf.story/reg-story :story.stdio-fixture {:doc "stdio-roundtrip fixture"})
 
 (rf/reg-event :stdio-fixture/quiet
   (fn [{:keys [db]} _]
@@ -40,14 +40,14 @@
     (println "STDIO-FIXTURE-THROW-PRINT")
     (throw (ex-info "stdio fixture: handler failed on purpose" {}))))
 
-(story/reg-variant :story.stdio-fixture/quiet
+(rf.story/reg-variant :story.stdio-fixture/quiet
   {:setup [[:stdio-fixture/quiet]]})
 
-(story/reg-variant :story.stdio-fixture/setup-print
+(rf.story/reg-variant :story.stdio-fixture/setup-print
   {:setup [[:stdio-fixture/print-in-setup]]})
 
-(story/reg-variant :story.stdio-fixture/script-print
+(rf.story/reg-variant :story.stdio-fixture/script-print
   {:script [[:dispatch-sync [:stdio-fixture/print-in-script]]]})
 
-(story/reg-variant :story.stdio-fixture/throw-print
+(rf.story/reg-variant :story.stdio-fixture/throw-print
   {:setup [[:stdio-fixture/print-then-throw]]})

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -5309,3 +5309,105 @@
         (is (pos? (:token-count body))
             ":token-count reflects the over-budget count")
         (is (= 1 (:cap-tokens body)))))))
+
+;; ---------------------------------------------------------------------------
+;; Named-check assertion copies honour the sensitive-record filter
+;; (rf2-gwye.60).
+;;
+;; A `:checks` group carries the SAME assertion-record maps as the top-level
+;; `:assertions` vec (`re-frame.story.result/check-record`), so a record the
+;; egress drops at the top level must not ride back out inside a group.
+;; Driven through the real `run-loop!` and looked for in the ENCODED frame —
+;; both slots — rather than in a handler's return value.
+;; ---------------------------------------------------------------------------
+
+(def ^:private check-private-sentinel "CHECK-PRIVATE-SENTINEL")
+
+(defn- reg-check-private-fixture!
+  "A variant whose setup seeds the accumulator with a programmer-stamped
+  `:sensitive? true` record (the record-don't-throw contract the
+  sensitive-assertion tests above already use), and whose TWO named checks
+  both expand to the atom that record matches — so one source record lands
+  in both groups, and a per-group drop count would double-count it."
+  []
+  (rf/reg-event :story-mcp.test/seed-private-record
+    (fn [{:keys [db]} _]
+      {:db        (assoc db
+                         :flag :yes
+                         :rf.story/assertions
+                         [{:assertion  :rf.assert/path-equals
+                           :payload    [[:flag] :yes]
+                           :passed?    false
+                           :sensitive? true
+                           :actual     check-private-sentinel
+                           :expected   :yes
+                           :reason     check-private-sentinel}])
+       :sensitive [[:rf.story/assertions]]}))
+  (rf.story/reg-check :check.button/private-a {:assertions [[:rf.assert/path-equals [:flag] :yes]]})
+  (rf.story/reg-check :check.button/private-b {:assertions [[:rf.assert/path-equals [:flag] :yes]]})
+  (rf.story/reg-variant :story.button/checked-private
+    {:setup  [[:story-mcp.test/seed-private-record]]
+     :checks [:check.button/private-a :check.button/private-b]}))
+
+(defn- call-checked-private
+  "One `tools/call` of `tool` on the checked-private variant through the real
+  `run-loop!`; returns the decoded response frame."
+  [tool args]
+  (first (run-frames!
+           (str (cheshire/generate-string
+                  {:jsonrpc "2.0" :id 1 :method "tools/call"
+                   :params  {:name      tool
+                             :arguments (merge {:variant-id "story.button/checked-private"
+                                                :max-tokens 0}
+                                               args)}})
+                "\n"))))
+
+(deftest named-check-assertion-copies-honour-the-sensitive-filter
+  (reg-check-private-fixture!)
+  (doseq [tool  ["run-variant" "preview-variant"]
+          dedup [true false]]
+    (testing (str tool " dedup=" dedup ", operator gate closed, caller asks anyway")
+      (let [frame (call-checked-private tool {:dedup dedup :include-sensitive true})]
+        (is (nil? (:error frame))
+            (str "a result envelope, not a protocol error: " (pr-str (:error frame))))
+        (is (not (clojure.string/includes? (pr-str frame) check-private-sentinel))
+            "no copy of the dropped record crosses the wire, in either slot")
+        (when-not dedup
+          (let [s (get-in frame [:result :structuredContent])]
+            (is (= 1 (:dropped-sensitive s))
+                "one source record, counted once — not once per group it appeared in")
+            (is (= #{"check.button/private-a" "check.button/private-b"}
+                   (set (map :check (:checks s))))
+                "check identity survives")
+            (is (every? #(= "fail" (:status %)) (:checks s))
+                "each check keeps its authoritative verdict — hiding its failure does not recompute a pass")
+            (is (every? #(and (seq (:assertions %)) (not-any? :sensitive? (:assertions %)))
+                        (:checks s))
+                "each group keeps its benign records and loses only the stamped one"))))))
+  (testing "both gates open restores the record inside the groups"
+    (rf.story-mcp.config/set-allow-sensitive-reads! true)
+    (let [frame (call-checked-private "run-variant" {:dedup false :include-sensitive true})
+          s     (get-in frame [:result :structuredContent])]
+      (is (clojure.string/includes? (pr-str frame) check-private-sentinel))
+      (is (every? #(some :sensitive? (:assertions %)) (:checks s))))))
+
+;; ---------------------------------------------------------------------------
+;; `run-loop!` leaves Clojure's executors alone (rf2-gwye.59).
+;;
+;; The CLI's `-main` releases Clojure's future/agent executor once stdin
+;; closes, so a session that ran a variant exits promptly instead of idling
+;; out the pool's keep-alive. That release belongs to the process OWNER:
+;; `run-loop!` is the embeddable half, and an embedding caller's later
+;; futures — and later sessions — must keep working after it returns.
+;; ---------------------------------------------------------------------------
+
+(deftest run-loop-leaves-clojure-futures-usable-after-eof
+  (let [frames (run-frames!
+                 (str "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                      "\"params\":{\"name\":\"run-variant\",\"arguments\":"
+                      "{\"variant-id\":\"story.button/primary\",\"dedup\":false,"
+                      "\"max-tokens\":0}}}\n"))]
+    (is (= "pass" (get-in (first frames) [:result :structuredContent :status]))
+        "precondition: the session really ran a variant on a worker future")
+    (is (= 42 (deref (future 42) 5000 ::timed-out))
+        "a future submitted after run-loop! returned still runs")))

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -61,6 +61,7 @@
   re-frame.error`, so these messages are hand-rolled at each throw and a
   shared builder cannot enforce them — only a boundary assertion can."
   (:require [cheshire.core :as cheshire]
+            [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.error]
@@ -451,3 +452,89 @@
             "the guard names what failed")
         (is (string? (cheshire/generate-string projected))
             "and its fallback encodes")))))
+
+;; ---- success payloads: a callable is a marker, not a server fault ----------
+;;
+;; rf2-gwye.58. Everything above guards the ERROR path. `[:assert-db path
+;; :pred fn-or-sym]` is a SUPPORTED Story authoring form
+;; (tools/story/spec/001-Authoring.md), so a live fn legitimately sits in
+;; ordinary SUCCESS data: the registered body, its explain plan, and the run's
+;; assertion evidence. Before the success projection all four tools below
+;; answered `-32603 Server fault: Cannot JSON encode object of class: class
+;; clojure.core$pos_QMARK_` — the run-variant one over a verdict of `:pass`.
+
+(def ^:private predicate-body
+  {:doc     "predicate assertion"
+   :db-seed {:count 1}
+   ;; Two author keys `wire-safe-ex-data` REWRITES on an exception payload.
+   ;; Success data is not an exception, so they must ride exactly as written.
+   :args    {:explain "author-explain" :rf.error/id "author-literal"}
+   :script  [[:assert-db [:count] :pred pos?]]})
+
+(def ^:private equality-body
+  (assoc predicate-body :script [[:assert-db [:count] 1]]))
+
+(def ^:private success-tools
+  ["get-variant" "variant->edn" "explain-variant" "run-variant"])
+
+(defn- call-success-tool
+  "Drive `tool` on `variant-id` through the real boundary, uncapped, with
+  dedup at its default (`dedup? true`) or explicitly off."
+  [tool variant-id dedup?]
+  (call-tool tool (str "{\"variant-id\":\"" variant-id "\",\"max-tokens\":0"
+                       (when-not dedup? ",\"dedup\":false") "}")))
+
+(deftest callable-in-a-success-payload-crosses-as-a-marker
+  (rf.story/reg-variant* :story.button/predicate predicate-body)
+  (is (= :pass (:status @(rf.story/run-variant :story.button/predicate)))
+      "precondition: Story itself runs the predicate form green")
+  (doseq [tool success-tools, dedup? [true false]]
+    (testing (str tool " dedup=" dedup?)
+      (let [[line frame] (call-success-tool tool "story.button/predicate" dedup?)]
+        (is (nil? (:error frame))
+            (str "a result envelope, not a protocol fault: " line))
+        (is (nil? (get-in frame [:result :isError]))
+            "a success, not a tool error")
+        (is (str/includes? line "clojure.core$pos_QMARK_")
+            "the callable is still named, by its class")
+        (is (not (str/includes? line "#object"))
+            "no raw printed object in either slot")
+        (is (nil? (re-find address-in-line line))
+            "and no identity hash")))))
+
+(deftest callable-projection-keeps-the-surrounding-data
+  (rf.story/reg-variant* :story.button/predicate predicate-body)
+  (let [s    (fn [tool] (structured (second (call-success-tool tool "story.button/predicate" false))))
+        body (:body (s "get-variant"))]
+    (testing "get-variant: the body survives, and the callable is marked in place"
+      (is (= 1 (get-in body [:db-seed :count])))
+      (is (= {:rf.story-mcp/unencodable "clojure.core$pos_QMARK_"}
+             (get-in body [:script 0 3]))))
+    (testing "literal author keys are not reinterpreted as exception vocabulary"
+      (is (= {:explain "author-explain" :rf.error/id "author-literal"}
+             (:args body))))
+    (testing "the text slot is still readable EDN carrying the same marker"
+      (let [[_ frame] (call-success-tool "variant->edn" "story.button/predicate" false)]
+        (is (= {:rf.story-mcp/unencodable "clojure.core$pos_QMARK_"}
+               (get-in (edn/read-string (result-text frame)) [:script 0 3])))))
+    (testing "variant->edn and explain-variant carry the same author data"
+      (is (= body (s "variant->edn")))
+      (is (= "story.button/predicate" (:variant-id (s "explain-variant"))))
+      (is (map? (:explain (s "explain-variant")))))
+    (testing "run-variant: the verdict and its evidence cross"
+      (let [r (s "run-variant")]
+        (is (= "pass" (:status r)))
+        (is (seq (:assertions r)))))))
+
+(deftest equality-only-assertion-carries-no-marker
+  ;; The control: a projection that marked everything would pass both tests
+  ;; above and be useless.
+  (rf.story/reg-variant* :story.button/equality equality-body)
+  (doseq [tool success-tools]
+    (testing tool
+      (let [[line frame] (call-success-tool tool "story.button/equality" false)]
+        (is (nil? (:error frame)))
+        (is (not (str/includes? line "rf.story-mcp/unencodable"))
+            "plain data is never marked"))))
+  (is (= "pass" (:status (structured (second (call-success-tool "run-variant" "story.button/equality" false)))))
+      "and the equality-only run still crosses with its verdict"))

--- a/tools/story-mcp/test/stdio-roundtrip.js
+++ b/tools/story-mcp/test/stdio-roundtrip.js
@@ -1,7 +1,9 @@
 // Stdio integration test for tools/story-mcp.
 //
-// Spawns the JVM story-mcp server via `clojure -M -m re-frame.story-mcp.server`
-// and walks the MCP handshake against it:
+// Spawns the JVM story-mcp server via
+// `clojure -M -i test/fixtures/stdio_prelude.clj -m re-frame.story-mcp.server`
+// (the README's preload launch shape — the prelude installs plain-atom and
+// registers a small fixture story) and walks the MCP handshake against it:
 //
 //   - initialize                  (negotiate protocolVersion 2025-06-18)
 //   - notifications/initialized   (notification, no response)
@@ -22,7 +24,15 @@
 //                                 (expect gated tool-execution error — proves
 //                                  the gating contract per spec/003)
 //   - tools/call no-such-tool     (expect method-not-found protocol error)
+//   - tools/call run-variant on the prelude's REGISTERED variants, whose
+//                                 handlers println after the server is up
+//                                 (expect every stdout line to parse as JSON,
+//                                  each marker on stderr only, the run
+//                                  verdicts intact — rf2-gwye.57)
 //   - ping                        (empty result, liveness probe)
+//   - close stdin                 (expect the server to exit 0 ON ITS OWN
+//                                  within a short bound — no kill on the
+//                                  success path, rf2-gwye.59)
 //
 // The representative agent-loop workflow against a running server with
 // --allow-writes enabled lives in the SDK-driven conformance harness
@@ -52,7 +62,22 @@ const TOOL_NAMES = JSON.parse(
 // We spawn the binary directly — no shell wrap — so Node 24+'s
 // shell-with-args deprecation (DEP0190) stays quiet.
 const CLOJURE = process.env.STORY_MCP_CMD || 'clojure';
-const ARGS = ['-M', '-m', 're-frame.story-mcp.server'];
+const ARGS = ['-M', '-i', 'test/fixtures/stdio_prelude.clj', '-m', 're-frame.story-mcp.server'];
+
+// Application output markers the prelude's handlers print under the server's
+// own dispatch (rf2-gwye.57). Each must reach stderr and never stdout.
+const APP_OUTPUT_MARKERS = [
+  'STDIO-FIXTURE-SETUP-PRINT',
+  'STDIO-FIXTURE-SCRIPT-PRINT',
+  'STDIO-FIXTURE-THROW-PRINT',
+];
+
+// After the last reply the harness CLOSES stdin and waits for the server to
+// exit on its own (rf2-gwye.59). A JVM that has released its executors exits
+// in well under a second; before that fix a session that ran a variant idled
+// out Clojure's 60 s executor keep-alive, so this bound separates the two
+// with room to spare on a slow runner.
+const EXIT_AFTER_EOF_BOUND_MS = 10000;
 
 function run() {
   return new Promise((resolve, reject) => {
@@ -62,12 +87,22 @@ function run() {
       cwd: CWD,
       env,
     });
-    child.stderr.on('data', (d) => process.stderr.write('[server] ' + d.toString()));
+    let stderrText = '';
+    child.stderr.on('data', (d) => {
+      stderrText += d.toString();
+      process.stderr.write('[server] ' + d.toString());
+    });
+    // Registered up front so the exit is observed however early it happens.
+    const exited = new Promise((r) =>
+      child.on('close', (code, signal) => r({ code, signal, at: Date.now() })),
+    );
 
     let next = 1;
     const pending = new Map();
     let buf = '';
+    let rawStdout = '';
     child.stdout.on('data', (chunk) => {
+      rawStdout += chunk.toString('utf8');
       buf += chunk.toString('utf8');
       let i;
       while ((i = buf.indexOf('\n')) >= 0) {
@@ -297,6 +332,41 @@ function run() {
       }
       console.log('OK   tools/call no-such-tool -> -32601 method-not-found');
 
+      // 6b. tools/call run-variant on REGISTERED variants whose handlers
+      // println (rf2-gwye.57). stdout is the protocol stream, so application
+      // output emitted under the server's dispatch must go to stderr. The line
+      // parser above fails the run on any non-JSON stdout line; these calls are
+      // what give it something to catch. `quiet` is the control, and the
+      // print-then-throw handler proves a failing run is contained too.
+      const runVariant = (variantId) =>
+        call('tools/call', {
+          name: 'run-variant',
+          arguments: { 'variant-id': variantId, dedup: false, 'max-tokens': 0 },
+        });
+      for (const [variantId, ran] of [
+        ['story.stdio-fixture/quiet', 'quiet'],
+        ['story.stdio-fixture/setup-print', 'setup'],
+        ['story.stdio-fixture/script-print', 'script'],
+      ]) {
+        const r = await runVariant(variantId);
+        const s = r.result?.structuredContent;
+        if (r.error || r.result?.isError || s?.status !== 'pass' || s?.['app-db']?.ran !== ran) {
+          throw new Error(
+            'run-variant ' + variantId + ' should pass with app-db.ran=' + ran + '; got: ' +
+              JSON.stringify(r).slice(0, 600),
+          );
+        }
+      }
+      const thrownResp = await runVariant('story.stdio-fixture/throw-print');
+      const thrownStatus = thrownResp.result?.structuredContent?.status;
+      if (thrownResp.error || thrownResp.result?.isError || thrownStatus === 'pass' || !thrownStatus) {
+        throw new Error(
+          'run-variant on a throwing handler should return a non-pass run verdict; got: ' +
+            JSON.stringify(thrownResp).slice(0, 600),
+        );
+      }
+      console.log('OK   tools/call run-variant (registered, printing handlers) -> verdicts intact (throwing handler -> ' + thrownStatus + ')');
+
       // 7. ping — empty result, MCP §Utilities/ping liveness probe.
       const pingResp = await call('ping', {});
       if (pingResp.result === undefined || Object.keys(pingResp.result || {}).length !== 0) {
@@ -304,8 +374,38 @@ function run() {
       }
       console.log('OK   ping -> empty result {}');
 
+      for (const marker of APP_OUTPUT_MARKERS) {
+        if (rawStdout.includes(marker)) {
+          throw new Error('application output ' + marker + ' reached stdout (the protocol stream)');
+        }
+        if (!stderrText.includes(marker)) {
+          throw new Error('application output ' + marker + ' never reached stderr');
+        }
+      }
+      console.log('OK   application output -> stderr only; every stdout line parsed as JSON');
+
+      // 8. Close stdin and let the server exit ON ITS OWN — no kill on this
+      // path (rf2-gwye.59). The session above ran variants on Clojure's
+      // future executor; the CLI must release it at EOF rather than idle out
+      // its keep-alive.
       clearTimeout(watchdog);
-      child.kill();
+      const eofAt = Date.now();
+      child.stdin.end();
+      const exit = await Promise.race([
+        exited,
+        new Promise((r) => setTimeout(() => r(null), EXIT_AFTER_EOF_BOUND_MS)),
+      ]);
+      if (exit === null) {
+        throw new Error(
+          'server still running ' + EXIT_AFTER_EOF_BOUND_MS + ' ms after stdin EOF ' +
+            '(a session that ran variants must release its executors and exit)',
+        );
+      }
+      if (exit.code !== 0) {
+        throw new Error('server exited ' + exit.code + ' (signal ' + exit.signal + ') after stdin EOF; expected 0');
+      }
+      console.log('OK   stdin EOF -> server exited 0 on its own in ' + (exit.at - eofAt) + ' ms');
+
       console.log('\nSTORY-MCP STDIO ROUND-TRIP GREEN');
       resolve();
     })().catch((e) => {


### PR DESCRIPTION
Remediates `rf2-fzbj.31` and its per-finding children `rf2-gwye.57`, `rf2-gwye.58`, `rf2-gwye.59`, `rf2-gwye.60` — one finding set on one surface (`tools/story-mcp/**`). Every finding was re-verified at tip before being fixed; all four still held, at the lines cited.

## The four findings

**1. An ordinary `println` corrupted the protocol stream (rf2-gwye.57, P2).** A `tools/call` runs the author's own code, and `*out*` in the CLI is stdout — so a diagnostic line in a Story event handler is not a frame, and the client's line parser rejects it over a run that SUCCEEDED. `server/handle-frame!` now binds `*out*` to stderr for the duration of a dispatch. The JSON reply never travelled through `*out*` (the loop holds its writer explicitly), `future` conveys the binding into the lifecycle worker, and nothing is changed process-wide (no `System/setOut`). The separately documented LOAD-TIME caveat is untouched.

**2. A supported predicate assertion made four succeeding tools fail JSON encoding (rf2-gwye.58, P2).** `[:assert-db path :pred fn-or-sym]` is supported authoring (`tools/story/spec/001-Authoring.md`), so a live fn sits in ordinary SUCCESS data, which the exception-only projection never saw. `get-variant`, `variant->edn`, `explain-variant` and `run-variant` all answered `-32603 Server fault: Cannot JSON encode object of class: class clojure.core$pos_QMARK_` — the last over a verdict of `:pass`. `result/wire-safe-success` now runs once inside `edn-result`, before both slots and before dedup/cap, replacing a non-data value in place with the existing bounded `{:rf.story-mcp/unencodable "<class name>"}` marker. It is type-preserving (`postwalk`), so a payload with no callable comes back equal — the text slot is the byte-stable EDN an agent diffs; and it is deliberately NOT `wire-safe-ex-data`, which renames `:explain` and `:rf.error/id` — exception vocabulary that on author data is just somebody's keys (pinned by a test).

**3. The CLI lingered for the executor's 60-second idle timeout after EOF (rf2-gwye.59, P3).** Every variant runs on a `future`, whose pool threads are non-daemon. `-main` now releases them in a `finally`. Deliberately not in `run-loop!`: that is the embeddable half, and a library caller's futures must outlive it (pinned by a test).

**4. A sensitive assertion record dropped from `:assertions` was shipped inside `:checks` (rf2-gwye.60, P2).** The check groups hold the SAME record maps, so adding a named check defeated the filter while the response still reported `:dropped-sensitive 1`. `egress/scrub-checks` applies the same filter to each group in both lifecycle tools. Each check keeps its authoritative `:status` — hiding its only failure must not recompute a vacuous pass — and the indicator stays the unique top-level count, since one record can appear in several groups.

## Tests, red before and green after

`test/stdio-roundtrip.js` now preloads a fixture story through the README's own documented launch shape (`clojure -M -i test/fixtures/stdio_prelude.clj -m re-frame.story-mcp.server`), runs registered variants whose handlers `println` (with a quiet control and a print-then-throw handler), then closes stdin and requires the server to exit 0 on its own — no kill on the success path.

| Run | Result |
|---|---|
| stdio, pre-fix | exit 1 — `FAIL: malformed JSON on stdout: STDIO-FIXTURE-SETUP-PRINT` |
| stdio, `-main` fix reverted only (planted, then restored) | exit 1 — server still running 10 000 ms after stdin EOF |
| stdio, fixed | exit 0 — markers on stderr only; EOF-to-exit 77 / 106 / 161 ms across runs |
| JVM, pre-fix (with the new tests) | exit 1 — 301 tests, 1709 assertions, **30 failures** |
| JVM, fixed | exit 0 — 301 tests, 1709 assertions, **0 failures** |

Baseline before any test was added: 296 tests / 1630 assertions, exit 0. The two controls (`equality-only-assertion-carries-no-marker`, `run-loop-leaves-clojure-futures-usable-after-eof`) passed in every run, the red ones included. The finding-3 red needed the rest of the change in place, so it was produced by planting a revert of only the `-main` `finally`: the plant was confirmed applied before the run and the restore verified by content hash (`git hash-object` default form reproduced the committed blob; `git diff --quiet HEAD` exit 0).

## Gates

All re-run on the final rebased base, each exit code captured directly from the runner and never through a pipe:

| Gate | CI job | Exit |
|---|---|---|
| `clojure -M:test` from `tools/story-mcp` | `jvm-tools-story-mcp` | 0 |
| `node test/stdio-roundtrip.js` | `node-test-tools-story-mcp` | 0 |
| `npm run test:story` from `tools/mcp-conformance` | `mcp-conformance-story` | 0 |
| `scripts/check_doc_slugs.py` | `verify-readme-links` | 0 |
| `scripts/check_readme_links.py --ci` | `verify-readme-links` | 0 |

The changed-surface classifier reports `tools_jvm=true` and `mcp_conformance=true` for this diff; `verify-readme-links` carries no surface guard and runs on every PR.

**A ratchet nobody nominated fired, and was repaired in my own lines rather than by moving its floor:** `scripts/check_require_alias_dialect.py` grades `tools/` at floor 0, and the new fixture arrived with the bare leaf aliases `story` / `plain-atom`. Renamed to `rf.story` / `rf.substrate.plain-atom` with their use sites, per `spec/Conventions.md` §Require-alias dialect; gate re-run exit 0, and the stdio round-trip re-run against the renamed prelude is exit 0. The rest of the repo-wide sweep (retired spellings, README inventories, test-lane bijection, JVM lane rosters, architecture census, fast-PR gap, CI reproduce commands, thrown-error messages, keyword-catalogue drift, retired composition vocab, gate scheduling, ai-tracking ratchet, no-hardcoded-paths) was exit 0 throughout.

## Scope notes

- Nothing outside `tools/story-mcp/**` is touched. No hot-zone file, and no file another live worktree holds. The `spec/API.md` the report cites resolves to the package's own `tools/story-mcp/spec/API.md`; the top-level hot-zone page is untouched.
- Nothing in `tools/story` was changed. Its `001-Authoring.md` is cited only as evidence that `:pred fn-or-sym` is supported, and the check-record producer in its `result.cljc` is correct as it stands — grouping the same maps is what makes check records useful, so the repair belongs in the story-mcp projection, which is where the bead places it.
- Prose, tables and fence contents are validated by no gate: the markdown was checked by hand. The one new link (`../../story/spec/001-Authoring.md`) resolves, and no table was added or had its column count changed.
- No AI attribution trailers: `CLAUDE.md` §Git Conventions forbids them and outranks the session reminder that asks for them.
