### PR TITLE
fix(ssr-ring, examples-substrates): bound the Node body deadline; boot and compose the Fresco login host (rf2-fzbj.24, rf2-fzbj.36, rf2-gwye.61, rf2-gwye.62)

### DIFF
--- a/examples/substrates/fresco/login/README.md
+++ b/examples/substrates/fresco/login/README.md
@@ -248,10 +248,44 @@ one, and the adapter refuses an answer that comes back with one:
 npx shadow-cljs release examples/login-fresco-server   --config-merge '{:closure-defines {fresco.login.server/build-id "2026-09-02-a1b2c3"}}'
 ```
 
-Then serve `host.clj`'s `handler` from any Ring adapter, with
-`LOGIN_FRESCO_SSR_NODE` pointing at the sidecar's URL, and open the page. The
-client boots through the same `core.cljs` either way: it looks for
-`__rf_payload`, and hydrates when it finds one instead of mounting.
+Then boot the JVM and serve `host.clj`'s `app`, with `LOGIN_FRESCO_SSR_NODE`
+pointing at the sidecar's URL:
+
+```clojure
+(require '[fresco.login.host :as host]
+         '[ring.adapter.jetty :as jetty])
+
+;; Install the SSR substrate adapter in THIS process. Requiring
+;; `re-frame.ssr` publishes its adapter; only `init!` seats one, and without
+;; a seated adapter the first request cannot create its frame — the page
+;; comes back as a bare HTTP 500 with a healthy sidecar sitting idle.
+(host/init!)
+
+;; `host/app`, not `host/handler`. `handler` is the SSR handler alone, and an
+;; SSR handler renders a document for EVERY request it is given — including
+;; the `/main.js` the page it just served asks the browser to fetch. `app`
+;; puts one route in front of it: `/` renders, everything else comes out of
+;; the compiled bundle's output directory, and a miss is a 404 rather than
+;; another login page.
+(jetty/run-jetty host/app {:port 3000 :join? false})
+```
+
+Open `http://localhost:3000`. The client boots through the same `core.cljs`
+either way: it looks for `__rf_payload`, and hydrates when it finds one
+instead of mounting.
+
+Three paths have to agree, and two environment variables move them together
+with the build: the `compile` above writes `out/examples/login-fresco`
+(`LOGIN_FRESCO_CLIENT_DIR`), that build's `:asset-path` is `"."` so its
+generated dependency URLs resolve against the document's own directory, and
+the page is served at `/` — so the output tree is served at `/` too, and
+`host.clj`'s `:script-src` is `/main.js`. Serve the page from some other
+path and the asset mapping moves with it.
+
+A deployment that already has a router and static-asset middleware does not
+need `make-app`: use
+[`ssr-middleware`](../../../../implementation/ssr-ring/src/re_frame/ssr/ring.clj)
+to slot the page in beside the routes it already serves.
 
 **The host runs**, and two gates say so rather than this paragraph. A JVM host
 has to hold the application's state, so `login.model` — the owner of every

--- a/examples/substrates/fresco/login/host.clj
+++ b/examples/substrates/fresco/login/host.clj
@@ -34,16 +34,43 @@
   halves and a host that reaches past it is refused by the sidecar rather
   than served.
 
-  ## Running it
+  ## Running it — `init!`, then `app`
 
-  See the example README. This namespace loads and runs on a plain Clojure
-  classpath — the shared `login.model` is `.cljc`, so the JVM holds the
-  application's state the same way the browser does — and it is driven,
-  over a real socket against the real sidecar launcher, by
-  `re-frame.ssr.ring.login-host-crossing-test`
-  (`implementation/ssr-ring/test/`, tagged `:crossing`)."
-  (:require [re-frame.ssr.ring :as rf.ssr.ring]
+  Two things a JVM host needs that neither the Node boot nor the browser
+  boot can do for it, because each of those initialises its OWN process:
+
+    (host/init!)                                     ;; installs the adapter
+    (jetty/run-jetty host/app {:port 3000 :join? false})
+
+  `init!` installs the SSR substrate adapter. Requiring `re-frame.ssr`
+  PUBLISHES its adapter; only `rf/init!` INSTALLS one, and without an
+  installed adapter the first request cannot create its frame — `ssr-handler`
+  projects the failure to a bare HTTP 500 before the renderer is reached, so
+  a perfectly healthy sidecar renders nothing (rf2-gwye.61).
+
+  `app` is the whole application: `handler` for the page, and the compiled
+  browser bundle's output tree for everything else. `handler` ALONE renders
+  a document for every request it is given, the `<script>` URL in the page
+  it just served included — so serving it bare answers `/main.js` with
+  another login page and the page never becomes interactive (rf2-gwye.62).
+  Routing is the host application's job, which is what `app` shows; the
+  library's own `ssr-middleware` is the other way to arrange it.
+
+  Composition uses `ring.util.response` / `ring.middleware.content-type`
+  from `ring/ring-core`, which every Ring server adapter already brings.
+
+  This namespace loads and runs on a plain Clojure classpath — the shared
+  `login.model` is `.cljc`, so the JVM holds the application's state the
+  same way the browser does — and it is driven, over a real socket against
+  the real sidecar launcher, by `re-frame.ssr.ring.login-host-crossing-test`
+  (`implementation/ssr-ring/test/`, tagged `:crossing`). See the example
+  README for the build commands the paths below assume."
+  (:require [re-frame.core :as rf]
+            [re-frame.ssr :as rf.ssr]
+            [re-frame.ssr.ring :as rf.ssr.ring]
             [re-frame.ssr.ring.node :as rf.ssr.ring.node]
+            [ring.middleware.content-type :as ring.content-type]
+            [ring.util.response :as ring.response]
             ;; The one render-state list, shared with `server.cljs`.
             [fresco.login.policy :as policy]
             ;; The application, on the JVM: every `auth.login` schema, fx,
@@ -70,6 +97,32 @@
   sidecar is not refused. Render state can carry server-only values, so a
   remote one is the operator's network and transport to secure."
   (or (System/getenv "LOGIN_FRESCO_SSR_NODE") rf.ssr.ring.node/default-endpoint))
+
+(def client-dir
+  "Where the compiled BROWSER bundle landed — the `:output-dir` of
+  `:examples/login-fresco` in `implementation/shadow-cljs.edn`, as seen from
+  the directory the README's build commands are run in.
+
+  That build's `:asset-path` is `\".\"`, which means its generated
+  dependency URLs are resolved against the DOCUMENT's own directory. The
+  page is served at `/`, so this whole tree is served at `/` too: the shell
+  asks for `/main.js` and the runtime then asks for `/cljs-runtime/…`, and
+  both land inside this directory. Move the page off `/` and the asset
+  mapping has to move with it."
+  (or (System/getenv "LOGIN_FRESCO_CLIENT_DIR") "out/examples/login-fresco"))
+
+(defn init!
+  "Boot this JVM: install the SSR substrate adapter.
+
+  A re-frame2 process installs ONE adapter, and installing it is an
+  application-lifecycle act — call this once, before the Ring server starts
+  accepting requests. It is NOT something the library does on a caller's
+  behalf at require time or per request: requiring `re-frame.ssr` publishes
+  the adapter, `rf/init!` seats it, and Spec 006 keeps those two apart on
+  purpose. Idempotent for this adapter, so a REPL that evaluates it twice is
+  fine."
+  []
+  (rf/init! rf.ssr/adapter))
 
 (defn make-handler
   "Build the Ring handler against ONE sidecar. `handler` below is this
@@ -105,8 +158,44 @@
      ;; The client bundle, and the element it adopts. `fresco.login.core/run`
      ;; reads `__rf_payload`, finds one, and HYDRATES rather than mounting.
      :app-element-id "app"
-     :script-src     "/js/main.js"}))
+     ;; The URL `client-dir`'s bundle is mapped to by `make-app` below. It
+     ;; is one fact in two places and they have to agree: a `:script-src`
+     ;; the application does not route is a page that never hydrates.
+     :script-src     "/main.js"}))
 
 (def handler
-  "The Ring handler this deployment serves. Hand it to any Ring adapter."
+  "The PAGE handler — `ssr-handler`, and nothing else. It renders a document
+  for every request it is given, so it wants a route in front of it rather
+  than a socket: serve `app` below, not this."
   (make-handler {:endpoint endpoint :build-id build-id}))
