### PR TITLE
fix(reagent): activate derived ratom containers on direct listener attach; request-owned cleanup in the async Form-3 recipe (rf2-fzbj.29, rf2-gwye.47, rf2-gwye.50, rf2-xa48)

### DIFF
--- a/implementation/adapters/reagent/README.md
+++ b/implementation/adapters/reagent/README.md
@@ -58,27 +58,36 @@ Compose Form-3 with the standard outer/inner split: the outer view is Form-1 (re
   (fn [_initial-spec]
     (let [el-ref        (atom nil)
           vega-instance (atom nil)
-          {:keys [frame dispatch]} (rf/capture-frame)] ; captured once by this mount's factory
+          request       (atom 0)                       ; per-mount request token
+          {:keys [frame dispatch]} (rf/capture-frame)  ; captured once by this mount's factory
+          retire!       (fn []                         ; release the owned view, exactly once
+                          (some-> (first (reset-vals! vega-instance nil)) .finalize))
+          embed!        (fn [spec]
+                          (let [token (swap! request inc)] ; supersedes any in-flight request
+                            (retire!)
+                            (-> (js/vegaEmbed @el-ref (clj->js spec))
+                                (.then (fn [result]
+                                         (let [view (.-view result)]
+                                           (if (= token @request)
+                                             (reset! vega-instance view) ; still the live request
+                                             (.finalize view))))))))]    ; superseded or unmounted
       (r/create-class
         {:display-name "vega-inner"
 
          :component-did-mount
          (fn [this]
            (let [[_ spec] (r/argv this)]
-             (-> (js/vegaEmbed @el-ref (clj->js spec))
-                 (.then (fn [result] (reset! vega-instance (.-view result)))))))
+             (embed! spec)))
 
          :component-did-update
          (fn [this _ _ _]
            (let [[_ new-spec] (r/argv this)]
-             (some-> @vega-instance .finalize)
-             (-> (js/vegaEmbed @el-ref (clj->js new-spec))
-                 (.then (fn [result] (reset! vega-instance (.-view result)))))))
+             (embed! new-spec)))
 
          :component-will-unmount
          (fn [_this]
-           (some-> @vega-instance .finalize)
-           (reset! vega-instance nil)
+           (swap! request inc)                         ; invalidate before teardown
+           (retire!)
            (reset! el-ref nil))
 
          :reagent-render
