### PR TITLE
fix(tools): refuse a column-dropping editor launch; honour the browser-proof timeout (rf2-fzbj.32, rf2-fzbj.33)

### DIFF
--- a/tools/template/test-support/page-boot-proof.cjs
+++ b/tools/template/test-support/page-boot-proof.cjs
@@ -253,6 +253,13 @@ function diagnose(lines) {
             val.textContent.trim().length > 0
           );
         },
+        // `waitForFunction(pageFunction, arg, options)` — the ARG slot is
+        // second and the options third, so an options object passed second is
+        // serialised into the page as an argument the callback never reads,
+        // options stays empty, and the wait silently takes Playwright's
+        // 30-second default instead of the configured budget. Nothing errors;
+        // a page that mounts late just passes.
+        undefined,
         { timeout: TIMEOUT_MS },
       );
     } catch (waitErr) {
@@ -294,6 +301,7 @@ function diagnose(lines) {
     await page.click('#app button');
     await page.waitForFunction(
       () => (document.querySelector('#app span').textContent || '').trim() === '1',
+      undefined, // the ARG slot — see the mount wait above.
       { timeout: TIMEOUT_MS },
     );
 

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -720,6 +720,132 @@
           (when (and @clojure-cli-available? @node-available?)
             (compile-and-run-emitted-test! :uix {}))))))
 