+
+(defn- page-request?
+  "The one route this example renders. Everything else is an asset of the
+  compiled bundle — which is why an unknown path gets a 404 rather than a
+  login page: a miss that renders looks like a working asset URL."
+  [{:keys [request-method uri]}]
+  (and (= :get request-method) (= "/" uri)))
+
+(defn make-app
+  "The whole Ring application: `page-handler` for the page, `client-dir`'s
+  compiled browser bundle for everything else.
+
+  Twelve lines, no router and no server framework — the minimum that makes
+  the documented build/serve sequence produce an interactive page. A real
+  deployment usually has a router and a static-asset middleware already, and
+  would use `re-frame.ssr.ring/ssr-middleware` to slot the page in
+  alongside them."
+  [page-handler client-dir]
+  (fn app [request]
+    (if (page-request? request)
+      (page-handler request)
+      (if-let [asset (ring.response/file-response (:uri request)
+                                                  {:root client-dir})]
+        (ring.content-type/content-type-response asset request)
+        (-> (ring.response/not-found "No such asset in this build.")
+            (ring.response/content-type "text/plain; charset=utf-8"))))))
+
+(def app
+  "What this deployment serves, once `init!` has run. Hand THIS to any Ring
+  adapter."
+  (make-app handler client-dir))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/node.clj
@@ -48,6 +48,15 @@
   refuses before the JVM gives up: the sidecar's render-timeout refusal is
   a diagnosable event, a socket the caller abandoned is not.
 
+  That budget bounds the WHOLE exchange, body included (rf2-fzbj.24).
+  `HttpRequest.Builder.timeout` bounds only the phase before the response
+  headers arrive, so a peer that answers 200 promptly and then stalls
+  mid-body is a wait the JDK never ends — and the Ring request, and its
+  frame, are held open for the length of it. The adapter therefore sends
+  ASYNCHRONOUSLY and waits on completion for the budget itself, CANCELLING
+  the exchange when it expires. Both halves throw the same
+  `:rf.error/ssr-node-deadline` with `:observed-by :jvm`.
+
   JSON is `org.clojure/data.json` — ssr-ring's one dependency beyond core
   and ssr, accepted by the ruling (first-party, no transitive deps).
 
@@ -124,7 +133,9 @@
             HttpRequest HttpRequest$BodyPublishers HttpResponse
             HttpResponse$BodyHandlers HttpTimeoutException]
            [java.nio.charset StandardCharsets]
-           [java.time Duration]))
+           [java.time Duration]
+           [java.util.concurrent CompletableFuture ExecutionException TimeUnit
+            TimeoutException]))
 
 (set! *warn-on-reflection* true)
 
