### PR TITLE
fix(story): execute and render the resolved scenario (rf2-fzbj.3, rf2-gwye.5/.6/.7)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -181,15 +181,28 @@ with?", the runtime composes them in this strict order (later wins):
 2. **Story args** — `:args` on the parent story.
 3. **Mode args** — the active `:mode`'s `:args` (deep-merge, not
    replace).
-4. **Variant args** — `:args` on the variant.
+4. **Variant args** — the variant's `:args` AFTER the `:extends` merge and
+   the `:compose` fold (root → fragments → child, last wins — see
+   [`017-Testing-Story.md`](017-Testing-Story.md) §Total merge order). The
+   plan compiler owns this layer.
 5. **Cell-local args** — runtime overrides from controls, supplied as
    `:cell-overrides` by programmatic callers.
 
 `(story/resolve-args variant-id {:active-modes [...]
                                 :cell-overrides {...}})` is the facade
-lookup. `re-frame.story.args/get-effective-args` is the sub-namespace
-alias with the same options. Plan execution additionally resolves the
-variant's inherited/composed args through the single plan compiler.
+lookup. It routes through `re-frame.story.plan/effective-args` — the
+compiled plan's `[:world :effective-args]`, the SAME value `run-variant`
+reports — so every surface that asks "what args does this variant render,
+save or share with?" gets one answer: the canvas, the controls panel, docs,
+snapshot identity, the save snapshot and Copy EDN agree with the run.
+
+`re-frame.story.args/resolve-args` (and its `get-effective-args` alias) is
+the PRIMITIVE underneath: it folds the four ambient / per-run layers around
+the variant's OWN `:args` and does NOT walk `:extends` / `:compose`. Reach
+for it only when that raw fold is what you mean. A consumer that wants the
+scenario's args and calls it renders a story default in place of an
+inherited value, and saving that snapshot writes the default onto a new
+variant as an override the author never made (rf2-gwye.7).
 
 Deep-merge (per Storybook's convention) for nested maps;
 override-by-replacement for vectors. This convention matches Phase 1
@@ -229,6 +242,13 @@ Strict order, per spec/007:
    - Evaluate `:loaders-complete-when` if provided. If truthy,
      proceed. Otherwise wait for the next non-loader event;
      re-evaluate.
+
+   `:loaders` and `:loaders-complete-when` here are the RESOLVED slots the
+   plan compiler produced — composed fragments' loaders first, then the
+   `:extends`-merged variant chain's — never the raw registered body, which
+   cannot see an inherited or composed fixture. Reading the raw body ran no
+   loaders at all for a child that only `:extends` or `:compose`s one, and
+   reported the run as passing (rf2-gwye.5).
 2. **Phase 2 — Events.** For each event in
    `(concat story-events variant-events)`:
    - `dispatch-sync` in order. Drain to completion between events.
@@ -566,9 +586,15 @@ the variant body).
    closures inspecting every future trace event.
 2. Lifecycle watchers are cleared
    (`loaders/clear-watchers!`).
-3. **The variant body's `:loaders-teardown` events dispatch-sync into
-   the variant frame in declared order.** Symmetric counterpart of
-   `:loaders` (rf2-lqs0b).
+3. **The RUN's `:loaders-teardown` events dispatch-sync into the variant
+   frame in declared order.** Symmetric counterpart of `:loaders`
+   (rf2-lqs0b). "The run's" is load-bearing: the events are the RESOLVED
+   slot (composed + inherited, like `:loaders`) CAPTURED when the frame was
+   allocated, so the cleanup releases what THIS run's loaders opened.
+   Re-reading the current registration at teardown meant an ordinary edit or
+   hot reload between a run and its destroy ran a cleanup whose setup never
+   fired, and skipped the one that did (rf2-gwye.6). A cleanup edited, added
+   or removed while a variant is mounted takes effect on the NEXT run.
 4. **The variant's `:frame-setup` decorator `:teardown` events
    dispatch-sync into the variant frame** in reverse-declaration order
    (innermost decorator's teardown runs first, outermost last).

--- a/tools/story/spec/008-Docs-Mode.md
+++ b/tools/story/spec/008-Docs-Mode.md
@@ -17,7 +17,7 @@
 
 The render shell already exposes every datum the docs pane needs —
 the variant body via the registrar, the resolved arg merge via
-`re-frame.story.args/resolve-args`, the decorator stack via
+`re-frame.story.plan/effective-args`, the decorator stack via
 `re-frame.story.decorators/resolve-decorators`, the workspace
 registry for prose lookups. What was missing was a **read-only
 presentation surface** that gathers them in the same order Storybook
@@ -63,7 +63,7 @@ The pane renders six sections, top-to-bottom:
 |---|-------------|---------------------------------------------------------------------------------|------------------------------------------------|
 | 1 | Header      | variant id, parent-story id, tags, variant `:doc` (or parent `:doc` fallback)   | always                                         |
 | 2 | Prose       | `:body` strings from `:layout :prose` workspaces that reference this variant   | at least one prose block found                 |
-| 3 | Args        | `(args/resolve-args variant-id {:cell-overrides nil})` × variant `:argtypes`    | always (renders "no args resolved" if empty)   |
+| 3 | Args        | `(plan/effective-args variant-id {:cell-overrides nil})` × variant `:argtypes`    | always (renders "no args resolved" if empty)   |
 | 4 | Decorators  | `(decorators/resolve-decorators variant-id {:active-modes … :cell-overrides nil})` | always (renders "no decorators" if empty)      |
 | 5 | Parameters  | variant body's `:modes` / `:substrates` / `:platforms` slots (story fallback)  | always (renders "no … declared" if all empty) |
 | 6 | Tags        | sorted variant tags (parent-story fallback)                                     | always (renders "no tags" if empty)            |
@@ -143,7 +143,7 @@ A three-column table — `key | default | doc` — sorted by arg-key.
 
 - **key.** The arg's keyword.
 - **default.** The resolved value via
-  `args/resolve-args variant-id {:cell-overrides nil}` — the args
+  `plan/effective-args variant-id {:cell-overrides nil}` — the args
   the variant renders WITHOUT runtime overrides. Read-only docs
   shouldn't reflect the user's transient edits in the controls
   panel.

--- a/tools/story/spec/010-Toolbar.md
+++ b/tools/story/spec/010-Toolbar.md
@@ -122,7 +122,8 @@ The "mode tuple" the toolbar consumes is the registry pair
 `[mode-id body]` where `body` is the above map. The toolbar reads
 `mode-id` for the chip label (rendered as `(str mode-id)`), `:doc` for
 the chip's `title=` tooltip, and ignores `:args` itself — `:args` is
-deep-merged downstream by `re-frame.story.args/resolve-args`.
+deep-merged downstream into the effective args
+(`re-frame.story.plan/effective-args`).
 
 ### Optional grouping — `:axis` (v1)
 

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -489,7 +489,7 @@ MUST fail. `explain` MUST show arg substitutions.
 **Run opts feed the SAME effective args the result reports.** The
 effective args are the full precedence chain
 `global < story < active-modes < variant < cell-overrides`
-(`re-frame.story.args/resolve-args`). The runner threads the per-run
+(`re-frame.story.plan/effective-args`). The runner threads the per-run
 layers — the UI/test surfaces' `:active-modes` and `:cell-overrides` —
 INTO plan compilation (the `:run-args` compiler input), so the substituted
 `[:arg key]` placeholders in **setup, script, db-seed, network replies, and

--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -281,7 +281,7 @@ Share semantics:
   (`re-frame.story.ui.share/declared-arg-keys`). Both drop classes feed the
   share-import hint's `:dropped` count, so a stale override DOWNGRADES the
   reproducibility status and surfaces the drift banner instead of being
-  installed as an orphan live arg `args/resolve-args` would merge into the
+  installed as an orphan live arg `plan/effective-args` would merge into the
   recipient's effective state (a partial artifact masquerading as full);
 - mount URL hydration runs in TWO passes with a SINGLE authoritative owner
   per slot (rf2-ovb1en — `re-frame.story.ui.shell/hydrate-url-state!`):

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -122,7 +122,7 @@ All under `re-frame.story`.
 | `assertions-passing?` | `(assertions-passing? result)` | [`004-Assertions.md`](004-Assertions.md) |
 | `valid-variant-id?` | `(valid-variant-id? [ns-part name-part])` — true iff the DECOMPOSED `[ns-part name-part]` strings name a canonical `:story.<path>/<variant>` id. STRING-shape grammar so an MCP write path validates a caller id BEFORE interning a keyword (the `fresh-keyword-checked` `shape-ok?` predicate). | [`001-Authoring.md`](001-Authoring.md) §Story id grammar |
 | `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id opts)` / `(variant-share-url variant-id base-url opts)` | [`005-SOTA-Features.md`](005-SOTA-Features.md) §Share URL (retired QR popover). The no-base forms return a query fragment without a leading `?`. |
-| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` | Five-layer args resolution; opts use `:active-modes` and `:cell-overrides`, not `:mode` / `:overrides`. |
+| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` | Five-layer args resolution, whose variant layer is the `:extends`/`:compose`-resolved one (routes through `re-frame.story.plan/effective-args`, so it equals a run's `:effective-args`); opts use `:active-modes` and `:cell-overrides`, not `:mode` / `:overrides`. |
 | `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` | The compiled decorator stack; accepts the same run-arg layers. See [`002-Runtime.md`](002-Runtime.md). |
 
 ### Execution verbs — `run` / `is` / `explain`

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1814,10 +1814,12 @@
 
 (defn resolve-args
   "Per `002-Runtime.md` §Args resolution precedence — materialise the effective args map for a
-  variant render given the active modes + cell overrides. See
-  `re-frame.story.args/resolve-args`."
-  ([variant-id]       (rf.story.args/resolve-args variant-id))
-  ([variant-id opts]  (rf.story.args/resolve-args variant-id opts)))
+  variant render given the active modes + cell overrides. The variant layer is
+  the `:extends`-merged / `:compose`-folded one the plan compiler resolves, so
+  this is the SAME value `run-variant` reports as `:effective-args`. See
+  `re-frame.story.plan/effective-args`."
+  ([variant-id]       (rf.story.plan/effective-args variant-id))
+  ([variant-id opts]  (rf.story.plan/effective-args variant-id opts)))
 
 (defn resolve-decorators
   "Per `002-Runtime.md` §Decorator composition order — return the variant's resolved decorator stack

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -120,7 +120,14 @@
   Returns the deep-merged args map. If the variant or its parent
   story is unregistered, the corresponding layer contributes `{}`. The
   fn never throws on a missing artefact; callers decide whether to surface
-  an inline diagnostic or record a `:rf.error/unknown-variant` assertion."
+  an inline diagnostic or record a `:rf.error/unknown-variant` assertion.
+
+  THE VARIANT LAYER HERE IS THE VARIANT'S OWN `:args`, read off the raw
+  side-table body — this fn resolves the five AMBIENT/RUN layers and does
+  NOT walk `:extends` / `:compose`, which the plan compiler owns. Ask
+  `re-frame.story.plan/effective-args` for the effective scenario args
+  (the value `run-variant` reports); reach for this fn only when the raw
+  layer fold is what you mean."
   ([variant-id]
    (resolve-args variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides] :as _opts}]

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -140,6 +140,25 @@
   allocated-decorator-stacks
   (atom {}))
 