+;; ---------------------------------------------------------------------------
+;; The driver's own timeout contract
+;; ---------------------------------------------------------------------------
+;;
+;; Every proof above hands the driver a deadline, and
+;; `run-broken-boot-witness!` hands it a deliberately SHORT one so its
+;; intentional failure is cheap. That only works if the driver honours it.
+;;
+;; Playwright's signature is `waitForFunction(pageFunction, arg, options)`, so
+;; a `{timeout}` object passed SECOND is serialised into the page as an
+;; argument the callback never reads, `options` stays empty, and the wait
+;; takes the library's 30-second default. Nothing errors and nothing is
+;; logged: a page that mounts or reacts late simply passes, and the witnesses
+;; above burn 30 s apiece where they asked for 8. `page.goto` takes its
+;; options correctly, which is what made the variable look partly effective.
+;;
+;; The fixtures below are hand-written HTML rather than an emitted scaffold:
+;; what is under test is the DRIVER, so the page has to be able to fail on
+;; demand, which a healthy generated page cannot. Each defines the two globals
+;; the dev-mode bundle check reads (tooth 3) so the run reaches the wait under
+;; test rather than tripping over the shape check.
+
+(def ^:private timeout-fixture-budget-ms
+  "The configured budget the two failing fixtures are run under. Its exact
+  value is the ASSERTION — the driver's failure must name this number and not
+  Playwright's default — so it is deliberately nothing like 30000."
+  1000)
+
+(defn ^:private timeout-fixture-page
+  "A whole `index.html` for one fixture. `body` is the `#app` subtree and
+  `script` whatever behaviour the case needs beyond the bundle-shape globals."
+  [title body script]
+  (str "<meta charset=\"utf-8\">\n"
+       "<title>" title "</title>\n"
+       "<div id=\"app\">" body "</div>\n"
+       "<script>window.goog = {}; window.cljs = {};\n" script "</script>\n"))
+
+(def ^:private timeout-fixtures
+  "One entry per wait the driver makes. `:expect-timeout?` false is the
+  control: the same short budget must still let a responsive page pass, or
+  `exit 1` would prove nothing but that 1000 ms is too little for anything."
+  [{:name            "never-mounts"
+    :wait            "the MOUNT wait"
+    :expect-timeout? true
+    :page            (timeout-fixture-page "never-mounts" "" "")}
+   {:name            "dead-click"
+    :wait            "the CLICK wait"
+    :expect-timeout? true
+    :page            (timeout-fixture-page
+                       "dead-click"
+                       "<h1>dead click</h1><button>+1</button><span>0</span>"
+                       "")}
+   {:name            "responsive"
+    :wait            "both waits (control)"
+    :expect-timeout? false
+    :page            (timeout-fixture-page
+                       "responsive"
+                       "<h1>responsive</h1><button>+1</button><span>0</span>"
+                       (str "document.querySelector('#app button')"
+                            ".addEventListener('click', function () {\n"
+                            "  document.querySelector('#app span').textContent = '1';\n"
+                            "});\n"))}])
+
+(defn ^:private run-timeout-fixture!
+  "Materialise one fixture as a `resources/public/index.html` and run the real
+  driver over it under `timeout-fixture-budget-ms`. Returns the driver's
+  {:exit :out}."
+  [^java.io.File root {:keys [name page]}]
+  (let [tmp  (tmp-dir (str "rf2-template-proof-timeout-" name "-"))
+        proj (.toFile tmp)]
+    (try
+      (let [public (io/file proj "resources/public")]
+        (.mkdirs public)
+        (spit (io/file public "index.html") page)
+        (run-boot-proof-driver!
+          root proj name :dev
+          {"RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS" (str timeout-fixture-budget-ms)}))
+      (finally (delete-recursively tmp)))))
+
+(deftest boot-proof-honours-the-configured-timeout-test
+  (testing "RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS governs the driver's mount
+            and click waits, not merely its page load"
+    (if-not @emitted-tests-enabled?
+      (skip-if-disabled! "the boot proof's own timeout contract")
+      (if-not @node-available?
+        (do (announce-browser-skip! "the boot proof's timeout contract"
+                                    "`node` is not on PATH")
+            (is true "`node` unavailable — skipping the driver timeout contract"))
+        (doseq [{:keys [name wait expect-timeout?] :as fixture} timeout-fixtures]
+          (testing (str name " — " wait)
+            (let [{:keys [exit out]} (run-timeout-fixture! (repo-root) fixture)
+                  budget-named       (str "Timeout " timeout-fixture-budget-ms "ms exceeded")]
+              (cond
+                (and (= 2 exit) (not @browser-proofs-required?))
+                (do (announce-browser-skip! (str "driver timeout contract — " name) out)
+                    (is true (str "Chromium unavailable — " name " did not run")))
+
+                (= 2 exit)
+                (is false
+                    (str "the driver timeout contract did NOT run for " name
+                         ": Chromium was not launchable and `CI` is set. Output:\n" out))
+
+                expect-timeout?
+                (do (is (= 1 exit)
+                        (str name " must FAIL: " wait " can never be satisfied on this "
+                             "page. Output:\n" out))
+                    ;; The verdict, and the whole point. An exit 1 alone is
+                    ;; earned either way — with the options object in the arg
+                    ;; slot the driver still fails, 30 seconds later, naming
+                    ;; Playwright's default. It is the NUMBER that says whose
+                    ;; deadline was in force.
+                    (is (string/includes? out budget-named)
+                        (str "the driver must name the CONFIGURED budget ("
+                             budget-named "). Naming 30000ms instead means the "
+                             "timeout reached Playwright as a page ARGUMENT "
+                             "rather than as an option, and every wait in this "
+                             "file is running unbounded by the value it asked "
+                             "for. Output:\n" out)))
+
+                :else
+                (is (zero? exit)
+                    (str "CONTROL — a page that mounts and reacts immediately must "
+                         "still PASS under the same short budget, or the two "
+                         "verdicts above prove only that " timeout-fixture-budget-ms
+                         "ms is too little for any page. Output:\n" out))))))))))
+
 ;; ===========================================================================
 ;; The setup skill's default scaffold — derivation lock + black-box fixture
 ;; ===========================================================================

--- a/tools/testbed-support/spec/README.md
+++ b/tools/testbed-support/spec/README.md
@@ -87,6 +87,15 @@ fall-through is declined with 422 `editor-position-unsupported`, and the
 browser's `editor://` fallback — which does carry the position — opens the file
 at the right place instead.
 
