### PR TITLE
fix(examples): settle SSR loads and release failed streaming frames (rf2-fzbj.37, rf2-gwye.43/.44/.45)

### DIFF
--- a/examples/capabilities/ssr/resources_ssr/core.cljc
+++ b/examples/capabilities/ssr/resources_ssr/core.cljc
@@ -310,7 +310,10 @@
       (`Thread/sleep`) so the managed-HTTP transport's async reply lands and
       its reply event dispatches — the JVM transport issues requests via
       `HttpClient/sendAsync`, so nothing settles the entry synchronously
-      inside the `:rf.resource/ensure` dispatch itself."
+      inside the `:rf.resource/ensure` dispatch itself.
+
+      `:frame` is the frame ID — `rf/resource-state`'s introspection target
+      keys the frame registry directly. See the call site."
      [{:keys [resource scope params frame]}]
      (let [deadline (+ (System/currentTimeMillis) preload-deadline-ms)]
        (loop []
@@ -364,10 +367,19 @@
            ;; The `[:ssr …]`-owned ensure that `:rf/server-init` kicked off has
            ;; to land on a terminal status (:loaded / :error) before the render
            ;; walk works with real data instead of an in-flight guess.
+           ;;
+           ;; `:frame fid`, not `:frame f`. Most of the public surface takes a
+           ;; frame VALUE or a frame-id keyword interchangeably — `app-db-value`
+           ;; just below is handed `f` — but `rf/resource-state`'s introspection
+           ;; target is the frame ID, which is what the runtime-db read keys the
+           ;; registry by. Hand it the value and every poll reads nil: no entry
+           ;; under that key, no terminal status, and the loop burns the whole
+           ;; `preload-deadline-ms` budget on a page that was ready in
+           ;; milliseconds.
            (await-resource-loaded! {:resource :articles/list
                                      :scope    :rf.scope/global
                                      :params   {}
-                                     :frame    f})
+                                     :frame    fid})
            (let [final-db      (rf/app-db-value f)
                  final-runtime (:rf.db/runtime (rf/frame-state-value f))   ;; this is where :rf.runtime/resources lives
                  hiccup        ((rf/view :app/root))

--- a/examples/capabilities/ssr/ssr/README.md
+++ b/examples/capabilities/ssr/ssr/README.md
@@ -78,6 +78,16 @@ client picking it up:
   `:fx-overrides` seam, so the render exercises the full
   [pipeline](../../../../docs/core/glossary.md#event-pipeline) without real
   network traffic.
+- Waiting for the page load, deliberately. `make-frame` drains the
+  *synchronous* event work and promises nothing more, so a fetch the
+  JVM transport issued through `HttpClient/sendAsync` is still in
+  flight when it returns. `handle-request` blocks on an explicit
+  `:articles/load-state` outcome before it reads anything off the
+  frame — bounded by a deadline, and settled by failure as well as
+  success, because a page that can only record success waits out its
+  whole budget every time the upstream is down. Anything but `:loaded`
+  answers 503; a pending request must not leave as a 200 carrying an
+  empty page.
 - Pure [hiccup](../../../../docs/core/glossary.md#hiccup) → HTML.
   `ssr/render-to-string` is a pure function from hiccup to an HTML
   string — no React server-render dependency, no DOM, JVM-runnable.

--- a/examples/capabilities/ssr/ssr/core.cljc
+++ b/examples/capabilities/ssr/ssr/core.cljc
@@ -147,14 +147,25 @@
     ;; the host's HTTP request map (Ring-shaped under the bundled adapter), the
     ;; place you'd read URL, headers, and cookies from.
     ;;
-    ;; This particular handler leaves db alone and just fires off the article
-    ;; fetch. An app with routing would stash the matched route here; a page
-    ;; that only ever shows articles has no route worth remembering.
-    {:db db
+    ;; This particular handler marks the page load pending and fires off the
+    ;; article fetch. An app with routing would stash the matched route here; a
+    ;; page that only ever shows articles has no route worth remembering.
+    ;;
+    ;; `:articles/load-state` is the page's OWN completion signal, and the
+    ;; server render is what makes it load-bearing. On the JVM the managed
+    ;; transport issues its request through `HttpClient/sendAsync`, so
+    ;; `make-frame` returning is emphatically NOT the fetch having finished —
+    ;; it only means the synchronous event work drained. Something has to say
+    ;; "this page is done loading", and it has to say so for the FAILURE case
+    ;; too, or a server that waits for articles to turn up waits for ever.
+    ;; `handle-request` blocks on this key reaching a terminal value; the
+    ;; client never reads it.
+    {:db (assoc db :articles/load-state :pending)
      :fx [[:rf.http/managed
            {:request    {:method :get :url "/api/articles"}
             :decode     :json
-            :on-success [:articles/loaded]}]]}))
+            :on-success [:articles/loaded]
+            :on-failure [:articles/load-failed]}]]}))
 
 ;; When the fetch comes back, this is where it lands — the `:on-success` target
 ;; from above. It takes the decoded reply and hands back the next app-db, which
@@ -163,7 +174,15 @@
 ;; on the client after hydration. Write it once.
 (rf/reg-event :articles/loaded
   (fn handler-articles-loaded [{:keys [db]} [_ {:keys [value]}]]
-    {:db (assoc db :articles value)}))
+    {:db (assoc db :articles value :articles/load-state :loaded)}))
+
+;; …and the other half of the outcome. A page load that can only ever record
+;; SUCCESS is a page load the server waits on until its deadline, every time
+;; the upstream is down. This handler is what turns a failed fetch into a
+;; terminal answer `handle-request` can act on immediately.
+(rf/reg-event :articles/load-failed
+  (fn handler-articles-load-failed [{:keys [db]} _]
+    {:db (assoc db :articles/load-state :failed)}))
 
 ;; You'll notice there's no `reg-event` for hydration here. That's on purpose:
 ;; `:rf/hydrate` is a reserved `:rf/*` event that `re-frame.ssr` owns, handler
@@ -250,6 +269,60 @@
   [(rf/view :pages/articles)])
 
 ;; ============================================================================