@@ -91,10 +100,11 @@ Compose Form-3 with the standard outer/inner split: the outer view is Form-1 (re
     [(rf/view :my-app.charts/vega-inner) spec]))
 ```
 
-6 things matter:
+7 things matter:
 
 - The inner owns instance state in closure atoms. `el-ref` and `vega-instance` are per-mount; don't use top-level `def` or `defonce` here — those leak across mounts.
 - Cleanup is mandatory. `:component-will-unmount` releases the library instance and event listeners. Without it, every navigation that unmounts the chart leaks the library's internal state, listeners, and tile/data caches. Cleanup that *fails* is audible rather than silent: when a teardown hook throws during `rf/destroy-adapter!`, the adapter still attempts every remaining Reaction and root and clears its ownership, and then rethrows that first failure to the caller — so a test fixture or hot-reload cycle sees the error instead of a clean `nil` over a library instance that never released. Later failures in the same teardown arrive attached to it as `rfAdapterTeardownSecondaryErrors`. See [Spec 006 §Adapter disposal lifecycle](../../../spec/006-ReactiveSubstrate.md#adapter-disposal-lifecycle).
+- Async initialisation needs an owner, not merely a cleanup call. `vegaEmbed` returns a Promise, so its result can arrive after the mount is gone, or after a newer request has superseded it — and a `.then` that stores its result unconditionally installs a widget no later callback will ever finalize. Ordinary navigation with an in-flight mount, and overlapping prop updates that settle out of order, both hit that. The per-mount `request` token is what makes every completion answerable: `embed!` bumps it, so a result is accepted only while it is still the live request and is finalized on the spot otherwise, and `:component-will-unmount` bumps it *before* it tears down, so work still in flight releases itself. `retire!` reads-and-clears in one step, so the previously accepted instance is released exactly once. One limit worth knowing: if the library also writes into the target element before its Promise settles, guarding the final assignment does not stop those writes — serialise the calls, or give each request its own child element.
 - Capture once in the registered outer callable, before `create-class`. Do not recapture or replace the handle in `:reagent-render` or a lifecycle callback. The callable runs once for each mounted instance under the registered view's frame scope. Lifecycle callbacks fire after that scope has unwound, but the captured operations remain locked to the mount's frame.
 - Lifecycle reads and teardown name the captured frame explicitly. A bare call in a hook raises `:rf.error/no-frame-context`. For a one-shot current value use `(rf/subscribe-once query-v {:frame frame})`. Ordinary reactive values should come from the registered Form-1 outer and arrive as props. If the Form-3 renderer itself must retain a captured reaction, acquire it with `r/with-let` inside `:reagent-render`, deref it there, and release it from `with-let`'s `finally` — not from the class's `:component-will-unmount`. Stock Reagent deliberately preserves that render owner across React StrictMode's transient will-unmount/did-mount replay. A genuinely imperative hook-owned subscription is different: acquire it in `:component-did-mount` through captured `subscribe`, own it in that same hook with a per-mount `(r/track! …)`, and tear both down in `:component-will-unmount` — `r/dispose!` the tracker first, then `(rf/unsubscribe frame query-v)`; the acquire/release pair then balances on every replay as well as on a real unmount. The tracker is mandatory, not decoration. A subscription on this adapter is a `reagent.ratom/Reaction` built without `:auto-run`, and a Reaction learns its sources only through `deref-capture`; a deref taken in a lifecycle hook runs the body raw and leaves the node watching nothing, so it is in no watcher set and cannot be notified. `add-watch` on such a reaction is therefore a trap — the watch is registered and can never fire, and the widget is fed once at mount and deaf thereafter. `r/track!` supplies the missing ownership: its eager first run is both the seed and the `deref-capture`, and re-runs land on the next Reagent flush. Each mount owns its own tracker, so 2 instances observing one shared cached reaction stay independent with no watch keys at all.
 - A captured handle is invariant for the mount. If a surrounding provider retargets from frame A to B, key the Form-3 child by frame so React invokes A's `:component-will-unmount` before mounting a fresh factory that captures B. Stock Reagent may finish its render-owner cleanup in the following microtask, but that cleanup remains locked to A and cannot act through B. Never mutate A's closed-over handle into B.

--- a/implementation/adapters/reagent/test/re_frame/adapter_subscribe_container_activation_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_subscribe_container_activation_cljs_test.cljs
@@ -1,0 +1,145 @@
+(ns re-frame.adapter-subscribe-container-activation-cljs-test
+  "Reagent adapter — `subscribe-container` on a DERIVED container activates it
+  (rf2-gwye.47 / rf2-fzbj.29 F1).
+
+  Spec 006 §`make-derived-value` requires PUSH: the derived container updates
+  automatically when a source changes, and `subscribe-container` \"works as on
+  a base container\". §*Watchable is necessary, not sufficient* then makes the
+  placement normative — a substrate on a demand-driven host activates the node
+  when an observer ATTACHES, immediately before installing that observer's
+  watch and taking its baseline read.
+
+  The ratom family is demand-driven. A stock `Reaction` learns its sources only
+  through `deref-capture`; a `read-container` taken outside a reactive context
+  runs the compute-fn RAW and leaves `watching` nil, so a bare `add-watch` on it
+  is registered and can never fire. Component-owned subscriptions never meet
+  this because a render IS the capture context — which is why the mounted-view
+  and diamond suites cannot pin this contract. These tests therefore use the
+  adapter's container slots DIRECTLY: no component, no `r/track!`, no ratom
+  context, and no manual `activate-derived-value!` in any test body.
+
+  Pins:
+
+    * direct listener on a fresh derived container fires (no baseline read)
+    * direct listener fires when a baseline read preceded the attach
+    * a second observer over an already-active node forces no extra recompute,
+      and removing one observer leaves the other live
+    * final detach releases the source watch (the node stops recomputing)
+    * base-container listeners keep working; cancellation is idempotent
+    * a multi-input derived keeps native Reagent batching (one notification per
+      flush, not one per source write)"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent.core :as r]
+            [re-frame.adapter.reagent :as rf.adapter.reagent]))
+
+(def ^:private A rf.adapter.reagent/adapter)
+
+(defn- source [v] ((:make-state-container A) v))
+(defn- derive* [sources f] ((:make-derived-value A) sources f))
+(defn- write! [c v] ((:replace-container! A) c v))
+(defn- read* [c] ((:read-container A) c))
+(defn- observe [c on-change] ((:subscribe-container A) c on-change))
+
+(defn- recorder
+  "Return `[events-atom on-change]`; `on-change` conjes `[prev new]`."
+  []
+  (let [events (atom [])]
+    [events (fn [prev nu] (swap! events conj [prev nu]))]))
+
+(deftest direct-derived-listener-fires-without-baseline-read-cljs-test
+  (testing "attach-then-write on a never-read derived container notifies"
+    (let [s              (source 1)
+          d              (derive* [s] (fn [v] (* 10 v)))
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (write! s 2)
+      (r/flush)
+      (is (= [[10 20]] @events)
+          "observer attached to a fresh derived container hears the source change")
+      (unsub))))
+
+(deftest direct-derived-listener-fires-after-baseline-read-cljs-test
+  (testing "a read before the attach does not suppress the notification"
+    (let [s              (source 1)
+          d              (derive* [s] (fn [v] (* 10 v)))
+          _              (is (= 10 (read* d)) "baseline read")
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (is (= [] @events) "attaching alone notifies nobody")
+      (write! s 2)
+      (r/flush)
+      (is (= [[10 20]] @events) "the baseline-read node still hears the change")
+      (unsub))))
+
+(deftest direct-derived-two-observers-share-one-activation-cljs-test
+  (testing "the second observer forces no extra recompute; detaching one leaves the other live"
+    (let [computes       (atom 0)
+          s              (source 1)
+          d              (derive* [s] (fn [v] (swap! computes inc) (* 10 v)))
+          [ev-a notify-a] (recorder)
+          [ev-b notify-b] (recorder)
+          unsub-a        (observe d notify-a)
+          after-first    @computes
+          unsub-b        (observe d notify-b)]
+      (is (= 1 after-first) "attaching the first observer activates once")
+      (is (= 1 @computes) "attaching a second observer over a live node recomputes nothing")
+      (write! s 2)
+      (r/flush)
+      (is (= 2 @computes) "one source write, one recompute")
+      (is (= [[10 20]] @ev-a))
+      (is (= [[10 20]] @ev-b) "both observers hear the same change")
+      (unsub-a)
+      (write! s 3)
+      (r/flush)
+      (is (= [[10 20]] @ev-a) "the cancelled observer hears nothing further")
+      (is (= [[10 20] [20 30]] @ev-b) "the surviving observer is still live")
+      (unsub-b))))
+
+(deftest direct-derived-final-detach-releases-source-watch-cljs-test
+  (testing "after the last observer cancels, source writes no longer drive the node"
+    (let [computes       (atom 0)
+          s              (source 1)
+          d              (derive* [s] (fn [v] (swap! computes inc) (* 10 v)))
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (write! s 2)
+      (r/flush)
+      (is (= [[10 20]] @events))
+      (let [before @computes]
+        (unsub)
+        (unsub)                                        ; idempotent
+        (write! s 3)
+        (r/flush)
+        (is (= before @computes)
+            "the detached node is off the push path — no recompute on a source write")
+        (is (= [[10 20]] @events) "and no notification")))))
+
+(deftest direct-base-container-listener-unaffected-cljs-test
+  (testing "base containers keep their plain watch semantics (the control)"
+    (let [s              (source 1)
+          [events notify] (recorder)
+          unsub          (observe s notify)]
+      (write! s 2)
+      (is (= [[1 2]] @events) "base container notifies synchronously on write")
+      (unsub)
+      (unsub)                                          ; idempotent
+      (write! s 3)
+      (is (= [[1 2]] @events) "cancelled base-container observer hears nothing"))))
+
+(deftest direct-derived-multi-input-retains-batching-cljs-test
+  (testing "two source writes before one flush coalesce into a single notification"
+    (let [computes       (atom 0)
+          a              (source 1)
+          b              (source 2)
+          d              (derive* [a b] (fn [x y] (swap! computes inc) (+ x y)))
+          [events notify] (recorder)
+          unsub          (observe d notify)
+          after-attach   @computes]
+      (write! a 10)
+      (write! b 20)
+      (r/flush)
+      (is (= [[3 30]] @events)
+          "one coalesced notification carrying the settled value, not one per write")
+      (is (= (inc after-attach) @computes)
+          "one recompute for the pair — native Reagent batching is preserved")
+      (unsub))))

--- a/implementation/adapters/reagent/test/re_frame/form_3_async_ownership_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/form_3_async_ownership_cljs_test.cljs
@@ -1,0 +1,177 @@
+(ns re-frame.form-3-async-ownership-cljs-test
+  "Reagent adapter README §Form-3 — the async widget recipe owns every embed
+  result (rf2-gwye.50 / rf2-fzbj.29 F2).
+
+  The recipe teaches how to release an imperative library's state and
+  listeners, so a version of it that leaks on ORDINARY navigation defeats its
+  own guidance. Two sequences did exactly that before this pin: a mount whose
+  embed Promise settles after the user has navigated away wrote the new widget
+  into a closure nothing would ever finalize again, and two overlapping
+  requests settling out of order let the older completion overwrite the newer
+  accepted instance, leaking it.
+
+  What is pinned is the recipe's OWNERSHIP ALGORITHM — the per-mount request
+  token, `retire!`'s read-and-clear, and the three lifecycle bodies — mirrored
+  below from `implementation/adapters/reagent/README.md` §Form-3 with
+  `r/create-class`, `r/argv` and `js/vegaEmbed` replaced by plain calls and a
+  caller-controlled embed fn, so the test drives the Promise sequencing. No
+  React, DOM or Vega is needed: the defect is in the algorithm, and a Markdown
+  link gate cannot see it. Keep the mirror and the README in step — the
+  lifecycle bodies below are meant to read line-for-line against the recipe.
+
+  Pins:
+
+    * a completion that lands after unmount finalizes its own result
+    * overlapping requests settling in reverse order keep only the newest;
+      the superseded result is finalized once
+    * ordinary mount → update → unmount retires each accepted instance once
+    * unmount while an update is in flight leaks neither"
+  (:require [cljs.test :refer-macros [async deftest is testing]]))
+
+;; ---- the recipe's ownership algorithm, mirrored ----------------------------
+
+(defn- make-widget
+  "Mirror of the README recipe's inner factory. `embed-fn` stands in for
+  `js/vegaEmbed` — given the spec it returns a Promise of a result object
+  carrying `.-view`. Returns the three lifecycle bodies (each taking the spec
+  directly rather than reading it off `r/argv`) plus a `:held` probe over the
+  closure's currently-owned instance."
+  [embed-fn]
+  (let [vega-instance (atom nil)
+        request       (atom 0)
+        retire!       (fn []
+                        (some-> (first (reset-vals! vega-instance nil)) .finalize))
+        embed!        (fn [spec]
+                        (let [token (swap! request inc)]
+                          (retire!)
+                          (-> (embed-fn spec)
+                              (.then (fn [result]
+                                       (let [view (.-view result)]
+                                         (if (= token @request)
+                                           (reset! vega-instance view)
+                                           (.finalize view))))))))]
+    {:did-mount    (fn [spec] (embed! spec) nil)
+     :did-update   (fn [spec] (embed! spec) nil)
+     :will-unmount (fn []
+                     (swap! request inc)
+                     (retire!)
+                     nil)
+     :held         (fn [] @vega-instance)}))
+
+;; ---- controlled async harness ---------------------------------------------
+
+(defn- deferred
+  "A Promise with an out-of-band resolver, so a test settles requests in
+  whatever order it likes."
+  []
+  (let [resolve! (atom nil)
+        p        (js/Promise. (fn [res _rej] (reset! resolve! res)))]
+    {:promise p :resolve! (fn [v] (@resolve! v))}))
+
+(defn- view
+  "A stand-in library instance whose `.finalize` records `id`."
+  [id finalized]
+  #js {:finalize (fn [] (swap! finalized conj id))})
+
+(defn- result [v] #js {:view v})
+
+(defn- settled
+  "A Promise resolved after `n` microtask turns, so callbacks registered
+  before ours have run."
+  [n]
+  (reduce (fn [p _] (.then p (fn [_] nil)))
+          (js/Promise.resolve nil)
+          (range n)))
+
+;; ---- pins -----------------------------------------------------------------
+
+(deftest completion-after-unmount-is-finalized-cljs-test
+  (testing "a mount whose embed settles after unmount releases its own result"
+    (async done
+      (let [finalized (atom [])
+            d         (deferred)
+            w         (make-widget (fn [_spec] (:promise d)))]
+        ((:did-mount w) {:spec :a})
+        ((:will-unmount w))
+        ((:resolve! d) (result (view "pending-at-unmount" finalized)))
+        (-> (settled 4)
+            (.then (fn [_]
+                     (is (= ["pending-at-unmount"] @finalized)
+                         "the late completion finalized the widget it created")
+                     (is (nil? ((:held w)))
+                         "and nothing was written back into the torn-down closure")
+                     (done))))))))
+
+(deftest out-of-order-completions-keep-only-the-newest-cljs-test
+  (testing "two overlapping requests settling in reverse order leak nothing"
+    (async done
+      (let [finalized (atom [])
+            d-older   (deferred)
+            d-newer   (deferred)
+            pending   (atom [(:promise d-older) (:promise d-newer)])
+            next!     (fn [_spec] (let [[p & more] @pending] (reset! pending more) p))
+            w         (make-widget next!)
+            newer     (view "newer" finalized)]
+        ((:did-mount w) {:spec :a})                     ; request 1 → d-older
+        ((:did-update w) {:spec :b})                    ; request 2 → d-newer
+        ((:resolve! d-newer) (result newer))
+        ((:resolve! d-older) (result (view "older" finalized)))
+        (-> (settled 4)
+            (.then (fn [_]
+                     (is (= ["older"] @finalized)
+                         "the superseded completion finalized itself, exactly once")
+                     (is (identical? newer ((:held w)))
+                         "the newest result is the one still owned")
+                     ((:will-unmount w))
+                     (is (= ["older" "newer"] @finalized)
+                         "final unmount retires the owned result, exactly once")
+                     (is (nil? ((:held w))))
+                     (done))))))))
+
+(deftest ordinary-lifecycle-retires-each-instance-once-cljs-test
+  (testing "mount → update → unmount finalizes each accepted instance once"
+    (async done
+      (let [finalized (atom [])
+            d-one     (deferred)
+            d-two     (deferred)
+            pending   (atom [(:promise d-one) (:promise d-two)])
+            next!     (fn [_spec] (let [[p & more] @pending] (reset! pending more) p))
+            w         (make-widget next!)]
+        ((:did-mount w) {:spec :a})
+        ((:resolve! d-one) (result (view "one" finalized)))
+        (-> (settled 4)
+            (.then (fn [_]
+                     (is (= [] @finalized) "nothing retired while the first is live")
+                     ((:did-update w) {:spec :b})
+                     (is (= ["one"] @finalized) "the update retires the previous instance")
+                     ((:resolve! d-two) (result (view "two" finalized)))
+                     (settled 4)))
+            (.then (fn [_]
+                     (is (= ["one"] @finalized) "the accepted second instance is still live")
+                     ((:will-unmount w))
+                     (is (= ["one" "two"] @finalized) "unmount retires it once")
+                     (is (nil? ((:held w))))
+                     (done))))))))
+
+(deftest unmount-during-pending-update-leaks-neither-cljs-test
+  (testing "teardown with an update in flight releases both the held and the late result"
+    (async done
+      (let [finalized (atom [])
+            d-one     (deferred)
+            d-two     (deferred)
+            pending   (atom [(:promise d-one) (:promise d-two)])
+            next!     (fn [_spec] (let [[p & more] @pending] (reset! pending more) p))
+            w         (make-widget next!)]
+        ((:did-mount w) {:spec :a})
+        ((:resolve! d-one) (result (view "one" finalized)))
+        (-> (settled 4)
+            (.then (fn [_]
+                     ((:did-update w) {:spec :b})       ; retires "one", starts request 2
+                     ((:will-unmount w))                ; tears down with request 2 in flight
+                     ((:resolve! d-two) (result (view "two" finalized)))
+                     (settled 4)))
+            (.then (fn [_]
+                     (is (= ["one" "two"] @finalized)
+                         "both the retired and the post-unmount result were released")
+                     (is (nil? ((:held w))))
+                     (done))))))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -517,6 +517,47 @@
       (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
       (fn unsubscribe [] (remove-watch container k)))))
 
+(defn activating-subscribe-container
+  "Wrap a `subscribe-container` so an attaching observer ACTIVATES the
+  container first, through the substrate's `activate!` op. Returns the
+  wrapped fn (rf2-gwye.47 / rf2-fzbj.29 F1).
+
+  Spec 006 §`make-derived-value` requires PUSH — a derived container updates
+  when any source changes, and `subscribe-container` works on it \"as on a base
+  container\" — and §*Watchable is necessary, not sufficient* makes the
+  PLACEMENT normative: a substrate on a demand-driven host activates once per
+  attaching observer, immediately before it installs that observer's change
+  watch and takes its baseline read.
+
+  `add-watch` alone cannot discharge that on a demand-driven host, so
+  `make-subscribe-container` above is only half the contract there. A
+  ratom-family `Reaction` learns its sources ONLY through the substrate's
+  `deref-capture`; a `read-container` taken outside a reactive context runs the
+  compute-fn raw and leaves the reaction watching nothing — watchable, watched,
+  and unable to notify anybody for as long as it lives. A component render is
+  normally that capture context, which is why component-owned subscriptions
+  never meet this and why the mounted-view and diamond suites cannot pin it:
+  the hole is in the DIRECT listener entry point, the one tools and custom
+  substrate consumers reach for, where a stale first paint never updates again.
+
+  `activate!` is the substrate's `:activate-reaction!` op — the SAME one
+  `make-ratom-adapter` routes as `:adapter/activate-derived-value!` for the
+  ViewCell path, so the two attachment routes cannot diverge. It is TOTAL (a
+  no-op on a base container, or on a derived value some other substrate
+  produced in a mixed-substrate test bundle) and IDEMPOTENT (a node already on
+  the push path is left alone), so the second and later observers over one
+  cached node force no recompute, and base-container observers are unaffected.
+
+  Activating BEFORE the watch is what keeps the attach itself silent: the first
+  capture run may move the value from its uncomputed state, and an observer not
+  yet installed cannot be notified of that non-change. Push-based-from-birth
+  substrates (the React-hook spine, plain-atom, test-react) need none of this
+  and use `make-subscribe-container` bare."
+  [subscribe-container activate!]
+  (fn activating-subscribe-container [container on-change]
+    (activate! container)
+    (subscribe-container container on-change)))
+
 ;; ---- derived value --------------------------------------------------------
 ;;
 ;; React-only substrates have no reaction primitive. The substrate
@@ -4046,6 +4087,10 @@
         (fn replace-container! [container new-value]
           (reset! container new-value)
           nil)
+        ;; BARE — the demand-driven activation this family also owes is added
+        ;; by `make-ratom-adapter`, which is where the substrate's
+        ;; `:activate-reaction!` op arrives. Nothing should re-export THIS
+        ;; entry as a contract `subscribe-container`; take the adapter map's.
         subscribe-container
         (make-subscribe-container gensym-prefix-sub)
         ;; Arity-specialised recompute closure via `build-recompute-fn`
@@ -4300,7 +4345,15 @@
                  :make-state-container      (:make-state-container spine-fns)
                  :read-container            (:read-container       spine-fns)
                  :replace-container!        (:replace-container!   spine-fns)
-                 :subscribe-container       (:subscribe-container  spine-fns)
+                 ;; rf2-gwye.47 — the direct listener entry point activates the
+                 ;; container it attaches to, so a demand-driven derived value
+                 ;; observed WITHOUT a component render is on the push path
+                 ;; too. Same `activate-reaction!` the ViewCell route gets
+                 ;; through `:adapter/activate-derived-value!` below; see
+                 ;; `activating-subscribe-container`.
+                 :subscribe-container       (activating-subscribe-container
+                                              (:subscribe-container spine-fns)
+                                              activate-reaction!)
                  :make-derived-value        (:make-derived-value   spine-fns)
                  :render                    (:render               spine-fns)
                  :render-to-string          (:render-to-string     spine-fns)

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1190,7 +1190,7 @@ Semantically, `subscribe-once` is `subscribe` + deref + immediate `unsubscribe`:
 subscribe-once(frame-id, query-v):
   r ← subscribe(frame-id, query-v)                     ;; cache hit OR miss; ref-count += 1
   v ← deref r                                          ;; current cached value
-  unsubscribe(frame-id, query-v)                       ;; ref-count -= 1; on 1→0, dispose synchronously
+  unsubscribe r                                        ;; release THIS reaction, not the address; ref-count -= 1; on 1→0, dispose synchronously
   return v
 ```
 