@@ -151,6 +162,19 @@
   "The fixed margin the derived HTTP timeout adds for the wire itself —
   loopback round trip, JSON framing, a busy event loop answering."
   500)
+
+(def ^:private completion-grace-ms
+  "The slack the completion wait allows over the derived HTTP budget before
+  it cancels the exchange itself.
+
+  The JDK bounds the phase BEFORE the response headers arrive and
+  classifies it precisely — a connect timeout is unreachability, a
+  header-wait timeout is a deadline. The completion wait exists to bound
+  what the JDK does not: consumption of the response BODY. Sized a little
+  longer than the budget, the JDK's own timer wins whenever it is going to
+  fire at all, so those classifications survive and this wait answers only
+  for the stall the JDK never sees."
+  100)
 
 (def ^:private sidecar-deadline-status
   "The HTTP status the sidecar's transport answers a deadline with — the
@@ -346,19 +370,53 @@
   (.orElse (.firstValue (.headers http-response) header-name) nil))
 
 (defn- send-request!
-  "Send `http-request` on `client`; the response, or the transport-class throw
-  (`unreachable` for no answer, `deadline` for the JVM's own timeout)."
-  ^HttpResponse [^HttpClient client ^HttpRequest http-request opts]
-  (try
-    (.send client http-request (HttpResponse$BodyHandlers/ofString))
-    ;; Order matters: HttpConnectTimeoutException IS-A HttpTimeoutException
-    ;; IS-A IOException. A connect timeout is unreachability, not a
-    ;; deadline; a body-read timeout is the JVM observing the deadline.
-    (catch HttpConnectTimeoutException cause
-      (throw-unreachable! opts cause))
-    (catch HttpTimeoutException _ (throw-deadline! opts :jvm))
-    (catch IOException cause
-      (throw-unreachable! opts cause))))
+  "Send `http-request` on `client` and return the COMPLETED response, or the
+  transport-class throw (`unreachable` for no answer, `deadline` for the
+  JVM's own budget expiring).
+
+  `sendAsync` and a bounded wait on completion, rather than the blocking
+  `send` (rf2-fzbj.24): the derived budget has to bound COMPLETE body
+  consumption, and `HttpRequest.Builder.timeout` does not — a peer that
+  answers 200 promptly and then stalls mid-body is a wait the JDK never
+  ends. Expiry CANCELS the exchange (`cancel(true)` reaches the underlying
+  JDK operation) rather than abandoning a live body reader behind a settled
+  outer result: the throw releases the caller's request frame, so a reader
+  left running would outlive the request that owns it."
+  ^HttpResponse [^HttpClient client ^HttpRequest http-request opts
+                 transport-timeout-ms]
+  (let [^CompletableFuture pending
+        (.sendAsync client http-request (HttpResponse$BodyHandlers/ofString))]
+    (try
+      (.get pending
+            (long (+ transport-timeout-ms completion-grace-ms))
+            TimeUnit/MILLISECONDS)
+      (catch TimeoutException _
+        (.cancel pending true)
+        (throw-deadline! opts :jvm))
+      ;; An interrupted host thread keeps its existing meaning — it is
+      ;; neither a deadline nor unreachability — but the exchange still has
+      ;; to go, and the flag is restored for whoever set it.
+      (catch InterruptedException cause
+        (.cancel pending true)
+        (.interrupt (Thread/currentThread))
+        (throw cause))
+      (catch ExecutionException wrapper
+        (let [cause (or (.getCause wrapper) wrapper)]
+          ;; Order matters: HttpConnectTimeoutException IS-A
+          ;; HttpTimeoutException IS-A IOException. A connect timeout is
+          ;; unreachability, not a deadline; the JDK's header-wait timeout
+          ;; is the JVM observing the deadline.
+          (cond
+            (instance? HttpConnectTimeoutException cause)
+            (throw-unreachable! opts cause)
+
+            (instance? HttpTimeoutException cause)
+            (throw-deadline! opts :jvm)
+
+            (instance? IOException cause)
+            (throw-unreachable! opts cause)
+
+            :else (throw cause)))))))
 
 (defn- interpret-response!
   "The seam result from a sidecar response, or the sidecar-class throw."
@@ -422,5 +480,6 @@
                            :escape-slash false)
             http-request (build-request render-endpoint request-json
                                         transport-timeout-ms)
-            http-response (send-request! client http-request validated-opts)]
+            http-response (send-request! client http-request validated-opts
+                                         transport-timeout-ms)]
         (interpret-response! validated-opts http-response)))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
@@ -422,8 +422,9 @@
       (is (str/includes? body "<!DOCTYPE html>") "shell: JVM-built")
       (is (str/includes? body "<div id=\"app\"")
           "shell: the #app root the client hydrator adopts by id")
-      (is (str/includes? body "src=\"/js/main.js\"")
-          "shell: the client bundle the example's README names")
+      (is (str/includes? body "src=\"/main.js\"")
+          "shell: the client bundle, at the URL `host/make-app` maps it to —
+           `/js/` was a path nothing served (rf2-gwye.62)")
       ;; The host names no `:content-type`, so the handler emits none and
       ;; leaves the header to the runtime — asserted as measured rather
       ;; than as assumed.

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
@@ -63,10 +63,15 @@
             [re-frame.ssr.ring :as rf.ssr.ring]
             [re-frame.ssr.ring.node :as rf.ssr.ring.node]
             [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support]
+            [re-frame.substrate.adapter :as rf.substrate.adapter]
             ;; THE SUBJECT. Requiring it is half the witness.
             [fresco.login.host :as host]
             [fresco.login.policy :as policy])
