### PR TITLE
fix(fresco): release the first render's root on a failed lowering; reject hydrate setup failures (rf2-fzbj.4, rf2-gwye.1, rf2-gwye.2)

### DIFF
--- a/implementation/fresco/src/re_frame/fresco/impl/mount.cljs
+++ b/implementation/fresco/src/re_frame/fresco/impl/mount.cljs
@@ -243,17 +243,37 @@
   `:identifier-prefix`, handed to `createRoot` as React's
   `identifierPrefix` untouched — no default, no coercion — so a page
   mounting two roots can keep their `useId` values apart. Name neither and
-  the call React receives is the bare one."
+  the call React receives is the bare one.
+
+  THE FIRST TREE IS LOWERED BEFORE `createRoot`, and the order is part of
+  what this fn promises: a construction that fails allocates nothing, so
+  the caller's container is theirs to retry on."
   ([container frame-kw hiccup] (root! container frame-kw hiccup nil))
   ([container frame-kw hiccup opts]
    (ensure-frame! frame-kw (:initial-events opts))
-   (let [ropts  (root-options (:identifier-prefix opts) nil)
-         handle {:root      (if ropts
-                              (react-dom-client/createRoot container ropts)
-                              (react-dom-client/createRoot container))
-                 :frame     frame-kw
-                 :container container}]
-     (render! handle hiccup)
+   (let [ropts   (root-options (:identifier-prefix opts) nil)
+         ;; LOWERED FIRST, and that order is the whole of the failed-
+         ;; construction rule. Lowering runs the CALLER's code — the codec
+         ;; forces a lazy child seq here, so an ordinary `(map fmt rows)`
+         ;; whose formatter throws throws on this line. `createRoot` first
+         ;; and that throw escapes between React taking ownership of the
+         ;; container and this fn returning the only handle that could
+         ;; give it back: `mount-client-root!` never tracks the Root, the
+         ;; public handle stays inert, and neither `h/unmount!` nor
+         ;; `drain-active-roots!` can reach it ever again. Lowered first
+         ;; there is nothing to reach — React was never handed the
+         ;; container. `hydrate-root!` already builds its element before
+         ;; `hydrateRoot`; this is that shape, for that reason
+         ;; (rf2-gwye.1, witnessed in
+         ;; `re-frame.fresco.public-root-lifecycle-dom-cljs-test`).
+         base    {:frame frame-kw :container container}
+         element (tree base hiccup)
+         handle  (assoc base :root (if ropts
+                                     (react-dom-client/createRoot container ropts)
+                                     (react-dom-client/createRoot container)))]
+     ;; `render!`'s line, not `render!` — it would lower the tree a second
+     ;; time, and lowering is where the caller's code runs.
+     (react-dom/flushSync (fn [] (.render (:root handle) element)))
      handle)))
 
 (defn adoption-window-closer

--- a/implementation/fresco/test/re_frame/fresco/public_root_lifecycle_dom_cljs_test.cljs
+++ b/implementation/fresco/test/re_frame/fresco/public_root_lifecycle_dom_cljs_test.cljs
@@ -42,6 +42,7 @@
   never touches the document, and the document is shared with every other
   browser suite."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.adapter.uix :as rf.adapter.uix]
             [re-frame.core :as rf]
             [re-frame.frame :as rf.frame]
@@ -167,6 +168,26 @@
   nil)
 
 (defn- connected? [container] (.-isConnected container))
+
+(defn- react-owned?
+  "Does React still hold a root on `container`? `createRoot` writes an own
+  property named `__reactContainer$<key>` INSIDE the constructor — before
+  any render — and `root.unmount()` blanks it again.
+
+  This is React's private bookkeeping, read here because nothing public
+  says the same thing and the DOM cannot: a root that never rendered
+  leaves the container exactly as empty as one that was never created, so
+  a reading taken off `innerHTML` is green either way. It is therefore
+  never read without the two-direction control in
+  [[a-failed-first-render-leaves-no-root-on-the-callers-container]]
+  standing beside it — a React that renamed or stopped writing the mark
+  reads *unowned everywhere*, which is the reassuring answer, and that
+  control is what goes red rather than the row quietly passing."
+  [container]
+  (boolean (some (fn [k]
+                   (and (str/starts-with? k "__reactContainer$")
+                        (some? (unchecked-get container k))))
+                 (js/Object.keys container))))
 
 ;; ---------------------------------------------------------------------------
 ;; W1 — tearing one root down must not reach the other