### PR DESCRIPTION
Remediates `rf2-fzbj.29` (both findings), its two per-finding children `rf2-gwye.47` and `rf2-gwye.50`, and the ride-along `rf2-xa48`.

Both findings were re-verified at this branch's base before any fix: each reproduced, neither was already repaired, and the reproduction is now a regression test that was RED before the change and green after.

## F1 — `subscribe-container` silently observed nothing on a derived ratom container (rf2-gwye.47)

Spec 006 §`make-derived-value` requires a derived container to PUSH — it "updates automatically when any source's value changes", and `subscribe-container` "works as on a base container" — and §*Watchable is necessary, not sufficient* makes the placement normative: a substrate on a demand-driven host activates the node **when an observer attaches**, immediately before installing that observer's watch and taking its baseline read.

The ratom family only ever installed the watch. A stock `Reaction` learns its sources through `deref-capture` alone; a `read-container` taken outside a reactive context runs the compute-fn raw and leaves `watching` nil, so the container was watchable, watched, and unable to notify anybody for as long as it lived. `:activate-reaction!` existed and was routed as `:adapter/activate-derived-value!`, but only for the ViewCell path — the **direct** listener entry point, the one tools and custom substrate consumers reach for, had no activation at all. A component render is normally the capture context, which is why ordinary component-owned subscriptions never met this and why the mounted-view and diamond suites could not pin it.