+The whole coordinate, not most of it. Some cases `launch-editor` *does* encode
+carry the line and discard the column: `gvim` and `joe` are launched with
+`+<line>`, `rmate`/`mate`/`mine` with `--line <line>`. None of those is a
+bare-file launch, so the fall-through test above cannot see them — a request
+asking for 27:9 would land on line 27, column 1, behind a 200. A request that
+asks for a **column** the chosen binary would not carry is therefore declined
+the same way, while the same binary still serves a request that asks only for a
+line, because that coordinate does arrive.
+
 Two routes answer that question, because the endpoint does not always choose
 the binary:
 
@@ -99,16 +108,21 @@ the binary:
   it picks a binary from the running process list, and that list reaches
   editors with no position case (Brackets on every platform; on Windows also
   `Cursor.exe`, whose capitalised process name the lowercase `cursor` case does
-  not match). The launch shim therefore asks `get-args.js` itself what it would
-  emit before launching, and declines the same way if the coordinate would be
-  dropped. A nil preference then falls back to the default `vscode://` scheme,
-  and a `{:custom …}` preference to its own template — which auto-detect had
-  been ignoring.
+  not match) — and editors with a *partial* one, `gvim` being in the Linux
+  process registry. The launch shim therefore asks `get-args.js` itself what it
+  would emit before launching, and declines the same way if any requested
+  component would be dropped: the argv for the bare file, or — when a column
+  was asked for — an argv that does not move when the column does. Neither
+  test names an editor, so a `launch-editor` release that learns one lifts its
+  decline with no edit here. A nil preference then falls back to the default
+  `vscode://` scheme, and a `{:custom …}` preference to its own template —
+  which auto-detect had been ignoring.
 
 A request carrying no line or column is not declined for position support:
 there is no position to lose, and classpath resolution is worth having. The
-ordinary admission, file and launch checks still apply. Editors whose position
-`launch-editor` does encode are unaffected and keep preferring the endpoint.
+ordinary admission, file and launch checks still apply. Editors that carry
+every component the request asked for are unaffected and keep preferring the
+endpoint.
 
 ## Endpoint wire contract
 

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -144,11 +144,27 @@
   ;; So the probe asks the dependency instead of predicting it: resolve the
   ;; editor with the same `guessEditor` the launch will use, then ask
   ;; `getArgumentsForPosition` what it would emit for a sentinel filename.
-  ;; `get-args.js` interpolates the position into every case it encodes and
-  ;; falls through to `return [fileName]` for the rest, so an argv that is the
-  ;; sentinel ALONE is exactly the documented drop — no editor list here to
-  ;; keep in step with the dependency, and a future release that learns an
-  ;; editor's position syntax lifts the decline with no edit.
+  ;; `get-args.js` falls through to `return [fileName]` for every command it
+  ;; has no case for, so an argv that is the sentinel ALONE is exactly the
+  ;; documented TOTAL drop — no editor list here to keep in step with the
+  ;; dependency, and a future release that learns an editor's position syntax
+  ;; lifts the decline with no edit.
+  ;;
+  ;; A CASE IT DOES ENCODE CAN STILL DROP HALF THE COORDINATE, which is why
+  ;; the bare-file test is not the whole question. `gvim` and `joe` return
+  ;; `['+<line>', file]` and `rmate`/`mate`/`mine` return `['--line', <line>,
+  ;; file]`: the line survives, the COLUMN is discarded, and the argv is not
+  ;; the bare file, so the test above passes it. All five are reachable by
+  ;; auto-detect — `gvim` sits in the Linux process registry — so a source
+  ;; chip carrying 27:9 would land on line 27 column 1 behind a 200 that
+  ;; suppressed the coordinate-preserving `editor://` fallback.
+  ;;
+  ;; The second probe therefore asks a DIFFERENTIAL question rather than
+  ;; enumerating those five: hold the sentinel file and the line fixed, vary
+  ;; only the column, and compare the two argvs. An editor that encodes the
+  ;; column cannot emit the same argv for two different ones; an editor that
+  ;; discards it cannot emit anything else. Like the test above it names no
+  ;; editor, so a release that learns a column lifts its decline with no edit.
   ;;
   ;; Auto-detect is therefore scanned twice on this path (once here, once
   ;; inside `launchEditor`). The resolved binary cannot be handed back as