@@ -566,6 +587,123 @@
           (detach! ca)
           (detach! cb)
           (is (= [false false] [(connected? ca) (connected? cb)])
+              "this witness left one of its own containers in the shared
+               browser-test document")
+          (rf.fresco.impl.collector/reset-runtime!))))))
+
+;; ---------------------------------------------------------------------------
+;; W6 — a first render that THROWS leaves nothing on the caller's container
+;; ---------------------------------------------------------------------------
+;;
+;; Lowering runs the CALLER's code. `[:ul (map fmt rows)]` is ordinary
+;; hiccup and the codec forces that seq to build the root's children, so a
+;; formatter that throws throws on the way INTO the first render — before
+;; React has been handed a tree, and with no invalid hiccup, no malformed
+;; option and no throwing component body anywhere in it.
+;;
+;; What the row is about is what the door OWNS when that happens.
+;; `h/render!` publishes its live-root map only once the constructor has
+;; returned, so a React root allocated BEFORE the lowering escapes through
+;; the gap: the public handle stays inert, `h/unmount!` is a no-op over
+;; nothing, `drain-active-roots!` has never heard of the root, and the
+;; caller's container carries one that nothing in the package can take
+;; down. The retry then calls `createRoot` on an already-rooted container,
+;; which React complains about in development (rf2-gwye.1 / rf2-fzbj.4
+;; finding 1).
+;;
+;; THE READING IS REACT'S OWN CONTAINER MARK, and the section note on
+;; [[react-owned?]] says why nothing else will do: the DOM is identical
+;; either way, because a root that never rendered leaves the container as
+;; empty as one that was never created. The mark is read only with the
+;; control below driving it in both directions on a working mount first.
+
+(deftest a-failed-first-render-leaves-no-root-on-the-callers-container
+  (if-not (rf.fresco.impl.mount/browser?)
+    (skip! ":node-test has no DOM")
+    (let [_       (fresh!)
+          control (rf.fresco.impl.mount/fresh-container!)
+          ca      (rf.fresco.impl.mount/fresh-container!)
+          probe   (rf.fresco/client-root)
+          a       (rf.fresco/client-root)]
+      (try
+        (testing "the INSTRUMENT first, driven in both directions on a
+                  working mount: a container React has never seen is
+                  unowned, one it holds a root on is owned, and it is
+                  unowned again the moment that root comes down. Without
+                  this the row's own reading is satisfied by a mark that
+                  is never written at all"
+          (is (false? (react-owned? control))
+              "a fresh container already reads as React-owned")
+          (rf.fresco/render! probe
+            [rf.fresco/frame-root {:id frame-a} [panel {:tag "control"}]]
+            control)
+          (is (true? (react-owned? control))
+              "React's container mark was not found on a live root, so the
+               reading below cannot discriminate and this row proves
+               nothing until the mark's spelling is re-established")
+          (rf.fresco/unmount! probe)
+          (is (false? (react-owned? control))
+              "React's container mark outlived the root that wrote it"))
+
+        (let [boom   (js/Error. "row formatting failed")
+              rows   (map (fn [_] (throw boom)) [1])
+              thrown (try (rf.fresco/render! a [:ul rows] ca) ::no-throw
+                          (catch :default e e))]
+
+          (testing "premise: ordinary user code failed while the codec was
+                    lowering the root's children, and the door let the
+                    caller's OWN exception through untouched"
+            (is (identical? boom thrown)
+                (str "h/render! answered " (pr-str thrown)
+                     " instead of the caller's exception")))
+
+          (testing "AND THE CONTAINER IS STILL THE CALLER'S. This is the
+                    reading the row exists for: a root allocated before the
+                    lowering ran would be on this node now, owned by
+                    nothing — the handle never published it, so neither
+                    `h/unmount!` nor the package's disposal drain could
+                    ever reach it again"
+            (is (false? (react-owned? ca))
+                "the failed first render left a React root on the container"))
+
+          (testing "`h/unmount!` after the failed call is safe, and answers
+                    the door's ordinary nil"
+            (is (nil? (rf.fresco/unmount! a))))
+
+          (testing "and the SAME handle mounts normally on the retry. A
+                    second `createRoot` over a container that already had
+                    one is exactly what the leak produces, and React says
+                    so on the console — a SECOND reading of the same fact,
+                    and one that only speaks in a development React, which
+                    is why the mark above is the row's discriminator"
+            (let [errors (atom [])
+                  real   (.-error js/console)]
+              (set! (.-error js/console)
+                    (fn [& args] (swap! errors conj (apply str args))))
+              (try
+                (rf.fresco/render! a
+                  [rf.fresco/frame-root {:id frame-a} [panel {:tag "retry"}]]
+                  ca)
+                (finally (set! (.-error js/console) real)))
+              (is (empty? (filterv #(str/includes? % "createRoot") @errors))
+                  (str "React complained about the retry: " (pr-str @errors)))
+              (is (= "alpha" (text-at ca ".label"))
+                  "the retry through the same handle did not paint")
+              (is (true? (react-owned? ca)))))
+
+          (testing "and that root comes down exactly once"
+            (rf.fresco/unmount! a)
+            (is (= "" (.-innerHTML ca)))
+            (is (false? (react-owned? ca)))
+            (is (nil? (rf.fresco/unmount! a))
+                "a second teardown through the same handle must be a no-op")))
+
+        (finally
+          (rf.fresco/unmount! probe)
+          (rf.fresco/unmount! a)
+          (detach! control)
+          (detach! ca)
+          (is (= [false false] [(connected? control) (connected? ca)])
               "this witness left one of its own containers in the shared
                browser-test document")
           (rf.fresco.impl.collector/reset-runtime!))))))

--- a/implementation/fresco/test/re_frame/fresco/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/fresco/test/re_frame/fresco/test_kit_mounted_dom_cljs_test.cljs
@@ -94,6 +94,14 @@
 (rf/reg-event ::toggle (fn [{:keys [db]} [_ id]]
                          {:db (update-in db [:todos id :done?] not)}))
 
+(rf/reg-event ::seed-boom
+  ;; A setup step that FAILS, deterministically, and a perfectly ordinary
+  ;; registered event otherwise. Core catches the handler body's throw in
+  ;; band, tears the half-built frame down and raises
+  ;; `:rf.error/initial-events-step-failed` — from INSIDE `rf/make-frame`,
+  ;; which is the first thing `hm/hydrate!` calls.
+  (fn [_ _] (throw (js/Error. "the hydration seed fails, deliberately"))))
+
 (defn- plain-child
   "An ORDINARY function, and that is the whole of it: in child head
   position the runtime refuses a plain function outright (HD-016,
@@ -753,6 +761,81 @@
                        (is (some? (some #(re-find #"early update" %) @reported))
                            (str "got " (pr-str @reported))))
                      (done))))))))