**Repair.** `re-frame.substrate.spine/activating-subscribe-container` wraps the shared `make-subscribe-container` with the substrate's own `:activate-reaction!` op, and `make-ratom-adapter` uses it for the adapter map's `:subscribe-container`. That is deliberately the adapter layer rather than `make-ratom-spine`: `make-ratom-adapter` is where the injected activation op already arrives, so **stock Reagent and reagent-slim get one shared repair with no second subscription algorithm and no edit in either adapter namespace**. The op is total (a no-op on a base container, or on a derived value another substrate produced in a mixed-substrate bundle) and idempotent (a node already capturing is left alone), so base containers are untouched and a second observer over one cached node forces no recompute. Activation runs *before* the watch, so the attach itself stays silent. Not `:auto-run true` — activation stays demand-driven and native Reagent batching is preserved.

**Pin:** `implementation/adapters/reagent/test/re_frame/adapter_subscribe_container_activation_cljs_test.cljs` — six tests driving the adapter's container slots directly, with no component, no `r/track!`, no ratom context and no manual `activate-derived-value!` in any test body: direct listener with and without a baseline read; two observers sharing one activation, then one detaching; final detach releasing the source watch; base-container listener + idempotent cancellation (the control, which passes both before and after); multi-input batching (two writes, one flush, one notification, one recompute).