@@ -188,6 +204,14 @@
        "var ed=guess(e)[0];"
        "var a=ed?getArgs(ed,'F',line||1,col||1):null;"
        "if(a&&a.length===1&&a[0]==='F'){"
+       "process.exit(" position-unsupported-exit ");}"
+       ;; The column differential. Only a request that ASKS for a column can
+       ;; lose one, so a line-only launch to `gvim` is still served — its
+       ;; coordinate arrives intact. The two sentinel columns are arbitrary
+       ;; and need only differ; the line is held at the value actually being
+       ;; launched so the probe answers about that coordinate and not another.
+       "if(a&&col&&JSON.stringify(getArgs(ed,'F',line||1,3))==="
+       "JSON.stringify(getArgs(ed,'F',line||1,4))){"
        "process.exit(" position-unsupported-exit ");}}"
        "l(f,e,function(file,msg){"
        "process.stderr.write('launch-editor: '+(msg||'no editor found')+'\\n');"

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -1246,14 +1246,20 @@
 (def ^:private dependency-probe-script
   "Ask the INSTALLED `launch-editor` what it would do — the same two questions
   `launch-shim` asks, put to the same two modules. Emits `key<TAB><json>` per
-  line. `F` is a sentinel filename: `get-args.js` interpolates the position
-  into every case it encodes and falls through to `return [fileName]` for the
-  rest, so an argv of the sentinel ALONE is exactly the documented drop."
+  line. `F` is a sentinel filename: `get-args.js` falls through to
+  `return [fileName]` for every command it has no case for, so an argv of the
+  sentinel ALONE is exactly the documented TOTAL drop."
   (str "var g=require('launch-editor/guess');"
        "var a=require('launch-editor/get-args');"
        "function say(k,v){process.stdout.write(k+'\\t'+JSON.stringify(v)+'\\n');}"
        "['code','code-insiders','cursor','zed','idea','windsurf'].forEach("
        "function(c){say(c,a(c,'F',27,9));});"
+       ;; The PARTIAL-drop class: cases `get-args.js` DOES encode, which carry
+       ;; the line and discard the column. Neither is the bare file, so the
+       ;; total-drop test cannot see them — this is what the shim's column
+       ;; differential is for. Two shapes, one probe each.
+       "say('gvim',a('gvim','F',27,9));"
+       "say('rmate',a('rmate','F',27,9));"
        ;; The auto-detect class: names that appear in the process registries
        ;; but not in the get-args switch.
        "say('brackets',a('Brackets','F',27,9));"
@@ -1293,7 +1299,7 @@
       (let [probe (run-dependency-probe)]
         (testing "the probe returned the keys it was asked for (a silently
                   empty map must not read as a pass)"
-          (is (= 11 (count probe)) "every probed key came back")
+          (is (= 13 (count probe)) "every probed key came back")
           (is (contains? probe "windsurf")))
 
         (testing "every command this endpoint DECLARES position-blind really is
@@ -1314,7 +1320,24 @@
               (is (not= "[\"F\"]" argv)
                   (str cmd " is not a bare-file launch"))
               (is (str/includes? argv "27")
-                  (str cmd " argv carries the requested line")))))
+                  (str cmd " argv carries the requested line"))
+              ;; The COLUMN, not merely the line. `gvim` below shows the two
+              ;; are separate promises: a case can encode one and drop the
+              ;; other, so an argv that merely differs from `["F"]` and
+              ;; carries a line proves nothing about the column the caller
+              ;; asked for.
+              (is (str/includes? argv "9")
+                  (str cmd " argv carries the requested COLUMN")))))
+
+        (testing "PARTIAL DROP — cases the dependency DOES encode, which carry
+                  the line and discard the column. Neither is a bare-file
+                  launch, so the check above passes them; this is the premise
+                  the shim's column differential rests on, and a release that
+                  learns either editor's column makes it red"
+          (is (= "[\"+27\",\"F\"]" (get probe "gvim"))
+              "gvim gets the line as `+27` and no column at all")
+          (is (= "[\"--line\",27,\"F\"]" (get probe "rmate"))
+              "rmate gets `--line 27` and no column at all"))
 
         (testing "AUTO-DETECT reaches position-blind binaries the declared set
                   cannot name — the audit's finding. Brackets is in all three
@@ -1392,6 +1415,33 @@
                       exist) but NOT as the decline, so widening the gate did
                       not turn column-only into a blanket refusal"
               (let [{:keys [ok message]} (rf.testbed.open-in-editor-server/launch! f nil 7 "nonexistent-dir/zed")]
+                (is (false? ok) "the nonexistent binary could not be launched")
+                (is (not= rf.testbed.open-in-editor-server/position-unsupported-error message)
+                    "…and it was a launch failure, not a capability refusal")))
+
+            ;; PARTIAL position loss. Every case above turns on a command
+            ;; `get-args.js` has NO case for, whose argv is the bare file.
+            ;; `gvim` has a case — `['+<line>', file]` — so its argv is not
+            ;; the bare file and the total-drop test waves it through, while
+            ;; the COLUMN is gone. It is reachable by auto-detect (the Linux
+            ;; process registry maps a running `gvim` to it), so a 27:9 chip
+            ;; landed on column 1 behind a 200 that suppressed the
+            ;; coordinate-preserving `editor://` fallback.
+            (testing "COLUMN DROPPED BY AN ENCODED CASE: gvim carries the line
+                      and discards the column, so a request that asks for one
+                      is declined on the same terms as a total drop"
+              (is (= {:ok false :message rf.testbed.open-in-editor-server/position-unsupported-error}
+                     (rf.testbed.open-in-editor-server/launch! f 27 9 "nonexistent-dir/gvim"))
+                  "line 27 would arrive, column 9 would not — a 200 here would claim both did")
+              (is (= {:ok false :message rf.testbed.open-in-editor-server/position-unsupported-error}
+                     (rf.testbed.open-in-editor-server/launch! f nil 9 "nonexistent-dir/gvim"))
+                  "a column with no line normalises to 1:9, and the 9 is still lost"))
+
+            (testing "PARTIAL-DROP POSITIVE CONTROL — the SAME command with a
+                      LINE ALONE still reaches the launcher, because the
+                      coordinate it asked for survives. This is what keeps the
+                      differential a column question rather than a gvim ban"
+              (let [{:keys [ok message]} (rf.testbed.open-in-editor-server/launch! f 27 nil "nonexistent-dir/gvim")]
                 (is (false? ok) "the nonexistent binary could not be launched")
                 (is (not= rf.testbed.open-in-editor-server/position-unsupported-error message)
                     "…and it was a launch failure, not a capability refusal")))))))))