+
+;; The THIRD way into the promise, and the one that used to escape it. The two
+;; rows above fail after `hydrate!` has allocated something — a root whose
+;; element the codec refuses, an adoption that never completes — so both were
+;; already inside the door's own boundary. A failing `:initial-events` step
+;; fails on the FIRST line instead, in `mint-frame!`, which ran outside every
+;; `try` and outside the `js/Promise.` at the bottom. The throw therefore
+;; landed on the CALLER's stack, past every `.catch` they had attached, and an
+;; ordinary `(-> (hm/hydrate! …) (.catch …) (.then done))` row did not go red:
+;; it TIMED OUT, reporting a budget where the real fault was a seeding
+;; handler (rf2-gwye.2 / rf2-fzbj.4 finding 2).
+;;
+;; So the row's first reading is that the call RETURNED, and its last is that
+;; the chain reached its completion continuation — `done` is called from
+;; nowhere else, which is what makes a regression here a red rather than a
+;; hang.
+
+(deftest l3-hydrate-rejects-a-failing-setup-step-and-leaves-nothing-behind
+  (if-not (rf.fresco.impl.mount/browser?)
+    (rf.fresco.roots-frames-support/skip! ":node-test has no React DOM")
+    (async done
+      (let [before   (rf.fresco.test.mounted/census)
+            frames   (set (rf/frame-ids))
+            children (body-children)
+            ;; THE FAULT: a valid registered event, in a valid
+            ;; `:initial-events` vector, whose handler fails the way real
+            ;; application setup can.
+            outcome  (try {:returned (rf.fresco.test.mounted/hydrate!
+                                       [row {:id 1}]
+                                       {:html           "<li class=\"row\">server</li>"
+                                        :initial-events [[::seed 3] [::seed-boom]]})}
+                          (catch :default e {:threw e}))]
+
+        (testing "it did NOT throw on the caller's own stack. A
+                  promise-returning door that throws lands outside every
+                  `.catch` attached to its result, so the chain below would
+                  never run and the row would time out instead of failing"
+          (is (nil? (:threw outcome))
+              (str "hydrate! threw synchronously: " (pr-str (:threw outcome)))))
+
+        (if-not (instance? js/Promise (:returned outcome))
+          ;; Nothing to chain, and `done` is owed from somewhere.
+          (do (is false (str "hydrate! answered " (pr-str outcome)
+                             " rather than a promise"))
+              (done))
+          (-> (:returned outcome)
+              (.then (fn [m]
+                       (is false (str "hydrate! resolved with " (pr-str m)
+                                      " for a setup step that failed")))
+                     (fn [e]
+                       (testing "it REJECTS, with CORE's refusal unchanged —
+                                 same id, same failing step, same index"
+                         (is (instance? ExceptionInfo e)
+                             (str "got " (pr-str e)))
+                         (is (= :rf.error/initial-events-step-failed
+                                (:rf.error/id (ex-data e))))
+                         (is (= [::seed-boom] (:event (ex-data e))))
+                         (is (= 1 (:step-index (ex-data e)))))))
+              (.then (fn [_] (rf.fresco.test.runtime/quiesced!)))
+              (.then (fn [_]
+                       (testing "and the page is as the call found it. Core
+                                 destroyed the frame it could not build, and
+                                 `mint-frame!` is this door's first
+                                 allocation — so a call that failed there
+                                 allocated nothing else to put back"
+                         (is (= frames (set (rf/frame-ids)))
+                             "a frame outlived the construction that failed")
+                         (is (= before (rf.fresco.test.mounted/census))
+                             (str "the census moved: " (pr-str before) " → "
+                                  (pr-str (rf.fresco.test.mounted/census))))
+                         (is (= children (body-children))
+                             "a container was appended for a hydration that
+                              never began"))
+                       ;; Reaching this line at all is the row's last claim.
+                       (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; W7 — settle-until!: the door for work the router has merely ENQUEUED

--- a/implementation/fresco/test_kit/src/re_frame/fresco/test/mounted.cljs
+++ b/implementation/fresco/test_kit/src/re_frame/fresco/test/mounted.cljs
@@ -898,70 +898,90 @@
 
   ## Every failure is a REJECTION, and every failure leaves nothing behind
 
-  Both of them: a form the codec refuses while `hydrate-root!` is still
-  building its element, which raises on this call's own stack, and an
-  adoption that never completes. A promise-returning door that threw
-  synchronously would throw past every `.catch` a caller had attached and
-  hang the test rather than fail it, so the refusal is handed to the
-  promise — the runtime's own `ex-info` unchanged for the first, this
-  door's timeout for the second.
+  All three of them: an `:initial-events` step whose handler fails, which
+  leaves `mint-frame!` carrying core's own
+  `:rf.error/initial-events-step-failed`; a form the codec refuses while
+  `hydrate-root!` is still building its element, which raises on this
+  call's own stack; and an adoption that never completes. A
+  promise-returning door that threw synchronously would throw past every
+  `.catch` a caller had attached and hang the test rather than fail it,
+  so the refusal is handed to the promise — the runtime's own `ex-info`
+  unchanged for the first two, this door's timeout for the third.
 
-  In both cases the page is put back as the call found it: the frame
+  In every case the page is put back as the call found it: the frame
   destroyed, the root taken down with its adoption window shut, and a
   container this facade minted removed. One the CALLER supplied is left
   where it is (see [[abandon!]])."
   ([form] (hydrate! form {}))
   ([form opts] (hydrate! form opts 3000))
   ([form {:keys [initial-events container html clock]} budget-ms]
-   (let [[frame-kw ordinal] (mint-frame! initial-events)
-         baseline  (census)
-         node      (or container (rf.fresco.impl.mount/fresh-container!))
-         supplied? (some? container)
-         _         (when (some? html) (set! (.-innerHTML node) html))
-         !refusal  (volatile! nil)
-         root      (try (rf.fresco.impl.mount/hydrate-root! node frame-kw form)
-                        (catch :default e (vreset! !refusal e) nil))]
-     (if-some [refusal @!refusal]
-       (do (abandon! frame-kw node supplied? nil)
-           (js/Promise.reject refusal))
-       (let [window   (:adoption root)
-             deadline (+ (js/Date.now) budget-ms)]
-         (js/Promise.
-           (fn [resolve reject]
-             (letfn [(tick []
-                       (cond
-                         (not (rf.fresco.impl.roots/adopting? window))
-                         ;; Past the closer AND past the reap horizon, so the
-                         ;; handle a caller receives is one whose tables have
-                         ;; settled. This is also where the construction
-                         ;; becomes a MOUNT — see [[handle-for]].
-                         ;;
-                         ;; `:clock` is installed HERE and not at the top of
-                         ;; this door, unlike [[mount!]]'s. Adoption is
-                         ;; React's own concurrent business and this promise
-                         ;; is driven by real `setTimeout`s that wait it out;
-                         ;; a clock installed before them would freeze the
-                         ;; wait it is inside, and the caller would hold a
-                         ;; promise that can never resolve. Nothing is lost:
-                         ;; an adopted tray is born settled (rf2-2rtt6.84),
-                         ;; so the timers a hydrated page arms are armed
-                         ;; after this line.
-                         (js/setTimeout
-                           (fn []
-                             (when clock (install-clock!))
-                             (resolve (handle-for root ordinal baseline
-                                                  (boolean clock))))
-                           16)
+   ;; THE REJECTION BOUNDARY ENCLOSES THE SYNCHRONOUS CONSTRUCTION TOO,
+   ;; which is what makes the promise above the WHOLE error channel rather
+   ;; than most of it. `mint-frame!` runs core's strict setup, so a seeding
+   ;; step whose handler throws left this door on the caller's own stack —
+   ;; before the `try` below, before the `js/Promise.` at the bottom, and
+   ;; therefore past every `.catch` the caller wrote. The asynchronous test
+   ;; that resulted did not fail, it TIMED OUT, hiding the real setup
+   ;; failure behind a budget (rf2-gwye.2, witnessed in
+   ;; `re-frame.fresco.test-kit-mounted-dom-cljs-test`).
+   ;;
+   ;; Nothing is rolled back here and nothing needs to be: core destroys
+   ;; the frame it could not build before it raises, and `mint-frame!` is
+   ;; this door's FIRST allocation, so a failure there is a call that
+   ;; allocated nothing. The two branches below that DO hold resources
+   ;; roll themselves back through [[abandon!]] and return their rejection
+   ;; rather than throwing it, so this catch never sees them.
+   (try
+     (let [[frame-kw ordinal] (mint-frame! initial-events)
+           baseline  (census)
+           node      (or container (rf.fresco.impl.mount/fresh-container!))
+           supplied? (some? container)
+           _         (when (some? html) (set! (.-innerHTML node) html))
+           !refusal  (volatile! nil)
+           root      (try (rf.fresco.impl.mount/hydrate-root! node frame-kw form)
+                          (catch :default e (vreset! !refusal e) nil))]
+       (if-some [refusal @!refusal]
+         (do (abandon! frame-kw node supplied? nil)
+             (js/Promise.reject refusal))
+         (let [window   (:adoption root)
+               deadline (+ (js/Date.now) budget-ms)]
+           (js/Promise.
+             (fn [resolve reject]
+               (letfn [(tick []
+                         (cond
+                           (not (rf.fresco.impl.roots/adopting? window))
+                           ;; Past the closer AND past the reap horizon, so the
+                           ;; handle a caller receives is one whose tables have
+                           ;; settled. This is also where the construction
+                           ;; becomes a MOUNT — see [[handle-for]].
+                           ;;
+                           ;; `:clock` is installed HERE and not at the top of
+                           ;; this door, unlike [[mount!]]'s. Adoption is
+                           ;; React's own concurrent business and this promise
+                           ;; is driven by real `setTimeout`s that wait it out;
+                           ;; a clock installed before them would freeze the
+                           ;; wait it is inside, and the caller would hold a
+                           ;; promise that can never resolve. Nothing is lost:
+                           ;; an adopted tray is born settled (rf2-2rtt6.84),
+                           ;; so the timers a hydrated page arms are armed
+                           ;; after this line.
+                           (js/setTimeout
+                             (fn []
+                               (when clock (install-clock!))
+                               (resolve (handle-for root ordinal baseline
+                                                    (boolean clock))))
+                             16)
 
-                         (< deadline (js/Date.now))
-                         (do (abandon! frame-kw node supplied? root)
-                             (reject (ex-info (str "hydrate! waited " budget-ms
-                                                   "ms and this root's adoption window "
-                                                   "never shut — the tree was not adopted.")
-                                              {:frame frame-kw :budget-ms budget-ms})))
+                           (< deadline (js/Date.now))
+                           (do (abandon! frame-kw node supplied? root)
+                               (reject (ex-info (str "hydrate! waited " budget-ms
+                                                     "ms and this root's adoption window "
+                                                     "never shut — the tree was not adopted.")
+                                                {:frame frame-kw :budget-ms budget-ms})))
 
-                         :else (js/setTimeout tick 4)))]
-               (tick)))))))))
+                           :else (js/setTimeout tick 4)))]
+                 (tick)))))))
+     (catch :default e (js/Promise.reject e)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Driving


### PR DESCRIPTION
Closes the two P2 findings the out-of-repo surface review filed against `impl_fresco`: `rf2-fzbj.4` (the aggregate, both findings) and its per-finding children `rf2-gwye.1` and `rf2-gwye.2`. Both were re-verified at this branch's merge base before anything was changed; both still held.

Remediation ownership is Mike's 2026-09-13 ruling, recorded on `rf2-fzbj` and `rf2-gwye`: the mayor remediates all open `rf2-fzbj.*` / `rf2-gwye.*` findings.

## Finding 1 — the first client render could allocate a React root that no public teardown owned

`impl/mount.cljs`'s `root!` called `react-dom-client/createRoot` and then `render!`, and `render!` evaluates `(tree handle hiccup)` — the codec's `root-element` → `as-element` → `expand-seq`, which **forces a lazy child seq** — inside the `flushSync` callback.

So lowering runs the *caller's* code after React has already taken the container. An ordinary `[:ul (map fmt rows)]` whose formatter throws left `root!` in the gap: `mount-client-root!` never reached `track-active-root!`, the opaque public handle stayed inert, and neither `h/unmount!` nor `drain-active-roots!` could reach that Root ever again. The container kept an untracked root; a retry called `createRoot` on an already-rooted container and React said so.

**The fix** is the order `hydrate-root!` already had: lower the initial element *before* `createRoot`, so a failed construction allocates nothing at all. `root!` then performs `render!`'s one line (`flushSync` + `.render`) with the already-built element rather than calling `render!`, because `render!` would lower the tree a second time and lowering is where the caller's code runs. Root options, the successful update path, the opaque handle and the active-set liveness rule are untouched.

**Not built, deliberately** — the bead offers a catch/unmount/rethrow around the render as the *alternative* repair, not as an addition. Lowering first removes the finding's whole window, and a throw out of `.render` itself is a component-body error React owns on its own path (the bead says so in terms); a `.unmount` inside such a catch would also draw React's "synchronously unmount while rendering" complaint for no measured gain.

## Finding 2 — the test kit's `hydrate!` threw setup failures instead of rejecting

`test_kit/.../test/mounted.cljs`'s `hydrate!` called `mint-frame!` in its outer `let` — outside the inner `try` (which enclosed `hydrate-root!` alone) and outside the `js/Promise.` below it. `mint-frame!` calls `rf/make-frame` with `:initial-events`, whose strict setup raises `:rf.error/initial-events-step-failed` after tearing its own failed frame down. So a setup handler that threw left this promise-returning door **synchronously**, past every `.catch` the caller had attached — and the asynchronous test did not go red, it **timed out**, reporting a budget where the fault was a seeding handler. The door's own docstring already promised the opposite.

**The fix** is one outer `try` around the whole synchronous construction, returning `js/Promise.reject` with the exception object unchanged. No new error id, no retry machinery, no extra validator. Nothing is rolled back there and nothing needs to be: core destroys the frame it could not build, `mint-frame!` is the door's first allocation, and the two branches that *do* hold resources already roll themselves back through `abandon!` and **return** their rejection rather than throwing it — so the new catch never sees them. The codec-refusal and adoption-timeout witnesses are unchanged; the docstring's "Both of them" paragraph now reads "All three of them".

**Not built** — the acceptance criteria's optional "a clocked peer remains unchanged if included" arm. `hydrate!` installs its clock only in the resolve branch (unlike `mount!`, which installs first), so the setup-failure path takes no clock hold at all and there is nothing for a peer to lose.

**`implementation/core/src/re_frame/frame.cljc` needed no change.** `rf2-gwye.2` names it as the supporting producer; it already tears the frame down and raises the canonical refusal. It was read only.

## The witnesses, and how ownership is read

Two rows, in the suites that already own these surfaces.

`public-root-lifecycle-dom-cljs-test` **W6** drives the public `h/client-root` + `h/render!` pair with valid lazy hiccup whose row formatter throws during the first lowering, and asserts the caller's own exception object comes back, that the container is unowned afterwards, that `h/unmount!` is then safe, that a corrected render through the *same* handle paints with no duplicate-`createRoot` warning, and that the final `h/unmount!` releases it once.

Ownership is read off **React's own container mark** (`__reactContainer$<key>`, written inside `createRoot` before any render and blanked by `root.unmount()`), because the DOM cannot discriminate: a root that never rendered leaves the container as empty as one that was never created, so `innerHTML` is green either way. That is React's private bookkeeping, so the row never reads it without a **two-direction control** on a live mount standing beside it — unowned → owned → unowned — and a React that renamed or stopped writing the mark reds *that control* rather than quietly greening the row. The premise was re-measured against the installed React 19.3.0 in a process-local probe: fresh container unowned; marked by `createRoot` **alone** and enumerable through `Object.keys`; a repeated `createRoot` warns; `unmount()` blanks it.

`test-kit-mounted-dom-cljs-test` adds the **third** way into `hm/hydrate!`'s rejection channel. The two existing hydration failure rows fail *after* the door has allocated something, so both were already inside its boundary; a failing `:initial-events` step fails on the first line instead. The row's first reading is that the call **returned**, and its last is that the chain reached its completion continuation — `done` is called from nowhere else, which is what makes a regression a red rather than a hang.

## Quality gates

Every number below is the runner's own exit code, captured with the redirect on one command line, never the harness's report about the same run. (The harness reported `0` for the red run below, where the captured code was `1` — quoted here because that disagreement is exactly why the captured number is the one that counts.)

| gate | CI job | captured exit | result |
|---|---|---|---|
| `clojure -M:test` in `implementation/fresco` | `jvm-fresco` — *JVM fresco (clojure -M:test)* | 0 | 3 tests, 92 assertions, 0 failures |
| `npm run test:cljs` | `cljs` — *CLJS (shadow-cljs :node-test)* | 0 | 12026 tests, 59835 assertions, 0 failures, 0 errors; build 2002 files, **0 warnings** |
| `npm run test:browser` (green) | `cljs-browser` — *CLJS (shadow-cljs :browser-test, headless Chromium)* | 0 | 1097 tests, 5999 assertions, 0 failures, 0 errors |
| `npm run test:browser` (**red control, pre-fix source**) | same | **1** | 1097 tests, 5993 assertions, **4 failures — exactly the two new rows** |
| `npm run test:fresco-invariants` | `fresco-guide-samples` + the `cljs` job's invariants step | 0 | reachability OK; 75 verbs at 426 sites across 29 pages resolve |
| `sh scripts/check-no-hardcoded-paths.sh` | `portability` | 0 | no hardcoded personal/home paths |
| `npm run build:fresco-release` | a step inside the `cljs` job | 0 | `:advanced` / `goog.DEBUG=false`, 163 files, 0 warnings; production erasure 8 sentinels absent + 3 positive controls; bundle isolation 6 absent + 4 controls |
| `clojure -M:test` in `migration/reagent-to-fresco/codemod` | `jvm-migration-fresco-codemod` | 0 | 64 tests, 617 assertions, 0 failures — the lane `implementation/fresco/**` arms through the shared slot rule and the codec `callback-contracts` roster |
| `sh scripts/test-fast-pr.sh` | the always-on static/ratchet checks, JVM tier and node tier | 0 | `PASS fast PR spine` — every repo-wide ratchet green (retired spellings, thrown-error messages, ambient durable reads, require-alias dialect, README inventories, keyword-catalogue drift, test-lane/JVM-roster bijections, gate scheduling, …), `clj-kondo` at the pinned 2026.04.15 with `errors: 0`, JVM `implementation/core` + `implementation/fresco`, and the node tier including per-namespace isolation |

**The red control is the deliverable, so here is what it said.** Against the pre-fix source with the new tests in place (the tree of this PR's first commit), the browser lane failed on four assertions and no others:

* `(false? (react-owned? ca))` → `(not (false? true))` — the leaked root, on the container, after the failed first render;
* the console capture → `["You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. …"]`, React's real duplicate-root complaint on the retry;
* `(nil? (:threw outcome))` → `hydrate!` threw synchronously, carrying `:rf.error/initial-events-step-failed`, step 1, event `::seed-boom`;
* `hydrate!` answered a map rather than a promise.

Every *control* assertion in both rows passed in that same run — the instrument's two-direction mark control, the identical-exception premise, the retry's paint — so the four reds are the defects and not a broken instrument. The pre-fix source was planted by checking out this PR's test-only commit, and the restore was verified by blob hash: `git hash-object` in its default form reproduced the committed blob for both files (`3abac65992…` for `mount.cljs`, `5b98797cd1…` for `mounted.cljs`), and `git diff --quiet HEAD` exited 0 as a second instrument.

**Gates this PR arms that are relied on in CI**, per the changed-surface classifier (`implementation_jvm`, `cljs_node_test`, `cljs_browser`, `fresco_controlled`, `fresco_hmr`, `migration_fresco_codemod`, `skills_structural` all true): `cljs-fresco-controlled` and `cljs-fresco-hmr`, the three-engine Playwright gates, are declared reliance on CI — neither is runnable on a reasonable local budget, and this change touches no controlled-input or HMR surface.

**Base.** Every gate above ran against merge base `2d618296e8`. Trunk has moved since, and the three-dot diff against that base is this PR's four files and nothing else — nothing to revert. Of what landed upstream in the interval, nothing is under `implementation/fresco/**` (the one `implementation/*/src` file to move is `core/src/re_frame/reply.cljc`, an unrelated `rf2-gwye.64` fix), and none of this PR's four files was touched, so there is no conflict and CI grades the merge result.

**No doc or spec page changed**, so no link gate is nominated. Nothing in `docs/design/fresco/` contradicts the new ordering: `architecture.md` says `root!` "ensures its frame before `createRoot`", which is still exactly what it does.