## F2 — the README's async Form-3 recipe leaked every result that settled late (rf2-gwye.50)

`implementation/adapters/reagent/README.md` §Form-3 taught a `.then` that stored its result unconditionally. Two ordinary sequences leaked:

* a mount whose embed Promise settles **after** unmount — the unmount callback saw `nil`, cleared both atoms, and the late completion then wrote a new view into a closure no callback would ever finalize again;
* two overlapping requests settling **out of order** — the older completion overwrote the accepted newer instance without finalizing it, and unmount then finalized only the older one.

The recipe exists specifically to teach release of library state and listeners, so a version that leaks on normal navigation defeats its own guidance.

**Repair.** A per-mount `request` token. `embed!` bumps it (superseding any in-flight request) and retires the previously accepted instance; a completion is accepted only while it is still the live request and finalizes itself otherwise; `retire!` reads-and-clears in one step so an accepted instance is released exactly once; `:component-will-unmount` invalidates the token *before* it tears down, so work still in flight releases itself. One new bullet in the "things matter" list explains the ownership rule and names the one limit it does not reach (a library that writes into the target element before its Promise settles — serialise, or give each request its own child element). No framework machinery was added; this is entirely inside the example.

**Pin:** `implementation/adapters/reagent/test/re_frame/form_3_async_ownership_cljs_test.cljs` — the recipe's ownership algorithm mirrored (closure state, token, `retire!`, the three lifecycle bodies) with `js/vegaEmbed` replaced by a caller-controlled Promise, so the four acceptance sequences are driven directly. No React, DOM or Vega needed; a Markdown link gate cannot see any of this.