### PR DESCRIPTION
Two surface-review findings, in disjoint tool trees. Both were re-verified at tip
before being fixed, and both were reproduced in this worktree with the real
dependency rather than taken from the review's prose.

## rf2-fzbj.32 (P2) — an editor launch that drops the requested COLUMN was reported as success

`launch-shim`'s capability probe asked one question: is the argv the BARE FILE?
That catches the total drop, because `get-args.js` falls through to
`return [fileName]` for every command it has no case for. It does not catch a
case it DOES encode which carries only half the coordinate. `gvim` and `joe` are
launched with `['+<line>', file]`, `rmate`/`mate`/`mine` with
`['--line', <line>, file]`: the line survives, the column is discarded, and the
argv is not the bare file, so the probe passed it.

`gvim` sits in `launch-editor`'s Linux process registry, so auto-detect reaches
it with no editor hint at all — the route the client takes for a nil preference
and for `{:custom …}`. A source chip carrying 27:9 then landed on line 27,
column 1, behind a 200 — and the 200 is what suppresses the
coordinate-preserving `editor://` fallback that would have opened the file in the
right place. `tools/testbed-support/spec/README.md` has always said a 200 means
the whole coordinate arrived.

**The fix** adds a second probe that asks a DIFFERENTIAL question rather than
enumerating those five commands: hold the sentinel file and the line fixed, vary
only the column, and compare the two argvs. An editor that encodes the column
cannot emit the same argv for two different ones; an editor that discards it
cannot emit anything else. Like the bare-file test it names no editor, so a
`launch-editor` release that learns a column lifts its own decline with no edit
here. Only a request that ASKS for a column can lose one, so a line-only launch
to `gvim` is still served.

