### PR TITLE
Pair skill: retire :errors listener-stream claim; reagent-slim: pin subscribe-container activation (rf2-byu8, rf2-59cz)

### DIFF
--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_subscribe_container_activation_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_subscribe_container_activation_cljs_test.cljs
@@ -1,0 +1,172 @@
+(ns re-frame.adapter.reagent-slim-subscribe-container-activation-cljs-test
+  "reagent-slim adapter — `subscribe-container` on a DERIVED container
+  activates it (rf2-59cz; the slim twin of
+  `re-frame.adapter-subscribe-container-activation-cljs-test`).
+
+  THE FIX IS SHARED; ONLY THE ASSERTION IS PER-ADAPTER. rf2-gwye.47 / PR
+  #9768 landed one repair, `re-frame.substrate.spine/activating-subscribe-
+  container`, wired in `make-ratom-adapter` rather than in
+  `make-ratom-spine` — that is where the substrate's `:activate-reaction!`
+  op arrives, so stock Reagent and reagent-slim share one subscription
+  algorithm with no edit in either adapter namespace. reagent-slim injects
+  `:activate-reaction! reagent2.ratom/activate!` and was therefore fixed by
+  that PR without a line of slim-side code. Nothing in this tree PINNED it,
+  so a change to the shared helper could regress reagent-slim silently while
+  the stock-Reagent suite stayed green. This namespace closes that.
+
+  Spec 006 §`make-derived-value` requires PUSH: the derived container updates
+  automatically when a source changes, and `subscribe-container` \"works as on
+  a base container\". §*Watchable is necessary, not sufficient* then makes the
+  placement normative — a substrate on a demand-driven host activates the node
+  when an observer ATTACHES, immediately before installing that observer's
+  watch and taking its baseline read.
+
+  reagent2's `Reaction` is demand-driven exactly as stock's is: it learns its
+  sources only through `deref-capture`, and `-deref` outside `*ratom-context*`
+  with no `auto-run` runs the body RAW and leaves `watching` nil, so `_queued-
+  run`'s `(some? watching)` guard means `flush!` moves nothing and a bare
+  `add-watch` is registered and can never fire. `reagent2.ratom/activate!` is
+  the rewrite's name for the capture run (stock spells it `reagent.ratom/run`
+  behind `IRunnable`). Component-owned subscriptions never meet the hole
+  because a render IS the capture context — which is why the slim mounted-view
+  suites cannot pin this contract. These tests therefore use the adapter's
+  container slots DIRECTLY: no component, no ratom context, and no manual
+  `ratom/activate!` in any test body.
+
+  Divergence from the stock twin, and it is only this: the settle step is
+  `reagent2.ratom/flush!` — the rewrite's synchronous reaction-queue drain —
+  in place of `reagent.core/flush`. Same six pins, same values.
+
+  Pins:
+
+    * direct listener on a fresh derived container fires (no baseline read)
+    * direct listener fires when a baseline read preceded the attach
+    * a second observer over an already-active node forces no extra recompute,
+      and removing one observer leaves the other live
+    * final detach releases the source watch (the node stops recomputing)
+    * base-container listeners keep working; cancellation is idempotent
+    * a multi-input derived keeps native batching (one notification per
+      flush, not one per source write)"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent2.ratom :as ratom]
+            [re-frame.adapter.reagent-slim :as rf.adapter.reagent-slim]))
+
+(def ^:private A rf.adapter.reagent-slim/adapter)
+
+(defn- source [v] ((:make-state-container A) v))
+(defn- derive* [sources f] ((:make-derived-value A) sources f))
+(defn- write! [c v] ((:replace-container! A) c v))
+(defn- read* [c] ((:read-container A) c))
+(defn- observe [c on-change] ((:subscribe-container A) c on-change))
+
+;; reagent2's Reaction flush queue is process-global. Drain it after each test
+;; so a source write that enqueued a watching Reaction cannot leak a stale
+;; recompute into a later suite sharing this node process — the same hygiene
+;; the sibling `reagent-slim-derived-container-replaced` suite keeps.
+(use-fixtures :each (fn [test-fn]
+                      (try (test-fn)
+                           (finally (ratom/flush!)))))
+
+(defn- recorder
+  "Return `[events-atom on-change]`; `on-change` conjes `[prev new]`."
+  []
+  (let [events (atom [])]
+    [events (fn [prev nu] (swap! events conj [prev nu]))]))
+
+(deftest slim-direct-derived-listener-fires-without-baseline-read-cljs-test
+  (testing "attach-then-write on a never-read derived container notifies"
+    (let [s              (source 1)
+          d              (derive* [s] (fn [v] (* 10 v)))
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (write! s 2)
+      (ratom/flush!)
+      (is (= [[10 20]] @events)
+          "observer attached to a fresh derived container hears the source change")
+      (unsub))))
+
+(deftest slim-direct-derived-listener-fires-after-baseline-read-cljs-test
+  (testing "a read before the attach does not suppress the notification"
+    (let [s              (source 1)
+          d              (derive* [s] (fn [v] (* 10 v)))
+          _              (is (= 10 (read* d)) "baseline read")
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (is (= [] @events) "attaching alone notifies nobody")
+      (write! s 2)
+      (ratom/flush!)
+      (is (= [[10 20]] @events) "the baseline-read node still hears the change")
+      (unsub))))
+
+(deftest slim-direct-derived-two-observers-share-one-activation-cljs-test
+  (testing "the second observer forces no extra recompute; detaching one leaves the other live"
+    (let [computes       (atom 0)
+          s              (source 1)
+          d              (derive* [s] (fn [v] (swap! computes inc) (* 10 v)))
+          [ev-a notify-a] (recorder)
+          [ev-b notify-b] (recorder)
+          unsub-a        (observe d notify-a)
+          after-first    @computes
+          unsub-b        (observe d notify-b)]
+      (is (= 1 after-first) "attaching the first observer activates once")
+      (is (= 1 @computes) "attaching a second observer over a live node recomputes nothing")
+      (write! s 2)
+      (ratom/flush!)
+      (is (= 2 @computes) "one source write, one recompute")
+      (is (= [[10 20]] @ev-a))
+      (is (= [[10 20]] @ev-b) "both observers hear the same change")
+      (unsub-a)
+      (write! s 3)
+      (ratom/flush!)
+      (is (= [[10 20]] @ev-a) "the cancelled observer hears nothing further")
+      (is (= [[10 20] [20 30]] @ev-b) "the surviving observer is still live")
+      (unsub-b))))
+
+(deftest slim-direct-derived-final-detach-releases-source-watch-cljs-test
+  (testing "after the last observer cancels, source writes no longer drive the node"
+    (let [computes       (atom 0)
+          s              (source 1)
+          d              (derive* [s] (fn [v] (swap! computes inc) (* 10 v)))
+          [events notify] (recorder)
+          unsub          (observe d notify)]
+      (write! s 2)
+      (ratom/flush!)
+      (is (= [[10 20]] @events))
+      (let [before @computes]
+        (unsub)
+        (unsub)                                        ; idempotent
+        (write! s 3)
+        (ratom/flush!)
+        (is (= before @computes)
+            "the detached node is off the push path — no recompute on a source write")
+        (is (= [[10 20]] @events) "and no notification")))))
+
+(deftest slim-direct-base-container-listener-unaffected-cljs-test
+  (testing "base containers keep their plain watch semantics (the control)"
+    (let [s              (source 1)
+          [events notify] (recorder)
+          unsub          (observe s notify)]
+      (write! s 2)
+      (is (= [[1 2]] @events) "base container notifies synchronously on write")
+      (unsub)
+      (unsub)                                          ; idempotent
+      (write! s 3)
+      (is (= [[1 2]] @events) "cancelled base-container observer hears nothing"))))
+
+(deftest slim-direct-derived-multi-input-retains-batching-cljs-test
+  (testing "two source writes before one flush coalesce into a single notification"
+    (let [computes       (atom 0)
+          a              (source 1)
+          b              (source 2)
+          d              (derive* [a b] (fn [x y] (swap! computes inc) (+ x y)))
+          [events notify] (recorder)
+          unsub          (observe d notify)
+          after-attach   @computes]
+      (write! a 10)
+      (write! b 20)
+      (ratom/flush!)
+      (is (= [[3 30]] @events)
+          "one coalesced notification carrying the settled value, not one per write")
+      (is (= (inc after-attach) @computes)
+          "one recompute for the pair — native batching is preserved")
+      (unsub))))

--- a/skills/re-frame2-pair/references/errors.md
+++ b/skills/re-frame2-pair/references/errors.md
@@ -61,7 +61,7 @@ Every `:rf.error/*` trace event carries `:rf.trace/trigger-handler` — `{:kind 
 
 ## Error observability
 
-Errors are not steered by app policy — recovery is framework-owned (the per-category typed default: frame-destroyed recovers + emits, sub-exception returns `nil`, handler-exception fails loud without crashing the app). Observability is the always-on `:errors` stream of `rf/register-listener!`, whose payload is an **error-keyed union of several record shapes**:
+Errors are not steered by app policy — recovery is framework-owned (the per-category typed default: frame-destroyed recovers + emits, sub-exception returns `nil`, handler-exception fails loud without crashing the app). Observability rides the always-on error-emit substrate, which carries **no public registration verb**: rf2-kuky.69 retired the `:errors` and `:events` streams from `rf/register-listener!`, whose vocabulary is now exactly `#{:trace :epoch}`. The production door is the frame-owned `:observability :errors` sink — declared on the frame's `make-frame` / `frame-root` config or once per process with `(rf/configure! {:observability …})`, and wired with `rf/register-observability-sink!` — which hands the sink an **already-projected** record. The underlying record is an **error-keyed union of several record shapes**:
 
 - per-event error record `{:error :event :event-id :frame :time :exception :elapsed-ms}` (plus `:source-coord` for macro-registered handlers), fanned out per production-reachable `:rf.error/*`;
 - frame-teardown report `{:error :rf.error/frame-teardown-failed :frame :hook-failures :reason :recovery :time}` — one bounded record per destroy whose cleanup hooks threw (EP-0008);


### PR DESCRIPTION
Two small, independent residue items, on disjoint surfaces.

## rf2-byu8 — pair skill still taught the retired `:errors` listener stream

`skills/re-frame2-pair/references/errors.md` said error observability is "the always-on `:errors` stream of `rf/register-listener!`". rf2-kuky.69 retired the `:errors` and `:events` members. At source, `listener-streams` in `implementation/core/src/re_frame/core.cljc` is now exactly `#{:trace :epoch}`, and the runtime refuses anything else with `:rf.error/unknown-listener-stream`. The sentence now points at the production door: the frame-owned `:observability :errors` sink, wired with `rf/register-observability-sink!`, which receives an already-projected record.

**Census:** I swept `skills/re-frame2-pair/**` for the four retired spellings. That found exactly one site.
- `:errors` stream and `:events` stream: every other `:errors`/`:events` hit is an unrelated map key. `references/stories.md`'s `:observability :errors` sink is the current vocabulary, checked against `spec/API.md`.
- `register-error-listener!` and `register-event-listener!` (both with an optional `un`): zero hits. The pattern has no `\b`, and the same search finds these names under `implementation/`, so that zero is real.
- Control: the same search finds `register-listener!` 24 times in the skill.

**Why it survived the sibling sweep:** the rf2-qnsk lock in `scripts/check_skill_migration_contract_drift.py` scans only `skills/re-frame-migration`.

**Adjacent finding, deliberately NOT fixed (out of scope):** `preload/re_frame2_pair/runtime.cljs` comments at lines 13, 1336, 1591 and 2062–2063 name `register-epoch-listener!` as a Tool-Pair surface. There is no such facade verb; it was retired under API-shrink #4 (rf2-9flalp). This is a different retirement from the one this bead covers, so it is left for routing.

## rf2-59cz — slim-side pin for subscribe-container activation (test-only)

PR #9768 fixed direct-listener activation in one shared place: `activating-subscribe-container`, wired in `make-ratom-adapter`. reagent-slim injects `:activate-reaction! reagent2.ratom/activate!`, so it was fixed with no slim-side code. Nothing asserted it. The new namespace `re-frame.adapter.reagent-slim-subscribe-container-activation-cljs-test` is the slim twin of the stock suite. It has the same six pins, runs over the slim adapter map's container slots (no component, no ratom context, no manual activation), and uses `reagent2.ratom/flush!` in place of `reagent.core/flush`. No source file is touched.

**Control:** I reverted the wiring locally and compiled with 0 warnings. The focused run of both activation namespaces then exited 1 with 26 failures: 13 in the new slim suite and 13 in the stock twin. The base-container control stayed green. I restored `spine.cljs` and verified the restore by blob hash (default form matched; `diff --quiet` exit 0). The same focused run then exited 0 (12 tests, 0 failures).

## Quality gates

Every number below is a runner exit code captured on the final base (trunk `84328e4c1c` plus this branch):
- `npm run test:cljs`, split into compile and run. The compile exited 0 with 0 warnings. The run exited 0: 12071 tests, 60161 assertions, 0 failures.
- `npm run test:reagent-slim:smoke` exited 0: 1 smoke, 0 failures.
- `skills-structural`, the re-frame2-pair arm under bb: 15 files, 0 failed.
- `check_skill_mcp_drift.py --ci` exited 0, and so did its `--self-test`.
- `check_doc_slugs.py` exited 0. A broken link planted in `errors.md` turned it red, so the gate reads this tree.
- All 24 `scripts/check*.py` ratchets that name `skills/` exited 0.
- `check_test_lane_bijection.py` exited 0. Stripping the `-cljs-test` suffix from the new ns turned it red with a B1 orphan naming this file.
- `check_jvm_lane_rosters.py` exited 0.

Relying on CI for the other surfaces the classifier arms for these paths: `cljs_browser`, `implementation_jvm`, `examples_compile`, `cljs_prod`, `reagent_slim_bundle`, `adapter_diagnostic` and `playground`.
