### PR TITLE
fix(flows,epoch): fence direct-clear settle trace delivery; correlate replay results with their own dispatch (rf2-gwye.63, rf2-fzbj.19)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -196,6 +196,19 @@
           ;; frame as the EVIDENCE key `:rf.frame/id` and so was
           ;; frame-less here, and dropped, on every real cascade.
           frame-id (:frame event-tags)]
+      ;; rf2-fzbj.19 — dispatch identity for an armed commit observation.
+      ;; `trace/deliver!` runs THIS stage before the public tooling fan-out, so
+      ;; the first `:rf.event/dispatched` to arrive here for a frame is the one
+      ;; the observation's armer started, strictly before any listener body for
+      ;; that event could start a nested cascade of its own. That ordering is
+      ;; what lets `perform-replay!` report the epoch ITS dispatch committed
+      ;; rather than whichever cascade happened to commit first. A no-op —
+      ;; one map read — when nothing is armed, which is every ordinary
+      ;; dispatch. Deliberately ahead of `skip-ops` and every routing branch
+      ;; below: this records identity, it buffers nothing.
+      (when (and frame-id (= :rf.event/dispatched operation))
+        (rf.epoch.state/note-observed-dispatch!
+          frame-id (:rf.trace/dispatch-id event-tags)))
       ;; Any path below that can mutate epoch state first claims the id-keyed
       ;; stores for the exact live frame incarnation. This serialises a fresh
       ;; same-id B publication against stale A's final destroy hook.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -281,12 +281,41 @@
 ;; from the one where the parent survived — the counts are identical when the
 ;; cascade commits exactly `depth` records.
 ;;
-;; COMMIT ORDER is where the identity is unambiguous, so the caller ARMS a
-;; one-shot slot for its frame and the commit funnel fills it with the FIRST
-;; epoch-id committed for that frame while the arming stands. The slot is
-;; filled at commit, so it names the parent whether or not the ring still
-;; holds it, and the caller then asks the ring — separately — whether that
-;; epoch is retained.
+;; COMMIT ORDER ALONE IS NOT THAT IDENTITY (rf2-fzbj.19). The router emits
+;; `:rf.event/dispatched` BEFORE it starts the dispatch's own drain, and a
+;; public trace listener is expressly allowed to `dispatch-sync` from there
+;; (see `trace/tooling`'s reentrancy note). That nested cascade runs to
+;; completion — and COMMITS — inside the armed window, before the armed
+;; caller's own event has run at all, so a first-commit slot hands back
+;; another operation's state, effects and trace under the replayed event's
+;; name. Measured witness: source epoch 6, the listener's nested event epoch
+;; 7, the actual replay epoch 8, and the result said `:event-id :review/add`
+;; with `:epoch-id 7`. Filtering by `:event-id` cannot repair it — the same
+;; handler with different arguments produces the same keyword.
+;;
+;; So the slot correlates on DISPATCH IDENTITY, and takes it from the one
+;; ordering the interleave cannot invert. `trace/deliver!` runs EPOCH CAPTURE
+;; as its own stage BEFORE the public tooling fan-out, so capture sees the
+;; armed caller's `:rf.event/dispatched` strictly before any listener body for
+;; that event runs — hence strictly before the listener can create a nested
+;; dispatch at all. The FIRST dispatch-id capture reports for the frame while
+;; the arming stands is therefore the armed caller's own, whatever order the
+;; tooling listeners happen to sit in; every later cascade (a listener's
+;; nested `dispatch-sync`, a queued child, the rest of the drain) is a
+;; different id and is refused. `note-commit!` fills the slot only from the
+;; record carrying THAT id.
+;;
+;; The slot is still filled at COMMIT, so it names the armed caller's epoch
+;; whether or not the ring still holds it, and the caller asks the ring —
+;; separately — whether that epoch is retained. rf2-e0g2's queued-child
+;; counterexample stays fixed for the same reason it was before, and now for a
+;; second: the child is neither the first commit nor the armed dispatch-id.
+;;
+;; `:fallback-epoch-id` keeps the historical first-commit reading for the one
+;; case correlation cannot reach: no `:rf.event/dispatched` was captured for
+;; the frame at all, so there is no id to correlate on. Dispatch ids and that
+;; emit are both dev-gated and vanish together, so this is the no-dispatch-id
+;; posture rather than a silent second-guess of a correlation that failed.
 ;;
 ;; The arming token keeps a second, concurrent arming honest instead of
 ;; silently clobbering: `take-observed-commit!` answers nil for a caller whose
@@ -298,34 +327,70 @@
 (defn arm-commit-observation!
   "Arm a one-shot commit observation for `frame-id`; returns the token to
   hand back to `take-observed-commit!`. Always pair the two — a caller that
-  arms and does not take leaves a slot the next commit writes into."
+  arms and does not take leaves a slot the next commit writes into.
+
+  Arm it IMMEDIATELY before the dispatch whose epoch you want: the armed
+  caller's own dispatch has to be the first one epoch capture sees for the
+  frame, which is what makes the correlation above exact."
   [frame-id]
   (let [token #?(:clj (Object.) :cljs (js-obj))]
     (swap! commit-observations assoc frame-id {:token token})
     token))
 
 (defn take-observed-commit!
-  "Disarm `frame-id`'s observation and return the FIRST epoch-id committed
-  for it while `token`'s arming stood — nil when nothing committed, or when a
-  later arming replaced this one."
+  "Disarm `frame-id`'s observation and return the epoch-id committed by the
+  DISPATCH the arming caller itself started — nil when it committed nothing,
+  or when a later arming replaced this one."
   [frame-id token]
   (let [slot (get @commit-observations frame-id)]
     (when (identical? token (:token slot))
       (swap! commit-observations dissoc frame-id)
-      (:epoch-id slot))))
+      (if (contains? slot :dispatch-id)
+        (:epoch-id slot)
+        (:fallback-epoch-id slot)))))
 