`spec/README.md` gains the partial-drop case, which its mechanism paragraph did
not describe.

### Verified at tip, not taken from the review

- `implementation/node_modules/launch-editor/get-args.js` at the pinned 2.14.1
  reads `case 'joe': case 'gvim': return ['+' + lineNumber, fileName]` and
  `case 'rmate': … return ['--line', lineNumber, fileName]`.
- The pre-fix predicate was still `a.length===1 && a[0]==='F'`.
- The finding's own cited closure, rf2-1i1ec, is CLOSED and is a different
  defect (a probe that did not RUN for a column-only request); this one is a
  probe that runs and accepts a line-only argv.

## rf2-fzbj.33 (P3) — the configured browser-proof timeout governed neither wait

Playwright's signature is `waitForFunction(pageFunction, arg, options)`. Both of
the driver's waits passed `{timeout: TIMEOUT_MS}` as the SECOND argument, so it
was serialised into the page as an argument neither callback reads, `options`
stayed empty, and each wait took the library's 30-second default. Nothing errors
and nothing is logged. `page.goto` takes its options correctly, which is what
made `RF2_TEMPLATE_BROWSER_PROOF_TIMEOUT_MS` look partly effective.

Two consequences: a custom budget could not fail a late mount or a late click,
and the deliberately broken boot/click witnesses — which ask for 8 s precisely so
their intentional failure is cheap — waited 30 s apiece.

**The fix** is `undefined` in the arg slot at both sites. No new option, no
timeout framework, no generator change.

## Regression tests — each shown RED against the pre-fix code, then green

Both plants were restored and the restore verified by comparing
`git hash-object` against the committed **blob** hash from `git rev-parse HEAD:<path>`
(match on the default form for all three files; `git diff --quiet HEAD -- <path>`
exit 0 beside it).

**rf2-fzbj.32** — `open_in_editor_server_test.clj` gains gvim `[27 9]` and
`[nil 9]` as refusals in the existing real-node decline block, with gvim
`[27 nil]` as the control that keeps this a column question rather than a gvim
ban. The real-package probe now pins the partial-drop premise (gvim, rmate)
beside the total-drop one, and the vocabulary assertion checks the COLUMN
survives and not only the line (the finding's acceptance criterion 3 — it
checked for line 27 and never for column 9).

With the differential predicate replaced by `if(false)`, the suite went
**exit 1, 2 failures / 337 assertions**, both of them the new gvim refusals, and
the actual value was `{:ok false, :message "launch-editor: (code 1)."}` — i.e.
the launch was ATTEMPTED rather than declined, which is the finding. Restored:
**exit 0, 47 tests / 337 assertions**.

**rf2-fzbj.33** — a new gated deftest materialises three hand-written fixtures (a
page that never mounts, a page whose click is dead, and a responsive control) and
runs the real driver over each under a 1000 ms budget. Exit 1 alone proves
nothing, because the broken driver also fails — just 30 seconds later — so the
assertion is that the failure NAMES the configured number. The control is what
keeps the two verdicts from meaning only that 1000 ms is too little for any page.
The fixtures are hand-written rather than emitted because what is under test is
the driver, and a healthy generated page cannot fail on demand.

With the `undefined` removed from both argument lists, the test went **exit 1, 2
failures / 5 assertions**, both reading `Timeout 30000ms exceeded` where the
configured budget was 1000 ms. Restored: **exit 0, 1 test / 5 assertions**.

The same discrimination was measured outside the JVM harness first, running the
checked-in driver directly against the same three pages: pre-fix
`Timeout 30000ms exceeded` on both failing pages, post-fix
`Timeout 1000ms exceeded`, healthy control exit 0 both ways.