## rf2-xa48 — spec/006 §`subscribe-once` pseudocode

One line. The release read as release-by-ADDRESS (`unsubscribe(frame-id, query-v)`); PR #9753 made the implementation release the exact reaction it acquired, through `unsubscribe-if-reaction`. Now reads `unsubscribe r ;; release THIS reaction, not the address; …`. No contract change — the rules beside it already said so.

## Quality gates

Every number below is the runner's own captured exit code, taken on one command line with the redirect, not a status reported about the run. All of them were re-run on the FINAL base after the rebase onto trunk; a pre-rebase green is evidence about a tree that no longer exists.

| gate | CI job | captured exit |
|---|---|---|
| `npm run test:cljs` (whole lane) | `cljs` | **0** — 12064 tests / 60134 assertions, 0 failures, 0 errors |
| `npm run test:browser` | `cljs-browser` | **0** — 1099 tests / 6006 assertions, 0 failures, 0 errors |
| `npm run test:adapter-smokes` | `adapter-testbed-smokes` | **0** — 2 specs, 0 failures |
| `sh scripts/test-fast-pr.sh` | (spine, not a CI job) | **0** — `PASS fast PR spine` |
| `clojure -M:test` in `implementation/adapters/reagent` | `jvm-reagent` | **0** (`--probe` lane: 0 tests by design) |
| `python scripts/check_doc_slugs.py` | `verify-readme-links` | **0** |
| `python scripts/check_readme_links.py --ci` | `verify-readme-links` | **0** |
| `python scripts/check_adapter_disposition.py` | `verify-readme-links` (step) | **0** |
| `python scripts/check_readme_inventories.py` | `verify-readme-links` (step) | **0** |
| `python scripts/check_test_lane_bijection.py` | `verify-readme-links` (step) | **0** — 1676 test-defining files, 45 lanes, both new files selected |
| `python scripts/check_retired_spellings.py --verbose` | `verify-skill-mcp-drift` (step) | **0** |
| `python scripts/check_require_alias_dialect.py --verbose` | `require-alias-dialect` (lint.yml) | **0** |