-(defn- note-commit!
-  "Record `epoch-id` against `frame-id`'s armed observation, once. A no-op
-  when nothing is armed (the ordinary hot path: one map read, no write)."
-  [frame-id epoch-id]
-  (when (and epoch-id (contains? @commit-observations frame-id))
+(defn note-observed-dispatch!
+  "Record `dispatch-id` as the armed observation's target for `frame-id`, once.
+
+  Called from the epoch-capture stage on `:rf.event/dispatched`. Capture runs
+  ahead of the public tooling fan-out, so the first id to arrive here is the
+  armed caller's own dispatch and not one a listener started from inside it.
+  A no-op when nothing is armed (the ordinary hot path: one map read, no
+  write), and after the first id has landed."
+  [frame-id dispatch-id]
+  (when (and dispatch-id (contains? @commit-observations frame-id))
     (swap! commit-observations
            (fn [observations]
              (let [slot (get observations frame-id)]
-               (if (and slot (not (contains? slot :epoch-id)))
-                 (assoc observations frame-id (assoc slot :epoch-id epoch-id))
+               (if (and slot (not (contains? slot :dispatch-id)))
+                 (assoc observations frame-id (assoc slot :dispatch-id dispatch-id))
                  observations))))
     nil))
+
+(defn- note-commit!
+  "Record `record`'s epoch-id against `frame-id`'s armed observation, once,
+  when the record was committed by the dispatch the observation targets. A
+  no-op when nothing is armed (the ordinary hot path: one map read, no
+  write)."
+  [frame-id record]
+  (let [epoch-id    (:epoch-id record)
+        dispatch-id (:dispatch-id record)]
+    (when (and epoch-id (contains? @commit-observations frame-id))
+      (swap! commit-observations
+             (fn [observations]
+               (let [slot (get observations frame-id)]
+                 (if-not slot
+                   observations
+                   (let [slot (cond-> slot
+                                (not (contains? slot :fallback-epoch-id))
+                                (assoc :fallback-epoch-id epoch-id)
+
+                                (and (some? dispatch-id)
+                                     (= dispatch-id (:dispatch-id slot))
+                                     (not (contains? slot :epoch-id)))
+                                (assoc :epoch-id epoch-id))]
+                     (assoc observations frame-id slot))))))
+      nil)))
 
 (defn reset-commit-observations!
   "Drop every armed commit observation (fixture / global history reset)."
@@ -1930,7 +1995,9 @@
   The commit observation is filled here rather than in `record!` because it
   answers \"which epoch did this dispatch commit?\", which is true of a record
   the ring immediately evicted — and true at depth 0, where `record!` appends
-  nothing at all."
+  nothing at all. It is handed the WHOLE record rather than the epoch-id alone
+  because the answer is correlated by the record's `:dispatch-id`, not by
+  commit order (rf2-fzbj.19)."
   [frame-id owner-token record]
   (boolean
     (with-frame-owner-lock
@@ -1938,7 +2005,7 @@
         (when (identical? (get @frame-owner-tokens frame-id) owner-token)
           (record! record)
           (set-last-settled-epoch! frame-id (:epoch-id record))
-          (note-commit! frame-id (:epoch-id record))
+          (note-commit! frame-id record)
           true)))))
 
 (defn cleanup-frame-owner!

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -720,10 +720,11 @@
                 not retain it>}
 
   `:epoch-id` names the epoch the REPLAYED EVENT committed and no other. The
-  identity is taken from COMMIT ORDER — a one-shot observation armed on the
-  frame across the dispatch, filled by the commit funnel with the first epoch
-  committed — and then checked against the ring, so an epoch the ring did not
-  keep reports the documented nil.
+  identity is taken from the DISPATCH — a one-shot observation armed on the
+  frame across the dispatch, which learns this dispatch's own id from the
+  epoch-capture stage and is then filled by the commit funnel from the record
+  carrying that id — and then checked against the ring, so an epoch the ring
+  did not keep reports the documented nil.
 
   Reading the ring alone cannot answer this (rf2-e0g2). Replay runs against
   CURRENT state and code (Tool-Pair §Replay), so it may legitimately enqueue
@@ -733,6 +734,15 @@
   would attach the child's operation, state and effects to the parent this
   response names under `:event-id` — wrong causal evidence handed to a tool
   that trusts the chain.
+
+  Nor can COMMIT ORDER answer it (rf2-fzbj.19). The router emits
+  `:rf.event/dispatched` before it starts this dispatch's drain, and a public
+  trace listener may `dispatch-sync` from there; that nested cascade commits
+  INSIDE this window and before the replayed event has run, so the first
+  commit is the callback's and not ours. The armed observation therefore
+  refuses every id but this dispatch's — see the commit-observation section in
+  `re-frame.epoch.state` for why the capture stage's ordering makes that id
+  unambiguous.
 
   A declared recordable fact ABSENT from the recorded token throws the
   canonical `:rf.error/missing-required-cofx` out of the dispatch exactly as

--- a/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
@@ -566,3 +566,129 @@
           "the reported epoch is the replayed parent's own record")
       (is (not= (:epoch-id source) (:epoch-id res))
           "…and it is the NEW record, not the source"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-fzbj.19 — a trace listener's own dispatch cannot steal replay's result
+;;
+;; The sibling counterexample to rf2-e0g2 above, and the one it left open. That
+;; one is about a cascade committing AFTER the replayed event; this is about one
+;; committing BEFORE it, while the replayed event has not run at all.
+;;
+;; The router emits `:rf.event/dispatched` before it starts the drain, and a
+;; public trace listener may `dispatch-sync` from there — `trace/tooling`
+;; documents that reentrancy explicitly. The nested cascade then runs to
+;; completion and COMMITS inside replay's armed window. Under the first-commit
+;; observation the response named the CALLBACK's epoch while still reporting
+;; `:event-id` as the replayed event's: a consumer that resolves the returned id
+;; against `epoch-history` — which is precisely what the one-call gesture exists
+;; to let it do — gets another operation's state, effects and trace.
+;;
+;; Both events execute correctly either way. What was wrong was the returned
+;; EVIDENCE, which is why this is P3 and why every assertion below is about
+;; correlation rather than about state.
+;; ---------------------------------------------------------------------------
+
+(def ^:private interleave-frame-id :epoch-replay/interleave)
+
+(defn- register-add-and-other! []
+  (rf/reg-event :review/add
+    (fn [{:keys [db]} [_ amount]] {:db (update db :n (fnil + 0) amount)}))
+  (rf/reg-event :review/other
+    (fn [{:keys [db]} _] {:db (assoc db :other true)})))
+
+(defn- call-with-interleaving-listener
+  "Run `(f)` with a ONE-SHOT public trace listener that dispatches
+  `nested-event` into `interleave-frame-id` the first time it sees an
+  `:rf.event/dispatched` for that frame — i.e. from inside the replay's own
+  dispatch, before the replay drains. Returns `[result fired?]`."
+  [nested-event f]
+  (let [fired? (atom false)]
+    (rf/register-listener! :trace ::interleave
+      (fn [ev]
+        (when (and (= :rf.event/dispatched (:operation ev))
+                   (= interleave-frame-id (get-in ev [:tags :frame]))
+                   (compare-and-set! fired? false true))
+          (rf/dispatch-sync nested-event {:frame interleave-frame-id}))))
+    (try
+      [(f) @fired?]
+      (finally
+        (rf/unregister-listener! :trace ::interleave)))))
+
+(deftest replay-result-names-its-own-dispatch-not-a-callbacks
+  (testing "a trace callback that dispatches a DIFFERENT event during replay's
+            `:rf.event/dispatched` commits first; the reported epoch is still
+            the replayed dispatch's own record, and both events run"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id interleave-frame-id})
+    (register-add-and-other!)
+    (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+    (let [source (last (rf/epoch-history interleave-frame-id))
+          [res fired?] (call-with-interleaving-listener
+                         [:review/other]
+                         #(rf/replay-epoch! interleave-frame-id (:epoch-id source)))
+          after  (rf/epoch-history interleave-frame-id)
+          named  (first (filter #(= (:epoch-id res) (:epoch-id %)) after))]
+      (is (true? fired?) "the callback did interleave — the witness is armed")
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= [:review/add :review/other :review/add] (mapv :event-id after))
+          "the callback's event committed BEFORE the replayed event — this is
+           the ordering the first-commit observation could not survive")
+      (is (= {:n 2 :other true} (rf/app-db-value interleave-frame-id))
+          "both events executed correctly; only the returned evidence was wrong")
+      ;; THE TOOTH.
+      (is (= (:epoch-id (last after)) (:epoch-id res))
+          "the reported epoch is the replayed dispatch's OWN new record")
+      (is (= [:review/add 1] (:trigger-event named))
+          (str "…and it resolves to the replayed trigger, not the callback's; "
+               "resolved " (pr-str (:trigger-event named))))
+      (is (= :review/other (:event-id (nth after 1)))
+          "sanity — the callback's record is the one the old code returned"))))
+
+(deftest replay-result-is-not-rescued-by-matching-the-event-id
+  (testing "the SAME handler with DIFFERENT arguments: filtering the history by
+            `:event-id` would still return the callback's record, so the
+            correlation has to be by dispatch identity"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id interleave-frame-id})
+    (register-add-and-other!)
+    (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+    (let [source (last (rf/epoch-history interleave-frame-id))
+          [res fired?] (call-with-interleaving-listener
+                         [:review/add 100]
+                         #(rf/replay-epoch! interleave-frame-id (:epoch-id source)))
+          after  (rf/epoch-history interleave-frame-id)
+          named  (first (filter #(= (:epoch-id res) (:epoch-id %)) after))
+          callback-record (first (filter #(= [:review/add 100] (:trigger-event %))
+                                         after))]
+      (is (true? fired?) "the callback did interleave — the witness is armed")
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= [:review/add :review/add :review/add] (mapv :event-id after))
+          "every record carries the SAME event-id — an `:event-id` filter has
+           nothing to discriminate on")
+      (is (= {:n 102} (rf/app-db-value interleave-frame-id))
+          "both dispatches executed: the seed 1, the callback's 100, the replay's 1")
+      ;; THE TOOTH — the assertion an `:event-id` filter cannot pass.
+      (is (= [:review/add 1] (:trigger-event named))
+          (str "the reported epoch resolves to the REPLAYED arguments, not the "
+               "callback's; resolved " (pr-str (:trigger-event named))))
+      (is (not= (:epoch-id callback-record) (:epoch-id res))
+          "the callback's record is never the reported epoch")
+      (is (= (:epoch-id (last after)) (:epoch-id res))
+          "the reported epoch is the replayed dispatch's own new record"))))
+
+(deftest replay-without-a-callback-is-unchanged
+  (testing "the green control: with no interleaving listener the ordinary replay
+            still reports its own new epoch"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id interleave-frame-id})
+    (register-add-and-other!)
+    (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+    (let [source (last (rf/epoch-history interleave-frame-id))
+          res    (rf/replay-epoch! interleave-frame-id (:epoch-id source))
+          after  (rf/epoch-history interleave-frame-id)
+          named  (first (filter #(= (:epoch-id res) (:epoch-id %)) after))]
+      (is (true? (:ok? res)) (str "the replay succeeded: " (pr-str res)))
+      (is (= 2 (count after)) "one seed record and one replay record")
+      (is (= (:epoch-id (last after)) (:epoch-id res)))
+      (is (= [:review/add 1] (:trigger-event named)))
+      (is (= {:n 2} (rf/app-db-value interleave-frame-id))))))

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -469,14 +469,37 @@
   binding wraps the whole pass because the throw is raised deep inside it, and
   unwinds with it because the settle is synchronous.
 
+  The pass ALSO runs under `owner-token`'s exact-owner trace continuation
+  (rf2-gwye.63). `:exact-owner-token` fences the pass's own writes — cache,
+  output, validation — but a trace it emits is a separate callback pipeline
+  whose stages recheck ownership only while a continuation predicate is
+  installed (`trace/continuation-live?` reads the always-true default
+  otherwise), and this settle runs inside the cold serialized region, which
+  DEFERS listener delivery past the release. `deferred-continue` captures
+  whatever predicate stood at emit time, so without this wrap the dependent's
+  `:rf.flow/computed` fan-out carries the always-continue default: a listener
+  that destroys A mid-fan-out no longer suppresses the listeners behind it,
+  and the observer receives A's computed evidence after A's destruction was
+  claimed. Every other route already supplies one — the ordinary event route
+  inherits the router's, and the sibling direct register / replace / clear
+  emits install their own (rf2-pwum1g, rf2-rxsldx). The scope wraps the WHOLE
+  pass, not the computed emit alone, so the sibling skip / failure / schema
+  observations cannot escape it either, and it AND-composes with any enclosing
+  predicate.
+
   `registry/clear-flow` calls this through the seam it publishes; the
   `:require` runs the other way."
   [frame-id owner-token]
   (when-let [db (rf.frame/frame-app-db-value frame-id)]
     (let [runtime-db (rf.frame/frame-runtime-db-value frame-id)
-          settled    (binding [*pass-caller* :direct-clear]
-                       (run-flows-on-db frame-id db runtime-db
-                                        {:exact-owner-token owner-token}))]
+          pass       #(binding [*pass-caller* :direct-clear]
+                        (run-flows-on-db frame-id db runtime-db
+                                         {:exact-owner-token owner-token}))
+          settled    (if rf.interop/debug-enabled?
+                       (rf.trace/call-with-continuation-predicate
+                         #(rf.frame/event-continuation-live? frame-id owner-token)
+                         pass)
+                       (pass))]
       (when-not (or (= stale-incarnation settled)
                     (identical? settled db))
         (rf.frame/swap-frame-db-exact! frame-id owner-token (constantly settled)))))

--- a/implementation/flows/test/re_frame/flows_direct_clear_settle_trace_incarnation_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_direct_clear_settle_trace_incarnation_cljs_test.cljc
@@ -1,0 +1,192 @@
+(ns re-frame.flows-direct-clear-settle-trace-incarnation-cljs-test
+  "rf2-gwye.63 — exact-incarnation fence for the traces the DIRECT-CLEAR SETTLE
+  emits, THROUGH the synchronous trace-emit callback pipeline (classification
+  projection → epoch capture → ordered tooling listeners).
+
+  The sibling of `re-frame.flows-replace-clear-trace-incarnation-cljs-test`
+  (rf2-rxsldx), which fences the direct lifecycle emits themselves. That fence
+  wraps `:rf.flow/cleared` and stops at the end of `clear-flow`'s exact-owner
+  postcheck. The SETTLE that runs one line later — `settle-frame-flows!`,
+  recomputing the cleared producer's dependents against its absence — is a
+  second, longer callback-bearing region, and before rf2-gwye.63 it supplied no
+  continuation predicate at all.
+
+  `run-flows-on-db` is called with `:exact-owner-token`, so the pass's own
+  WRITES (dirty cache, output install, schema validation, the final
+  `swap-frame-db-exact!`) are fenced. A trace is not a write: `trace/emit!` is
+  a separate synchronous pipeline whose stages recheck ownership ONLY while a
+  continuation predicate is installed — `trace/continuation-live?` reads the
+  always-true default otherwise — and the settle runs INSIDE the cold serialized
+  region, which DEFERS listener delivery until after the release.
+  `deferred-continue` captures whatever predicate stood at emit time, so the
+  ordinary always-continue default was what the whole deferred fan-out carried.
+
+  Consequence, reproduced below: an ordered trace LISTENER destroys incarnation
+  A and publishes a same-id B while the dependent's `:rf.flow/computed` is
+  fanning out, and every SUBSEQUENT listener still receives A's
+  incarnation-less computed event after A's destruction has been claimed. The
+  event route does not behave that way (it inherits the router's exact-owner
+  scope), nor do the neighbouring direct lifecycle emits, so the direct-clear
+  COMPUTE stream disagreed with both at the same supported callback boundary.
+
+  The fix wraps the whole settle pass in
+  `trace/call-with-continuation-predicate` bound to A's pinned incarnation. The
+  already-entered delivery (the listener that destroys A) stands once; every
+  LATER listener is suppressed the instant A's exact ownership is lost. The
+  scope covers the WHOLE pass rather than the computed emit alone, so the
+  sibling skip / failure / schema observations cannot escape it either.
+
+  Listener fan-out order is insertion order, so the destroyer is registered
+  FIRST (the already-entered delivery that may stand) and the observer SECOND
+  (the subsequent delivery the fence must suppress). Order is used only to make
+  a deterministic witness — applications are not required to depend on it.
+
+  This file is `*-cljs-test.cljc` so the shadow-cljs `:node-test` build
+  (ns-regexp `cljs-test$`) discovers it under CLJS AND the cognitect JVM runner
+  runs it — the lifecycle code under test is all `.cljc`, so the boundary is
+  exercised on both hosts."
+  (:require #?(:clj  [clojure.test :refer [deftest is use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.flows :as rf.flows]
+            [re-frame.frame :as rf.frame]
+            [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
+
+(use-fixtures :each
+  (rf.test-support/make-reset-runtime-fixture {:adapter rf.substrate.plain-atom/adapter}))
+
+(def ^:private producer-id :flow.settle.fence/producer)
+(def ^:private dependent-id :flow.settle.fence/dependent)
+
+(defn- seed-frame!
+  "Stand up `frame-id` with the two-flow chain the witness needs and drive one
+  ordinary event through it, so the settle triggered by clearing the producer
+  has a real dependent to recompute.
+
+      [:input] --producer--> [:source] --dependent--> [:derived]
+
+  Returns the frame's app-db after seeding."
+  [frame-id]
+  (rf/make-frame {:id frame-id})
+  (rf/reg-event ::seed (fn [_ _] {:db {:input 5}}))
+  (rf/reg-flow producer-id
+    {:frame frame-id :inputs [[:input]] :output-path [:source]}
+    identity)
+  (rf/reg-flow dependent-id
+    {:frame frame-id :inputs [[:source]] :output-path [:derived]}
+    (fn [source] (or source :absent)))
+  (rf/dispatch-sync [::seed] {:frame frame-id})
+  (rf/app-db-value frame-id))
+
+(defn- dependent-computed?
+  "True for the DEPENDENT's own `:rf.flow/computed` trace event."
+  [ev frame-id]
+  (and (= :rf.flow/computed (:operation ev))
+       (= dependent-id (get-in ev [:tags :flow-id]))
+       (= frame-id (get-in ev [:tags :frame]))))
+
+;; ===========================================================================
+;; THE WITNESS — a listener that destroys A mid-fan-out must fence the ones
+;; behind it.
+;; ===========================================================================
+
+(deftest direct-clear-settle-trace-listener-loss-fences-subsequent-listeners
+  ;; rf2-gwye.63 (red before the fix). Clearing the producer settles the
+  ;; dependent, which emits `:rf.flow/computed` with A live. The destroyer
+  ;; listener — the already-entered delivery — destroys A and publishes same-id
+  ;; B exactly once. Before the fix the settle pass installed no continuation
+  ;; predicate, so the deferred fan-out carried the always-true default and the
+  ;; observer still received A's computed event after A's destruction was
+  ;; claimed. After the fix the pinned-A predicate suppresses every listener
+  ;; past the loss.
+  (let [frame-id        :flow.settle.fence/subject
+        destroyer-hits  (atom 0)
+        observer-dep    (atom [])       ;; the dependent's computed events seen
+        armed?          (atom true)
+        b-token         (atom nil)
+        b-flow-registry (atom ::unset)]
+    (is (= {:input 5 :source 5 :derived 5} (seed-frame! frame-id))
+        "precondition — the seeding drain materialised the chain in topological order")
+    ;; Listener 1 (registered FIRST → fans out FIRST): the DESTROYER.
+    (rf.trace.tooling/register-listener!
+      ::destroyer
+      (fn [ev]
+        (when (and (dependent-computed? ev frame-id)
+                   (compare-and-set! armed? true false))
+          (swap! destroyer-hits inc)
+          (rf.frame/destroy-frame! frame-id)
+          (rf/make-frame {:id frame-id})
+          (reset! b-token (rf.frame/frame-incarnation-token frame-id))
+          (reset! b-flow-registry (get (rf.flows/flows-snapshot) frame-id ::none)))))
+    ;; Listener 2 (registered SECOND): the SUBSEQUENT observer.
+    (rf.trace.tooling/register-listener!
+      ::observer
+      (fn [ev]
+        (when (dependent-computed? ev frame-id)
+          (swap! observer-dep conj ev))))
+    (try
+      (is (= producer-id (rf/clear :flow producer-id {:frame frame-id}))
+          "clear returns the id even though A's owner was lost mid-emit")
+      (is (= 1 @destroyer-hits)
+          "the destroyer received the dependent's `:rf.flow/computed` once — the
+           already-entered delivery stands")
+      (is (some? @b-token) "the destroyer published a same-id B")
+      (is (identical? @b-token (rf.frame/frame-incarnation-token frame-id))
+          "B remains the live incarnation")
+      ;; THE TOOTH: the subsequent listener never receives A's stale event.
+      (is (empty? @observer-dep)
+          (str "the SUBSEQUENT listener received ZERO of A's `:rf.flow/computed` "
+               "events — the fence suppresses every trace stage after A's exact "
+               "ownership is lost (removing the settle pass's "
+               "`call-with-continuation-predicate` wrapper makes this fail); saw "
+               (pr-str (mapv #(get-in % [:tags :result]) @observer-dep))))
+      ;; B is never mutated by A's stale settle tail.
+      (is (= ::none @b-flow-registry) "B started with an empty flow registry")
+      (is (= {} (rf/app-db-value frame-id))
+          "A's stale settle tail never installed a db into the successor")
+      (finally
+        (rf.trace.tooling/unregister-listener! ::destroyer)
+        (rf.trace.tooling/unregister-listener! ::observer)))))
+
+;; ===========================================================================
+;; GREEN CONTROL / over-fence tooth — with A live through the fan-out the
+;; ordinary settle trace still reaches the subsequent listener exactly once,
+;; and the synchronous clear behaves exactly as before.
+;; ===========================================================================
+
+(deftest direct-clear-settle-trace-with-live-owner-emits-once
+  ;; rf2-gwye.63 mutation tooth. The exact-incarnation fence must NOT suppress
+  ;; the ordinary settle trace when A stays live through the fan-out, and must
+  ;; not change what the settle computes or installs.
+  (let [frame-id :flow.settle.fence/live
+        touched  (atom 0)
+        observed (atom [])]
+    (is (= {:input 5 :source 5 :derived 5} (seed-frame! frame-id))
+        "precondition — the seeding drain materialised the chain")
+    (rf.trace.tooling/register-listener!
+      ::live-touch
+      (fn [ev]
+        (when (dependent-computed? ev frame-id)
+          (swap! touched inc))))            ;; observe only — A stays live
+    (rf.trace.tooling/register-listener!
+      ::live-observer
+      (fn [ev]
+        (when (dependent-computed? ev frame-id)
+          (swap! observed conj ev))))
+    (try
+      (is (= producer-id (rf/clear :flow producer-id {:frame frame-id})))
+      (is (= 1 @touched) "the first listener saw the dependent's computed event")
+      (is (= 1 (count @observed))
+          "the SUBSEQUENT listener also received it — the live-owner settle is
+           not over-fenced")
+      (is (= :absent (get-in (first @observed) [:tags :result]))
+          "the observed computed event carries the dependent's recomputation
+           against the producer's absence")
+      (is (= {:input 5 :derived :absent} (rf/app-db-value frame-id))
+          "ordinary synchronous direct-clear behaviour is preserved — the
+           producer's leaf is vacated and the dependent settled before return")
+      (finally
+        (rf.trace.tooling/unregister-listener! ::live-touch)
+        (rf.trace.tooling/unregister-listener! ::live-observer)))))


### PR DESCRIPTION
Two trace-delivery findings from the 2026-09-12/13 surface review, both about a trace callback reaching — or being answered by — the wrong owner. Each was re-verified at this branch's base before it was fixed; both premises still held.

## rf2-gwye.63 (P2) — flows: fence the direct-clear settle to the captured frame owner

`settle-frame-flows!` runs `run-flows-on-db` with `:exact-owner-token`, which fences the pass's own writes — dirty cache, output install, schema validation, the final `swap-frame-db-exact!`. A trace is not a write. `trace/emit!` is a separate synchronous callback pipeline whose stages recheck ownership only while a continuation predicate is installed (`trace/continuation-live?` reads the always-true default otherwise), and this settle runs inside the cold serialized region, which DEFERS listener delivery past the release — `deferred-continue` captures whatever predicate stood at emit time. So the dependent's `:rf.flow/computed` fan-out carried the always-continue default.

Consequence: a listener that destroys incarnation A mid-fan-out no longer suppressed the listeners behind it, and the next listener received A's computed evidence after A's destruction had been claimed. The ordinary event route inherits the router's exact-owner scope, and the sibling direct register / replace / clear emits install their own (rf2-pwum1g, rf2-rxsldx) — the direct-clear compute stream was the one boundary that disagreed.

**Fix:** wrap the whole settle pass in `trace/call-with-continuation-predicate` bound to the pinned incarnation. The whole pass rather than the computed emit alone, so the sibling skip / failure / schema observations cannot escape it either; it AND-composes with any enclosing predicate; behind `debug-enabled?` so the production settle path is unchanged.

**Regression:** `implementation/flows/test/re_frame/flows_direct_clear_settle_trace_incarnation_cljs_test.cljc`, shaped as the bead's reproducer — producer `[:input] -> [:source]`, dependent `[:source] -> [:derived]`, destroyer listener first, observer second, a direct `(rf/clear :flow …)` with no intervening dispatch — plus the live-owner control the bead asks for (one computed delivery, dependent updated to `:absent`, ordinary synchronous clear behaviour preserved).

## rf2-fzbj.19 (P3) — epoch: correlate a replay result with the actual dispatch

`perform-replay!` armed a frame-level one-shot observation across its `dispatch-sync!` and took the FIRST epoch committed for that frame. The router emits `:rf.event/dispatched` before it starts that dispatch's drain, and a public trace listener may `dispatch-sync` from there — an allowed reentrancy `trace/tooling` documents. That nested cascade runs to completion and COMMITS inside the armed window, before the replayed event has run at all, so the response named the callback's epoch while still reporting `:event-id` as the replayed event's. A consumer resolving the returned id against `epoch-history` — the whole point of the one-call gesture — got another operation's state, effects and trace.

Reproduced at this base before fixing: source epoch 6, callback epoch 7, actual replay epoch 8, result `:epoch-id 7`. Both events execute correctly either way; what was wrong is the returned evidence, which is why this is P3.

**Fix:** correlate on dispatch identity. `trace/deliver!` runs epoch capture as its own stage BEFORE the public tooling fan-out, so capture sees the armed caller's `:rf.event/dispatched` strictly before any listener body for that event runs — hence strictly before a listener can create a nested dispatch at all. The first dispatch-id capture reports for the frame while an arming stands is therefore the armed caller's own, whatever order the tooling listeners sit in, and `note-commit!` fills the slot only from the record carrying that id. The historical first-commit reading survives as `:fallback-epoch-id` for the one case correlation cannot reach — no dispatched emit captured at all, which is also the posture in which no dispatch ids exist.

This is deliberately NOT a router change. The bead's recommendation allowed "a private router/epoch correlation seam if needed"; none is needed, because the capture-before-fan-out ordering already supplies the identity. `implementation/core/src/re_frame/router.cljc` is untouched.

Two candidate correlations were measured and rejected rather than shipped: `:parent-dispatch-id` is nil on BOTH the replay and the nested dispatch (handler scope is not bound during the `:event/dispatched` emit, so the nested dispatch inherits no parent), and a first-`:rf.event/dispatched`-seen rule read off the public listener stream is listener-order dependent. Only the capture stage's position makes the ordering unconditional.

**Regression:** three deftests appended to `implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc` beside the rf2-e0g2 queued-child controls — the different-handler interleave, the same-handler/different-arguments control (where an `:event-id` filter has nothing to discriminate on, so a naive filter fails the test), and a no-callback green control. All three drive the public `register-listener!` / `dispatch-sync` / `replay-epoch!` surface.

## Red-before / green-after

Each new test was shown red against the pre-fix code and green after, with the source restored by blob hash.

| gate | with fix | with fix reverted |
|---|---|---|
| `jvm-flows` (`clojure -M:test`, `implementation/flows`) | exit 0 — 268 tests, 6226 assertions, 0 failures | exit 1 — 1 failure, the new tooth only (same 268/6226) |
| `jvm-epoch` (`clojure -M:test`, `implementation/epoch`) | exit 0 — 541 tests, 7315 assertions, 0 failures | exit 1 — 5 failures, both new interleave teeth only (same 541/7315); the no-callback control stayed green, so the fallback preserves the old reading |

Restores verified against the committed blob (`git rev-parse HEAD:<path>` equal to `git hash-object <path>`, default form; `git diff --quiet HEAD` exit 0), not by reading a diff.

## Quality gates

All run locally from this worktree on the final rebased base, each exit code captured on its own command line and quoted:

| gate | CI job (`.github/workflows/test.yml`) | captured exit | result |
|---|---|---|---|
| `clojure -M:test` in `implementation/flows` | `jvm-flows` ("JVM flows (clojure -M:test)") | 0 | 268 tests, 6226 assertions, 0 failures |
| `clojure -M:test` in `implementation/epoch` | `jvm-epoch` | 0 | 541 tests, 7315 assertions, 0 failures |
| `bash scripts/test-epoch-prod-gate.sh` | `jvm-epoch-prod-gate` ("JVM epoch under the production gate (-Dre-frame.debug=false)") | 0 | 27 tests, 114 assertions, 0 failures; 6 of 28 namespaces, posture pin green — the trace change stays elided |
| `npm run test:cljs` | `cljs-tests` / consolidated `:node-test` | 0 | 12051 tests, 60086 assertions, 0 failures |
| all 43 `check_*` scripts CI invokes (lint.yml, test.yml, docs.yml), in their CI form | `lint` / `docs` / `verify-readme-links` | 0 each, 43 of 43 | includes `check_test_lane_bijection.py` and `check_jvm_lane_rosters.py`, which grade the new test namespace; no roster entry was needed |

Gate-read-my-tree evidence: `scripts/test-epoch-prod-gate.sh` prints `gate root:` naming this worktree; the CLJS bundle's loader hard-codes this worktree's `.shadow-cljs` path; and the flows/epoch JVM gates went red on a fault planted only here. The new CLJS coverage was confirmed compiled rather than assumed — both new namespaces' assertion strings are present in `.shadow-cljs/builds/node-test/dev/out/cljs-runtime`, beside an existing rf2-e0g2 control string, with a nonsense probe reading 0.

No spec page, doc or markdown was touched, so `check_doc_slugs.py` and `check_readme_links.py` grade nothing of mine — they were run anyway and are green.

## Not built, and why

- **rf2-gwye.63** asked for the fence to cover "at least the computed trace"; it covers the whole pass, which was the bead's own preference. Nothing else was suggested.
- **rf2-fzbj.19 AC5** (Pair's cascade attachment describes the replayed dispatch) is discharged by direct record correlation, which the criterion names as sufficient. `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` is held by another worker and is untouched; it needs no change, because it resolves whatever `:epoch-id` the result carries and that id is now the right one.
- **rf2-fzbj.19 AC3/AC4** (rf2-e0g2 queued-child controls, missing-required-cofx propagation, observation cleanup, incomplete-input refusal, ordinary replay) are existing tests and all still pass; no new coverage was added for them.
- No new public hook, scheduler, event, per-flow owner registry, transaction system, gate or retention change — none is needed by either repair.

Closes rf2-gwye.63. Closes rf2-fzbj.19.
