### PR TITLE
fix(spec,skills,ssr): structural draft schema, never the submission schema, at the form draft path (rf2-ex1r)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_doc_example_form_action_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_doc_example_form_action_test.clj
@@ -130,7 +130,12 @@
       (let [schema-forms (forms (fence "(def AddToCartFields"))
             seam-forms   (forms (fence "defn decode-form-params"))
             helper-forms (forms (fence "defn write-form-errors"))
-            handler-form (first (forms (fence "rf/reg-event :cart/add-item")))]
+            handler-form (first (forms (fence "rf/reg-event :cart/add-item")))
+            ;; The symbol the page registers at the form slice's `:draft` path.
+            draft-sym    (->> schema-forms
+                              (filter #(= [:cart :add-form :draft] (second %)))
+                              first
+                              (#(nth % 2)))]
         ;; The two `def`s (skip the `reg-app-schema` calls — `rf` is not
         ;; required here and `FormSlice` lives in Pattern-Forms).
         (doseq [f schema-forms :when (= 'def (first f))]
@@ -156,11 +161,16 @@
          :event-schema (eval (:schema (nth handler-form 2)))
          ;; The registration form's last element is the handler fn.
          :handler    (eval (last handler-form))
-         ;; The symbol the page types the form slice's `:draft` with.
-         :draft-schema-sym (->> schema-forms
-                                (filter #(= [:cart :add-form :draft] (second %)))
-                                first
-                                (#(nth % 2)))}))))
+         ;; The schema the page registers at the form slice's `:draft` path,
+         ;; by symbol and by VALUE. Deftest 3 validates what the arm really
+         ;; writes against the value; a registration naming a schema no fence
+         ;; defines fails loudly here rather than pinning nothing.
+         :draft-schema-sym draft-sym
+         :draft-schema     (let [v (resolve draft-sym)]
+                             (assert v (str "the page registers " draft-sym
+                                            " at [:cart :add-form :draft] but"
+                                            " no fence defines it"))
+                             @v)}))))
 
 ;; ---------------------------------------------------------------------------
 ;; The two canonical call sites, derived from the page rather than invented
@@ -414,13 +424,28 @@
             `[:cart :add-form :draft]` and separately rules that the token must
             never enter that draft. When both pointed at the token-requiring
             schema the canonical draft was invalid BY CONSTRUCTION. Proven here
-            against what the real handler writes, not against a transcription."
-    (let [{:keys [fields draft-schema-sym]} @example
+            against what the real handler writes, not against a transcription.
+
+            rf2-ex1r: the same defect one level down. The page then registered
+            the strict SUBMISSION schema at that path, while the arm writes back
+            the very values that just FAILED it — and `reg-app-schema` rejects a
+            failing candidate WHOLE, `:db` and `:fx` alike, so a dev build threw
+            away the 400, the errors and the repopulated draft together. The
+            assertion meant to catch that patched `:quantity` to a valid 1
+            before validating, so it could not; it now validates the write
+            UNPATCHED, against the schema the page really registers."
+    (let [{:keys [fields draft-schema]} @example
           bad-post (assoc @server-post :quantity 0)
           {:keys [db fx]} (invoke {:server? true :active-token "tok-abc"} bad-post)
-          drafted  (get-in db [:cart :add-form :draft])]
-      (is (= 'AddToCartFields draft-schema-sym)
-          "the draft is typed with the FIELD schema, not the POST envelope")
+          drafted  (get-in db [:cart :add-form :draft])
+          ;; `quantity=abc` cannot be decoded, so it reaches the arm — and the
+          ;; draft — as the string it arrived as. Driven through the page's own
+          ;; seam, not typed here.
+          garbled  (-> (parse-form-urlencoded
+                        "csrf-token=tok-abc&item-id=sku-1&quantity=abc")
+                       decode-post
+                       (->> (invoke {:server? true :active-token "tok-abc"}))
+                       (get-in [:db :cart :add-form :draft]))]
       (is (= [[:rf.server/set-status 400]] fx)
           "a malformed POST is answered 400 by the handler's own arm")
       (is (= {:item-id "sku-1" :quantity 0} drafted)
@@ -428,9 +453,21 @@
            re-render reads the SLICE, so without this the user's input is lost")
       (is (not (contains? drafted :csrf-token))
           "and the token did NOT, because the page re-renders this slice")
-      (is (m/validate fields (assoc drafted :quantity 1))
-          "the draft the arm writes is a value the registered draft schema can
-           accept — it is not unsatisfiable by construction")
+      (is (m/validate draft-schema drafted)
+          "the value the arm REALLY writes — the rejected submission, unpatched
+           — satisfies the schema registered at the draft path, so
+           reg-app-schema keeps the candidate and the 400 page survives a dev
+           build")
+      (is (not (m/validate fields drafted))
+          "control: that same value is exactly what the SUBMISSION schema
+           refuses, so the assertion above does not pass merely because the two
+           schemas agree. With `fields` registered at the draft path it goes
+           red — which is what it did before rf2-ex1r")
+      (is (= {:item-id "sku-1" :quantity "abc"} garbled)
+          "an undecodable quantity reaches the draft as the string it arrived as")
+      (is (m/validate draft-schema garbled)
+          "and the registered draft schema admits that too — the other value
+           the arm legitimately writes")
       (is (seq (get-in db [:cart :add-form :errors]))
           "errors were written beside it")
       (is (nil? (get-in db [:cart :items]))

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -22,8 +22,8 @@ The prompt mentions: an SSR app handling a form POST, progressive enhancement, "
 Two shapes reach the action handler and they are not the same shape. The no-JS POST body carries the editable fields **plus a CSRF token**; the hydrated client dispatches the fields **alone**. Split the schema along that line — one registration still admits both call sites:
 
 ```clojure
-;; The editable fields: what the user may type, what the form slice's :draft
-;; holds, and what BOTH platforms submit. This is what the handler validates.
+;; The editable fields as a VALID submission: what BOTH platforms submit and what
+;; the handler validates against. Registered at NO path — see the draft below.
 (def AddToCartFields
   [:map
    [:item-id  [:string {:min 1}]]
@@ -37,10 +37,21 @@ Two shapes reach the action handler and they are not the same shape. The no-JS P
   (conj AddToCartFields
         [:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]))
 
-(rf/reg-app-schema [:cart :add-form :draft] AddToCartFields)   ;; the fields, never the token
+;; What :draft may hold at ANY instant — including the rejected submission the
+;; failure arm writes back. STRUCTURAL: keys optional (the arm `select-keys` an
+;; untrusted body) and :quantity admits the string an undecodable `quantity=abc`
+;; arrives as. This is the one that gets registered.
+(def AddToCartDraft
+  [:map
+   [:item-id  {:optional true} :string]
+   [:quantity {:optional true} [:maybe [:or :int :string]]]])
+
+(rf/reg-app-schema [:cart :add-form :draft] AddToCartDraft)   ;; STRUCTURAL — never AddToCartFields, never the token
 ```
 
 One schema doing all three jobs looks like economy and is a live production bug. The hydrated client has no session token to add, so a token-requiring schema sends every client submission down the handler's own validation arm — and that arm is ordinary code, not the elided `:schema` tripwire, so the form 400s in the release build and never navigates. It also makes the draft unsatisfiable by construction, since the failure arm must never write a credential into a slice the page re-renders. The token is not form state and not a field; it is a per-request credential belonging to the POST envelope, and the CSRF arm below gives it a stronger check than any string schema could. Malli maps are open, so `AddToCartFields` validates the server's body unchanged and the extra key passes through to the arm that owns it.
+
+**The draft is typed with neither of those two.** The failure arm writes the submission that just *failed* `AddToCartFields` back into `:draft` — the write that makes the no-JS path honest — and `reg-app-schema` rejects a failing candidate **whole**, `:db` and `:fx` alike. Register `AddToCartFields` at the draft path and a dev build discards the 400, the errors and the repopulated draft together. This is [`forms.md` §The two-schema rule](forms.md#the-two-schema-rule--structural-at-the-path-strict-at-the-submit): structural at the path, strict at the submit.
 
 The view runs on both platforms; the `action` attribute is what makes it work JS-off, and `:on-submit` is purely additive:
 

--- a/spec/Pattern-FormAction.md
+++ b/spec/Pattern-FormAction.md
@@ -36,9 +36,9 @@ client dispatches the editable fields **alone**. One schema describes what they
 share, and it is the one everything else is built from.
 
 ```clojure
-;; The editable fields — what the user may type, what the form slice's :draft
-;; holds, and what BOTH platforms submit. This is the schema the handler
-;; validates against.
+;; The editable fields as a VALID submission — what BOTH platforms submit, and
+;; the schema the handler validates against. Registered at NO path: the draft
+;; below is typed with a structural schema instead.
 (def AddToCartFields
   [:map
    [:item-id  [:string {:min 1}]]
@@ -53,8 +53,17 @@ share, and it is the one everything else is built from.
   (conj AddToCartFields
         [:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]))
 
+;; What `[:cart :add-form :draft]` may hold at ANY instant — including the
+;; rejected submission the failure arm writes back. STRUCTURAL: keys optional
+;; (the arm `select-keys` an untrusted body), and :quantity admits the string an
+;; undecodable `quantity=abc` arrives as. This is the one that gets registered.
+(def AddToCartDraft
+  [:map
+   [:item-id  {:optional true} :string]
+   [:quantity {:optional true} [:maybe [:or :int :string]]]])
+
 (rf/reg-app-schema [:cart :add-form]        FormSlice)
-(rf/reg-app-schema [:cart :add-form :draft] AddToCartFields)   ;; the fields, never the token
+(rf/reg-app-schema [:cart :add-form :draft] AddToCartDraft)   ;; STRUCTURAL — never AddToCartFields, never the token
 ```
 
 (`FormSlice` is the standard slice from [Pattern-Forms §Form slice](Pattern-Forms.md#the-form-slice).)
@@ -83,6 +92,17 @@ equality compare against the session's active token, in the server-guarded CSRF
 arm — which is strictly stronger than any string schema could be. Malli maps
 are open, so `AddToCartFields` validates the server's POST body unchanged; the
 extra key simply passes through to the arm that owns it.
+
+**Why the draft is typed with neither of them.** The failure arm writes the
+submission that just *failed* `AddToCartFields` back into `:draft` — the write
+[§Failure path](#failure-path--re-render-with-errors) calls what makes the no-JS
+path honest. An app schema rejects a failing candidate whole, `:db` and `:fx`
+alike ([010 §Validation order on event processing](010-Schemas.md#validation-order-on-event-processing)),
+so with `AddToCartFields` at the draft path a development build discards the
+400, the errors and the repopulated draft together. The draft path takes the
+structural `AddToCartDraft`; the strict schema runs where it can decide
+something, in the handler's validation arm (the same rule as
+[Pattern-Forms §The form slice](Pattern-Forms.md#the-form-slice)).
 
 ### The view (runs on both platforms)
 

--- a/spec/Pattern-Forms.md
+++ b/spec/Pattern-Forms.md
@@ -39,25 +39,37 @@ Schema (CLJS reference):
    [:submit-error      {:default nil}   [:maybe :any]]])
 ```
 
-The form's *value schema* is separate from the slice schema — it describes the shape the form is collecting:
+The form's *value schema* is separate from the slice schema — it describes the shape the form is collecting, and it comes as **two** schemas that are not interchangeable:
 
 ```clojure
+;; STRUCTURAL — what :draft may legally hold at ANY instant of editing. The
+;; blank first render, a half-typed email and a cleared field are all legal
+;; app-db states, so every value is permissive. This is the one registered.
+(def LoginDraft
+  [:map
+   [:email    :string]
+   [:password [:maybe :string]]])
+
+;; The SUBMISSION schema — what a valid submission looks like. Registered at
+;; NO path: it is the argument to validate-against in :form.login/submit below.
 (def LoginForm
   [:map
    [:email    [:re #".+@.+"]]
    [:password [:string {:min 8}]]])
 ```
 
-Both are registered:
+Two are registered, and `LoginForm` is not one of them:
 
 ```clojure
 (rf/reg-app-schema [:auth :login]              FormSlice)
-(rf/reg-app-schema [:auth :login :draft]       LoginForm)            ;; or via the slice's :draft path
+(rf/reg-app-schema [:auth :login :draft]       LoginDraft)           ;; STRUCTURAL — never LoginForm
 ```
 
 In a typed host, both are types: `LoginFormSlice` wraps `FormSlice` parameterised by a `LoginFormDraft` shape.
 
-These registrations are a **development tripwire**, not the form's validation. `reg-app-schema` checks are elided from production builds ([010 §Production builds](010-Schemas.md#production-builds)), so `LoginForm` will catch a malformed draft while you are developing and catch nothing in a release build. The user-facing validation that decides whether the submit button is enabled, and the server-side check that decides whether a submission is accepted, are both ordinary handler code — see [Pattern-FormAction §Validation is the handler's job](Pattern-FormAction.md#validation-is-the-handlers-job) for the server half.
+**Never register the submission schema at the `:draft` path.** An app schema does not warn: a failing candidate rejects the whole event transition, `:db` and `:fx` alike ([010 §Validation order on event processing](010-Schemas.md#validation-order-on-event-processing)). With `LoginForm` there, `:form.login/initialise` cannot seed its own `login-form-defaults` — an empty email fails the regex — and no half-typed edit commits. The strict schema belongs where it can decide something: the submit handler's `validate-against`, which runs in every build.
+
+These registrations are a **development tripwire**, not the form's validation. `reg-app-schema` checks are elided from production builds ([010 §Production builds](010-Schemas.md#production-builds)), so `LoginDraft` will catch a malformed draft while you are developing and catch nothing in a release build. The user-facing validation that decides whether the submit button is enabled, and the server-side check that decides whether a submission is accepted, are both ordinary handler code — see [Pattern-FormAction §Validation is the handler's job](Pattern-FormAction.md#validation-is-the-handlers-job) for the server half.
 
 ## Canonical rules
 


### PR DESCRIPTION
Closes **rf2-ex1r** — the spec and implementation half of PR #9773's F1. That PR fixed the skill leaf `patterns/forms.md`; the spec it derives from still carried the defect, so the next derivation would have restored it.

## What was wrong

A form has two schemas. The `:draft` path takes a **structural** one, because a blank first render, a half-typed field and a rejected submission written back are all legal app-db states. The strict **submission** schema is the argument to the handler's own validation and is registered nowhere. `reg-app-schema` rejects a failing candidate **whole** — the event's `:db` *and* its `:fx` — so a strict schema at a draft path does not warn: it silently discards the event.

All three sites were re-verified at source before editing:

| Site | Registered at the draft path | What it broke |
|---|---|---|
| `spec/Pattern-Forms.md` | strict `LoginForm` at `[:auth :login :draft]` | the page's own `:form.login/initialise` cannot seed `login-form-defaults` (`""` fails the email regex); no half-typed edit commits; no submit ever fires |
| `spec/Pattern-FormAction.md` | strict `AddToCartFields` at `[:cart :add-form :draft]` | the failure arm writes the rejected `{:item-id "sku-1" :quantity 0}` back into that draft — so a dev build discards the 400, the errors and the repopulated draft together, the exact write the page calls "what makes the no-JS path honest" |
| `skills/re-frame2/patterns/form-action.md` | the same, derived from the page above | same |

And `ssr_doc_example_form_action_test.clj` **pinned** the faulty registration (`(is (= 'AddToCartFields draft-schema-sym))`), guarded by an assertion that could not fail: `(m/validate fields (assoc drafted :quantity 1))` patched the offending field to a valid value before validating.

## What landed

- **`spec/Pattern-Forms.md`** — a structural `LoginDraft` is registered at the draft path; `LoginForm` is registered nowhere and stays the argument to `validate-against` in `:form.login/submit`. One paragraph states the rule and its concrete in-page consequence.
- **`spec/Pattern-FormAction.md`** and **`skills/re-frame2/patterns/form-action.md`** — a structural `AddToCartDraft` (`:item-id` optional `:string`; `:quantity` optional `[:maybe [:or :int :string]]`) is registered at the draft path. The keys are optional because the arm writes `select-keys` of an untrusted body, and `:string` is there because an undecodable `quantity=abc` reaches the arm — and the draft — as the string it arrived as. `AddToCartFields` still drives the handler's validation arm, unchanged. The skill's new paragraph links `forms.md` §The two-schema rule, which is the reference wording.
- **The SSR test** — the symbol pin is gone (a rename that still works should stay green), and the draft assertion now validates the arm's **unpatched** write against the schema the page really registers, resolved by value from the page's own fence. A control asserts the submission schema refuses that same value, so the green cannot come from the two schemas agreeing. A second case drives `quantity=abc` through the page's own decode seam.

## The red, and the green

**SSR test, fixed test against the pre-fix page** — exit **1**: `Ran 16 tests containing 52 assertions. 2 failures, 0 errors.` Both failures are the new assertion, `(m/validate draft-schema drafted)`, failing against the strict `AddToCartFields` on `{:item-id "sku-1", :quantity 0}` and `{:item-id "sku-1", :quantity "abc"}`. The control passed. That run read the page out of this worktree (the test anchors it to its own classpath resource), which is also the proof that the gate read this tree. With the page fixed, the same namespace is green inside the full `jvm-ssr` run below.

**Fenced recipes, executed.** A scratch probe — **not committed**, per the bead — reads the fences out of all three pages at run time and dispatches them against a plain-atom JVM frame with the schemas artefact active. It was run against the pre-fix pages (taken from the base commit) and against this branch:

| Case | Pre-fix | Post-fix |
|---|---|---|
| Pattern-Forms: `initialise` seeds `{:email "" :password ""}` | FAIL (nil) | PASS |
| Pattern-Forms: half-typed edit commits | FAIL | PASS |
| Pattern-Forms: invalid submit writes errors, 0 requests | FAIL | PASS |
| Pattern-Forms: valid submit reaches `:submitting`, 1 request | FAIL (0 requests) | PASS |
| control: `LoginForm` still refuses `{:email "nope" :password "x"}` and accepts a valid pair | PASS | PASS |
| control: a malformed draft (`:email 42`) is still rejected | PASS | PASS |
| FormAction spec + skill: `quantity 0` → 400 **and** draft survive | FAIL ×2 | PASS ×2 |
| FormAction spec + skill: `quantity=abc` → 400 **and** draft survive | FAIL ×2 | PASS ×2 |
| FormAction spec + skill: valid POST commits and redirects | FAIL ×2 | PASS ×2 |
| **exit** | **1** (2/12) | **0** (12/12) |

The pre-fix "valid POST" row fails for a reason worth naming: the harness seeds a blank slice (`:draft {}`), and the strict draft schema rejects that seed too — the "blank first render cannot initialise" half of the same defect. The harness control for the pre-fix run is therefore the post-fix run: identical harness and classpath, only the page root differs.

## Quality gates

Each captured on one command line with its own `echo $?`; every number is the captured one, not a harness report.

| Gate | Base | Exit | CI job |
|---|---|---|---|
| SSR doc-example namespace, fixed test vs pre-fix page | `76edd2bea6` | **1** (the red above) | — |
| `clojure -M:test` in `implementation/ssr` | `76edd2bea6` | **0** (677 tests, 4526 assertions) | `test.yml` → `jvm-ssr` |
| `npm run test:cljs` | `76edd2bea6` | **0** (12065 tests, 60143 assertions) | `test.yml` node/CLJS |
| `check_doc_slugs.py` | `76edd2bea6` | **0** | `test.yml` → `verify-readme-links` |
| `python -m mkdocs build --strict` (stages `spec/` via `mkdocs_hooks.py`; both pages built) | `76edd2bea6` | **0** | `docs.yml` |
| every `run: python …` step of `verify-skill-mcp-drift`, driven from `test.yml`'s own lines (49) | `84328e4c1c` | **0** failures | `test.yml` → `verify-skill-mcp-drift` |
| recipe probe, post-fix | `84328e4c1c` | **0** (12/12) | — |
| `scripts/test-fast-pr.sh` (classifier: docs tier, JVM core+ssr, node/CLJS, clj-kondo) | `84328e4c1c` | **0** — `PASS fast PR spine`: JVM core 2317 tests / ssr 677 tests / node-CLJS 12065 tests, 0 failures each; docs tier incl. `mkdocs --strict`; clj-kondo at CI's pinned 2026.04.15, 0 errors | — |

The branch was rebased once, onto `84328e4c1c`, after the first four rows; trunk touched none of these four files in between, and the fast spine re-covers the docs, JVM and CLJS rows on the final base.

### Not machine-checked

Nearly all of this diff sits **inside fenced code blocks**, and neither link gate looks inside a fence — both strip fences before reading a single link — so the `check_doc_slugs.py` green above inspected none of the fenced changes. The fence contents were instead checked by being **executed** (the probe and the SSR test above) and by reading the diff by hand. The new links are all in prose, which the slug gate does grade. The prose and the one new table were read by hand.

### Declined, with the reason

- **The `check_skill_re_frame2_drift.py` rule refusing a strict schema at a `:draft` path.** It is now possible — no shipped page would trip it — but it is not "a few lines": the honest formulation (a symbol registered at a `:draft` path must not also be the argument to `validate-against` / `m/explain`) needs a scanner, a message, a second spec-page roster (`spec/Pattern-Forms.md` is on no extra-files list today), wiring, and dirty and clean self-test cases — about 40 lines. Left for a sibling bead, as the brief allowed.
- **A tracked doc-fence suite** — the bead rules it out; the probe stays scratch.

## Bead

rf2-ex1r is closed with a reason naming this PR, and the same verdict is appended to its notes, because a reopen erases a close reason.

No AI-attribution trailers: CLAUDE.md § Git Conventions forbids them and outranks the session-level harness reminder that asks for them.