-  (:import [java.util.concurrent TimeUnit]))
+  (:import [java.net InetSocketAddress]
+           [java.nio.file Files Path]
+           [java.nio.file.attribute FileAttribute]
+           [java.util.concurrent TimeUnit]
+           [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]))
 
 ;; ===========================================================================
 ;; The runtime reset, plus the application's registrations
@@ -251,6 +256,157 @@
             (str f " keeps no copy of the app-db key list (found "
                  copies " — a second copy can drift the SAFE way, which "
                  "the sidecar cannot refuse)"))))))
+
+;; ===========================================================================
+;; UNTAGGED — the documented LAUNCH: the JVM boot, and the client assets
+;; (rf2-gwye.61, rf2-gwye.62)
+;;
+;; Still no Node. The peer here is an in-process JDK `HttpServer` answering
+;; `/render` the way the sidecar does, which is enough to make the host emit
+;; a real page — and a real page is what carries the `<script src>` the
+;; second row then has to route. The `:crossing` rows below keep the real
+;; launcher; what these two witness is the host APPLICATION around it.
+;; ===========================================================================
+
+(defn- with-render-peer
+  "Run `(f url hits)` against a loopback peer that answers `/render` with
+  `host/build-id` and `body`. `hits` counts the renders it served, so a
+  caller can prove a request did NOT reach the renderer."
+  [^String body f]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)
+        bytes  (.getBytes body "UTF-8")
+        hits   (atom 0)]
+    (.createContext server "/render"
+                    (proxy [HttpHandler] []
+                      (handle [^HttpExchange ex]
+                        (swap! hits inc)
+                        (.add (.getResponseHeaders ex) "x-rf-ssr-build" host/build-id)
+                        (.sendResponseHeaders ex 200 (alength bytes))
+                        (with-open [out (.getResponseBody ex)] (.write out bytes))
+                        nil)))
+    (.start server)
+    (try
+      (f (str "http://127.0.0.1:" (.getPort (.getAddress server))) hits)
+      (finally (.stop server 0)))))
+
+(def ^:private rendered-marker "<form id=\"stub-rendered-login\"></form>")
+
+(def ^:private page-request
+  "The one route `make-app` renders. It is `/` and not `/login` because the
+  browser build's `:asset-path` is `\".\"`: its generated dependency URLs
+  resolve against the DOCUMENT's directory, so the page and the output tree
+  have to share one."
+  {:uri "/" :request-method :get :headers {}})
+
+(deftest the-documented-boot-installs-the-adapter
+  ;; rf2-gwye.61. The example's Node boot and browser boot each initialise
+  ;; their OWN process; neither can initialise the JVM. Requiring
+  ;; `re-frame.ssr` PUBLISHES its adapter — `rf/init!` is what seats one —
+  ;; so a host whose launch omits it serves a bare 500 with a healthy
+  ;; sidecar sitting idle, before the renderer is ever reached.
+  ;;
+  ;; The suite's own fixture seats the adapter, which is exactly why this
+  ;; row has to unseat it first: a witness for the documented STARTUP cannot
+  ;; run inside a fixture that supplies what the startup is accused of
+  ;; omitting. It reseats it through `host/init!` — the documented boot —
+  ;; so the next fixture run finds what it expects.
+  (with-render-peer rendered-marker
+    (fn [url hits]
+      (let [h (host/make-handler {:endpoint url :build-id host/build-id})]
+        (rf/destroy-adapter!)
+        (testing "NEGATIVE CONTROL — no adapter, and the request dies at frame
+                  setup rather than at the renderer"
+          (is (nil? (rf.substrate.adapter/current-adapter))
+              "nothing is seated — the state the documented launch leaves behind")
+          (let [{:keys [status body]} (h request)]
+            (is (= 500 status) "a bare internal error, not a rendered page")
+            (is (not (str/includes? (str body) rendered-marker))
+                "the sidecar's markup is nowhere — this failed before the render")
+            (is (zero? @hits) "…and the renderer was never dialled")))
+
+        (testing "the documented boot — `host/init!` — seats the SSR adapter,
+                  and the SAME handler then renders"
+          (host/init!)
+          (is (some? (rf.substrate.adapter/current-adapter)))
+          (let [{:keys [status body]} (h request)]
+            (is (= 200 status))
+            (is (str/includes? (str body) rendered-marker)
+                "Node's body markup crossed into the JVM-owned document")
+            (is (= 1 @hits) "…and this one request reached the renderer")))
+
+        (testing "it is idempotent, so a REPL that evaluates the launch twice
+                  is not punished for it"
+          (is (nil? (host/init!))))))))
+
+(deftest the-composed-app-serves-the-client-bundle-at-the-shell-s-script-url
+  ;; rf2-gwye.62. `ssr-handler` renders a document for EVERY request it is
+  ;; given, so serving it bare answered the `<script src>` in the page it had
+  ;; just served with another copy of that page — and the script never ran.
+  ;; Routing is the host application's job; `host/make-app` is the minimum
+  ;; that does it, and this row drives the shell's OWN advertised URL rather
+  ;; than a literal copy of it, so the two cannot drift apart silently.
+  (with-render-peer rendered-marker
+    (fn [url hits]
+      (let [^Path client-dir (Files/createTempDirectory
+                               "rf2-login-fresco-client"
+                               (into-array FileAttribute []))
+            dir-file         (.toFile client-dir)
+            page             (host/make-handler {:endpoint url
+                                                 :build-id host/build-id})
+            app              (host/make-app page (.getAbsolutePath dir-file))]
+        (try
+          (spit (io/file dir-file "main.js") "console.log('login client');")
+          (.mkdirs (io/file dir-file "cljs-runtime"))
+          (spit (io/file dir-file "cljs-runtime" "goog.base.js") "goog.provide('x');")
+
+          (let [{:keys [status body]} (app page-request)
+                script-src (second (re-find #"<script src=\"([^\"]+)\"" (str body)))]
+            (testing "the page route still renders, and advertises a script URL"
+              (is (= 200 status))
+              (is (str/includes? (str body) rendered-marker))
+              (is (= "/main.js" script-src)
+                  "the shell's :script-src — aligned with the asset mapping below"))
+
+            (testing "…and THAT URL serves JavaScript, not another login page"
+              (let [before @hits
+                    {:keys [status headers body]} (app {:uri            script-src
+                                                        :request-method :get
+                                                        :headers        {}})]
+                (is (= 200 status))
+                (is (= "text/javascript" (get headers "Content-Type"))
+                    "a script, by content type — never text/html")
+                (is (= "console.log('login client');" (slurp body))
+                    "the compiled bundle's own bytes")
+                (is (= before @hits)
+                    "no SSR render was performed for an asset fetch"))))
+
+          (testing "the dependency URLs the dev build generates are reachable
+                    too — `:asset-path \".\"` resolves them against the page"
+            (let [{:keys [status headers]} (app {:uri            "/cljs-runtime/goog.base.js"
+                                                 :request-method :get
+                                                 :headers        {}})]
+              (is (= 200 status))
+              (is (= "text/javascript" (get headers "Content-Type")))))
+
+          (testing "an asset this build does not carry is a MISS, not a login
+                    page — a 200 here is what made every wrong URL look served"
+            (let [before @hits
+                  {:keys [status body]} (app {:uri            "/no-such-asset.js"
+                                              :request-method :get
+                                              :headers        {}})]
+              (is (= 404 status))
+              (is (not (str/includes? (str body) rendered-marker)))
+              (is (not (str/includes? (str body) "<!DOCTYPE html")))
+              (is (= before @hits) "and it cost no render")))
+
+          (testing "the mapping is confined to the build's own tree"
+            (is (= 404 (:status (app {:uri            "/../host.clj"
+                                      :request-method :get
+                                      :headers        {}})))))
+
+          (finally
+            (doseq [^java.io.File f (reverse (file-seq dir-file))]
+              (.delete f))))))))
 
 ;; ===========================================================================
 ;; :crossing — the real launcher, a real socket, the advertised handler

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/node_body_deadline_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/node_body_deadline_test.clj
@@ -1,0 +1,201 @@
+(ns re-frame.ssr.ring.node-body-deadline-test
+  "rf2-fzbj.24 — THE DERIVED HTTP DEADLINE BOUNDS THE WHOLE EXCHANGE,
+  INCLUDING THE BODY.
+
+  `re-frame.ssr.ring.node/renderer` derives one explicit HTTP budget per
+  request (`http-timeout-ms` — `:timeout-ms` + `:admission-ms` +
+  `wire-margin-ms`, S6) and an operator sizes a deployment by it. The JDK's
+  own `HttpRequest.Builder.timeout` bounds the phase BEFORE the response
+  headers arrive and nothing after it, so a peer that answers 200 promptly
+  and then stalls mid-body held the synchronous Ring request — and its
+  request frame — open indefinitely, and eventually returned SUCCESS past
+  the stated budget.
+
+  The existing deadline coverage cannot see this. `node-crossing-test`'s
+  `(d)` arm proves the SIDECAR's 504 arrives first (`:observed-by
+  :sidecar`); a healthy in-process fake returns a completed body. Both need
+  the answer to complete.
+
+  This namespace is untagged — it runs in the default `:test` lane
+  (`jvm-ssr-ring`) and spawns no Node. The peer is a JDK `HttpServer` on a
+  port-0 loopback socket that sends the expected build header and the first
+  of two promised body bytes, then WITHHOLDS the second until the test
+  releases it (with a finite backstop, so a regression stalls the row
+  rather than the run).
+
+  Three things are asserted, and the first is the defect:
+
+    1. the handler returns the projected, fail-closed 5xx WELL INSIDE the
+       backstop, carrying `:rf.error/ssr-node-deadline` / `:observed-by
+       :jvm` / the derived `:http-timeout-ms`, with no partial Node markup
+       and no hydration payload, and the request frame gone;
+    2. releasing the withheld byte afterwards produces NO second response
+       and revives nothing — the exchange was cancelled, not parked;
+    3. the SAME renderer serves the next request normally, so cancelling
+       one exchange does not poison the shared `HttpClient`."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as rf.error-emit]
+            [re-frame.ssr.ring :as rf.ssr.ring]
+            [re-frame.ssr.ring.node :as rf.ssr.ring.node]
+            [re-frame.ssr.ring.test-support :as rf.ssr.ring.test-support])
+  (:import [java.io IOException OutputStream]
+           [java.net InetSocketAddress]
+           [java.util.concurrent CountDownLatch TimeUnit]
+           [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]))
+
+(use-fixtures :each rf.ssr.ring.test-support/reset-runtime)
+
+;; ===========================================================================
+;; The peer: 200, the right build, one byte now and one byte later
+;; ===========================================================================
+
+(def ^:private build-id "body-deadline-build-1")
+
+(def ^:private backstop-ms
+  "How long the peer withholds its second body byte before giving up and
+  sending it anyway. It exists so the UNREPAIRED code fails this row
+  instead of hanging the lane; every assertion below is sized well under
+  it, so a pass can never be the backstop firing."
+  4000)
+
+(defn- with-stalling-peer
+  "Run `(f url release-latch)` against a loopback `HttpServer` whose
+  `/render` answers HTTP 200 with `x-rf-ssr-build` and a promised body of
+  two bytes. The FIRST request writes `A`, flushes it, and then waits on
+  the returned latch (or `backstop-ms`) before writing `B`. Every later
+  request answers `AB` at once, so a caller can prove the renderer still
+  works after a cancelled exchange.
+
+  The server keeps the JDK's default dispatcher — one handler at a time —
+  so the caller counts the latch down before issuing its second request."
+  [f]
+  (let [release  (CountDownLatch. 1)
+        seen     (atom 0)
+        server   (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext
+      server "/render"
+      (proxy [HttpHandler] []
+        (handle [^HttpExchange ex]
+          (try
+            (.add (.getResponseHeaders ex) "x-rf-ssr-build" build-id)
+            (.sendResponseHeaders ex 200 2)
+            (let [^OutputStream out (.getResponseBody ex)
+                  stall?            (= 1 (swap! seen inc))]
+              (.write out (int 65))                       ; A
+              (.flush out)
+              (when stall?
+                (.await release backstop-ms TimeUnit/MILLISECONDS))
+              (.write out (int 66))                       ; B
+              (.flush out))
+            ;; A cancelled exchange can make the late write fail. Whether it
+            ;; does is the OS's business — a write into a closed socket's
+            ;; send buffer usually succeeds — so this is swallowed rather
+            ;; than asserted on.
+            (catch IOException _ nil)
+            (finally (.close ex)))
+          nil)))
+    (.start server)
+    (try
+      (f (str "http://127.0.0.1:" (.getPort (.getAddress server))) release)
+      (finally
+        (.countDown release)
+        (.stop server 0)))))
+
+;; ===========================================================================
+;; The app, the handler, and the error stream
+;; ===========================================================================
+
+(def ^:private request {:uri "/body-deadline" :request-method :get :headers {}})
+
+(defn- register-app! []
+  (rf/reg-event :rf.test.body-deadline/init
+    {:platforms #{:server}}
+    (fn [_ _] {:db {:heading "Body deadline"}})))
+
+(def ^:private render-timeout-ms 50)
+
+(def ^:private derived-http-timeout-ms
+  "The budget the adapter advertises for this renderer, read from the
+  adapter's own pure derivation rather than restated as a literal."
+  (rf.ssr.ring.node/http-timeout-ms {:timeout-ms   render-timeout-ms
+                                     :admission-ms 0}))
+
+(defn- handler [url]
+  (rf.ssr.ring/ssr-handler
+    {:initial-events [[:rf.test.body-deadline/init]]
+     :payload        [:heading]
+     :renderer       (rf.ssr.ring.node/renderer
+                       {:endpoint     url
+                        :entry        "app/root"
+                        :build-id     build-id
+                        :timeout-ms   render-timeout-ms
+                        :admission-ms 0
+                        :render-state {:app-db [:heading]}})
+     :error-view     (fn [{:keys [code]}]
+                       [:main#body-deadline-error [:p (str "projected:" (name code))]])}))
+
+(defn- capture-errors! []
+  (let [seen (atom [])]
+    (rf.error-emit/register-error-listener! ::body-deadline-recorder
+                                            (fn [record] (swap! seen conj record)))
+    seen))
+
+(defn- render-failure-data [records]
+  (->> records
+       (filter #(= :rf.error/ssr-render-failed (:error %)))
+       (map #(-> % :exception ex-data))
+       first))
+
+;; ===========================================================================
+;; The row
+;; ===========================================================================
+
+(deftest a-peer-that-stalls-mid-body-hits-the-derived-deadline-and-frees-the-frame
+  (register-app!)
+  (with-stalling-peer
+    (fn [url release]
+      (let [seen          (capture-errors!)
+            frames-before (set (rf/frame-ids))
+            h             (handler url)
+            t0            (System/nanoTime)
+            {:keys [status body]} (h request)
+            elapsed-ms    (/ (- (System/nanoTime) t0) 1e6)]
+
+        (testing "the derived HTTP budget bounds COMPLETE body consumption,
+                  not just the wait for headers"
+          (is (< elapsed-ms 2500.0)
+              (format (str "the handler returned in %.1f ms; the budget is %d ms "
+                           "and the peer's backstop is %d ms, so anything near "
+                           "the backstop means the body read was unbounded")
+                      elapsed-ms derived-http-timeout-ms backstop-ms))
+          (is (= 500 status) "projected, fail-closed — never a late success")
+          (is (str/includes? body "<main id=\"body-deadline-error\">")
+              "the :error-view rendered")
+          (is (not (str/includes? body "__rf_payload"))
+              "no hydration payload on the error arm")
+          (is (not (str/includes? body "AB"))
+              "no partial or completed Node markup escapes"))
+
+        (testing "it is the JVM's own deadline, with the derived budget in ex-data"
+          (let [{:keys [observed-by timeout-ms http-timeout-ms] :as data}
+                (render-failure-data @seen)]
+            (is (= :rf.error/ssr-node-deadline (:rf.error/id data)))
+            (is (= :jvm observed-by)
+                "the JVM observed it — the peer never sent a 504")
+            (is (= render-timeout-ms timeout-ms))
+            (is (= derived-http-timeout-ms http-timeout-ms))))
+
+        (testing "the request frame is gone — a stalled peer cannot retain
+                  per-request state"
+          (is (= frames-before (set (rf/frame-ids)))))
+
+        (testing "releasing the withheld byte revives nothing, and the SAME
+                  renderer still serves the next request"
+          (.countDown release)
+          (let [{:keys [status body]} (h request)]
+            (is (= 200 status) "the shared HttpClient survived the cancellation")
+            (is (str/includes? body "AB") "…and this answer's body crossed whole")))
+
+        (rf.error-emit/unregister-error-listener! ::body-deadline-recorder)))))


### PR DESCRIPTION
Four beads, one cluster: the Fresco login example's JVM host runs through
ssr-ring's pipeline, so its two launch defects and ssr-ring's deadline defect
share a surface.

- **rf2-fzbj.24** — bound Node response-body reads and release timed-out
  request frames.
- **rf2-fzbj.36** — complete Fresco SSR host startup and asset serving (its
  two findings are split as the two children below; closed with them).
- **rf2-gwye.61** — initialize the Fresco login JVM host before serving.
- **rf2-gwye.62** — serve client assets in the launch recipe.

All three findings were re-verified at this worktree's tip before any fix.
None was already repaired.

## rf2-fzbj.24 — the derived HTTP budget did not bound the body

`node/renderer` derives one explicit HTTP budget per request
(`http-timeout-ms` = `:timeout-ms` + `:admission-ms` + `wire-margin-ms`) and
an operator sizes a deployment by it. `HttpRequest.Builder.timeout` bounds
only the wait for response *headers*, so a peer that answered 200 promptly and
then stalled mid-body was a wait the JDK never ended.

**Measured at tip, pre-fix**: with a 550 ms budget, a loopback peer that sent
the expected build header and the first of two promised body bytes held the
synchronous Ring request — and its request frame — open until it released the
second byte, and the handler then returned **HTTP 200 with the complete body
at 4505.7 ms**. Success past the stated deadline, not merely a slow error.

**Repair.** `send-request!` sends with `sendAsync` and waits on completion for
the derived budget, cancelling the exchange with `cancel(true)` on expiry
rather than leaving a body reader running behind a settled outer result. The
completion wait carries a small grace (`completion-grace-ms`, 100 ms) over the
budget so the JDK's own timer still wins whenever it fires at all — which is
what keeps connect-timeout classified as unreachability and header-wait as a
deadline. Both expiry paths throw the existing `:rf.error/ssr-node-deadline`
with `:observed-by :jvm`, so projection, the four distinct error codes and
frame teardown are unchanged. An interrupted host thread keeps its existing
meaning (rethrown), with the exchange cancelled and the interrupt flag
restored.

**Regression**: `implementation/ssr-ring/test/re_frame/ssr/ring/node_body_deadline_test.clj`,
untagged so it runs in the default lane on every PR. It asserts the projected
5xx well inside the peer's backstop, `:observed-by :jvm` with the derived
`:http-timeout-ms`, no partial Node markup and no hydration payload, the
request frame gone, and that the **same** renderer serves the next request
normally afterwards.

## rf2-gwye.61 — the documented JVM boot installed no adapter

Requiring `re-frame.ssr` *publishes* its adapter; only `rf/init!` seats one,
and the example's Node boot and browser boot each initialise their own
process. So the documented launch served a bare 500 with a healthy matching
sidecar sitting idle.

**Measured at tip, pre-fix**, against a loopback render peer: adapter `nil`,
`GET /` returned **500 `Internal error`** (14 bytes, `text/plain`) and the peer
recorded **zero** renders — the request died at frame setup. `(rf/init!
ssr/adapter)` in the same process, same handler: **200**, the rendered page,
one render.

**Repair**: `fresco.login.host/init!`, an application-lifecycle call, plus the
README launch snippet that makes it. Nothing initialises implicitly, per
request or at require time.

## rf2-gwye.62 — the shell's script URL was answered by the SSR handler

`ssr-handler` renders a document for every request it is given, including the
`/js/main.js` the page it had just served asked the browser to fetch.

**Measured at tip, pre-fix**: the page emitted `<script src="/js/main.js">`;
`GET /js/main.js` returned **200 `text/html`, a complete 552-byte login
document**, and performed a second SSR render. `/cljs-runtime/...` and an
unknown asset did the same.

**Repair**: `host/make-app` — one route in front of the page handler. `/`
renders; everything else is served out of the compiled bundle's output tree
(`ring.util.response/file-response`, which carries its own containment guard);
a miss is a 404, not another login page. `:script-src` moves to `/main.js` to
match, which is what the build's own `:asset-path "."` requires — its
generated dependency URLs resolve against the document's directory, so page
and output tree have to share one. `client-dir` is env-overridable
(`LOGIN_FRESCO_CLIENT_DIR`), matching the two env knobs already there.

**Regression**: two untagged rows added to the existing host witness,
`implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj`.
The boot row unseats the fixture's adapter first — a witness for the
documented startup cannot run inside a fixture that supplies what the startup
is accused of omitting — and reseats it through `host/init!`. The asset row
drives the shell's **own** advertised script URL rather than a copy of it, so
the shell and the mapping cannot drift apart silently, and asserts JavaScript
content type and bytes, a reachable generated dependency URL, a 404 (not a
login page) for an unknown asset, no SSR render for any of them, and
containment.

The `:crossing` document row's `src="/js/main.js"` pin moved to `/main.js`
with it.

## Controls

| gate | RED (pre-fix) | GREEN |
|---|---|---|
| `node_body_deadline_test` | exit 1, 9 failures — 200 at 4505.7 ms carrying the body, `:rf.error/id` nil | exit 0, 12 assertions |
| `login_host_crossing_test` | exit 1 — `No such var: host/init!` against the planted pre-fix `host.clj` | exit 0, 34 assertions |
| `check_readme_links.py --ci` | exit 1 naming this README and line, under a planted broken target | exit 0 |

The deadline test's RED was captured against unmodified source before the fix.
The host rows' RED was captured by restoring the pre-fix `host.clj` blob over
the committed tree after committing; the restore was verified by blob hash
against `git rev-parse HEAD:<path>` (match) and `git diff --quiet HEAD` (exit
0). The README plant's restore was verified the same way.

The pre-fix behaviour of both host findings was additionally measured through
the real, unmodified `host/make-handler` against a loopback render peer — the
figures quoted above — so the host RED is behavioural and not only a missing
Var.

## Quality gates

Every number below is the runner's own exit code, captured on one command line
and read back from a per-worktree, per-attempt file.

| gate | command | CI job | exit |
|---|---|---|---|
| ssr-ring JVM suite | `clojure -M:test` (from `implementation/ssr-ring`) | `jvm-ssr-ring` (`test.yml`) | **0** — 243 tests, 1246 assertions |
| JVM/Node/JVM crossing | `clojure -M:crossing-test` | `jvm-node-crossing` (`test.yml`) | **0** — 10 tests, 107 assertions, real sidecar |
| README/source-adjacent links | `python scripts/check_readme_links.py --ci` | `verify-readme-links` (`test.yml`) | **0** |
| doc slugs/anchors | `python scripts/check_doc_slugs.py` | `verify-readme-links` (`test.yml`) | **0** |
| public-API manifest drift | `clojure -M -m re-frame.api-manifest.gen --check` | `api-manifest` (`lint.yml`) | **0** — 470 public vars, in sync |
| retired image keys | `python scripts/check_retired_image_keys.py` | `docs.yml` | **0** |
| retired spellings | `python scripts/check_retired_spellings.py` | `docs.yml` | **0** |
| require-alias dialect | `python scripts/check_require_alias_dialect.py` | `docs.yml` | **0** |
| JVM lane rosters | `python scripts/check_jvm_lane_rosters.py` | `docs.yml` | **0** — 31 artefacts, CI bijection |
| test-lane bijection | `python scripts/check_test_lane_bijection.py` | `docs.yml` | **0** |
| README inventories | `python scripts/check_readme_inventories.py` | `docs.yml` | **0** |
| thrown error messages | `python scripts/check_thrown_error_messages.py` | `docs.yml` | **0** |
| hardcoded paths | `sh scripts/check-no-hardcoded-paths.sh` | `docs.yml` | **0** |

All re-run on the final rebased base (`origin/main` at `a7eb771dd3`), not on
the pre-rebase tree. `check_retired_image_keys.py` was RED at my original base
and is green after the rebase — the offending line was in
`implementation/machines/test/re_frame/machine_after_delay_resolution_fence_cljs_test.cljc`,
repaired on trunk by `c7e4becdf9`, not by anything here.

**`cljs-examples-compile` is declared as CI reliance rather than run locally.**
The classifier arms `examples_compile` on `examples/*`, so the job runs on this
PR. It was not run here: this worktree has no `implementation/node_modules`,
the gate takes no build filter (it hands all 58 builds to one
`shadow-cljs compile`), and linking the coordinator's shared tree is the hazard
the dispatch rules name. The diff contains **no file in any CLJS build graph** —
`host.clj` has no `host.cljs` sibling, so ClojureScript never loads it as a
macro namespace (which is why it is named `host.clj`), and the other four
changed files are a `.clj`, two JVM tests and Markdown. The same reasoning
covers the conservatively-armed `cljs_browser`, `cljs_prod` and
`bundle_isolation` surfaces.

**Checked by hand, because no gate reads them**: the README's prose, its new
fenced Clojure snippet (fence contents are stripped before either link gate
reads a file), and the section's headings. No spec page was touched, so
`check_doc_slugs.py` is reported for completeness rather than as a nominated
gate.

## Not built, and why

- **A peer-side witness that the cancelled exchange closed the socket.** Three
  instrumented runs observed no `IOException` on the peer's late write — a
  write into a closed socket's send buffer usually succeeds, so this is an
  OS-dependent signal and would be a flaky assertion. The test asserts the
  observable contract instead (prompt projected 5xx, frame released, no late
  success, shared client still usable); cancellation itself is `cancel(true)`
  on the JDK's own `sendAsync` future.
- **A public timeout knob or a streaming thread pool.** rf2-fzbj.24 says
  neither is needed, and neither was added.
- **A generic server framework, router or static-asset library for the
  example.** rf2-gwye.62 says application setup is sufficient; `make-app` is
  twelve lines over `ring/ring-core`, which every Ring server adapter already
  brings, and the docstring points a real deployment at `ssr-middleware`
  instead.
- **`re-frame.ssr.ring/ssr-handler` was not changed.** Routing is the host
  application's job and its own docs already say so; this repairs the example
  recipe, not the library contract.

## Files another row holds

None. `implementation/shadow-cljs.edn` (hot zone) and
`implementation/ssr/src/re_frame/ssr.cljc` (read-only for this row) were both
cited by the beads and **neither needed a change** — the launch recipe serves
the existing `:examples/login-fresco` output as it is already built, and the
adapter-publication behaviour `ssr.cljc` documents is correct; the example was
simply not installing what it published.

## Commit trailers

The AI-attribution trailers this harness asks for were declined, per
CLAUDE.md's Git Conventions section, which outranks the harness reminder.
