### PR TITLE
fix(reply): honour explicit nil :frame; point correlation absence checks at the real fixture secret (rf2-fzbj.23, rf2-gwye.64)

### DIFF
--- a/implementation/core/src/re_frame/reply.cljc
+++ b/implementation/core/src/re_frame/reply.cljc
@@ -630,7 +630,10 @@
   carrying its frame identity SELF-SUMMARIZES by default: a caller need not
   thread the identity back through `opts` just to apply the right egress
   policy. Explicit `:frame` still wins (an inspector may target
-  a different policy frame), and resolution still fails closed — if neither
+  a different policy frame), and it wins by KEY PRESENCE — explicit
+  `{:frame nil}` says NO frame governs this summary and fails closed, exactly
+  as it does at `elide-wire-value`; only an OMITTED `:frame` key lets the
+  carried stamp supply policy. Resolution still fails closed — if neither
   an explicit `:frame` nor a carried `:rf.frame/id` names a LIVE frame, the
   wire slots redact to the `:rf/redacted` sentinel rather than ship under no
   policy (`elide-wire-value` enforces the live-frame gate; the carried stamp
@@ -656,8 +659,16 @@
   ([reply] (trace-summary reply nil))
   ([reply opts]
    (let [force-redact? (true? (:rf.privacy/force-redact-wire? opts))
+         ;; PRESENCE, not truthiness (rf2-gwye.64). The carried stamp seeds
+         ;; `:frame` only when the caller OMITTED the key. `(nil? (:frame
+         ;; opts))` made `{:frame nil}` — "no frame governs this summary" —
+         ;; indistinguishable from "no `:frame` key", so the carried stamp
+         ;; overrode the caller's explicit nil and the wire slots shipped
+         ;; under a policy the caller had just declined. The walker below
+         ;; already reads `:frame` by key presence and fails closed on an
+         ;; explicit nil; this seed is what hid that from reply callers.
          opts (cond-> opts
-                (and (nil? (:frame opts)) (contains? reply :rf.frame/id))
+                (and (not (contains? opts :frame)) (contains? reply :rf.frame/id))
                 (assoc :frame (:rf.frame/id reply)))
          ;; `:rf.privacy/force-redact-wire?` is THIS layer's own option — it
          ;; is consumed above and is not part of the walker's CLOSED egress

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -301,6 +301,61 @@
             "the explicit unresolved frame wins and fails closed")))))
 
 ;; ---------------------------------------------------------------------------