+;; WAITING FOR THE PAGE LOAD
+;; ============================================================================
+;;
+;; The one step people leave out. `make-frame` drains the SYNCHRONOUS event
+;; work its `:initial-events` set in motion — and that is all it promises. The
+;; article fetch `:rf/server-init` starts is not synchronous: the JVM managed
+;; transport issues it through `HttpClient/sendAsync`. So the moment
+;; `make-frame` returns, the request is very probably still in flight, app-db
+;; still has no `:articles`, and a render taken right there emits "No
+;; articles." over a 200 — a page that looks fine and is wrong.
+;;
+;; So wait, explicitly, on the `:articles/load-state` signal the events above
+;; maintain. Two properties make this a wait rather than a hope:
+;;
+;;   - It is BOUNDED. `page-load-deadline-ms` caps it, the way the framework's
+;;     own SSR blocking drain caps its route-resource wait. A server that
+;;     blocks a request thread for ever on a silent upstream is a worse bug
+;;     than the one we're fixing.
+;;   - It settles on FAILURE too, not just success. Polling for non-nil
+;;     `:articles` would look simpler and would hang for the full deadline on
+;;     every failed fetch — which is exactly why `:rf/server-init` declares an
+;;     `:on-failure` target.
+;;
+;; (This page has no route table, so the framework's route-keyed
+;; `rf.ssr/drain-blocking-resources!` has nothing to drain for it. The
+;; `resources_ssr` sibling explains that split at length.)
+
+#?(:clj
+   (def ^:private page-load-deadline-ms
+     "Wall-clock budget for `await-page-load!` — mirrors the framework's own
+      SSR blocking-drain default (`re-frame.ssr`'s
+      `default-ssr-blocking-timeout-ms`)."
+     5000))
+
+#?(:clj
+   (defn- await-page-load!
+     "Block until this request's page load reaches a terminal
+      `:articles/load-state` (`:loaded` / `:failed`), or the deadline
+      elapses. Returns that terminal value, or `:timed-out`.
+
+      Yields the JVM thread between checks (`Thread/sleep`) so the managed
+      transport's async reply can land and its reply event dispatch — nothing
+      settles inside the `:rf.http/managed` call itself."
+     [f]
+     (let [deadline (+ (System/currentTimeMillis) page-load-deadline-ms)]
+       (loop []
+         (let [state (:articles/load-state (rf/app-db-value f))]
+           (cond
+             (#{:loaded :failed} state)            state
+             (>= (System/currentTimeMillis) deadline) :timed-out
+             :else (do (Thread/sleep 5)
+                       (recur))))))))
+
+;; ============================================================================
 ;; SERVER ENTRY POINT
 ;; ============================================================================
 ;;
@@ -260,8 +333,10 @@
 ;;      :rf.server/request coeffect will read back out.
 ;;   3. make-frame stands up a fresh frame; its :initial-events step fires
 ;;      :rf/server-init, which pulls the request via that coeffect.
-;;   4. The runtime drains — the article fetch resolves, app-db settles, and
-;;      everything quiets down.
+;;   4. await-page-load! blocks until the article fetch reaches a terminal
+;;      outcome — loaded, failed, or out of time. Only `:loaded` goes on to
+;;      render; the other two answer 503 rather than dress a pending request
+;;      up as a finished empty page.
 ;;   5. Render the settled state to a string with the pure hiccup -> HTML
 ;;      emitter.
 ;;   6. Serialise that same state and tuck it into the HTML as the payload.
@@ -270,8 +345,8 @@
 ;;      per request. It drops the frame record and fires
 ;;      `:ssr/on-frame-destroyed`, which hands back the request slot, the
 ;;      response accumulator, and the error-trace buffer. The `finally` covers
