### PR TITLE
fix(test-quiet): a discovery directory is not a classpath root (rf2-fzbj.8)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -774,24 +774,19 @@
                [#{} []])
        second))
 
-(defn- classpath-file
+(defn- resolved-through-classpath
   "The file `require` will actually load for the classpath-relative resource
-  path `ns-path`, or nil when nothing on THIS run's classpath answers to it.
+  path `ns-path` — a forward-slashed canonical path — or nil when nothing on
+  THIS run's classpath answers to it.
 
-  A resource answered from inside a jar is nil too: a jar entry is never
-  one of the loose source files the discovery walk just handed us, so it is
+  A resource answered from inside a jar is nil too: a jar entry is never one
+  of the loose source files the discovery walk just handed us, so it is
   `some other file` by the only definition that matters here."
   [^String ns-path]
   (when-let [url (io/resource ns-path)]
     (when (= "file" (.getProtocol url))
-      (try (io/file (.toURI url)) (catch Exception _ nil)))))
-
-(defn- canonical-path
-  "`file`'s canonical path, forward-slashed, or nil if the filesystem
-  refuses to answer."
-  [^java.io.File file]
-  (try (str/replace (.getCanonicalPath file) "\\" "/")
-       (catch java.io.IOException _ nil)))
+      (try (str/replace (.getCanonicalPath (io/file (.toURI url))) "\\" "/")
+           (catch Exception _ nil)))))
 
 (defn- own-path-defect
   "Why `file` will not reach the runner as ITS OWN namespace, or nil.
@@ -821,9 +816,9 @@
   (if complaint
     complaint
     (let [ns-path  (ns->path declared ext)
-          resolved (some-> (classpath-file ns-path) canonical-path)]
+          resolved (resolved-through-classpath ns-path)]
       (when-not (or (= rel ns-path)
-                    (and resolved (= resolved (str/replace canonical "\\" "/"))))
+                    (= resolved (str/replace canonical "\\" "/")))
         (str "it declares `" declared "`, which `require` loads from `"
              ns-path "` - "
              (if resolved

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -774,17 +774,63 @@
                [#{} []])
        second))
 
+(defn- classpath-file
+  "The file `require` will actually load for the classpath-relative resource
+  path `ns-path`, or nil when nothing on THIS run's classpath answers to it.
+
+  A resource answered from inside a jar is nil too: a jar entry is never
+  one of the loose source files the discovery walk just handed us, so it is
+  `some other file` by the only definition that matters here."
+  [^String ns-path]
+  (when-let [url (io/resource ns-path)]
+    (when (= "file" (.getProtocol url))
+      (try (io/file (.toURI url)) (catch Exception _ nil)))))
+
+(defn- canonical-path
+  "`file`'s canonical path, forward-slashed, or nil if the filesystem
+  refuses to answer."
+  [^java.io.File file]
+  (try (str/replace (.getCanonicalPath file) "\\" "/")
+       (catch java.io.IOException _ nil)))
+
 (defn- own-path-defect
   "Why `file` will not reach the runner as ITS OWN namespace, or nil.
 
   Either the reader cannot read its `(ns ...)` form — in which case
   discovery drops it and it contributes no namespace at all — or the name
-  it declares resolves to some other file's path."
-  [{:keys [rel ext declared complaint]}]
-  (when (not= rel (some-> declared (ns->path ext)))
-    (or complaint
-        (str "it declares `" declared "`, which discovery resolves to `"
-             (ns->path declared ext) "` - a different file."))))
+  it declares resolves to some other file.
+
+  `-d` CHOOSES WHERE COGNITECT SCANS; IT IS NOT A CLASSPATH ROOT.  Cognitect
+  reads the namespace out of each discovered file and hands it to `require`,
+  which resolves it against the unchanged classpath — so
+  `-d test/re_frame`, narrowing a large tree during local debugging, is an
+  ordinary selection and not a defect, even though every file under it then
+  spells a path relative to `-d` that differs from its resource path.  Two
+  answers therefore clear a file, and it is a defect only if NEITHER does:
+
+    - its path relative to the scan directory already IS its resource path
+      (the default `-d test` lane, and every temp-dir fixture, which is why
+      this arm must stay: nothing there is on the classpath at all); or
+    - `require`'s own resolution of that resource path, on this run's real
+      classpath, lands on THIS VERY FILE.
+
+  The second arm is strictly weaker than the first, so this rule can only
+  ever clear a file the older path-string comparison reddened — never redden
+  one it cleared."
+  [{:keys [canonical rel ext declared complaint]}]
+  (if complaint
+    complaint
+    (let [ns-path  (ns->path declared ext)
+          resolved (some-> (classpath-file ns-path) canonical-path)]
+      (when-not (or (= rel ns-path)
+                    (and resolved (= resolved (str/replace canonical "\\" "/"))))
+        (str "it declares `" declared "`, which `require` loads from `"
+             ns-path "` - "
+             (if resolved
+               (str "and on this run's classpath that is `" resolved
+                    "`, a different file.")
+               (str "and nothing on this run's classpath answers to that"
+                    " path, so `require` cannot load this file at all.")))))))
 
 (defn- collision-defects
   "One `[path complaint]` per file for every namespace declared by MORE
@@ -821,9 +867,12 @@
   namespace, as `[path complaint]` pairs sorted by path.
 
   Empty is the only acceptable answer.  Two rules, both required: a file
-  must declare a namespace that resolves to ITS OWN path
-  (`own-path-defect`), and no two files may declare the SAME one
-  (`collision-defects`).  The first alone leaves the shadowing door open,
+  must declare a namespace that resolves to ITS OWN FILE — by its path
+  relative to the scan directory, or by `require`'s own resolution against
+  the real classpath, which is what makes a nested `-d` an ordinary
+  selection rather than a defect (`own-path-defect`) — and no two files may
+  declare the SAME one (`collision-defects`).  The first alone leaves the
+  shadowing door open,
   because it derives each file's extension from that file and so clears a
   `.clj`/`.cljc` pair — and a repeated relative path under two roots —
   where each half spells its own path perfectly and only one of them ever

--- a/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
@@ -255,3 +255,89 @@
 
   (testing "and this artefact's own test tree is clean"
     (is (= [] (rf.test-quiet.runner/discovery-defects ["test"])))))
+
+;; ----------------------------------------------------------------------
+;; A DISCOVERY DIRECTORY IS NOT A CLASSPATH ROOT (rf2-fzbj.8).
+;;
+;; `-d` chooses where cognitect SCANS. It does not change resource
+;; resolution: cognitect reads each discovered file's `(ns ...)` form and
+;; hands the name to `require`, which resolves it against the unchanged
+;; classpath. So narrowing a large tree during local debugging —
+;; `-d test/re_frame` under the classpath root `test` — is an ordinary
+;; supported selection, and cognitect runs it.
+;;
+;; Comparing the declared namespace's resource path against a path relative
+;; to `-d` made every file under such a directory a defect: the two strings
+;; are SUPPOSED to differ there. Measured on this artefact before the
+;; repair: `clojure -M:test -d test/re_frame -n
+;; re-frame.test-quiet-pin-passing-test` named all SEVEN files under
+;; `test/re_frame` — the selected one included — and exited 1 before a test
+;; ran, while the identical command through raw `cognitect.test-runner`
+;; exited 0 having run it.
+;;
+;; These rows need the REAL classpath, so they use this artefact's own
+;; tracked `src` and `test` roots rather than a temp tree. A temp-dir
+;; fixture cannot reach the defect at all: nothing in it is on the
+;; classpath, so both halves of the rule are exercised only here.
+
+(deftest a-nested-discovery-directory-is-not-a-defect
+  (testing "THE DEFECT: every file under a nested `-d` spells a path
+            relative to that directory which differs from its resource
+            path, so a path-string comparison names all of them"
+    (let [nested (rf.test-quiet.runner/discovery-defects ["test/re_frame"])]
+      (is (= [] nested)
+          (str "a directory BELOW the classpath root `test` is an ordinary"
+               " discovery selection; cognitect runs it. Got:\n"
+               (str/join "\n" (map pr-str nested))))))
+
+  (testing "the same holds one root over, so this is the rule and not a
+            property of the test tree"
+    (is (= [] (rf.test-quiet.runner/discovery-defects ["src/re_frame/test_quiet"]))))
+
+  (testing "THE CONTROL: the root spelling is still clean, so the repair
+            did not buy the nested case by disarming the guard"
+    (is (= [] (rf.test-quiet.runner/discovery-defects ["test"])))
+    (is (= [] (rf.test-quiet.runner/discovery-defects ["src"])))))
+
+(deftest a-file-the-classpath-answers-with-another-file-is-still-named
+  (testing "THE OTHER HALF: resolution is what clears a file, so a file
+            whose declared namespace `require` answers with a DIFFERENT
+            real file is still refused — this is the shadowing door the
+            rule exists to hold shut, and it is the one case a nested `-d`
+            could plausibly have opened"
+    (with-tree {"shadow.clj" (str "(ns re-frame.test-quiet.runner)\n"
+                                  "(defn totally-different [] :nope)\n")}
+      (fn [dir]
+        (let [defects (rf.test-quiet.runner/discovery-defects [(.getPath dir)])]
+          (is (= ["shadow.clj"] (defect-paths defects))
+              "the stray copy is named")
+          (let [complaint (complaint-for defects "shadow.clj")]
+            (is (str/includes? complaint "re_frame/test_quiet/runner.clj")
+                (str "the complaint names the resource path `require` will"
+                     " load; got: " complaint))
+            (is (str/includes? complaint "a different file")
+                (str "and says the classpath answers it with another file;"
+                     " got: " complaint))
+            (is (str/includes? complaint "src/re_frame/test_quiet/runner.clj")
+                (str "naming that file, because the operator cannot act on"
+                     " `a different file` without knowing which; got: "
+                     complaint))))))))
+
+(deftest a-namespace-nothing-on-the-classpath-answers-says-so
+  (testing "the third outcome: the declaration resolves to a path no
+            classpath root carries, so `require` would throw. The complaint
+            must say THAT, not claim some other file exists"
+    (with-tree {"stray.clj" (str "(ns probe.nothing-answers-this-test\n"
+                                 "  (:require [clojure.test"
+                                 " :refer [deftest is]]))\n"
+                                 "(deftest g (is (= 1 1)))\n")}
+      (fn [dir]
+        ;; The file's own path relative to `-d` is `stray.clj`; its
+        ;; declaration resolves to `probe/nothing_answers_this_test.clj`,
+        ;; which neither matches nor exists anywhere on the classpath.
+        (let [complaint (-> (rf.test-quiet.runner/discovery-defects [(.getPath dir)])
+                            (complaint-for "stray.clj"))]
+          (is (some? complaint) "the file must still be named")
+          (is (str/includes? complaint "nothing on this run's classpath")
+              (str "the complaint must describe the actual mismatch; got: "
+                   complaint)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -1648,3 +1648,124 @@
               (str "the run must be refused BEFORE any test executes,"
                    " because by the time a tally exists the missing file is"
                    " already invisible to it; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; A DISCOVERY DIRECTORY IS NOT A CLASSPATH ROOT (rf2-fzbj.8).
+;;
+;; `-d` chooses where cognitect SCANS. Resource resolution is untouched:
+;; cognitect reads each discovered file's `(ns ...)` form and hands the name
+;; to `require`, which resolves it against the classpath as it stands. So
+;; narrowing a large tree while debugging — `-d test/re_frame` under the
+;; classpath root `test` — is a supported selection that cognitect runs.
+;;
+;; The guard compared each file's path RELATIVE TO `-d` against its
+;; namespace's resource path, which under a nested `-d` are supposed to
+;; differ. Measured on this artefact before the repair: `clojure -M:test
+;; -d test/re_frame -n re-frame.test-quiet-pin-passing-test` named all
+;; SEVEN files under that directory as defects — the requested one
+;; included — and exited 1 before a test ran, while the identical
+;; discovery directory through raw `cognitect.test-runner` exited 0 having
+;; run it.
+;;
+;; The rule itself is pinned against a real classpath in
+;; `re-frame.test-quiet-discovery-integrity-test`. What needs a process is
+;; the end-to-end claim: the SAME namespace, selected through the real
+;; `-main` at three discovery depths, runs and tallies identically — and
+;; a genuinely broken file under the deepest of them is STILL refused, so
+;; the repair bought the nested case by resolving paths rather than by
+;; standing the guard down.
+
+(defn- invoke-quiet-runner-rooted
+  "Relaunch a fresh JVM on `-main` with `classpath-root` on the classpath
+  and `discovery-dir` — which may be nested arbitrarily deep beneath it —
+  as the `-d` value. The harness above passes ONE directory as both, which
+  is precisely the case that cannot distinguish a discovery directory from
+  a classpath root."
+  [^java.io.File classpath-root ^java.io.File discovery-dir & runner-args]
+  (let [java-executable (str (io/file (System/getProperty "java.home") "bin"
+                                      (if (str/includes?
+                                            (str/lower-case
+                                              (System/getProperty "os.name"))
+                                            "win")
+                                        "java.exe" "java")))
+        classpath       (str (System/getProperty "java.class.path")
+                             (System/getProperty "path.separator")
+                             (.getAbsolutePath classpath-root))
+        command         (into [java-executable "-cp" classpath "clojure.main"
+                               "-m" "re-frame.test-quiet.runner"
+                               "-d" (.getAbsolutePath discovery-dir)]
+                              runner-args)
+        process-builder (ProcessBuilder. ^java.util.List command)]
+    ;; Same reason as `invoke-quiet-runner-with-env`: an outer shell that
+    ;; exported `RF2_MIN_TESTS` for another lane must not perturb these pins.
+    (.remove (.environment process-builder) "RF2_MIN_TESTS")
+    (drain-process (.start process-builder))))
+
+(defn- write-deep-fixture!
+  "Write `source` verbatim at `relative-path` under `dir`, creating the
+  intervening directories. Unlike `write-raw-fixture!` the caller owns the
+  whole path, because the nesting IS the subject here."
+  [^java.io.File dir relative-path source]
+  (let [file (io/file dir relative-path)]
+    (.mkdirs (.getParentFile file))
+    (spit file (str source "\n"))))
+
+(deftest a-nested-discovery-directory-runs-the-same-suite
+  (with-fixture-dir
+    (fn [root]
+      ;; Classpath root is `root`; the suite sits two levels down, so its
+      ;; path relative to each candidate `-d` differs from its resource
+      ;; path `probe/deep/good_test.clj` at every depth but the first.
+      (write-deep-fixture! root "probe/deep/good_test.clj"
+        (str "(ns probe.deep.good-test\n"
+             "  (:require [clojure.test :refer [deftest is]]\n"
+             "            [re-frame.test-quiet]))\n"
+             "(deftest a-passing-test (is (= 1 1)))"))
+
+      (testing "the same namespace, selected at three discovery depths,
+                runs and tallies identically"
+        (doseq [[relative dir] [["<root>"     root]
+                                ["probe"      (io/file root "probe")]
+                                ["probe/deep" (io/file root "probe" "deep")]]]
+          (let [{:keys [exit out err timed-out?]}
+                (invoke-quiet-runner-rooted root dir
+                                            "-n" "probe.deep.good-test")]
+            (is (not timed-out?) (str "-d " relative " must terminate"))
+            (is (zero? exit)
+                (str "-d " relative " selects a valid, loadable namespace"
+                     " under the classpath root and must exit 0 — the"
+                     " defect was a refusal before any test ran; got exit "
+                     exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+            (is (str/includes? out "Ran 1 tests containing 1 assertions.")
+                (str "and the counts must be the SAME at every depth, or the"
+                     " narrowing silently changed what ran; got -d " relative
+                     ":\n" out))
+            (is (not (str/includes? err "will not reach the runner"))
+                (str "and no file may be complained about; got -d " relative
+                     " stderr:\n" err)))))
+
+      (testing "THE CONTROL: a genuinely undiscoverable file under the
+                DEEPEST discovery directory is still refused, so the repair
+                resolves paths rather than standing the guard down"
+        ;; One unescaped `\"` in the ns docstring: the reader consumes the
+        ;; rest of the file and hits EOF, so discovery drops it silently.
+        (write-deep-fixture! root "probe/deep/unreadable_test.clj"
+          (str "(ns probe.deep.unreadable-test\n"
+               "  \"A docstring with a stray \" quote in it.\"\n"
+               "  (:require [clojure.test :refer [deftest is]]))\n"
+               "(deftest silently-dropped (is (= 1 1)))"))
+        (let [{:keys [exit out err]}
+              (invoke-quiet-runner-rooted root (io/file root "probe" "deep"))]
+          (is (= 1 exit)
+              (str "an unreadable file must still red the lane under a"
+                   " nested `-d`; got exit " exit "\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          (is (str/includes? err "unreadable_test.clj")
+              (str "and the diagnostic must name it; got stderr:\n" err))
+          (is (not (str/includes? err "good_test.clj"))
+              (str "while the healthy sibling beside it must NOT be named —"
+                   " naming every file under the directory is the whole"
+                   " defect; got stderr:\n" err))
+          (is (not (str/includes? out "Ran "))
+              (str "and the run is refused before any test executes; got:\n"
+                   out)))))))


### PR DESCRIPTION
Remediates **rf2-fzbj.8** — the one confirmed finding on the `impl_build_support` surface.

## The defect

`-d` chooses where `cognitect.test-runner` **scans**. It is not a classpath root: cognitect reads
each discovered file's `(ns ...)` form and hands the name to `require`, which resolves it against
the unchanged classpath. So narrowing a large tree while debugging — `-d test/re_frame` under the
classpath root `test` — is a supported selection, and cognitect runs it.

The quiet runner's discovery guard compared each file's path **relative to `-d`** against its
namespace's resource path. Under a nested `-d` those two strings are *supposed* to differ, so the
guard rejected every correctly-located file before a test ran, and told the programmer to fix or
move code that was already right.

Reproduced at this branch's merge base, from `implementation/test-quiet`:

| command | exit | result |
|---|---|---|
| `clojure -M:test -d test -n re-frame.test-quiet-pin-passing-test` | 0 | `Ran 1 tests containing 1 assertions.` |
| `clojure -M:test -d test/re_frame -n re-frame.test-quiet-pin-passing-test` | 1 | 7 files named as defects, including the requested one; no test ran |
| raw `cognitect.test-runner`, identical classpath and identical nested `-d` | 0 | `Ran 1 tests containing 1 assertions.` |

## The fix

`own-path-defect` now clears a file when **either** answer holds, and names it only if neither does:

1. its path relative to the scan directory already **is** its resource path — the default `-d test`
   lane, and every temp-dir fixture, where nothing is on the classpath at all; or
2. `require`'s own resolution of that resource path, on this run's real classpath, lands on
   **this very file**.

The second arm is strictly weaker than the first, so the rule can only ever *clear* a file the old
string comparison reddened — it can never redden one the old rule cleared. That is the property
that matters while other lanes run through this runner.

The unreadable-`(ns ...)`-form check and the two-files-one-namespace collision check are untouched.
The complaint text now describes the resolution that actually happened — which real file the
classpath answers with, or that nothing answers at all — instead of asserting "a different file"
when no such file exists.

## Regression coverage

Four new rows, all RED against the pre-fix source and green after (see *Quality gates*).

`implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj` — three rows
against the **real** classpath, because a temp tree cannot reach this defect at all (nothing in one
is on the classpath, so only these exercise the resolution arm):

* a nested `-d` under the `test` root and under the `src` root is clean, with the root spellings
  still clean as the control;
* a file whose declared namespace the classpath answers with a **different real file** is still
  named — the shadowing door, and the one a nested `-d` could plausibly have opened — and the
  complaint names the file it resolves to;
* a declaration nothing on the classpath answers says exactly that.

`implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj` — one subprocess row
driving the real `-main` over one classpath root at three discovery depths (`<root>`, `probe`,
`probe/deep`) for a suite at `probe/deep/good_test.clj` declaring `probe.deep.good-test`, asserting
exit 0 and **equal** tallies at every depth; plus the control that an unreadable file under the
deepest of them still reds the lane, names itself, and does **not** name its healthy sibling.

The existing harness passes one directory as both classpath root and `-d`, which is precisely the
case that cannot tell the two apart, so the row carries its own `invoke-quiet-runner-rooted`.

## Quality gates

All re-run on the **final base** (`origin/main` at `76edd2bea6`, after the last rebase). Each exit is
the runner's own, captured by a redirect-and-echo on one command line, never through a pipe.

| gate | CI job (`.github/workflows/test.yml`) | command | result on final base | exit |
|---|---|---|---|---|
| `jvm-test-quiet` | `jvm-test-quiet` — *JVM test-quiet (clojure -M:test)* | `clojure -M:test` in `implementation/test-quiet` | 71 tests / 369 assertions, 0 failures | 0 |
| `js-harness-self-tests` | `js-harness-self-tests` — *JS harness self-tests (quiet reporters + path policy)* | `npm run test:scripts` in `implementation` | 123 tests, 0 failures | 0 |
| node-test lane witness | `cljs-node-test` | `npm run test:cljs` in `implementation` | compile completed with 0 warnings, then 12065 tests / 60143 assertions, 0 failures | 0 |

**Control — the deliverable, since other workers run their gates through this runner and
reporter.** On that same final base, the `implementation/test-quiet` tree from `origin/main`
(pre-fix source, pre-existing tests only) measured **67 tests / 343 assertions, exit 0**. This branch
measures **71 / 369, exit 0**. The difference is exactly the four new deftests, and no pre-existing
row moved. The swapped-in files were restored and each matched its committed blob hash, and
`git diff --quiet HEAD` exited 0. The same 67/343 → 71/369 comparison held on the branch's
original base before the rebases.

**Each new row shown RED first.** With only `runner.clj` reverted to the merge base and the new
tests in place, the suite ran `71 tests / 369 assertions` with **11 failures across exactly the four
new deftests** and every pre-existing row green. The source was restored and verified by blob hash
against the committed object — `git hash-object` matched `git rev-parse HEAD:<path>`, and
`git diff --quiet HEAD -- <path>` exited 0.

**Known-failing fixtures still report as failed.** The suite's red/error/undiscoverable-file
subprocess rows all exercise a fixture that must fail and still pass, and the new nested row's own
control adds an unreadable file under the deepest discovery directory and requires exit 1.

**Gate provenance.** `jvm-test-quiet` was shown to read *this* worktree by the red-then-green
transition above, which only this tree carries. `js-harness-self-tests` was shown to read it by a
planted fault in `implementation/scripts/lib/browser-test-report.cjs` (`entries.length === 0` →
`=== 99`): `node --test scripts/_browser-test-report.test.cjs` went to exit 1, was restored, blob
hash matched the committed object, and re-ran at exit 0. The node-test build printed its config path
from this worktree.

**Ratchets covering these paths**, all exit 0: `check_retired_spellings`, `check_thrown_error_messages`,
`check_require_alias_dialect`, `check_test_lane_bijection`, `check_jvm_lane_rosters`,
`check_readme_inventories`, `check_retired_composition_vocab`, `check_escaped_continuations`,
`check_flattened_lists`, `check-no-hardcoded-paths.sh`, `check-ai-tracking-ratchet.sh`,
`check-beads-pr-boundary.sh`, `check-commit-attribution.sh`.

Surface classifier over the three changed paths: `implementation_jvm=true`, `cljs_node_test=true`.

No spec page, no doc page and no fenced doc content is touched, so no link or slug gate is
nominated. No hot-zone file is touched — `implementation/shadow-cljs.edn` and `.github/workflows/**`
are unchanged, and no finding needed them.

## Findings recorded without a change

The bead's other items are validations and explicit no-action decisions, not defects, and the
second review pass over this surface on 2026-09-13 independently confirmed that — it created no new
bead and recorded "no additional confirmed independent actionable defect beyond reused rf2-fzbj.8".

* **`compile-node-test.cjs` / `browser-test-report.cjs` parser controls** — the review's six-assertion
  probe passed and raised no finding. Re-confirmed at this tip by the tracked, gated equivalent:
  `js-harness-self-tests` ran 123 tests, 0 failures, covering
  `_compile-node-test-warnings.test.cjs`, `_compile-node-test-signal.test.cjs` and
  `_browser-test-report.test.cjs`. No change.
* **CLJS discovered-var floor vs JVM/browser executed-test floor** — the review deliberately did not
  turn the asymmetry into a finding, because rf2-whld already rules NO GATE for executed-assertion
  counting. Not reopened.
* **The fixture guard's callable-Var / custom-`IFn` false positives** — already fixed under rf2-4yw1
  and still pinned by the contract suite's three green rows. Not reopened.
* **The review's "it may also reject a parent discovery directory containing multiple classpath
  roots"** — the same comparison, not separately reproduced by the review. The fix covers it by
  construction (each file resolves through its own classpath root), and the `src`-root row exercises
  a second root. No extra gate added for it.

`implementation/package.json` is untouched: no finding named a script entry.

## Verification the gates cannot do

The two markdown tables above were checked by hand for column counts; nothing in this repo validates
prose, tables or fence contents.