## Quality gates

All run in this worktree, each captured with the redirect and the exit echo on
one command line, and all re-run after the rebase onto the current trunk.

| Gate | CI job | Exit | Result |
|---|---|---|---|
| `tools/testbed-support` `clojure -M:test`, `RF2_REQUIRE_NODE_PROBES=1` | `jvm-tools-testbed-support` | 0 | 47 tests / 337 assertions |
| `tools/template` `clojure -M:test` (emitted tier off) | `jvm-tools-template` | 0 | 43 tests / 320 assertions |
| `tools/template` new timeout deftest, `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` | `jvm-tools-template` | 0 | 1 test / 5 assertions |
| `scripts/check_doc_slugs.py` | `verify-readme-links` | 0 | silent pass |
| `scripts/check_readme_links.py --ci` | `verify-readme-links` | 0 | silent pass |
| ESLint over the whole JS corpus | `eslint` (lint.yml) | 0 | 0 errors; 2 pre-existing warnings in files not touched here |
| clj-kondo `--lint tools/template/src --lint tools/template/test` | `clj-kondo` (lint.yml) | 0 | 0 errors, 0 warnings |
| Splint over `tools/testbed-support` + `tools/template` | `splint` (lint.yml) | 0 | style warnings only, no parse errors |
| `scripts/check_retired_spellings.py` | lint.yml ratchets | 0 | |
| `scripts/check_retired_composition_vocab.py` | lint.yml ratchets | 0 | |
| `scripts/check_retired_image_keys.py` | lint.yml ratchets | 0 | |
| `scripts/check-ai-tracking-ratchet.sh` | `check-ai-tracking-ratchet` | 0 | nothing under `ai/` tracked |

`clj-kondo`'s `--lint` list does not include `tools/testbed-support`; Splint's
`../tools` does, so both `.clj` files are covered.

**Which tree each gate read.** The two JVM gates and the doc gate print no root,
so the proof is the red from a planted fault: each went red on a fault that
existed only in this worktree, and green again once restored. The doc gate was
exercised the same way — a broken anchor planted in
`tools/testbed-support/spec/README.md` returned
`BROKEN ANCHOR: tools\testbed-support\spec\README.md:90 -> #toolsup-a-planted-fault`,
exit 1.

**Checked by hand, because no gate covers it.** Nothing validates markdown prose,
tables or fence contents. The `spec/README.md` edits add prose only — no new
heading, no table row, no fenced block, and no new link — so the existing wire
contract table is untouched and its column counts are unchanged. The anchors and
link targets on that page were confirmed by `check_doc_slugs.py` above.

**Not run here, relied on from CI.** The full emitted-app tier
(`RF2_TEMPLATE_RUN_EMITTED_TESTS=1` across every deftest) needs a cold
shadow-cljs compile plus an `:advanced` release per substrate; `jvm-tools-template`
provisions both and runs it. The public-API manifest drift check is unaffected —
this change adds and removes no public var (`launch-shim` is private; the
vocabulary, the declared position-blind set and both error constants are
untouched).

## Findings recorded rather than built

- The review's optional suggestion to broaden the shim into general editor
  support, or to add a second launcher, was declined in the finding itself and is
  not built here.
- A symmetric LINE differential was considered and not built: the existing
  bare-file test already covers every line-dropping branch the pinned dependency
  has, so a second differential would be speculative generality.
- No wall-clock assertion was added to the template test. Measured on this box,
  the same healthy fixture took 19 s on a cold Chromium and 1 s warm, so elapsed
  time cannot discriminate; the failure message naming the configured number can,
  and does so deterministically.

Beads: rf2-fzbj.32, rf2-fzbj.33. Both fzbj beads carry exactly one confirmed
finding each, and both are fixed here. No `rf2-gwye.N` child covers either
surface (the only two open gwye children are the reagent pair).

No AI attribution trailers are included: `CLAUDE.md` § Git Conventions forbids
them and outranks the session-level harness reminder that asks for them.