The whole CLJS lane was run rather than the Reagent namespaces alone, because `spine.cljs` is shared: reagent-slim and UIx ride the same lane and were green in it.

**RED-then-green controls, both discriminating:**

* *F1.* Pre-fix run of the full lane: captured exit **1**, 13 failures, **all 13 in the new activation namespace and none anywhere else** across 59851 assertions. Post-fix on the same tree: exit 0.
* *F2.* With the mirror's algorithm reverted to the pre-fix README shape and everything else at its final state: captured exit **1**, 7 failures, **all in the async-ownership namespace** — and the F1 namespace stayed green in that same run, so the two are independently attributed. `ordinary-lifecycle-retires-each-instance-once` passed under the sabotage, which is correct: the sequential path was never the defect. Restore verified by blob hash against the committed object (`git rev-parse HEAD:<path>` matched `git hash-object <path>`) and by `git diff --quiet HEAD`, not by reading a diff.
* *Link gates.* Both were sabotage-verified rather than trusted on a silent green: a broken anchor planted in `spec/006-ReactiveSubstrate.md` took `check_doc_slugs.py` to exit 1 naming the file and line, and a broken target planted in the adapter README took `check_readme_links.py --ci` to exit 1 naming that file and line. Each fault existed only in the working tree, so the red proves which tree was read. Both restored and blob-hash verified.