+;; Per-frame ALLOCATE-TIME `:loaders-teardown`, for exactly the reason the
+;; decorator capture above exists (rf2-gwye.6). Teardown used to re-read the
+;; CURRENT registration, so an ordinary edit / hot-reload between a run and its
+;; destroy ran a cleanup whose `:loaders` never fired and skipped the cleanup
+;; for the resource the live run actually opened — closing the wrong socket,
+;; timer or subscription, or none at all. The capture is the RESOLVED slot
+;; (the compiled plan's, when the caller threaded a `world`), so an inherited /
+;; composed cleanup is owned by the run too. PRESENCE is the signal, not
+;; contents: a run that owns NO cleanup captures `[]`, and teardown must run
+;; that empty vector rather than fall back to a cleanup the newest
+;; registration grew after the run started. Evicted by `run-teardown-walks!`.
+(defonce
+  ^{:doc "frame-id → the `:loaders-teardown` events CAPTURED at `allocate!`
+         time (resolved from the compiled plan's `:world` when one was
+         threaded). Read (and evicted) by `run-teardown-walks!` so a run's
+         cleanup releases what that run opened."}
+  allocated-loaders-teardown
+  (atom {}))
+
 (defn- ensure-stub-event!
   "Register a `reg-fx` handler under `stub-id` that handles a
   redirected fx call. Idempotent — re-registration replaces the slot
@@ -690,35 +709,35 @@
   story-runtime which expects a fresh app-db; the caller (`runtime/
   reset-variant`) destroys first.
 
-  `classification` (optional, 3-arity; rf2-lsr95i) is the variant's
-  EFFECTIVE `:sensitive`/`:large` app-db classification — a map with
-  `:sensitive`/`:large` keys, already `:extends`-merged root→child. The
-  runtime (`run-phase-0!`) threads its ALREADY-COMPILED plan's `[:world
-  :sensitive]` / `[:world :large]` here (`plan/variant-plan` folds
-  `:sensitive`/`:large` through the `:extends` chain via `context-keys`
-  — the SAME merge `allocate-inline!` already receives for an inline
-  plan run, rf2-cmjly3 finding 12). Omitted (2-arity — direct/test
-  callers with no compiled plan on hand) falls back to the raw variant
-  body's OWN `:sensitive`/`:large`, i.e. no `:extends` inheritance; that
-  is only correct for a variant with no `:extends` parent, which is what
-  every such caller in this codebase exercises. Before this fn threaded
-  a classification arg, `allocate!` ALWAYS read the raw un-merged body —
-  so a variant that only `:extends`ed a classified parent, declaring no
-  classification itself, silently dropped the parent's redaction.
+  `world` (optional) is the ALREADY-COMPILED plan's `:world` — the SCENARIO
+  this frame is allocated for, with `:extends` and `:compose` resolved. The
+  runtime (`run-phase-0!`) threads `(:world plan)`; three groups of slots are
+  read off it:
 
-  `plan-fx-overrides` (optional, 4-arity; rf2-shx4) is the compiled plan's
-  `[:world :frame :fx-overrides]` map — the lowering `:network` folds
-  `{:rf.http/managed :rf.http/managed-test-stub}` into. It merges UNDER the
-  decorator stack's materialised stubs (the plan map wins), exactly as
-  `allocate-inline!` has always merged its own. Omitted (2-/3-arity) leaves
-  the decorator stubs alone. Before this arity existed the registered path
-  passed only the decorator stack, so an authored `:network` fixture's
-  redirect never reached the frame and the variant executed the REAL
-  `:rf.http/managed` transport."
-  ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil nil))
-  ([variant-id decorator-stack classification]
-   (allocate! variant-id decorator-stack classification nil))
-  ([variant-id decorator-stack classification plan-fx-overrides]
+  - `:sensitive` / `:large` — the EFFECTIVE app-db classification
+    (rf2-lsr95i). `plan/variant-plan` folds them through the `:extends` chain
+    via `context-keys` — the SAME merge `allocate-inline!` receives for an
+    inline plan run (rf2-cmjly3 finding 12). Reading the raw body here
+    silently dropped a classified parent's redaction from a child that only
+    `:extends`ed it.
+  - `[:frame :fx-overrides]` — the compiled frame overrides (rf2-shx4), e.g.
+    the `:network` lowering's `{:rf.http/managed :rf.http/managed-test-stub}`
+    redirect. They merge UNDER the decorator stack's materialised stubs (the
+    plan map wins), exactly as `allocate-inline!` merges its own; without
+    them an authored `:network` fixture reached the REAL transport.
+  - `:loaders` / `:loaders-complete-when` / `:loaders-teardown` — the RESOLVED
+    loader world (rf2-gwye.5). The events-only classification is taken from
+    it, so a variant that only `:extends` (or `:compose`s) a loader fixture
+    takes the four-phase path that fixture needs instead of jumping to
+    `:ready` with its loaders unrun; and its `:loaders-teardown` is CAPTURED
+    for this run in `allocated-loaders-teardown` (rf2-gwye.6).
+
+  Omitted (2-arity — direct / test callers with no compiled plan on hand)
+  every slot falls back to the RAW registered body, i.e. no `:extends` /
+  `:compose` resolution. That is only correct for a variant with neither,
+  which is what every such caller in this codebase exercises."
+  ([variant-id decorator-stack] (allocate! variant-id decorator-stack nil))
+  ([variant-id decorator-stack world]
    (when rf.story.config/enabled?
      (install-canonical-frame-events!)
      (let [fx-stack       (rf.story.decorators/fx-overrides-map (:fx-override decorator-stack))
@@ -731,12 +750,19 @@
            ;; path passed only the decorator stack, so an authored `:network`
            ;; fixture's redirect was silently dropped and the variant reached
            ;; the REAL `:rf.http/managed` transport.
-           fx-overrides   (merge decor-fx plan-fx-overrides)
+           fx-overrides   (merge decor-fx (get-in world [:frame :fx-overrides]))
            ;; Inline the variant-body lookup (`variant-body` is defined
            ;; lower in this ns) — go through the registrar directly so
            ;; the events-only classification doesn't depend
            ;; on the file's declaration order.
            v-body         (rf.story.registrar/handler-meta :variant variant-id)
+           ;; THE SCENARIO THIS FRAME IS ALLOCATED FOR: the compiled plan's
+           ;; `:world` when the caller has one (every `run-variant` /
+           ;; `prepare-run!` path), else the raw registered body for the
+           ;; 2-arity direct callers. Every `:extends`/`:compose`-sensitive
+           ;; slot below reads THIS, so the classification, the loader world
+           ;; and the captured cleanup all describe ONE scenario.
+           scenario       (or world v-body)
            ;; EP-0026 §Default Image / §Layered Resolution — the FULL `:images`
            ;; vector this variant frame is created with:
            ;;
@@ -768,9 +794,12 @@
            ;; plus the image ids (for frame-meta tooling read-back).
            config-map     (variant-frame-config
                             variant-id fx-overrides
-                            (assoc (select-keys v-body [:sensitive :large])
+                            (assoc (select-keys scenario [:sensitive :large])
                                    :image-ids (keep image-id author-images)))
-           events-only?   (rf.story.loaders/events-only-variant? v-body decorator-stack)]
+           ;; Classify off the RESOLVED loader world: an inherited or composed
+           ;; `:loaders` / `:loaders-complete-when` keeps the variant off the
+           ;; events-only fast path, so its fixture actually runs (rf2-gwye.5).
+           events-only?   (rf.story.loaders/events-only-variant? scenario decorator-stack)]
        ;; EP-0023 §Stories / §Frame-derived live registration resolution
        ;; — the frame carries the resolved, sealed image GENERATION so
        ;; `process-event!`'s `call-with-frame-resolution` routes the whole cascade
@@ -798,12 +827,12 @@
        ;; already redacted in any trace the variant's setup emits. (The frame
        ;; annotation that previously rode the frame config is removed.)
        ;;
-       ;; rf2-lsr95i: prefer the caller-supplied EFFECTIVE (`:extends`-merged)
-       ;; classification; fall back to the raw body's own `:sensitive`/`:large`
-       ;; only when no `classification` was threaded (the 2-arity direct/test
-       ;; callers below `run-phase-0!`, none of which exercise `:extends`).
+       ;; rf2-lsr95i: the EFFECTIVE (`:extends`-merged) classification when a
+       ;; compiled `world` was threaded; the raw body's own
+       ;; `:sensitive`/`:large` for the 2-arity direct / test callers below
+       ;; `run-phase-0!`, none of which exercise `:extends`.
        (apply-variant-classification!
-         variant-id (or classification (select-keys v-body [:sensitive :large])))
+         variant-id (select-keys scenario [:sensitive :large]))
        ;; Drive the lifecycle by variant shape. Events-only
        ;; variants jump straight to :ready (no skeleton ever shows);
        ;; everything else takes the classical four-phase route through
@@ -822,6 +851,15 @@
        ;; re-run path (run-phase-0!) reset-state!'s teardown reads the PRIOR
        ;; stash BEFORE this line overwrites it with the current stack.
        (swap! allocated-decorator-stacks assoc variant-id decorator-stack)
+       ;; …and the RESOLVED `:loaders-teardown` this run owns, for the same
+       ;; reason and with the same lifetime (rf2-gwye.6). Stashed even when
+       ;; EMPTY: presence is what tells teardown this run's cleanup is known,
+       ;; so a cleanup added to the registration AFTER the run started never
+       ;; fires against a resource it never opened. In the re-run path
+       ;; (`run-phase-0!`) `reset-state!`'s teardown consumes the PRIOR capture
+       ;; before this line overwrites it.
+       (swap! allocated-loaders-teardown assoc variant-id
+              (vec (:loaders-teardown scenario)))
        variant-id))))
 
 ;; ---- inline-plan allocation ----------------------------------------------
@@ -1008,12 +1046,24 @@
   ;; rather than a require this `.cljc` cannot make.
   (when-let [drop (rf.story.late-bind/get-fn :drop-a11y-state)]
     (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
-  ;; Step 3 — variant body :loaders-teardown. Runs BEFORE
-  ;; decorator teardown so loader-installed narrower state is cleaned
-  ;; up before decorator-installed wider state.
+  ;; Step 3 — the run's :loaders-teardown. Runs BEFORE decorator teardown so
+  ;; loader-installed narrower state is cleaned up before decorator-installed
+  ;; wider state.
+  ;;
+  ;; The events come from the ALLOCATE-TIME capture (rf2-gwye.6), mirroring
+  ;; step 4's decorator capture: cleanup must release what THIS run's loaders
+  ;; opened, and re-reading the registration here handed an edited body's
+  ;; cleanup to a run that never set it up. The capture is also the RESOLVED
+  ;; slot, so an `:extends`-inherited / `:compose`d cleanup runs at all
+  ;; (rf2-gwye.5). Falls back to the current registration only for a frame
+  ;; torn down without going through `allocate!`'s stash path; `find`, not
+  ;; `get`, so a run that captured NO cleanup keeps its empty answer.
   (try
-    (let [v-body (rf.story.registrar/handler-meta :variant variant-id)
-          evs    (:loaders-teardown v-body)]
+    (let [captured (find @allocated-loaders-teardown variant-id)
+          evs      (if captured
+                     (val captured)
+                     (:loaders-teardown (rf.story.registrar/handler-meta :variant variant-id)))]
+      (swap! allocated-loaders-teardown dissoc variant-id)
       (when (seq evs)
         (apply-loaders-teardown! variant-id evs)))
     (catch #?(:clj Throwable :cljs :default) _ nil))

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -432,9 +432,9 @@
 ;; "narrower-than-the-decorator stack tears down first".
 
 (defn- apply-loaders-teardown!
-  "Walk the variant body's `:loaders-teardown` vector and dispatch-sync
-  each event into the variant's frame in declared order. Per `002-
-  Runtime.md` §Loader teardown contract.
+  "Walk the supplied `:loaders-teardown` vector — the RUN's resolved cleanup,
+  captured at allocation — and dispatch-sync each event into the variant's
+  frame in declared order. Per `002-Runtime.md` §Loader teardown contract.
 
   Exception handling is identical to `apply-frame-teardown!`: re-frame's
   interceptor chain catches handler throws and emits
@@ -1012,8 +1012,8 @@
   1. Clear lifecycle watchers + per-frame stub-call log; drop the
      per-variant assertion accumulators + the play-runner's per-frame
      run-state via the late-bind hooks.
-  2. Dispatch-sync the variant body's `:loaders-teardown` events
-     (declared order) — cleans up loader-installed narrower
+  2. Dispatch-sync the RUN's `:loaders-teardown` events (declared order,
+     from the allocate-time capture) — cleans up loader-installed narrower
      state. BEFORE the decorator teardown.
   3. Dispatch-sync the `:frame-setup` decorator `:teardown` events
      (reverse-declaration order) — cleans up decorator-installed wider
@@ -1092,9 +1092,11 @@
   1. Drop per-variant assertion accumulators (`drop-assertion-accumulators`
      late-bind shim) + per-frame stub-call log.
   2. Clear lifecycle watchers (`rf.story.loaders/clear-watchers!`).
-  3. Dispatch-sync the variant body's `:loaders-teardown` events in
-     declared order. Exceptions are caught and projected
-     into the variant frame's `:rf.story/assertions` as
+  3. Dispatch-sync the RUN's `:loaders-teardown` events in declared order —
+     the resolved slot captured when this run's frame was allocated, so the
+     cleanup releases what this run's loaders opened even if the
+     registration changed meanwhile (rf2-gwye.6). Exceptions are caught and
+     projected into the variant frame's `:rf.story/assertions` as
      `:rf.error/exception` records with
      `:phase :phase-loaders-teardown`. The walk never aborts.
   4. Dispatch-sync the variant's `:frame-setup` decorator `:teardown`
@@ -1107,7 +1109,7 @@
      inside `rf/destroy-frame!`).
   6. `rf/destroy-frame!` runs the frame's own teardown walk.
 
-  Step 3 fires BEFORE step 4: the variant body's `:loaders-teardown`
+  Step 3 fires BEFORE step 4: the run's `:loaders-teardown`
   cleans up what `:loaders` opened (innermost in resource-scope terms);
   decorator `:teardown` cleans up what decorator `:init` opened
   (outermost). Matches the rule 'narrower-than-the-decorator stack

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -105,6 +105,7 @@
   (:require [re-frame.late-bind         :as rf.late-bind]
             [re-frame.story.args        :as rf.story.args]
             [re-frame.story.fingerprint :as rf.story.fingerprint]
+            [re-frame.story.plan        :as rf.story.plan]
             [re-frame.story.registrar   :as rf.story.registrar]
             [re-frame.story.tags        :as rf.story.tags]))
 
@@ -293,7 +294,7 @@
   ([variant-id {:keys [active-modes cell-overrides substrate] :as _opts}]
    (let [variant      (variant-body-slice variant-id)
          story        (story-body-slice variant-id)
-         effective    (rf.story.args/resolve-args variant-id
+         effective    (rf.story.plan/effective-args variant-id
                                          {:active-modes   active-modes
                                           :cell-overrides cell-overrides})
          ;; EP-0002 — the variant frame is the explicit

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -1968,6 +1968,40 @@
               "re-frame2-story: variant-plan target must be a keyword id or a map"
               {:target target})))))
 
+(defn effective-args
+  "Return the effective args a run of REGISTERED `variant-id` executes with:
+  the compiled plan's `[:world :effective-args]` — the `:extends`-merged and
+  `:compose`-folded variant arg layer with the ambient + per-run layers
+  (`rf.story.args/run-arg-layers`) folded around it.
+
+  `opts` is the `{:active-modes [...] :cell-overrides {...}}` shape
+  `rf.story.args/resolve-args` takes.
+
+  This is the ONE answer to \"what args does this variant render / save /
+  share with?\", and it is the SAME value `run-variant` reports. The plan
+  compiler is the single authority for the variant layer;
+  `rf.story.args/resolve-args` reads `:args` off the raw side-table body, so
+  it cannot see an inherited or composed one — a child that only `:extends` a
+  parent resolved there as the STORY DEFAULT, and saving that snapshot wrote
+  the default onto a new variant as an explicit override the author never
+  made (rf2-gwye.7). Consumers needing the effective scenario args route
+  here rather than re-walking `:extends` / `:compose` themselves.
+
+  Best-effort, like every other tooling read over the compiler
+  (`rf.story.view-args/compiled-view-args-schema`): a plan that cannot compile
+  — an unregistered variant, an unresolvable `[:arg key]`, a view-args
+  violation — falls back to `rf.story.args/resolve-args`, so a caller
+  rendering a broken registration still sees the layers that DO resolve
+  instead of an exception."
+  ([variant-id] (effective-args variant-id nil))
+  ([variant-id opts]
+   (or (try
+         (get-in (variant-plan variant-id
+                               {:run-args (rf.story.args/run-arg-layers variant-id opts)})
+                 [:world :effective-args])
+         (catch #?(:clj Exception :cljs :default) _ nil))
+       (rf.story.args/resolve-args variant-id opts))))
+
 (defn explain
   "Return the `:explain` map for `target` (§Explain API). Convenience over
   `(:explain (variant-plan target opts))`. Shows the source chain, parent

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -270,14 +270,15 @@
   routing past them keeps the phase reads honest: `current-state`
   stays `:ready` end-to-end.
 
-  The loader BODY (`:loaders` + `:loaders-complete-when`)
-  defaults to the registered variant body but MAY be supplied explicitly,
-  so the inline-plan path (which has no registration) feeds the loader
-  slots the compiler carried onto the plan's `:world`. The default keeps
-  the registered path reading the side-table verbatim."
-  ([variant-id] (run-loaders! variant-id (rf.story.frames/variant-body variant-id)))
-  ([variant-id loader-body]
-   (if (= :ready (rf.story.loaders/current-state variant-id))
+  The loader BODY (`:loaders` + `:loaders-complete-when`) is ALWAYS supplied
+  by the caller, and always comes off the COMPILED PLAN's `:world` — the
+  registered path through `prepare-context`, the inline path (which has no
+  registration) through `prepare-inline-context`. It used to default to the
+  raw registered body, which is what made a variant that only `:extends` (or
+  `:compose`s) a loader fixture run no loaders at all while reporting `:pass`
+  (rf2-gwye.5): the compiler resolves those slots, the side-table does not."
+  [variant-id loader-body]
+  (if (= :ready (rf.story.loaders/current-state variant-id))
     ;; Events-only fast-path. Lifecycle already terminal-
     ;; for-mount; the loader cascade has nothing to do.
     true
@@ -306,7 +307,7 @@
             true)
           (do
             (record-loader-incomplete! variant-id variant-body)
-            false)))))))
+            false))))))
 
 ;; ---- error recording -----------------------------------------------------
 
@@ -767,6 +768,11 @@
      ;; with no `:extends`, and is the strictly-more-correct extends-aware
      ;; value when the variant inherits args.
      :effective-args   (get-in plan [:world :effective-args] {})
+     ;; The RESOLVED loader world phase 1 executes — the twin of the inline
+     ;; path's `:loader-body`. `:loaders` / `:loaders-complete-when` fold in
+     ;; the composed fragments and the `:extends` chain, which the raw
+     ;; registered body this phase used to read cannot express (rf2-gwye.5).
+     :loader-body      (select-keys (:world plan) [:loaders :loaders-complete-when])
      :snapshot         (rf.story.identity/snapshot-identity variant-id opts)}))
 
 (defn- ensure-fresh-frame!
@@ -848,10 +854,11 @@
   project evidence from this run only, and so do the tape-projected
   assertions (rf2-3okc).
 
-  Classification comes from the already-compiled plan's
-  `[:world :sensitive]` / `[:world :large]` slots, after `:extends`
-  resolution. Registered and inline plans therefore apply inherited
-  classification through the same allocation boundary."
+  The frame is allocated FROM the already-compiled plan's `:world`, so the
+  classification (`:sensitive` / `:large`), the lowered frame `:fx-overrides`
+  and the loader world (`:loaders` / `:loaders-complete-when` /
+  `:loaders-teardown`) all reach the frame `:extends`- and `:compose`-resolved.
+  Registered and inline plans therefore allocate from the same shape."
   [{:keys [variant-id decorator-stack plan] :as ctx}]
   (ensure-fresh-frame! variant-id)
   ;; rf2-shx4 — realize the compiled `:network` fixture BEFORE allocation, so
@@ -860,13 +867,11 @@
   ;; emits the `{:rf.http/managed :rf.http/managed-test-stub}` redirect but
   ;; registers nothing, so without this the variant reached the REAL transport.
   (rf.story.network/install-for-frame! variant-id (get-in plan [:world :network]))
-  (rf.story.frames/allocate! variant-id decorator-stack
-                     (select-keys (:world plan) [:sensitive :large])
-                     ;; …and carry the plan's lowered frame `:fx-overrides`
-                     ;; (the redirect above) onto the frame — the registered
-                     ;; path dropped it entirely; `allocate-inline!` already
-                     ;; merged it.
-                     (get-in plan [:world :frame :fx-overrides]))
+  ;; Allocate from the compiled `:world` — one argument carrying every
+  ;; scenario slot the frame needs (classification, the lowered frame
+  ;; `:fx-overrides`, the resolved loader world), rather than a positional
+  ;; list that grew one entry per slot somebody noticed was missing.
+  (rf.story.frames/allocate! variant-id decorator-stack (:world plan))
   (swap! rf.story.play/pending-exceptions assoc variant-id [])
   (rf.story.config/reset-redacted-failures! variant-id)
   (rf.story.play/install-trace-listener! variant-id)
@@ -952,15 +957,12 @@
   "Phase 1: drive loaders to completion. Thin wrapper that returns
   `ctx` so the orchestrator stays a clean threaded pipeline.
 
-  The loader body defaults to the registered variant body
-  (`run-loaders!` 1-arity); an inline run threads `:loader-body` on the
-  ctx (the plan's `:world` loader slots), so an inline plan's loaders run
-  through the SAME phase fn without reading the side-table."
+  The loader body is the ctx's `:loader-body` — the compiled plan's `:world`
+  loader slots — on BOTH paths: `prepare-context` puts the registered run's
+  there, `prepare-inline-context` the inline run's. Neither reads the
+  side-table, so an inherited / composed fixture runs (rf2-gwye.5)."
   [{:keys [variant-id loader-body] :as ctx}]
-  (assoc ctx :loaders-complete?
-         (if (contains? ctx :loader-body)
-           (run-loaders! variant-id loader-body)
-           (run-loaders! variant-id))))
+  (assoc ctx :loaders-complete? (run-loaders! variant-id loader-body)))
 
 (defn- run-phase-2!
   "Phase 2: dispatch the plan's `[:world :setup]`, then mark events

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -41,6 +41,7 @@
             [re-frame.core                       :as rf]
             [re-frame.story.args                 :as rf.story.args]
             [re-frame.story.config               :as rf.story.config]
+            [re-frame.story.plan                 :as rf.story.plan]
             [re-frame.story.predicates           :as rf.story.predicates]
             [re-frame.story.registrar            :as rf.story.registrar]
             [re-frame.story.review-dialog        :as rf.story.review-dialog]
@@ -50,7 +51,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Pure: args-snapshot helper
 ;;
-;; The snapshot IS `(rf.story.args/resolve-args variant-id opts)` — the effective
+;; The snapshot IS `(rf.story.plan/effective-args variant-id opts)` — the effective
 ;; args after the five-layer precedence chain (global < story < modes <
 ;; variant < cell-overrides) collapses. This wrapper exists so callers
 ;; have a single entry point + so the JVM test corpus can pin the
@@ -74,7 +75,7 @@
   ([variant-id]
    (snapshot-args variant-id nil))
   ([variant-id {:keys [active-modes cell-overrides] :as _opts}]
-   (rf.story.args/resolve-args variant-id
+   (rf.story.plan/effective-args variant-id
                       {:active-modes   (or active-modes [])
                        :cell-overrides (or cell-overrides {})})))
 

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -305,12 +305,19 @@
   composed / extended overrides; routing both through the compiled plan
   removes the divergence (single source of truth).
 
+  `plan` is the render's ALREADY-COMPILED variant plan — the one
+  `canvas-inner` compiles once for the whole render (decorators, effective
+  args, loader classification and these overrides all read it), rather than a
+  second compile of its own, which also cost the run opts: recompiled bare,
+  an `[:arg key]` resolvable only through an active-mode / cell-override layer
+  threw `:rf.error/story-missing-arg` here.
+
   `eff-args` is the post-control effective args; `resolve-render-sub-overrides`
   re-substitutes the RAW (pre-`[:arg]`) overrides against them so a
   control-driven override value reflects the live control, exactly as on the
   render-variant path."
-  [variant-id eff-args]
-  (rf.story.render/resolve-render-sub-overrides (rf.story.plan/variant-plan variant-id) eff-args))
+  [plan eff-args]
+  (rf.story.render/resolve-render-sub-overrides plan eff-args))
 
 (defn sub-overrides-scope
   "A Reagent component that wraps `child`'s render in the override-context
@@ -535,22 +542,37 @@
         ;; canvas decorator recompile needs the same opts.
         run-opts       {:active-modes   (:active-modes rk)
                         :cell-overrides (:cell-overrides rk)}
-        decorator-pack (rf.story.decorators/resolve-decorators variant-id run-opts)
-        eff-args       (rf.story.args/resolve-args variant-id run-opts)
+        ;; ONE plan compile per render, and every SCENARIO-shaped read below
+        ;; comes off it: the decorator stack, the effective args, the
+        ;; view-state sub-overrides, the events-only classification. The canvas
+        ;; used to compile twice (inside `resolve-decorators`, then inside the
+        ;; sub-override resolver) and answer the args and loader questions from
+        ;; the RAW registered body — so a variant that `:extends` or
+        ;; `:compose`s its args rendered the story default while `run-variant`
+        ;; reported the inherited value (rf2-gwye.7), and one that inherited
+        ;; `:loaders` was misclassified as events-only, suppressing the
+        ;; skeleton for a fixture that does have loading to do (rf2-gwye.5).
+        plan           (rf.story.plan/variant-plan
+                         variant-id
+                         {:run-args (rf.story.args/run-arg-layers variant-id run-opts)})
+        decorator-pack (rf.story.decorators/resolve-decorator-refs
+                         (get-in plan [:world :decorators] []))
+        eff-args       (get-in plan [:world :effective-args] {})
         assertions     (rf.story.runtime/read-assertions variant-id)
         ;; Resolve the variant's view-state subscription
         ;; overrides (arg-substituted) for the render-path binding below.
-        sub-ovr        (resolve-sub-overrides variant-id eff-args)
+        sub-ovr        (resolve-sub-overrides plan eff-args)
         substrates     (variant-substrate-set variant-id (:substrate rk))
         multi?         (and variant-id (> (count substrates) 1))
         ;; Events-only variants take the lifecycle fast-
         ;; path (`mount-ready!` jumps :pre-mount → :ready directly) so
         ;; the skeleton must not engage even on the brief render
         ;; window before `frames/allocate!` runs. Pure-data check
-        ;; against the variant body + decorator stack, mirroring
-        ;; `loaders/events-only-variant?`.
+        ;; against the RESOLVED loader world + decorator stack — the same
+        ;; `[:world …]` slots `frames/allocate!` classifies from, so the
+        ;; canvas and the runtime agree about which variants load.
         events-only?   (rf.story.loaders/events-only-variant?
-                         variant-body decorator-pack)
+                         (:world plan) decorator-pack)
         ;; rf2-4iu7tu: events-only?'s skeleton suppression (below /
         ;; `loading-phase?`'s events-only? arm) means THIS render — not
         ;; `component-did-mount` — is the one that reaches `frame-provider`

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -66,6 +66,7 @@
   (:require [clojure.string                    :as str]
             [reagent.core                      :as r]
             [re-frame.story.budgets            :as rf.story.budgets]
+            [re-frame.story.plan               :as rf.story.plan]
             [re-frame.story.registrar          :as rf.story.registrar]
             [re-frame.story.args               :as rf.story.args]
             [re-frame.story.decorators         :as rf.story.decorators]
@@ -275,7 +276,7 @@
   gets BOTH derived controls AND validation from one source — including
   any `:extends`-inherited / `:compose`-d `:component`."
   ([variant-id]
-   (resolve-argtypes variant-id (rf.story.args/resolve-args variant-id)))
+   (resolve-argtypes variant-id (rf.story.plan/effective-args variant-id)))
   ([variant-id eff-args]
    (let [vb      (rf.story.registrar/handler-meta :variant variant-id)
          story   (rf.story.args/parent-story-id variant-id)
@@ -380,7 +381,7 @@
   through."
   [variant-id path value]
   (let [shell (rf.story.ui.state/get-state)
-        base  (get (rf.story.args/resolve-args variant-id {:active-modes (:active-modes shell)})
+        base  (get (rf.story.plan/effective-args variant-id {:active-modes (:active-modes shell)})
                    (first path))]
     (rf.story.ui.state/swap-state! rf.story.ui.state/set-cell-override variant-id (vec path) value base)))
 
@@ -958,11 +959,11 @@
     (fn [variant-id]
       (let [shell        @rf.story.ui.state/shell-state-atom
             overrides    (get-in shell [:cell-overrides variant-id])
-            eff-args     (rf.story.args/resolve-args
+            eff-args     (rf.story.plan/effective-args
                            variant-id
                            {:active-modes   (:active-modes shell)
                             :cell-overrides overrides})
-            saved-args   (rf.story.args/resolve-args
+            saved-args   (rf.story.plan/effective-args
                            variant-id
                            {:active-modes (:active-modes shell)})
             argtypes     (resolve-argtypes variant-id eff-args)

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -55,7 +55,6 @@
             [re-frame.story.ui.markdown :as rf.story.ui.markdown]
             [re-frame.story.ui.test-mode.pure :as rf.story.ui.test-mode.pure]
             #?@(:cljs [[reagent.core :as r]
-                       [re-frame.story.args :as rf.story.args]
                        [re-frame.story.decorators :as rf.story.decorators]
                        [re-frame.story.ui.state :as rf.story.ui.state]])
             [re-frame.story.theme.typography :as rf.story.theme.typography :refer [sans-stack mono-stack]]
@@ -621,7 +620,7 @@
      `:argtypes` entry exists)."
      [variant-id]
      (let [shell    @rf.story.ui.state/shell-state-atom
-           eff-args (rf.story.args/resolve-args
+           eff-args (rf.story.plan/effective-args
                       variant-id
                       {:active-modes (:active-modes shell)
                        ;; :docs is read-only — overrides are deliberately

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -134,6 +134,7 @@
             [re-frame.core :as rf]
             [re-frame.story.args :as rf.story.args]
             [re-frame.story.decorators :as rf.story.decorators]
+            [re-frame.story.plan      :as rf.story.plan]
             [re-frame.story.registrar :as rf.story.registrar]
             [re-frame.story.ui.state :as rf.story.ui.state]
             [re-frame.story.theme.typography :as rf.story.theme.typography :refer [mono-stack]]
@@ -510,7 +511,7 @@
         substrates   (resolve-substrate-set variant-body story-body
                                             (or (:substrate shell) :reagent))
         view-id      (or (:component variant-body) (:component story-body))
-        eff-args     (rf.story.args/resolve-args
+        eff-args     (rf.story.plan/effective-args
                        variant-id
                        {:active-modes   (:active-modes shell)
                         :cell-overrides (get-in shell [:cell-overrides variant-id])})]

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -78,8 +78,8 @@
             #?@(:cljs [[reagent.core              :as r]
                        [re-frame.core             :as rf]
                        [re-frame.late-bind        :as rf.late-bind]
-                       [re-frame.story.args       :as rf.story.args]
                        [re-frame.story.config     :as rf.story.config]
+                       [re-frame.story.plan       :as rf.story.plan]
                        [re-frame.story.registrar  :as rf.story.registrar]
                        [re-frame.story.view-args  :as rf.story.view-args]
                        [re-frame.story.ui.trace-buffer :as rf.story.ui.trace-buffer]])
@@ -470,7 +470,7 @@
                trace-rows     (project-failures events)
                schema         (resolve-component-schema variant-id)
                vfns           (validator-fns)
-               eff-args       (rf.story.args/resolve-args variant-id)
+               eff-args       (rf.story.plan/effective-args variant-id)
                args-viols     (args-violations eff-args schema vfns)
                schema-known?  (some? schema)
                validator-on?  (some? (:validate vfns))]

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -120,7 +120,7 @@
     (let [story-id   (rf.story.args/parent-story-id variant-id)
           vb         (rf.story.registrar/handler-meta :variant variant-id)
           sb         (when story-id (rf.story.registrar/handler-meta :story story-id))
-          arg-keys   (set (keys (rf.story.args/resolve-args variant-id)))
+          arg-keys   (set (keys (rf.story.plan/effective-args variant-id)))
           argtype-ks (into (set (keys (:argtypes sb)))
                            (keys (:argtypes vb)))
           schema     (rf.story.view-args/compiled-view-args-schema variant-id)
@@ -334,7 +334,7 @@
   ([shell] (egress-edn-snippet shell (.now js/Date)))
   ([shell now-ms]
    (when-let [vid (:selected-variant shell)]
-     (let [eff    (rf.story.args/resolve-args
+     (let [eff    (rf.story.plan/effective-args
                     vid
                     {:active-modes   (:active-modes shell)
                      :cell-overrides (get-in shell [:cell-overrides vid])})

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -77,6 +77,7 @@
                        [re-frame.story.args :as rf.story.args]
                        [re-frame.story.config :as rf.story.config]
                        [re-frame.story.decorators :as rf.story.decorators]
+                       [re-frame.story.plan    :as rf.story.plan]
                        [re-frame.story.runtime :as rf.story.runtime]
                        ;; The merged `rf/frame-provider {:frame …}` shape
                        ;; routes through Reagent's `:r>` interop head, which
@@ -367,7 +368,7 @@
                                                    [:cell-overrides
                                                     variant-id])}
            decorator-pack (rf.story.decorators/resolve-decorators variant-id run-opts)
-           eff-args       (rf.story.args/resolve-args variant-id run-opts)
+           eff-args       (rf.story.plan/effective-args variant-id run-opts)
            assertions     (rf.story.runtime/read-assertions variant-id)
            errors         (:errors decorator-pack)]
        ;; Per rf2-9la06: stamp `data-test-variant` on each cell so

--- a/tools/story/test/re_frame/story/resolved_scenario_test.clj
+++ b/tools/story/test/re_frame/story/resolved_scenario_test.clj
@@ -1,0 +1,297 @@
+(ns re-frame.story.resolved-scenario-test
+  "rf2-fzbj.3 (rf2-gwye.5 / .6 / .7) — a REGISTERED run executes and reports
+  the scenario its compiled plan resolves, and a run's loader cleanup belongs
+  to that run.
+
+  The three defects share one root. The plan compiler resolves `:extends` and
+  `:compose` into `[:world …]` (loaders, loader teardown, completion policy,
+  effective args), while registered execution and the save / share / canvas
+  readers re-read the RAW registration:
+
+  1. Loaders (rf2-gwye.5) — an extends-only or compose-only variant skipped
+     its inherited / composed loaders AND their teardown, and still reported
+     `:pass` / `:ready`.
+  2. Cleanup ownership (rf2-gwye.6) — teardown read the CURRENT registration,
+     so a hot reload between a run and its destroy (or re-run) ran a cleanup
+     whose setup never ran and skipped the one that did.
+  3. Effective args (rf2-gwye.7) — the facade resolver and the save snapshot
+     read the variant's own `:args`, so an inherited value was replaced by the
+     story default, and a saved variant made that replacement permanent.
+
+  Every test drives `run-variant` / `destroy-variant!` and reads what the
+  handlers actually saw (the `calls` atom) or the frame's app-db."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.async :as rf.story.async]
+            [re-frame.story.config :as rf.story.config]
+            [re-frame.story.frames :as rf.story.frames]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.plan :as rf.story.plan]
+            [re-frame.story.play.runner-events :as rf.story.play.runner-events]
+            [re-frame.story.registrar :as rf.story.registrar]
+            [re-frame.story.runtime :as rf.story.runtime]
+            [re-frame.story.save-variant :as rf.story.save-variant]
+            [re-frame.story.ui.state :as rf.story.ui.state]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(def ^:private calls (atom []))
+
+(defn- recording-event! [id]
+  (rf/reg-event (keyword "rs" (name id))
+    (fn [_ _] (swap! calls conj id) {})))
+
+(defn- reset-all [t]
+  (rf.story/clear-all!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.config/set-global-args! {})
+  (reset! rf.story.frames/stub-call-log {})
+  (reset! rf.story.frames/allocated-decorator-stacks {})
+  (rf.story.play.runner-events/clear-all-runs!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (reset! calls [])
+  (doseq [id [:close :frag :frag-close :own :own-close :setup :script
+              :opened-a :closed-a :closed-b]]
+    (recording-event! id))
+  (rf/reg-event :rs/load
+    (fn [{:keys [db]} _] (swap! calls conj :load) {:db (assoc db :loaded true)}))
+  (rf/reg-event :rs/never-ready
+    (fn [{:keys [db]} _] {:db (assoc db :rf.story/loaders-complete? false)}))
+  (t))
+
+(use-fixtures :each reset-all)
+
+(defn- run-it!
+  ([vid] (run-it! vid nil))
+  ([vid opts] (rf.story.async/deref-blocking (rf.story/run-variant vid opts) 5000)))
+
+(defn- loader-incomplete? [result]
+  (boolean (some #(= :rf.error/loader-incomplete (:assertion %)) (:assertions result))))
+
+;; ===========================================================================
+;; 1 · rf2-gwye.5 — registered runs execute the RESOLVED loader world
+;; ===========================================================================
+
+(deftest extends-only-child-runs-inherited-loaders-and-cleanup
+  (rf.story/reg-variant :story.rs/base
+    {:loaders [[:rs/load]] :loaders-teardown [[:rs/close]]})
+  (rf.story/reg-variant :story.rs/child {:extends :story.rs/base})
+  (let [result (run-it! :story.rs/child)]
+    (is (= [:load] @calls) "the inherited loader ran")
+    (is (true? (:loaded (rf/app-db-value :story.rs/child)))
+        "and its app-db effect landed before the run settled")
+    (is (= :pass (:status result))))
+  (rf.story/destroy-variant! :story.rs/child)
+  (is (= [:load :close] @calls) "the inherited cleanup ran once on destroy"))
+
+(deftest compose-only-variant-runs-fragment-loaders-and-cleanup
+  (rf.story/reg-fragment :fragment.rs/loader
+    {:loaders [[:rs/load]] :loaders-teardown [[:rs/close]]})
+  (rf.story/reg-variant :story.rs/composed {:compose [:fragment.rs/loader]})
+  (run-it! :story.rs/composed)
+  (is (= [:load] @calls) "the composed fragment's loader ran")
+  (rf.story/destroy-variant! :story.rs/composed)
+  (is (= [:load :close] @calls) "the composed fragment's cleanup ran once"))
+
+(deftest composed-loaders-run-before-the-variants-own
+  (rf.story/reg-fragment :fragment.rs/pre
+    {:loaders [[:rs/frag]] :loaders-teardown [[:rs/frag-close]]})
+  (rf.story/reg-variant :story.rs/both
+    {:compose [:fragment.rs/pre]
+     :loaders [[:rs/own]] :loaders-teardown [[:rs/own-close]]})
+  (run-it! :story.rs/both)
+  (is (= [:frag :own] @calls)
+      "spec/017 §Total merge order — composed fragments, then the variant chain")
+  (rf.story/destroy-variant! :story.rs/both)
+  (is (= [:frag :own :frag-close :own-close] @calls)))
+
+(deftest inherited-false-completion-predicate-stops-setup-and-play
+  (rf.story/reg-variant :story.rs/gated
+    {:loaders [[:rs/load]] :loaders-complete-when :rs/never-ready})
+  (rf.story/reg-variant :story.rs/gated-child
+    {:extends :story.rs/gated
+     :setup   [[:rs/setup]]
+     :script  [[:dispatch [:rs/script]]]})
+  (let [result (run-it! :story.rs/gated-child)]
+    (is (= [:load] @calls) "the loader ran; setup and play did not")
+    (is (loader-incomplete? result)
+        "the inherited predicate's verdict is reported as loader-incomplete")
+    (is (not= :pass (:status result)))))
+
+(deftest rerun-runs-the-resolved-cleanup-once
+  (rf.story/reg-variant :story.rs/base
+    {:loaders [[:rs/load]] :loaders-teardown [[:rs/close]]})
+  (rf.story/reg-variant :story.rs/child {:extends :story.rs/base})
+  (run-it! :story.rs/child)
+  (run-it! :story.rs/child)
+  (is (= [:load :close :load] @calls)
+      "the in-place reset closes the first run's resource before re-opening")
+  (rf.story/destroy-variant! :story.rs/child)
+  (is (= [:load :close :load :close] @calls)))
+
+(deftest loader-controls-direct-no-loader-and-inline
+  (testing "direct variant — unchanged"
+    (rf.story/reg-variant :story.rs/direct
+      {:loaders [[:rs/load]] :loaders-teardown [[:rs/close]]})
+    (run-it! :story.rs/direct)
+    (rf.story/destroy-variant! :story.rs/direct)
+    (is (= [:load :close] @calls)))
+  (testing "no-loader variant still takes the events-only fast path"
+    (reset! calls [])
+    (rf.story/reg-variant :story.rs/plain {:setup [[:rs/setup]]})
+    (let [result (run-it! :story.rs/plain)]
+      (is (= [:setup] @calls))
+      (is (= :ready (:lifecycle result)))
+      (is (not (loader-incomplete? result))))
+    (rf.story/destroy-variant! :story.rs/plain))
+  (testing "inline plan — unchanged"
+    (reset! calls [])
+    (rf.story.async/deref-blocking
+      (rf.story.runtime/run-inline-plan
+        {:loaders [[:rs/load]] :loaders-teardown [[:rs/close]]})
+      5000)
+    (is (= [:load :close] @calls))))
+
+;; ===========================================================================
+;; 2 · rf2-gwye.6 — a run's loader cleanup survives a hot reload
+;; ===========================================================================
+
+(defn- reg-reload! [teardown]
+  (rf.story/reg-variant :story.rs/reload
+    (cond-> {:loaders [[:rs/opened-a]]}
+      teardown (assoc :loaders-teardown teardown))))
+
+(deftest hot-reload-then-destroy-runs-the-cleanup-the-run-owns
+  (reg-reload! [[:rs/closed-a]])
+  (run-it! :story.rs/reload)
+  (reg-reload! [[:rs/closed-b]])
+  (rf.story/destroy-variant! :story.rs/reload)
+  (is (= [:opened-a :closed-a] @calls)
+      "A closed what A's run opened; B, whose setup never ran, did not run"))
+
+(deftest hot-reload-then-rerun-closes-the-prior-run-then-adopts-the-new-cleanup
+  (reg-reload! [[:rs/closed-a]])
+  (run-it! :story.rs/reload)
+  (reg-reload! [[:rs/closed-b]])
+  (run-it! :story.rs/reload)
+  (is (= [:opened-a :closed-a :opened-a] @calls)
+      "the reset closed the previous run's resource with ITS cleanup")
+  (rf.story/destroy-variant! :story.rs/reload)
+  (is (= [:opened-a :closed-a :opened-a :closed-b] @calls)
+      "the new run owns the new cleanup"))
+
+(deftest hot-reload-removing-or-adding-cleanup-follows-the-run
+  (testing "cleanup removed after the run opened its resource — A still runs"
+    (reg-reload! [[:rs/closed-a]])
+    (run-it! :story.rs/reload)
+    (reg-reload! nil)
+    (rf.story/destroy-variant! :story.rs/reload)
+    (is (= [:opened-a :closed-a] @calls)))
+  (testing "cleanup added after a run that had none — nothing runs"
+    (reset! calls [])
+    (reg-reload! nil)
+    (run-it! :story.rs/reload)
+    (reg-reload! [[:rs/closed-b]])
+    (rf.story/destroy-variant! :story.rs/reload)
+    (is (= [:opened-a] @calls))))
+
+(deftest parent-edit-does-not-rewrite-an-inherited-runs-cleanup
+  (rf.story/reg-variant :story.rs/parent
+    {:loaders [[:rs/opened-a]] :loaders-teardown [[:rs/closed-a]]})
+  (rf.story/reg-variant :story.rs/heir {:extends :story.rs/parent})
+  (run-it! :story.rs/heir)
+  (rf.story/reg-variant :story.rs/parent
+    {:loaders [[:rs/opened-a]] :loaders-teardown [[:rs/closed-b]]})
+  (rf.story/destroy-variant! :story.rs/heir)
+  (is (= [:opened-a :closed-a] @calls)))
+
+(deftest destroy-twice-does-not-repeat-the-cleanup
+  (reg-reload! [[:rs/closed-a]])
+  (run-it! :story.rs/reload)
+  (rf.story/destroy-variant! :story.rs/reload)
+  (rf.story/destroy-variant! :story.rs/reload)
+  (is (= [:opened-a :closed-a] @calls)))
+
+;; ===========================================================================
+;; 3 · rf2-gwye.7 — effective args agree across run, facade, save, snippet
+;; ===========================================================================
+
+(def ^:private inherited {:count 42 :nested {:v 7 :keep 1}})
+
+(defn- reg-args-scenario! []
+  (rf.story/reg-story :story.rsargs {:args {:count 0 :nested {:v 0 :keep 1}}})
+  (rf.story/reg-mode :Mode.rsargs/loud {:args {:count 5 :theme :loud}})
+  (rf.story/reg-variant :story.rsargs/parent {:args {:count 42 :nested {:v 7}}})
+  (rf.story/reg-variant :story.rsargs/child {:extends :story.rsargs/parent})
+  (rf.story/reg-fragment :fragment.rsargs/args {:args {:count 42 :nested {:v 7}}})
+  (rf.story/reg-variant :story.rsargs/composed {:compose [:fragment.rsargs/args]})
+  (rf.story/reg-variant :story.rsargs/deep
+    {:extends :story.rsargs/parent :args {:nested {:v 9}}})
+  (rf.story/reg-variant :story.rsargs/direct {:args {:count 3}}))
+
+(defn- surfaces
+  "The effective args each surface reports for `vid` under run `opts`."
+  [vid opts]
+  (let [run (run-it! vid opts)]
+    (rf.story/destroy-variant! vid)
+    {:run      (:effective-args run)
+     :facade   (rf.story/resolve-args vid opts)
+     :snapshot (rf.story.save-variant/snapshot-args vid opts)}))
+
+(deftest inherited-and-composed-args-agree-on-every-surface
+  (reg-args-scenario!)
+  (doseq [vid [:story.rsargs/child :story.rsargs/composed]]
+    (is (= {:run inherited :facade inherited :snapshot inherited} (surfaces vid nil))
+        (str vid " — the resolved variant layer beats the story default"))))
+
+(deftest saved-variant-round-trip-keeps-the-inherited-args
+  (reg-args-scenario!)
+  (doseq [vid [:story.rsargs/child :story.rsargs/composed]]
+    (let [saved-id (keyword "story.rsargs" (str "saved-" (name vid)))
+          snippet  (rf.story.save-variant/gen-variant-snippet
+                     {:variant-id saved-id
+                      :extends    vid
+                      :args       (rf.story.save-variant/snapshot-args vid)})
+          [_ id body] (edn/read-string snippet)]
+      (rf.story.registrar/reg-variant* id body)
+      (is (= inherited (get-in (rf.story.plan/variant-plan saved-id)
+                               [:world :effective-args]))
+          (str vid " — the saved form re-registers the args the user saw")))))
+
+(deftest nested-args-deep-merge-through-the-chain
+  (reg-args-scenario!)
+  (is (= {:run      {:count 42 :nested {:v 9 :keep 1}}
+          :facade   {:count 42 :nested {:v 9 :keep 1}}
+          :snapshot {:count 42 :nested {:v 9 :keep 1}}}
+         (surfaces :story.rsargs/deep nil))))
+
+(deftest run-layers-fold-around-the-resolved-variant-layer
+  (reg-args-scenario!)
+  (testing "an active mode sits BELOW the inherited variant args"
+    (let [expected (assoc inherited :theme :loud)]
+      (is (= {:run expected :facade expected :snapshot expected}
+             (surfaces :story.rsargs/child {:active-modes [:Mode.rsargs/loud]})))))
+  (testing "a cell override sits above everything"
+    (let [expected (assoc inherited :count 99)]
+      (is (= {:run expected :facade expected :snapshot expected}
+             (surfaces :story.rsargs/child {:cell-overrides {:count 99}}))))))
+
+(deftest direct-variant-args-control
+  (reg-args-scenario!)
+  (let [expected {:count 3 :nested {:v 0 :keep 1}}]
+    (is (= {:run expected :facade expected :snapshot expected}
+           (surfaces :story.rsargs/direct nil)))))

--- a/tools/story/test/re_frame/story/ui/canvas_resolved_args_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_resolved_args_cljs_test.cljs
@@ -1,0 +1,119 @@
+(ns re-frame.story.ui.canvas-resolved-args-cljs-test
+  "rf2-gwye.7 — the canvas renders the RESOLVED scenario's args.
+
+  `canvas-inner` hands the variant's view its effective args. Before the fix
+  it read them from `rf.story.args/resolve-args`, which folds only the
+  variant's OWN `:args`, so a variant that `:extends` a parent (or
+  `:compose`s a fragment) carrying args rendered the STORY DEFAULT instead,
+  while `run-variant` (which reads the compiled plan) reported the inherited
+  value. The canvas and the run described two different scenarios.
+
+  Each test observes the value the view actually rendered: the probe view
+  prints the props it was handed, read back through the same expanded-hiccup
+  walk `canvas-substrate-routing-cljs-test` uses. No DOM, no React."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as rf.frame]
+            [re-frame.machines :as rf.machines]
+            [re-frame.registrar :as rf.registrar]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.story :as rf.story]
+            [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.ui.canvas :as rf.story.ui.canvas]
+            [re-frame.story.ui.state :as rf.story.ui.state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as rf.story.test-helpers.e2e-multi-frame]
+            [re-frame.subs :as rf.subs]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn- probe-view [args]
+  [:div {:data-test "resolved-args-probe"}
+   (str "count=" (:count args) " nested=" (get-in args [:nested :v]))])
+
+(defn- register-probes! []
+  (rf/reg-view* :views/resolved-args-probe probe-view)
+  (rf.story/reg-story :story.canvas-args
+    {:component :views/resolved-args-probe
+     :args      {:count 0 :nested {:v 0}}})
+  (rf.story/reg-mode :Mode.canvas-args/loud {:args {:count 5 :theme :loud}})
+  ;; Every variant declares `:loaders` so `events-only-variant?` is false on
+  ;; both sides of the fix: the skeleton gate is then governed only by the
+  ;; lifecycle `ready-tree` drives, and the args are the one thing that varies.
+  (rf.story/reg-variant :story.canvas-args/parent
+    {:args {:count 42 :nested {:v 7}} :loaders [[:noop/loader]]})
+  (rf.story/reg-variant :story.canvas-args/child
+    {:extends :story.canvas-args/parent :loaders [[:noop/loader]]})
+  (rf.story/reg-fragment :fragment.canvas-args/args
+    {:args {:count 42 :nested {:v 7}}})
+  (rf.story/reg-variant :story.canvas-args/composed
+    {:compose [:fragment.canvas-args/args] :loaders [[:noop/loader]]})
+  (rf.story/reg-variant :story.canvas-args/direct
+    {:args {:count 3} :loaders [[:noop/loader]]}))
+
+(defn- reset-all! []
+  (rf.story/clear-all!)
+  (rf.registrar/clear-all!)
+  (reset! rf.frame/frames {})
+  (try (rf/init! rf.substrate.plain-atom/adapter) (catch :default _ nil))
+  (rf.subs/reg-runtime-sub :rf/machine
+    (fn [runtime-db [_ machine-id]]
+      (get-in runtime-db [:rf.runtime/machines :snapshots machine-id])))
+  (rf.machines/reset-timers!)
+  (rf.story.loaders/clear-watchers!)
+  (rf.story.ui.canvas/reset-first-rendered!)
+  (rf.story.ui.state/reset-shell-state!)
+  (rf.story/install-canonical-vocabulary!)
+  (rf.frame/ensure-default-frame!)
+  (register-probes!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- helpers -------------------------------------------------------------
+
+(def ^:private canvas-inner @#'rf.story.ui.canvas/canvas-inner)
+
+(defn- rendered
+  "Drive `variant-id`'s lifecycle to `:ready` so the skeleton is elided, render
+  the canvas's inner tree, and return the text the probe view painted."
+  [variant-id]
+  (rf/make-frame {:id variant-id})
+  (rf.story.loaders/mount! variant-id)
+  (rf.story.loaders/start-loaders! variant-id)
+  (rf.story.loaders/finish-loaders! variant-id)
+  (rf.story.loaders/finish-events! variant-id)
+  (rf.story.ui.canvas/mark-variant-rendered! variant-id)
+  (let [tree (rf.story.test-helpers.e2e-multi-frame/expand-tree (canvas-inner variant-id))
+        text (some-> (rf.story.test-helpers.e2e-multi-frame/find-by-test-id
+                       tree "resolved-args-probe")
+                     last)]
+    (rf.story/destroy-variant! variant-id)
+    text))
+
+(defn- shell! [f] (rf.story.ui.state/swap-state! f))
+
+;; ===========================================================================
+
+(deftest canvas-renders-inherited-and-composed-args
+  (testing "an :extends child and a :compose-only variant render the args
+            their compiled plan resolves (parent / fragment beat the story
+            default, nested maps deep-merge), not the story default"
+    (is (= "count=42 nested=7" (rendered :story.canvas-args/child))
+        ":extends — the parent's args reach the view")
+    (is (= "count=42 nested=7" (rendered :story.canvas-args/composed))
+        ":compose — the fragment's args reach the view")))
+
+(deftest canvas-args-keep-mode-and-cell-precedence
+  (testing "the run layers still fold AROUND the resolved variant layer:
+            an active mode sits BELOW the inherited variant args, a cell
+            override sits above everything"
+    (shell! #(assoc % :active-modes [:Mode.canvas-args/loud]))
+    (is (= "count=42 nested=7" (rendered :story.canvas-args/child))
+        "the inherited variant arg beats the active mode's")
+    (shell! #(assoc-in % [:cell-overrides :story.canvas-args/child] {:count 99}))
+    (is (= "count=99 nested=7" (rendered :story.canvas-args/child))
+        "a cell override beats the inherited arg")))
+
+(deftest canvas-args-direct-variant-control
+  (testing "control — a variant with no :extends / :compose renders its own
+            args, unchanged by the fix"
+    (is (= "count=3 nested=0" (rendered :story.canvas-args/direct)))))

--- a/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_unrelated_write_dom_cljs_test.cljs
@@ -13,8 +13,16 @@
 
   Counted at the two seams each render crosses exactly once:
   `rf.story.runtime/snapshot-identity` (outer) and
-  `rf.story.decorators/resolve-decorators` (inner). The hot-reload tick is
-  the control — a run input, so it MUST still reach both.
+  `rf.story.render/resolve-render-sub-overrides` (inner). The hot-reload tick
+  is the control — a run input, so it MUST still reach both.
+
+  The inner seam was `rf.story.decorators/resolve-decorators` until
+  `canvas-inner` stopped calling it: the render now compiles the variant plan
+  ONCE and reads the decorator refs, the effective args, these sub-overrides
+  and the loader classification off that one plan (rf2-gwye.5 / rf2-gwye.7).
+  A spy on a fn the render no longer calls counts zero for BOTH the unrelated
+  writes and the tick, which passes the two `= 0` assertions vacuously — the
+  control is what caught it, which is why the control is here.
 
   Ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build mounts
   real DOM; `:node-test` also loads it, where the body self-gates on
@@ -29,8 +37,8 @@
             [re-frame.registrar :as rf.registrar]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
             [re-frame.story :as rf.story]
-            [re-frame.story.decorators :as rf.story.decorators]
             [re-frame.story.loaders :as rf.story.loaders]
+            [re-frame.story.render :as rf.story.render]
             [re-frame.story.runtime :as rf.story.runtime]
             [re-frame.story.ui.canvas :as rf.story.ui.canvas]
             [re-frame.story.ui.state :as rf.story.ui.state]
@@ -89,7 +97,7 @@
               root       (rdc/create-root mount-node)
               inner      (atom 0)
               outer      (atom 0)
-              resolve    rf.story.decorators/resolve-decorators
+              resolve    rf.story.render/resolve-render-sub-overrides
               snapshot   rf.story.runtime/snapshot-identity]
           (try
             (react-dom/flushSync
@@ -101,9 +109,8 @@
             ;; known arity, which compiles to a direct-arity dispatch that a
             ;; variadic stand-in does not answer — the render would throw and
             ;; every count would read a vacuous 0.
-            (with-redefs [rf.story.decorators/resolve-decorators
-                          (fn ([a] (swap! inner inc) (resolve a))
-                              ([a b] (swap! inner inc) (resolve a b)))
+            (with-redefs [rf.story.render/resolve-render-sub-overrides
+                          (fn [a b] (swap! inner inc) (resolve a b))
                           rf.story.runtime/snapshot-identity
                           (fn ([a] (swap! outer inc) (snapshot a))
                               ([a b] (swap! outer inc) (snapshot a b)))]

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -159,6 +159,30 @@
         (is (= 1 (get-in src [:world :effective-args :n]))
             "the source still carries its own args, unreplaced")))))
 
+;; ---- rf2-gwye.7 — the copied args are the RESOLVED scenario's -------------
+
+(deftest edn-snippet-carries-inherited-and-composed-args
+  (testing "rf2-gwye.7: Copy EDN pins the args the focused cell actually runs
+            with. An :extends parent's (or a :compose fragment's) args beat
+            the story default, exactly as the compiled plan resolves them.
+            Before the fix the snippet read the variant's OWN :args only, so
+            the story default replaced the inherited value in the pasted form."
+    (rf.story/reg-story :story.egress {:args {:n 0 :nested {:v 0}}})
+    (rf.story/reg-variant :story.egress/parent
+                          {:tags #{:dev} :setup [] :args {:n 42 :nested {:v 7}}})
+    (rf.story/reg-variant :story.egress/child
+                          {:tags #{:dev} :setup [] :extends :story.egress/parent})
+    (rf.story/reg-fragment :fragment.egress/args {:args {:n 42 :nested {:v 7}}})
+    (rf.story/reg-variant :story.egress/composed
+                          {:tags #{:dev} :setup [] :compose [:fragment.egress/args]})
+    (doseq [vid [:story.egress/child :story.egress/composed]]
+      (rf.story.ui.state/swap-state! (fn [s] (assoc s :selected-variant vid)))
+      (let [[_ _ body] (reader/read-string
+                         (rf.story.ui.share/egress-edn-snippet
+                           (rf.story.ui.state/get-state) 1700000000000))]
+        (is (= {:n 42 :nested {:v 7}} (:args body))
+            (str vid " — the copied :args are the resolved scenario's, not the story default"))))))
+
 (deftest edn-snippet-nil-without-variant
   (testing "no variant focused → no EDN snippet"
     (is (nil? (rf.story.ui.share/egress-edn-snippet (rf.story.ui.state/get-state))))))


### PR DESCRIPTION
Remediates **rf2-fzbj.3** and its per-finding children **rf2-gwye.5**, **rf2-gwye.6**, **rf2-gwye.7**
(the 2026-09-12/13 surface reviews of `tools/story/**`). All three findings reproduced at this tip
before the fix; each is fixed with a regression test that was red first.

Three defects shared one root: the plan compiler resolves `:extends` and `:compose` into `[:world …]`
(loaders, loader teardown, completion policy, effective args), while registered execution and the
UI / export readers re-read the RAW registration.

## 1 · Inherited and composed loaders never ran (rf2-gwye.5)

A variant that only `:extends` a parent's (or `:compose`s a fragment's) loader fixture ran **no**
loaders, skipped their teardown, and still reported `:status :pass` / `:lifecycle :ready`.

- `runtime/prepare-context` threads the compiled plan's `[:world :loaders]` /
  `[:world :loaders-complete-when]` as `:loader-body`; `run-phase-1!` now always uses it, so
  `run-loaders!` no longer defaults to the raw registered body (its 1-arity is gone — both the
  registered and inline paths supply the resolved slots).
- `frames/allocate!` classifies events-only from the resolved loader world, so an inherited fixture
  takes the four-phase path instead of jumping to `:ready`.
- The canvas classifies from the same `[:world …]` slots, so the skeleton gate agrees with the runtime.

## 2 · Hot reload replaced the active run's loader cleanup (rf2-gwye.6)

Teardown read the CURRENT registration, so an ordinary edit between a run and its destroy (or re-run)
dispatched a cleanup whose `:loaders` never fired, and skipped the cleanup for the resource the live
run actually opened.

- `allocate!` captures the run's **resolved** `:loaders-teardown` in a new
  `allocated-loaders-teardown`, beside the existing decorator-stack capture that solved exactly this
  problem for `:frame-setup` (rf2-x76af2.19); `run-teardown-walks!` consumes and evicts it.
- Presence of the capture is the signal (`find`, not `get`): a run that owns no cleanup keeps its
  empty answer, so a cleanup ADDED after the run started cannot fire against a resource it never
  opened. Loader-before-decorator order and the never-abort exception handling are unchanged.

## 3 · Canvas / save / share args ignored extends and compose (rf2-gwye.7)

`args/resolve-args` folds the ambient and per-run layers around the variant's OWN `:args`, so an
inherited value was replaced by the story default — and saving that snapshot wrote the default onto a
new variant as an explicit override the author never made.

- New **`plan/effective-args`**: the compiled `[:world :effective-args]`, i.e. the same value
  `run-variant` reports, falling back to `args/resolve-args` when a plan cannot compile (the
  best-effort contract `view-args/compiled-view-args-schema` already uses).
- The facade `story/resolve-args` and every consumer that asks what a variant renders / saves /
  shares with now routes through it: canvas, controls, docs, multi-substrate, workspace, schema
  validation, snapshot identity, save snapshot and Copy EDN. `args/resolve-args` stays as the
  documented raw primitive.
- No `args -> plan -> args` cycle: `plan` already requires `args`, and every switched consumer is
  outside `plan`'s transitive require closure.

Two incidental simplifications the above required: `allocate!` takes the compiled `:world` as one
argument instead of a classification map and an fx-override map positionally (its 3-/4-arity had no
callers outside `run-phase-0!`; every test calls the 2-arity), and `canvas-inner` compiles the plan
ONCE per render for decorators, args, sub-overrides and the loader classification — it previously
compiled twice and then answered the args question from the raw body.

## Regression tests (red before, green after)

- `tools/story/test/re_frame/story/resolved_scenario_test.clj` (new, JVM) — 16 tests / 33 assertions
  covering all three findings: extends-only, compose-only and composed-plus-own loader ordering; an
  inherited false `:loaders-complete-when` stopping setup and play with `:rf.error/loader-incomplete`;
  reset and destroy running the resolved cleanup once; hot reload on destroy, on re-run, and with the
  cleanup removed or added; a parent edit under an inherited run; double destroy; and effective-args
  agreement across run result, facade, save snapshot and a generated-snippet read/register/plan round
  trip, with nested deep-merge, active-mode precedence and cell-override cases. Controls: a direct
  variant, a no-loader variant on the fast path, and an inline plan.
- `tools/story/test/re_frame/story/ui/canvas_resolved_args_cljs_test.cljs` (new, CLJS) — observes the
  value the probe view actually rendered for `:extends` and `:compose` variants, plus mode/cell
  precedence and a direct-variant control.
- `tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs` — Copy EDN pins the resolved args.

**Controls, both directions:**

- JVM — against the pre-fix source the new namespace ran 16 tests / 33 assertions with **25
  failures** (captured exit 1); after the fix, **0 failures** (captured exit 0).
- CLJS — the two namespaces were re-run against a build compiled with the two pre-fix consumer reads
  planted back (`canvas-inner`'s `eff-args` and `egress-edn-snippet`'s): **captured exit 1, 6
  failures** — the `:extends`, `:compose` and active-mode canvas cases and the Copy EDN case — while
  the direct-variant and cell-override controls stayed green, so the tests discriminate rather than
  failing wholesale. The plant was restored and verified by blob hash against the committed objects.

## Quality gates

Every number below is the exit code captured in the same shell as the run, not a harness report.

| Gate | CI job | Result |
|---|---|---|
| `clojure -M:test` from `tools/story` | `jvm-tools-story` (`tools_jvm` surface) | **exit 0** — 1962 tests, 7261 assertions, 0 failures |
| New JVM namespace, pre-fix source | same | **exit 1** — 25 failures (the red control) |
| `scripts/check_doc_slugs.py` (nominated by PATH for `tools/story/spec/*`) | `verify-readme-links` | **exit 0**; planted a broken link target in an edited line of `002-Runtime.md` and it went **red (exit 1)** naming that file and line, so the gate demonstrably read this worktree. Restore verified by blob hash against the committed object. |
| Whole `:node-test` lane (`node scripts/compile-node-test.cjs …` then `node out/node-test.js`) | `CLJS (shadow-cljs :node-test)` (`cljs_node_test` surface) | compile **exit 0** (2003 files, 0 warnings); suite **exit 0** — 12028 tests, 59840 assertions, 0 failures. Both new CLJS namespaces ran in it. |
| Story CLJS namespaces against a planted pre-fix build | same | **exit 1**, 6 failures (the red control above) |
| `scripts/lint_kondo.py` (pinned clj-kondo, the CI gate's own paths incl. `tools/story`) | `clj-kondo` | `errors: 0` under `--fail-level error` |
| `check_jvm_lane_rosters.py`, `check_test_lane_bijection.py`, `check_readme_inventories.py`, `check_thrown_error_messages.py`, `check_readme_links.py --ci` | their CI jobs | **exit 0** each — ratchets grading the paths this PR touches, including the bijection gate that proves the new test files are selected by a lane |
| `story-xray-browser` and `CLJS (:browser-test)` | the browser jobs (`story_xray_browser` surface — `tools/story/src` changed) | not run locally; relying on CI. The `:browser-test` lane is where the re-pointed `canvas_unrelated_write_dom_cljs_test` counter is verified. |

**One existing DOM test needed its instrument re-pointed, and its own control is what caught that.**
`canvas_unrelated_write_dom_cljs_test` (rf2-ohc5) counts `canvas-inner` renders by spying on
`resolve-decorators`, which `canvas-inner` no longer calls now that it compiles the plan once. A spy
on an uncalled fn reads 0 for the unrelated writes AND for the hot-reload tick, so the two `= 0`
assertions passed vacuously and the `pos?` control failed — which is exactly what a control is for.
The counter now sits at `resolve-render-sub-overrides`, the seam the inner render still crosses
exactly once. That test runs only in the `:browser-test` lane, so its green is CI's to report.

**One CI check is red for a reason outside this change: `MkDocs build`.** The failing STEP is the
`check_retired_image_keys.py` ratchet, and the line it names is
`implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc:75`, which
this PR does not touch. It is already on `main` (introduced by `717ae20730`), and the docs workflow
has been failing on `main` for every run since. Reproduced locally at this branch's merge base:
captured exit 1, naming that same machines file. Nothing in `tools/story` appears in its output.

Nothing validates spec prose, tables or fence contents, so the `tools/story/spec` edits were checked
by hand: the args-precedence list keeps its five numbered layers, the teardown guarantee keeps its
six numbered steps with the ordering rule intact, and the one table cell edited in `008-Docs-Mode.md`
keeps its column count.

## Not done, and why

- The review's "consider" extras (a gate around the loader capture, a facade for the args resolver)
  are not built: the fix plus its regression test is the whole of each finding.
- `allocate!`'s 2-arity still falls back to the raw registered body for direct/test callers, exactly
  as the classification fallback already did; a compiled plan is what carries resolution.