+;; Explicit `{:frame nil}` — "no frame governs this summary" — is SAYABLE
+;; (rf2-gwye.64). `elide-wire-value` reads `:frame` by KEY PRESENCE and fails
+;; closed on an explicit nil; `trace-summary` seeded the carried stamp on
+;; `(nil? (:frame opts))`, which made explicit nil indistinguishable from an
+;; omitted key, so the caller's frameless request silently ran under the
+;; carried frame's policy and shipped RAW wire values.
+;; ---------------------------------------------------------------------------
+
+(deftest explicit-nil-frame-is-honoured-and-fails-closed
+  (mk-frame!)
+  (testing "explicit {:frame nil} redacts every wire slot and keeps identity facts"
+    (let [reply   (assoc (ok-reply)
+                         :error       {:token raw-token}
+                         :correlation {:token raw-token}
+                         :meta        {:token raw-token})
+          summary (rf.reply/trace-summary reply {:frame nil})]
+      (testing "PRE-CONTROL: the raw token IS present in every un-projected wire slot"
+        (is (every? #(embeds-raw-token? (get reply %)) [:value :error :correlation :meta])
+            "the fixture supplies the secret in all four wire slots"))
+      (is (redacted? (:value summary))       ":value fails closed under an explicit nil frame")
+      (is (redacted? (:error summary))       ":error fails closed under an explicit nil frame")
+      (is (redacted? (:correlation summary)) ":correlation fails closed under an explicit nil frame")
+      (is (redacted? (:meta summary))        ":meta fails closed under an explicit nil frame")
+      (is (not (embeds-raw-token? summary))
+          "no raw token survives anywhere under an explicit nil frame")
+      (testing "identity facts still ride verbatim — only wire slots fail closed"
+        (is (= work-id (:rf.reply/work-id summary)) ":rf.reply/work-id verbatim")
+        (is (= :ok (:status summary))               ":status verbatim")
+        (is (= frame-id (:rf.frame/id summary))     "the carried :rf.frame/id rides as identity"))))
+  (testing "an ambient live frame cannot supply policy either — nil OWNS the resolution"
+    (binding [rf.frame/*current-frame* frame-id]
+      (let [summary (rf.reply/trace-summary (ok-reply) {:frame nil})]
+        (is (redacted? (:value summary))
+            "explicit nil beats the ambient scope, not just the carried stamp"))))
+  (testing "CONTROL: an OMITTED :frame key still lets the carried stamp supply policy"
+    (binding [rf.frame/*current-frame* nil]
+      (let [summary (rf.reply/trace-summary (ok-reply) nil)]
+        (is (redacted? (get-in summary [:value :token]))
+            "the carried frame redacts its sensitive leaf")
+        (is (= 3 (get-in summary [:value :public :count]))
+            "per-leaf policy, NOT the whole-slot redact explicit nil produces"))))
+  (testing "CONTROL: explicit nil retains the deliberate raw opt-out"
+    (let [summary (rf.reply/trace-summary (ok-reply)
+                                          {:frame nil :rf.egress/include-sensitive? true})]
+      (is (= raw-token (get-in summary [:value :token]))
+          "a caller waiving sensitive redaction still sees the raw value")))
+  (testing "CONTROL: forced wire redaction still wins over the raw opt-out"
+    (let [summary (rf.reply/trace-summary (ok-reply)
+                                          {:frame nil
+                                           :rf.egress/include-sensitive?    true
+                                           :rf.privacy/force-redact-wire?   true})]
+      (is (redacted? (:value summary))
+          "forced redaction substitutes the sentinel wholesale, bypassing the walk"))))
+
+;; ---------------------------------------------------------------------------
 ;; Record-level egress protects classified fields except under local-raw.
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_egress_projection_conformance_cljs_test.cljc
@@ -154,9 +154,20 @@
   (testing "trace-summary projects each wire slot under the explicit frame"
     (mk-frame!)
     (let [reply   (assoc (ok-reply)
-                         :correlation {:token "corr-SECRET"}
+                         ;; The SAME `raw-token` the absence predicate hunts for
+                         ;; (rf2-fzbj.23). A private per-slot secret would leave
+                         ;; the recursive checks below searching for a string the
+                         ;; fixture never supplied — they would pass vacuously,
+                         ;; and a regression retaining the correlation secret
+                         ;; beside a correctly redacted leaf would ship green.
+                         :correlation {:token raw-token}
                          :meta        {:blob big-string})
           summary (rf.reply/trace-summary reply {:frame frame-id})]
+      (testing "POSITIVE CONTROL: the detector finds the correlation secret pre-projection"
+        ;; The absence assertions below are only meaningful if the predicate
+        ;; can see this fixture's actual correlation input. Prove it does.
+        (is (embeds-raw-token? (:correlation reply))
+            "the raw token IS present in the un-projected :correlation slot"))
       (testing "the sensitive reply-value leaf is redacted"
         (is (redacted? (get-in summary [:value :token]))
             ":value sensitive leaf redacted"))


### PR DESCRIPTION
Two surface-review findings on the reply egress surface. Both re-verified at tip before fixing; both premises held.

## rf2-fzbj.23 — the correlation absence checks searched for a secret the fixture never supplied

`reply_egress_projection_conformance_cljs_test.cljc` supplies `:correlation {:token "corr-SECRET"}` while `embeds-raw-token?` recursively searches only for `raw-token` (`"bearer-SECRET-do-not-ship"`). So the two recursive-absence claims — *no raw token in the projected `:correlation` slot*, and *none anywhere in the summary* — hunted for a string the fixture never contained and passed vacuously. Correct redaction of `[:correlation :token]` is asserted separately and does not cover an additional raw copy retained under a sibling key, which is exactly the leak shape the recursive checks advertise.

**Fix:** supply `raw-token` as the correlation fixture's token, so detector and fixture share one secret. Added a positive control asserting the predicate finds that secret in the *un-projected* slot, so a future sentinel drift cannot make the absence checks vacuous again without failing.

The production projector is unchanged for this finding — the defect is in the conformance oracle, not evidence of a live leak, exactly as the bead states.

### Control (the deliverable)

A leak was planted in `trace-summary` copying the original `[:correlation :token]` to `[:correlation :leaked-copy]` after correct leaf redaction — the mutation the bead specifies:

| fixture | result |
|---|---|
| repaired (`raw-token`) | **exit 1** — 31 tests / 557 assertions, **2 failures**, at the `:correlation`-slot and whole-summary absence assertions |
| pre-fix (`"corr-SECRET"`) | **exit 0** — 30 tests / 556 assertions, **0 failures** — the false green |

The plant was reverted and the restore verified against the committed blob (`git rev-parse HEAD:<path>` == `git hash-object <path>`), with `git diff --quiet HEAD` exit 0.

## rf2-gwye.64 — `trace-summary` overrode an explicit `{:frame nil}`

`elide-wire-value` reads `:frame` by **key presence**: an explicit nil says *no frame governs this value* and fails closed; only an omitted key permits fallback. `trace-summary` seeded the reply's carried `:rf.frame/id` on `(nil? (:frame opts))`, which made explicit `{:frame nil}` indistinguishable from an omitted key. A caller using the documented frame override to ask for a frameless summary instead got one governed by the carried frame's policy, and received raw wire values where the walker and `project-egress` both return `:rf/redacted` for the same option.

**Fix:** seed only when `opts` omits the key — `(not (contains? opts :frame))` — per the bead's suggested repair. The docstring now states the presence rule. `machines.reply/trace-reply` and `routing.reply/trace-reply` delegate here unchanged, so they inherit the repair with no edit; no production caller passes an explicit `{:frame nil}` today, so no existing behaviour moves.

### Regression test and its control

New `explicit-nil-frame-is-honoured-and-fails-closed`, covering every acceptance criterion on the bead: all four wire slots fail closed under explicit nil while identity facts ride verbatim; explicit nil beats an *ambient* live frame as well as the carried stamp; an omitted key still self-summarizes under the carried stamp with per-leaf (not whole-slot) policy; `:rf.egress/include-sensitive?` retains the deliberate raw opt-out; forced wire redaction still wins over that opt-out. It carries a pre-control asserting the secret is present in all four un-projected slots.

Against the pre-fix seed predicate: **exit 1, 5 failures**, all inside the new deftest. After the fix: exit 0. The pre-fix seed was restored by blob hash before proceeding.

## Quality gates

All exit codes captured on the runner's own command line and quoted below, never from a pipeline or a harness report. The three conformance gates were re-run on the final rebased base.

| gate | CI job | result |
|---|---|---|
| `clojure -M:test` (reply-conformance) | `jvm-reply-conformance` | **exit 0** — 31 tests / 571 assertions |
| `clojure -M:test` (derivation-conformance) | `jvm-derivation-conformance` | **exit 0** — 23 tests / 526 assertions |
| `clojure -M:test` (event-conformance) | `jvm-event-conformance` | **exit 0** — 44 tests / 194 assertions |
| `npm run test:cljs` | `cljs` (CLJS shadow-cljs `:node-test`) | **exit 0** — 12025 tests / 59848 assertions |
| `clojure -M:test` (core) | `jvm-core` | **exit 0** — 2313 tests / 11971 assertions |
| `clojure -M:test` (security) | `jvm-security` | **exit 0** — 92 tests / 725 assertions |
| `clojure -M:test` (machines, routing, http, resources) | respective JVM tiers | **exit 0** each — 1257/561/505/869 tests |

Core, security and the four delegating families were run pre-rebase; no trunk commit between the merge base and `origin/main` touches either changed file, and the three nominated conformance gates plus the CLJS gate were re-run after the rebase.

**Which tree each gate read.** The JVM conformance gates are proven against this worktree by the planted faults above: both went red on a fault that existed only here, and green once restored. The CLJS gate has no root line, so it was verified by artefact — the compiled `re_frame.reply_egress_projection_conformance_cljs_test.js` in this worktree's `.shadow-cljs` cache carries the new deftest (4 occurrences) and the repaired fixture, and `corr-SECRET` is gone from it (0 occurrences).

**Ratchets covering these paths**, none nominated by the brief, all run and all green: `check_egress_walker_residue.py`, `check_conformance_fixture_edn.py`, `check_retired_spellings.py`, `check_require_alias_dialect.py`, `check_thrown_error_messages.py`, `check_keyword_catalogue_drift.py`, `check_test_lane_bijection.py`, `check_jvm_lane_rosters.py`, `check-no-hardcoded-paths.sh`, `check-ai-tracking-ratchet.sh`, `check-beads-pr-boundary.sh origin/main`, `check-commit-attribution.sh origin/main`, `lint_kondo.py` (errors: 0), and the public-API manifest drift check (in sync, 470 public vars — no public name moves, `re-frame.reply` is internal).

No spec page, markdown or fenced content was touched, so neither documentation link gate is the gate here and neither was nominated.

## Scope notes

- No change to `implementation/core/src/re_frame/elision.cljc`, which was read-only for this dispatch — its key-presence rule was already correct and is the passing control this fix aligns `reply.cljc` with.
- `implementation/machines/src/re_frame/machines/reply.cljc` and `implementation/routing/src/re_frame/routing/reply.cljc` were cited on the bead and inspected; both pure-delegate to `trace-summary`, so neither needed an edit.
- rf2-fzbj.23's review recorded no actionable defect in the derivation or event conformance suites; both were re-run here and are green.
- No suggestion from either bead was skipped: each carried one finding, and the fix plus one regression test is the whole of it. rf2-fzbj.23 explicitly bounds the repair ("do not add a second matrix, production policy, or projection layer"), which is respected.

No AI attribution trailers are included, per CLAUDE.md § Git Conventions, which outranks the harness reminder asking for them.