**Checked by hand, because nothing validates it.** Neither link gate looks inside a fenced code block, and `mkdocs build --strict` grades no anchors at all, so: the edited `subscribe-once` pseudocode fence in `spec/006-ReactiveSubstrate.md` and the whole Form-3 recipe fence in the adapter README were read by hand for balanced parens, correct Clojure and consistent comment alignment; the README's "7 things matter" count was updated from 6 to match the added bullet; no tables were touched in either file.

## Not built, and why

* *"Coordinate a matching slim assertion" (rf2-gwye.47 acceptance).* reagent-slim **is** fixed by this change — it shares `make-ratom-adapter` and already injects `:activate-reaction! ratom/activate!`, and its suite is green in the lane above — but its assertion belongs in `implementation/adapters/reagent-slim/test/**`, which another worker holds in this wave. The change I would have made: a slim twin of `adapter_subscribe_container_activation_cljs_test.cljs`, same six pins, against `rf.adapter.reagent-slim/adapter`'s slots with `reagent2`'s synchronous flush in place of `r/flush`. Routed rather than made.
* *"Serialize operations or give each request an isolated target" (rf2-gwye.50).* Reduced to one sentence of prose in the new README bullet rather than a second worked example: the finding itself records the late-DOM-write risk as unverified and explicitly not a third defect, and a second example would double the recipe to guard something the recipe cannot control.

**Relying on CI for these**, declared rather than claimed: `cljs-examples-compile`, `cljs-bundle-isolation`, `cljs-reagent-slim-bundle-isolation`, `cljs-elision`, `cljs-perf-bundle` and the other lanes the fast-PR spine has no tier for. No require edge was added or moved, so the bundle-isolation surfaces should be inert, but that is a prediction and CI is the measurement.