-;;      both the happy path and the throw path, so even a request that blows up
-;;      halfway doesn't strand a half-built frame.
+;;      the happy path, the 503 path and the throw path, so no request strands
+;;      a half-built frame.
 
 #?(:clj
    (defn handle-request [request]
@@ -289,70 +364,81 @@
                                :initial-events [[:rf/server-init]]})]
        (try
          (rf/with-frame f
-           (let [final-db      (rf/app-db-value f)        ;; the app-db partition
-                 final-runtime (:rf.db/runtime (rf/frame-state-value f))    ;; the runtime-db partition (serializable)
-                 hiccup   ((rf/view :app/root))
-                 ;; Hash the tree ONCE, then spend that one hash on both
-                 ;; channels below. `render-tree-hash` is a full walk of the
-                 ;; tree, so computing it here rather than letting the emitter
-                 ;; do its own is the difference between one walk and two.
-                 render-hash (rf.ssr/render-tree-hash hiccup)
-                 ;; `:render-hash` stamps data-rf-render-hash="<hex>" onto the
-                 ;; root element. That hex string is the tripwire: the client
-                 ;; recomputes the hash after its first render, and if the two
-                 ;; don't match, the runtime raises :rf.ssr/hydration-mismatch
-                 ;; instead of quietly serving a subtly-broken page.
-                 ;; No `:doctype?` here — this handler wraps a *fragment*
-                 ;; (`<div id='app'>…</div>`) inside its own hand-written
-                 ;; document envelope below, which already opens with
-                 ;; `<!DOCTYPE html>`. `:doctype?` is for a root view that
-                 ;; renders the whole `[:html …]` document; asking for it here
-                 ;; would prefix a *second* doctype onto the fragment and nest
-                 ;; it inside `<div id='app'>`.
-                 ;; The same hash rides in the payload too, so something
-                 ;; without a DOM to parse — a server log line, a CDN cache key
-                 ;; — can read it straight.
-                 html     (rf.ssr/render-to-string hiccup
-                                               {:render-hash render-hash})
-                 ;; You'll notice the payload carries no `:rf/frame-id`, and
-                 ;; that's the intended shape. The server rendered under a
-                 ;; throwaway per-request gensym (`f`); the client hydrates its
-                 ;; own fixed `app-frame` (defined below). The two frames have
-                 ;; nothing to say to each other by name. A `:rf/frame-id` in
-                 ;; the payload isn't a "hydrate into this" instruction — it's
-                 ;; evidence. `rf.ssr/hydrate!` checks any id it finds against the
-                 ;; `:frame` you explicitly pass, and raises
-                 ;; `:rf.error/hydration-frame-id-mismatch` if they disagree.
-                 ;; Leaving it out is the no-argument-to-have-here shape, which
-                 ;; is exactly what this output and the static `index.html`
-                 ;; both use. A deployment that *does* want to carry one stamps
-                 ;; a stable id both sides agree on ahead of time — never a
-                 ;; per-request gensym.
-                 payload  {:rf/version     rf.ssr.payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
-                           :rf/app-db      final-db        ;; app-db partition
-                           :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
-                           :rf/render-hash render-hash}]
-             {:status  200
-              :headers {"Content-Type" "text/html"}
-              :body
-              (str "<!DOCTYPE html><html><head>"
-                   "<meta charset='utf-8'/>"
-                   "<title>SSR demo</title>"
-                   "</head><body>"
-                   "<div id='app'>" html "</div>"
-                   ;; Run the payload through the EDN-aware escaper before it
-                   ;; goes in the `<script>`. If an article body happened to
-                   ;; contain the literal text `</script>` and we wrote it raw,
-                   ;; the browser would close the script element right there and
-                   ;; eat the rest of our state. The escaper sidesteps that by
-                   ;; rewriting `<` to its unicode reader escape — but *only*
-                   ;; inside EDN string literals, so the client's
-                   ;; `cljs.reader/read-string` still reads it back unchanged.
-                   "<script id='__rf_payload' type='application/edn'>"
-                   (rf.ssr.html-helpers/escape-edn-script-body (pr-str payload))
-                   "</script>"
-                   "<script src='/main.js'></script>"
-                   "</body></html>")}))
+           ;; Step 4 — wait for the page load to finish before reading a thing
+           ;; off the frame. Anything other than `:loaded` is a deliberate
+           ;; terminal outcome, and it answers 503 rather than a 200 carrying
+           ;; an empty page: "still loading" and "loaded, nothing to show" are
+           ;; different answers and a cache must not be able to confuse them.
+           ;; The `finally` below still tears the frame down on this path.
+           (if-let [outcome (#{:failed :timed-out} (await-page-load! f))]
+             {:status  503
+              :headers {"Content-Type" "text/plain; charset=utf-8"
+                        "Cache-Control" "no-store"}
+              :body    (str "Articles unavailable (" (name outcome) ").")}
+             (let [final-db      (rf/app-db-value f)        ;; the app-db partition
+                   final-runtime (:rf.db/runtime (rf/frame-state-value f))    ;; the runtime-db partition (serializable)
+                   hiccup   ((rf/view :app/root))
+                   ;; Hash the tree ONCE, then spend that one hash on both
+                   ;; channels below. `render-tree-hash` is a full walk of the
+                   ;; tree, so computing it here rather than letting the emitter
+                   ;; do its own is the difference between one walk and two.
+                   render-hash (rf.ssr/render-tree-hash hiccup)
+                   ;; `:render-hash` stamps data-rf-render-hash="<hex>" onto the
+                   ;; root element. That hex string is the tripwire: the client
+                   ;; recomputes the hash after its first render, and if the two
+                   ;; don't match, the runtime raises :rf.ssr/hydration-mismatch
+                   ;; instead of quietly serving a subtly-broken page.
+                   ;; No `:doctype?` here — this handler wraps a *fragment*
+                   ;; (`<div id='app'>…</div>`) inside its own hand-written
+                   ;; document envelope below, which already opens with
+                   ;; `<!DOCTYPE html>`. `:doctype?` is for a root view that
+                   ;; renders the whole `[:html …]` document; asking for it here
+                   ;; would prefix a *second* doctype onto the fragment and nest
+                   ;; it inside `<div id='app'>`.
+                   ;; The same hash rides in the payload too, so something
+                   ;; without a DOM to parse — a server log line, a CDN cache key
+                   ;; — can read it straight.
+                   html     (rf.ssr/render-to-string hiccup
+                                                 {:render-hash render-hash})
+                   ;; You'll notice the payload carries no `:rf/frame-id`, and
+                   ;; that's the intended shape. The server rendered under a
+                   ;; throwaway per-request gensym (`f`); the client hydrates its
+                   ;; own fixed `app-frame` (defined below). The two frames have
+                   ;; nothing to say to each other by name. A `:rf/frame-id` in
+                   ;; the payload isn't a "hydrate into this" instruction — it's
+                   ;; evidence. `rf.ssr/hydrate!` checks any id it finds against the
+                   ;; `:frame` you explicitly pass, and raises
+                   ;; `:rf.error/hydration-frame-id-mismatch` if they disagree.
+                   ;; Leaving it out is the no-argument-to-have-here shape, which
+                   ;; is exactly what this output and the static `index.html`
+                   ;; both use. A deployment that *does* want to carry one stamps
+                   ;; a stable id both sides agree on ahead of time — never a
+                   ;; per-request gensym.
+                   payload  {:rf/version     rf.ssr.payload-policy/pattern-protocol-version  ;; the SSR-owned constant, not a literal
+                             :rf/app-db      final-db        ;; app-db partition
+                             :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
+                             :rf/render-hash render-hash}]
+               {:status  200
+                :headers {"Content-Type" "text/html"}
+                :body
+                (str "<!DOCTYPE html><html><head>"
+                     "<meta charset='utf-8'/>"
+                     "<title>SSR demo</title>"
+                     "</head><body>"
+                     "<div id='app'>" html "</div>"
+                     ;; Run the payload through the EDN-aware escaper before it
+                     ;; goes in the `<script>`. If an article body happened to
+                     ;; contain the literal text `</script>` and we wrote it raw,
+                     ;; the browser would close the script element right there and
+                     ;; eat the rest of our state. The escaper sidesteps that by
+                     ;; rewriting `<` to its unicode reader escape — but *only*
+                     ;; inside EDN string literals, so the client's
+                     ;; `cljs.reader/read-string` still reads it back unchanged.
+                     "<script id='__rf_payload' type='application/edn'>"
+                     (rf.ssr.html-helpers/escape-edn-script-body (pr-str payload))
+                     "</script>"
+                     "<script src='/main.js'></script>"
+                     "</body></html>")})))
          ;; Whatever happened above — success or exception — the frame goes
          ;; away here. destroy-frame! fires `:ssr/on-frame-destroyed`, which
          ;; clears the request slot and the SSR side-channel atoms for us, so

--- a/examples/capabilities/ssr/ssr_streaming/core.cljc
+++ b/examples/capabilities/ssr/ssr_streaming/core.cljc
@@ -202,75 +202,86 @@
            _   (rf/reg-app-schema [:cards] {:frame fid} CardsSchema)
            _   (rf/make-frame {:id fid :doc "ssr-streaming-example frame"
                                :platform :server
-                               :initial-events [[:rf/server-init]]})
-           hiccup (rf/with-frame fid ((rf/view :dashboard/root)))
-           {:keys [shell-html continuations]}
-           (rf/with-frame fid (rf.ssr/streaming-render-shell hiccup))
-           ;; Render the shell handed us one continuation per boundary —
-           ;; the slow subtrees it deferred. Drain them in order, collecting
-           ;; each resolved subtree's HTML plus its hydration delta. This is
-           ;; the loop the writer thread would run, flushing each chunk the
-           ;; moment it's ready.
-           resolved-chunks
-           (mapv (fn [entry]
-                   (let [{:keys [id html delta failed?]}
-                         (rf/with-frame fid
-                           (rf.ssr/streaming-render-continuation fid entry))]
-                     {:id    id
-                      :template (if failed?
-                                  (rf.ssr/streaming-failed-template id html)
-                                  (rf.ssr/streaming-resolved-template id html))
-                      :delta-script (when (and (not failed?) (some? delta))
-                                      (rf.ssr/streaming-hydrate-delta-script
-                                        id (pr-str delta)))
-                      :failed? failed?}))
-                 continuations)
-           ;; Which boundaries blew up. The server has always known this
-           ;; per continuation; carrying it into the final payload is what
-           ;; lets the client's boundary re-render its declared fallback
-           ;; instead of every view inferring failure from missing state.
-           failed-boundaries (into #{} (comp (filter :failed?) (map :id))
-                                   resolved-chunks)
-           render-hash (rf/with-frame fid (rf.ssr/render-tree-hash hiccup))
-           ;; The final payload: the canonical, whole app-db. This is the
-           ;; load-bearing idea of the example. Those per-card deltas are a
-           ;; speed bet — they exist only to paint each region early. This
-           ;; payload is the truth, and if a delta ever disagrees with it,
-           ;; the payload wins. You get streaming's latency with a single
-           ;; authoritative hydrate's correctness.
-           ;;
-           ;; `:payload` decides what crosses the wire, and it's fail-closed
-           ;; — nothing leaves unless you say so. This demo's app-db is safe
-           ;; to ship whole (every key the dashboard fills is meant for the
-           ;; client), so we opt in with `:rf.ssr.payload/whole-app-db`. Real
-           ;; apps usually pass an explicit allowlist of top-level keys
-           ;; instead.
-           final-payload (rf/with-frame fid
-                           (rf.ssr/streaming-build-final-payload
-                             fid render-hash
-                             ;; No `:version` — the builder sources `:rf/version`
-                             ;; from the SSR artefact's compiled-in
-                             ;; pattern-protocol constant, so both wire ends agree
-                             ;; with no hand-pinned literal.
-                             {:payload :rf.ssr.payload/whole-app-db
-                              :failed-boundaries failed-boundaries}))
-           ;; Strip the payload's `:rf/frame-id` before it goes over the
-           ;; wire. The two sides don't share a frame id: the server renders
-           ;; under this per-request gensym frame (`fid`), the client hydrates
-           ;; a fixed `app-frame` (below). When `rf.ssr/hydrate!` sees a frame-id on the
-           ;; wire, it checks it against the client's explicit `:frame` and
-           ;; fails closed if they differ — which a gensym always would. Send
-           ;; no frame-id and the client's explicit target simply stands. (If
-           ;; you do want one on the wire, share a stable id both sides agree
-           ;; on, not a gensym.) See the
-           ;; [SSR guide — hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
-           final-payload (dissoc final-payload :rf/frame-id)
-           _ (rf/destroy-frame! fid)]
-       {:shell shell-html
-        :resolved-chunks resolved-chunks
-        :final-payload final-payload
-        :failed-boundaries failed-boundaries
-        :render-hash render-hash})))
+                               :initial-events [[:rf/server-init]]})]
+       ;; Everything from here on owns a live frame, so it runs inside
+       ;; `try`/`finally` — the same shape the non-streaming sibling uses.
+       ;; A boundary that throws is already handled (the drain below turns it
+       ;; into a `:failed?` chunk); what this covers is a failure OUTSIDE
+       ;; that recovery — a shell walk or a final-payload build that blows up.
+       ;; Without the `finally` those paths return through the exception and
+       ;; the per-request frame survives it, so a long-lived host leaks one
+       ;; frame per failed request. The original exception still propagates:
+       ;; `finally` releases the frame, it does not swallow the error.
+       (try
+         (let [hiccup (rf/with-frame fid ((rf/view :dashboard/root)))
+               {:keys [shell-html continuations]}
+               (rf/with-frame fid (rf.ssr/streaming-render-shell hiccup))
+               ;; Render the shell handed us one continuation per boundary —
+               ;; the slow subtrees it deferred. Drain them in order, collecting
+               ;; each resolved subtree's HTML plus its hydration delta. This is
+               ;; the loop the writer thread would run, flushing each chunk the
+               ;; moment it's ready.
+               resolved-chunks
+               (mapv (fn [entry]
+                       (let [{:keys [id html delta failed?]}
+                             (rf/with-frame fid
+                               (rf.ssr/streaming-render-continuation fid entry))]
+                         {:id    id
+                          :template (if failed?
+                                      (rf.ssr/streaming-failed-template id html)
+                                      (rf.ssr/streaming-resolved-template id html))
+                          :delta-script (when (and (not failed?) (some? delta))
+                                          (rf.ssr/streaming-hydrate-delta-script
+                                            id (pr-str delta)))
+                          :failed? failed?}))
+                     continuations)
+               ;; Which boundaries blew up. The server has always known this
+               ;; per continuation; carrying it into the final payload is what
+               ;; lets the client's boundary re-render its declared fallback
+               ;; instead of every view inferring failure from missing state.
+               failed-boundaries (into #{} (comp (filter :failed?) (map :id))
+                                       resolved-chunks)
+               render-hash (rf/with-frame fid (rf.ssr/render-tree-hash hiccup))
+               ;; The final payload: the canonical, whole app-db. This is the
+               ;; load-bearing idea of the example. Those per-card deltas are a
+               ;; speed bet — they exist only to paint each region early. This
+               ;; payload is the truth, and if a delta ever disagrees with it,
+               ;; the payload wins. You get streaming's latency with a single
+               ;; authoritative hydrate's correctness.
+               ;;
+               ;; `:payload` decides what crosses the wire, and it's fail-closed
+               ;; — nothing leaves unless you say so. This demo's app-db is safe
+               ;; to ship whole (every key the dashboard fills is meant for the
+               ;; client), so we opt in with `:rf.ssr.payload/whole-app-db`. Real
+               ;; apps usually pass an explicit allowlist of top-level keys
+               ;; instead.
+               final-payload (rf/with-frame fid
+                               (rf.ssr/streaming-build-final-payload
+                                 fid render-hash
+                                 ;; No `:version` — the builder sources `:rf/version`
+                                 ;; from the SSR artefact's compiled-in
+                                 ;; pattern-protocol constant, so both wire ends agree
+                                 ;; with no hand-pinned literal.
+                                 {:payload :rf.ssr.payload/whole-app-db
+                                  :failed-boundaries failed-boundaries}))
+               ;; Strip the payload's `:rf/frame-id` before it goes over the
+               ;; wire. The two sides don't share a frame id: the server renders
+               ;; under this per-request gensym frame (`fid`), the client hydrates
+               ;; a fixed `app-frame` (below). When `rf.ssr/hydrate!` sees a frame-id on the
+               ;; wire, it checks it against the client's explicit `:frame` and
+               ;; fails closed if they differ — which a gensym always would. Send
+               ;; no frame-id and the client's explicit target simply stands. (If
+               ;; you do want one on the wire, share a stable id both sides agree
+               ;; on, not a gensym.) See the
+               ;; [SSR guide — hydrate, then verify](../../../../docs/ssr/concepts.md#the-client-side-hydrate-then-verify).
+               final-payload (dissoc final-payload :rf/frame-id)]
+           {:shell shell-html
+            :resolved-chunks resolved-chunks
+            :final-payload final-payload
+            :failed-boundaries failed-boundaries
+            :render-hash render-hash})
+         (finally
+           (rf/destroy-frame! fid))))))
 
 ;; ============================================================================
 ;; CLIENT ENTRY POINT (.cljs branch — browser hydration)

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -677,6 +677,124 @@
                (-> payload :rf/app-db :articles first :title))
             "the payload round-trips through the EDN reader unchanged")))))
 
