### PR TITLE
test(machines): rename the ::replace listener id off the retired image-key spelling (rf2-yvmc)

### DIFF
--- a/implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc
@@ -72,7 +72,7 @@
     (rf/make-frame {:id frame-id})
     (seed! 5000)
     (rf.trace.tooling/register-listener!
-      ::replace
+      ::swap-observer
       (fn [ev]
         (when (and replace?
                    (= :rf.sub/run (:operation ev))
@@ -92,7 +92,7 @@
         (rf.machines.timer/after-schedule-fx {:frame frame-id} args)
         (then {:fired? @fired? :b-entry @b-entry :arms @arms :cancels cancels}))
       (finally
-        (rf.trace.tooling/unregister-listener! ::replace)
+        (rf.trace.tooling/unregister-listener! ::swap-observer)
         (swap! rf.machines.timer/after-timers dissoc frame-id)))))
 
 (deftest delay-resolution-loss-preserves-successor-timer


### PR DESCRIPTION
## What

Renames the trace-listener id `::replace` to `::swap-observer` at both sites
(`register-listener!` line 75, `unregister-listener!` line 95) in
`implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc`.
Two lines changed; nothing else touched.

## Why

Trunk has been red on `docs.yml`'s `MkDocs build` since PR #9748 merged.
`scripts/check_retired_image_keys.py` matches a bare `:replace` keyword in
Clojure source whenever an image/`make-frame` token co-occurs within its
4-line window; here `(rf/make-frame {:id frame-id})` sits three lines above
the listener id, so the gate reports:

    live-retired::replace: implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc:75
        ::replace

The token is a listener id, not an image key. The fix is on this side:

* **Not** a removed-context marker — the line does not discuss the EP-0026
  retirement, so a marker would be a false statement to the gate.
* **Not** a loosening of the gate — it is right to be strict, and
  `scripts/check_retired_image_keys.py` and its fixtures are untouched.

`::swap-observer` names what the listener does (destroys frame A, publishes
same-id B mid-delay). The gate's `:replace` pattern is
`:replace(?!-)(?![\w.+!?<>=*/-])`, and `:replace-standard` is a separate exact
pattern, so the new spelling shares no stem with either.

## Quality gates (captured exit codes, run locally in the worker worktree)

The gate's own shadow-cljs line names this worktree's `shadow-cljs.edn`, so
these ran against this branch's tree, not a sibling's.

| Gate | Exit |
| --- | --- |
| `python scripts/check_retired_image_keys.py --verbose` **before** the rename | **1** (naming this file, line 75 — quoted above) |
| `python scripts/check_retired_image_keys.py --verbose` **after** | **0** (`no live retired EP-0026 image keys on the surface.`) |
| `python scripts/check_retired_image_keys.py --self-test` | **0** |
| `node out/node-test.js --test=re-frame.machine-after-delay-resolution-fence-cljs-test` | **0** — `Ran 3 tests containing 12 assertions. 0 failures, 0 errors.` |
| full CLJS lane — compile (`node scripts/compile-node-test.cjs node-test out/node-test.js`) | **0** (2002 files, 2001 compiled, 0 warnings) |
| full CLJS lane — run (`node out/node-test.js`) | **0** — `Ran 12022 tests containing 59807 assertions. 0 failures, 0 errors.` |
| `scripts/check_retired_composition_vocab.py`, `check_retired_spellings.py`, `check_keyword_catalogue_drift.py`, `check_require_alias_dialect.py`, `check_test_lane_bijection.py` | **0** each |

Assertion count is unchanged: the file carries 12 `(is ` forms before and
after (the diff touches no assertion line), and the focused run reports 12.

## CI note — read the local exits, not this PR's check set

`docs.yml`'s `detect` job classifies a PR's three-dot changed-file list against
a deliberately narrower allowlist than the workflow's `push.paths` filter.
`implementation/machines/**` is on the push filter but **not** on the PR-side
list, so on this PR `detect` reports `docs_surface=false` and `MkDocs build` is
**SKIPPED** — exactly how PR #9748 shipped this red while the main push that
merged it ran the gate and went red. So the captured local exits above are the
evidence for this change; the gate will next execute on the main push that
merges it, and should be green.

Every gate above finished before this was marked ready; no gate is outstanding.
The PR's own check set is relied on via CI as usual.