+;; ============================================================================
+;; ssr — the page load has to SETTLE before the render (rf2-gwye.43,
+;; rf2-fzbj.37 F1).
+;;
+;; `make-frame` drains the SYNCHRONOUS event work its `:initial-events` start,
+;; and that is all it promises. The article fetch `:rf/server-init` kicks off
+;; is not synchronous — the JVM managed transport issues it through
+;; `HttpClient/sendAsync` — so the pre-fix `handle-request` read `app-db` the
+;; instant `make-frame` returned, rendered "No articles." over a 200, and
+;; destroyed the only frame the reply could have landed in. The static
+;; `index.html` masked it (its article state is baked in) and so did every
+;; test here, because a synchronous canned stub HAS settled by then.
+;;
+;; The fix gives the load an explicit `:articles/load-state` outcome
+;; (`:pending` → `:loaded` / `:failed`) and blocks on it, bounded, before
+;; reading anything off the frame. These two tests pin both halves: a genuinely
+;; DELAYED reply is waited for, and a non-`:loaded` outcome answers 503 rather
+;; than dressing a pending request up as a finished empty page.
+;; ============================================================================
+
+(deftest ssr-example-handle-request-waits-for-a-delayed-article-reply
+  (testing "examples/capabilities/ssr/ssr — a reply that lands AFTER `make-frame`
+            returns is still in the rendered HTML and in the hydration payload;
+            the handler waits for the page load rather than racing it
+            (rf2-gwye.43)"
+    (require 'ssr.core :reload)
+    (init-ssr!)
+    ;; The one difference from `install-canned-articles-stub!`: `:after-ms`.
+    ;; The canned stub defers its reply through `:dispatch-later` (rf2-j1mo4),
+    ;; so `:articles/loaded` fires on a host timer well after `make-frame`'s
+    ;; synchronous drain has finished — the shape a real `sendAsync` reply has.
+    (rf/reg-fx :ssr.http/delayed-canned-articles
+      {:platforms #{:server :client}}
+      (fn [frame-ctx args-map]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx
+                (assoc args-map
+                       :after-ms 150
+                       :value [{:id "a" :title "Article A" :body "Body A"}])))))
+    (let [handle-request (resolve 'ssr.core/handle-request)
+          frames-before  (set (keys @rf.frame/frames))
+          resp           (rf/with-fx-overrides
+                           {:rf.http/managed :ssr.http/delayed-canned-articles}
+                           (handle-request {:uri "/articles"}))]
+      (is (= 200 (:status resp)))
+      (is (clojure.string/includes? (:body resp) "Article A")
+          "the delayed article reached the rendered HTML")
+      (is (not (clojure.string/includes? (:body resp) "No articles."))
+          (str "the empty-state render is the pre-fix symptom: it means the "
+               "handler returned before the reply landed"))
+      (let [payload (extract-payload-edn (:body resp))]
+        (is (= [{:id "a" :title "Article A" :body "Body A"}]
+               (:articles (:rf/app-db payload)))
+            "and the hydration payload carries it too, not an empty app-db"))
+      (is (empty? (clojure.set/difference (set (keys @rf.frame/frames))
+                                          frames-before))
+          "the per-request frame is still torn down on the waited path"))))
+
+(deftest ssr-example-handle-request-terminates-deliberately-on-failure-and-deadline
+  (testing "examples/capabilities/ssr/ssr — a failed fetch and an exhausted
+            deadline each answer 503 and leave no frame behind, rather than
+            presenting unresolved work as a successful empty page
+            (rf2-gwye.43)"
+    (require 'ssr.core :reload)
+    (init-ssr!)
+    (let [handle-request (resolve 'ssr.core/handle-request)]
+      (testing "a failed reply settles immediately on :failed"
+        ;; The `:on-failure` target is what makes this terminal. Without it the
+        ;; load-state would sit at `:pending` and every failed fetch would cost
+        ;; the full deadline.
+        (rf/reg-fx :ssr.http/canned-articles-failure
+          {:platforms #{:server :client}}
+          (fn [frame-ctx args-map]
+            (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-failure)]
+              (stub frame-ctx (assoc args-map :kind :rf.http/transport)))))
+        (let [frames-before (set (keys @rf.frame/frames))
+              started       (System/currentTimeMillis)
+              resp          (rf/with-fx-overrides
+                              {:rf.http/managed :ssr.http/canned-articles-failure}
+                              (handle-request {:uri "/articles"}))
+              elapsed       (- (System/currentTimeMillis) started)]
+          (is (= 503 (:status resp))
+              "a failed article fetch is not a 200")
+          (is (not (clojure.string/includes? (:body resp) "No articles."))
+              "and it does not render the empty page as though the load finished")
+          (is (< elapsed 2000)
+              (str "the :on-failure outcome is terminal, so the handler must not "
+                   "burn the deadline; took " elapsed "ms"))
+          (is (empty? (clojure.set/difference (set (keys @rf.frame/frames))
+                                              frames-before))
+              "the 503 path tears the per-request frame down too")))
+      (testing "a reply that never arrives stops at the deadline"
+        ;; A stub that does nothing: the request is issued and no reply is ever
+        ;; dispatched, so `:articles/load-state` stays `:pending`. Shorten the
+        ;; example's own budget so the test costs milliseconds rather than the
+        ;; shipped five seconds.
+        (rf/reg-fx :ssr.http/never-replies
+          {:platforms #{:server :client}}
+          (fn [_frame-ctx _args-map] nil))
+        (let [frames-before (set (keys @rf.frame/frames))
+              started       (System/currentTimeMillis)
+              resp          (with-redefs-fn
+                              {(resolve 'ssr.core/page-load-deadline-ms) 50}
+                              (fn []
+                                (rf/with-fx-overrides
+                                  {:rf.http/managed :ssr.http/never-replies}
+                                  (handle-request {:uri "/articles"}))))
+              elapsed       (- (System/currentTimeMillis) started)]
+          (is (= 503 (:status resp))
+              "an unresolved load answers 503, never a 200 empty page")
+          (is (clojure.string/includes? (:body resp) "timed-out")
+              "and says which terminal outcome it was")
+          (is (< elapsed 2000)
+              (str "the wait is bounded by the deadline; took " elapsed "ms"))
+          (is (empty? (clojure.set/difference (set (keys @rf.frame/frames))
+                                              frames-before))
+              "the deadline path leaves no live request frame"))))))
+
 (deftest ssr-streaming-example-final-payload-hydrates-without-frame-id-mismatch
   (testing "examples/capabilities/ssr/ssr_streaming — the dynamic `handle-request`
             `:final-payload` feeds into `rf.ssr/hydrate!` against the example's
@@ -701,6 +819,50 @@
             "hydrate! applied the final-payload (no frame-id conflict thrown)")
         (is (= 3 (count (:cards (rf/app-db-value client-frame))))
             "the client app-db carries the three streamed cards after hydration")))))
+
+;; ============================================================================
+;; ssr_streaming — the request frame is released on the FAILURE path too
+;; (rf2-gwye.45, rf2-fzbj.37 F3).
+;;
+;; The streaming handler used to hold `destroy-frame!` as the last binding of
+;; one long `let`, so it ran only when every preceding binding had succeeded.
+;; The deliberate `:card.flaky` boundary was never the problem — the drain
+;; turns that into a `:failed?` chunk and returns normally. What leaked was a
+;; failure OUTSIDE that recovery: a shell walk or final-payload build that
+;; throws returns through the exception and past the destroy, stranding one
+;; frame per failed request in a long-lived host. The fix is the `try`/`finally`
+;; the non-streaming sibling already demonstrates.
+;; ============================================================================
+
+(deftest ssr-streaming-example-releases-its-frame-on-an-outer-render-failure
+  (testing "examples/capabilities/ssr/ssr_streaming — the happy path (including
+            the intentional :card.flaky fallback) and an outer shell-render
+            failure both leave the frame registry at its captured baseline, and
+            the original exception still propagates (rf2-gwye.45)"
+    (require 'ssr-streaming.core :reload)
+    (init-ssr!)
+    (let [handle-request (resolve 'ssr-streaming.core/handle-request)
+          frames-before  (set (keys @rf.frame/frames))]
+      ;; Baseline: the ordinary request, whose one deliberately-throwing card is
+      ;; recovered inside the boundary, already leaves nothing behind.
+      (let [result (handle-request {:uri "/dashboard"})]
+        (is (= #{:card.flaky} (:failed-boundaries result))
+            "the intentional card failure is still isolated by its boundary")
+        (is (empty? (clojure.set/difference (set (keys @rf.frame/frames))
+                                            frames-before))
+            "the happy path leaves the registry at its baseline"))
+      ;; And now a failure the boundary CANNOT catch, injected after the frame
+      ;; has been allocated: the shell walk itself throws.
+      (with-redefs [rf.ssr/streaming-render-shell
+                    (fn [& _] (throw (ex-info "boom — shell render failure" {})))]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (handle-request {:uri "/dashboard"}))
+            "the outer render throw propagates (the example does not swallow it)")
+        (let [new-frames (clojure.set/difference (set (keys @rf.frame/frames))
+                                                 frames-before)]
+          (is (empty? new-frames)
+              (str "the `finally` must release the per-request frame on the "
+                   "throw path; leaked frames: " (pr-str new-frames))))))))
 
 (deftest resources-ssr-example-dynamic-payload-hydrates-without-frame-id-mismatch
   (testing "examples/capabilities/ssr/resources_ssr — the payload the dynamic
@@ -1119,6 +1281,69 @@
           "after the release the SAME invalidation refetches nothing (still 1 in
            total) — the release genuinely ended the hold rather than only
            emptying a set"))))
+
+;; ============================================================================
+;; resources_ssr — the preload poll reads the resource it means to await
+;; (rf2-gwye.44, rf2-fzbj.37 F2).
+;;
+;; `await-resource-loaded!` used to be handed `:frame f` — the frame VALUE
+;; `make-frame` returns. `rf/resource-state`'s introspection target is the
+;; frame ID (it keys the frame registry directly), so every poll read nil, no
+;; poll ever saw a terminal status, and the loop ran to `preload-deadline-ms`
+;; on EVERY request, including one whose resource was already `:loaded`. The
+;; response still carried the article, so a content-only assertion passed over
+;; the top of a five-second stall and an entirely ineffective readiness check.
+;;
+;; This test is keyed on the two things a content assertion cannot see: the
+;; target the poll actually reads, and how many times it goes round.
+;; ============================================================================
+
+(deftest resources-ssr-example-preload-poll-exits-on-the-resource-it-awaits
+  (testing "examples/capabilities/ssr/resources_ssr — a synchronously loaded
+            resource exits the preload poll at once, on a terminal status read
+            from the request's OWN entry, instead of exhausting
+            preload-deadline-ms against an unrecognised key (rf2-gwye.44)"
+    (require 'resources-ssr.core :reload)
+    (init-ssr!)
+    (rf/reg-fx :resources-ssr.http/canned
+      {:platforms #{:server :client}}
+      (fn [frame-ctx args-map]
+        (let [stub (rf.registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx
+                (assoc args-map
+                       :value [{:slug "welcome" :title "Welcome to re-frame2"}])))))
+    (let [handle-request (resolve 'resources-ssr.core/handle-request)
+          original       rf/resource-state
+          polls          (atom [])
+          ;; Spy on the public introspection read the example's poll goes
+          ;; through, recording what it was ASKED and what it got back, and
+          ;; returning the real answer unchanged.
+          resp           (with-redefs [rf/resource-state
+                                       (fn [opts]
+                                         (let [entry (original opts)]
+                                           (swap! polls conj
+                                                  {:keyword-target? (keyword? (:frame opts))
+                                                   :status          (:status entry)})
+                                           entry))]
+                           (rf/with-fx-overrides
+                             {:rf.http/managed :resources-ssr.http/canned}
+                             (handle-request {:uri "/articles"})))]
+      (is (= 200 (:status resp)))
+      (is (clojure.string/includes? (:body resp) "Welcome to re-frame2")
+          "the page still renders the loaded article (behaviour preserved)")
+      (is (seq @polls) "the example's preload poll ran at all")
+      (is (every? :keyword-target? @polls)
+          "every poll addresses the frame by ID — a frame VALUE is not a
+           registry key and reads as an absent entry")
+      (is (= :loaded (:status (last @polls)))
+          "the poll's final read saw the request's own entry settle :loaded —
+           pre-fix every read returned nil under an unrecognised key")
+      ;; The count is the sharp instrument here: pre-fix this was ~850 polls of
+      ;; nil across the whole five-second budget. A synchronously loaded
+      ;; resource settles before the first read.
+      (is (< (count @polls) 20)
+          (str "a settled resource exits the poll immediately rather than "
+               "burning preload-deadline-ms; polls: " (count @polls))))))
 
 ;; ============================================================================
 ;; state-machine-walkthrough — chapter §Headless testing. Two flavours:


### PR DESCRIPTION
Remediates `rf2-fzbj.37` and its three per-finding children `rf2-gwye.43`, `rf2-gwye.44`, `rf2-gwye.45` — the capability SSR examples' request flow. All three findings were re-verified at tip before being fixed; each reproduced exactly as the review described.

## What was wrong, and what changed

### F1 / rf2-gwye.43 — the plain SSR example returned before its article request settled

`examples/capabilities/ssr/ssr/core.cljc`

`make-frame` drains the **synchronous** event work its `:initial-events` set in motion, and promises nothing more. The article fetch `:rf/server-init` kicks off is not synchronous — the JVM managed transport issues it through `HttpClient/sendAsync` — so `handle-request` read app-db the instant `make-frame` returned, rendered `No articles.` under a **200**, and then destroyed the only frame the reply could have landed in. The static `index.html` masked it (its article state is baked in) and so did every existing test, because a synchronous canned stub *has* settled by then.

The fix gives the page load an explicit outcome and waits for it:

- `:rf/server-init` marks `:articles/load-state :pending` and now declares an `:on-failure [:articles/load-failed]` target, so a failed fetch is terminal too — polling for non-nil `:articles` would have hung for the whole budget on every failed request;
- a private `await-page-load!` blocks until that key reaches `:loaded` / `:failed`, bounded by `page-load-deadline-ms` (5000, mirroring the framework's own SSR blocking-drain default);
- anything but `:loaded` answers **503** rather than presenting pending work as a finished empty page. The existing `finally` still tears the frame down on that path.

The README gained one bullet saying why the wait is there.

### F2 / rf2-gwye.44 — the resources SSR preload poll read a frame value as an ID

`examples/capabilities/ssr/resources_ssr/core.cljc`

`await-resource-loaded!` was handed `:frame f`, the frame **value** `make-frame` returns. `rf/resource-state`'s introspection target is the frame **ID**: it forwards straight to `rf.frame/frame-app-db-value` / `frame-runtime-db-value`, which key the `frames` registry directly. So every poll read `nil` under an unrecognised key, no poll ever saw a terminal status, and every request — including one whose resource was already `:loaded` — burned the whole five-second `preload-deadline-ms`. Measured here on the pre-fix source: **827 polls**, all `nil`, against a resource that was `:loaded` from the first read.

One-argument repair: pass `fid`. A comment at the call site says why this one call takes the id while `rf/app-db-value` two lines below takes the value.

### F3 / rf2-gwye.45 — the streaming example released its frame only on the success path

`examples/capabilities/ssr/ssr_streaming/core.cljc`

`destroy-frame!` was the last binding of one long `let`, so it ran only when every preceding binding had succeeded. The deliberate `:card.flaky` boundary was never the problem — the drain turns that into a `:failed?` chunk and returns normally. What leaked was a failure **outside** that recovery: a shell walk or final-payload build that throws returns through the exception and past the destroy. The post-allocation pipeline now runs inside `try`/`finally` with `destroy-frame!` in the `finally` — the shape the non-streaming sibling already demonstrates. The original exception still propagates; the per-card fallback policy is untouched.

## Regression tests

Four new `deftest`s in `implementation/core/test/re_frame/examples_test.clj`. The example tree stays test-free (rf2-8cevm).

| test | pins |
| --- | --- |
| `ssr-example-handle-request-waits-for-a-delayed-article-reply` | a reply deferred with `:after-ms` still reaches both the HTML and the hydration payload |
| `ssr-example-handle-request-terminates-deliberately-on-failure-and-deadline` | a failed fetch and an exhausted deadline each answer 503 promptly and leak no frame |
| `resources-ssr-example-preload-poll-exits-on-the-resource-it-awaits` | every poll addresses the frame by **id**, the final read sees `:loaded`, and the loop goes round fewer than 20 times |
| `ssr-streaming-example-releases-its-frame-on-an-outer-render-failure` | happy path *and* an injected outer shell-render failure both leave the frame registry at its captured baseline |

The resources test is deliberately keyed on the target the poll reads and the number of iterations rather than on response content: pre-fix the response **did** eventually contain the article, which is exactly how a content-only assertion passed over the top of a five-second stall.

### Red-then-green control

The three example sources were reverted to their committed pre-fix blobs and the namespace re-run. All four new tests went red, and **no existing test regressed** — `9 failures, 1 errors` across exactly those four, everything else green. Highlights from that run:

- plain SSR returned `200` with `No articles.` and `:rf/app-db {}`;
- the failure case returned `200` rather than `503`, and the deadline sub-test errored because `page-load-deadline-ms` did not exist yet;
- the resources poll ran **827** times;
- streaming leaked `#{:rf.frame/36978}` on the injected shell failure.

The three files were then restored and the restore verified by version control's own blob hash (`git rev-parse HEAD:<path>` against `git hash-object <path>` — the default form matched for all three), and independently by `git diff --quiet HEAD` exiting 0.

## Quality gates

All exit codes below are the runner's own, captured with the redirect and the `echo` on one command line, and quoted from the captured file — never from a harness report about the same run. Every gate was run twice: once on the pre-rebase tree and again on the final rebased base.

| gate | CI job | captured exit | result |
| --- | --- | --- | --- |
| `clojure -M:test` (core artefact — the lane that runs `examples_test.clj`) | `jvm-core` — *JVM core (clojure -M:test)*, armed by `implementation_jvm` | **0** (both runs) | 2317 tests, 11994 assertions, 0 failures, 0 errors |
| `node implementation/scripts/check-examples-compile.cjs` | `cljs-examples-compile`, armed by `examples_compile` | **0** (both runs) | all 58 swept builds compiled, zero warnings — `examples/ssr`, `examples/ssr-streaming` and `examples/resources-ssr` among them |
| `python scripts/check_readme_links.py --ci` | `verify-readme-links` | **0** | silent |

`.github/scripts/report-changed-surfaces.sh` on the changed paths reports `implementation_jvm=true` and `examples_compile=true`, so both lanes are armed for this PR.

After the rebase the branch was diffed against its merge base (`origin/main...HEAD`): five files, all mine, and no overlap with anything trunk moved in the interval — nothing a sibling landed is reverted here.

No spec page is touched, so `scripts/check_doc_slugs.py` is not the gate here; the one README edit adds no links and no tables, and its prose and bullet nesting were checked by hand — nothing validates those.

## Skipped, and why

- **Baked dev source-coordinate drift** (the review's own lower-priority observation). `ssr/index.html` bakes `pages:articles:228:1` while the live registration is now line 251; it was already stale at 232 before this change. The review deferred this to a future browser check that would determine whether the drift has any visible hydration-warning or tool-location consequence, and warned explicitly against letting it expand the three request-flow fixes into fixture-generation work. Left as filed. The same observation covers `resources_ssr` and `ssr_streaming`; neither of those files' view registrations moved here.
- **No change to `spec/`, and no new gate.** Each finding got the fix and one regression, nothing else.

## One thing for the mayor to route (library, not this surface)

`rf/resource-state` does not normalise a frame **value** to its id, while `rf.frame/frame-target->id`'s own docstring says a frame value "is accepted EVERYWHERE a keyword id is (API-shrink #1, rf2-csbbwu)". Handing it a value is a silent nil — indistinguishable from a genuinely absent entry, which is precisely the confusion its fail-closed nil-`:frame` guard exists to prevent. F2 does not need that change (passing the id is correct and is what the finding asked for), and `implementation/resources/**` is outside this worktree's fence, so nothing here touches it. `rf2-fzbj.7` owns `impl_resources`.
