### PR TITLE
fix(http): :rf.http/managed wrapper terminals are :final? so :spawn-all joins resolve (rf2-6gxs)

### DIFF
--- a/implementation/http/src/re_frame/http/machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http/machine_wrapper.cljc
@@ -5,18 +5,21 @@
   invokable state machine, so a parent machine can write
 
     {:spawn {:machine-id :rf.http/managed
-              :data       {:request {:method :get :url \"/api/me\"}}}
+              :data       {:request {:url \"/api/me\" :method :get}}}
      :on     {:succeeded :authenticated
               :failed    :login}}
 
   and the wrapper:
     1. issues the request on entry to its `:requesting` state,
-    2. transitions to `:succeeded` / `:failed` on the reply,
-    3. dispatches `[<parent-id> [:succeeded value]]` (or
-       `[<parent-id> [:failed failure]]`) back to the parent, where
+    2. transitions to `:succeeded` / `:failed` on the reply — both `:final?`
+       leaves whose `:output-key` is `:rf/result`, so the wrapper completes
+       the way every child machine does (Spec 005 §Child completion protocol),
+    3. under a `:spawn` parent, dispatches `[<parent-id> [:succeeded value]]`
+       (or `[<parent-id> [:failed failure]]`) back to the parent, where
        `<parent-id>` and `<self-id>` come from spawn-fx's framework-
        reserved injection into the actor's initial `:data`
-       (`:rf/parent-id`, `:rf/self-id`).
+       (`:rf/parent-id`, `:rf/self-id`). Under a `:spawn-all` parent the
+       finality alone folds into the join (see `:dispatch-done`).
 
   The wrapper machine is registered via the `:machines/reg-machine`
   late-bind hook: neither optional artefact statically requires the other.
@@ -43,6 +46,22 @@
 
 ;; ---- machine-shape wrapper spec -------------------------------------------
 
+(defn- parent-to-notify
+  "The parent a terminal state's `:entry` should dispatch to, or nil.
+
+  Only a `:spawn` child notifies its parent by event. A `:spawn-all` child
+  carries the runtime's `:rf/join-child` membership record, and completes
+  through finality alone: the finalize cascade mints the join's completion
+  carrier from `:output-key`. A `:final?` state's `:entry` still runs (Spec 005
+  §Final states §Composition with `:entry` / `:exit`), so without this gate a
+  join child would ALSO send `[:succeeded value]` into its parent — a spurious
+  event that a parent carrying the single-`:spawn` `:on {:succeeded …}` habit
+  transitions on, exiting its `:spawn-all` state and tearing down its own join
+  (rf2-6gxs)."
+  [data]
+  (when (nil? (:rf/join-child data))
+    (:rf/parent-id data)))
+
 (defn http-managed-machine-spec
   "Return the machine-shape wrapper spec for `:rf.http/managed`.
 
@@ -60,22 +79,27 @@
      `:rf/parent-id` / `:rf/self-id` keys stamped by spawn-fx.
    - `:fire-request` builds an args map for the underlying fx,
      overriding `:on-success` / `:on-failure` so the reply lands back
-     at the wrapper actor as `[:rf.http/succeeded value]` /
-     `[:rf.http/failed failure]`.
-   - `:succeeded` / `:failed` are terminal leaf states; their
-     `:entry` dispatches the parent's `[:succeeded value]` or
-     `[:failed failure]`. When `:rf/parent-id` is nil (direct dispatch
-     of `[:rf.http/managed ...]` to the wrapper rather than `:spawn`
-     spawning), the parent-dispatch is a benign no-op."
+     at the wrapper actor as `[:rf.http/succeeded reply]` /
+     `[:rf.http/failed reply]`.
+   - `:record-value` / `:record-failure` store the ONE value a parent sees —
+     `(:value reply)` / `(:error reply)` — under `:rf/result`.
+   - `:succeeded` / `:failed` are `:final?` leaves with `:output-key
+     :rf/result` (`:failed` also `:error? true`), so a `:spawn-all` join
+     resolves on them. Their `:entry` dispatches the parent's
+     `[:succeeded value]` / `[:failed failure]` for a `:spawn` child only;
+     when `:rf/parent-id` is nil (direct dispatch of `[:rf.http/managed ...]`
+     to the wrapper rather than `:spawn` spawning), the parent-dispatch is a
+     benign no-op."
   []
   {:doc "Spec 014 — :rf.http/managed as a child-invokable state machine.
 
          Wraps the :rf.http/managed fx in a machine envelope. Use via
          `:spawn {:machine-id :rf.http/managed :data {:request {...}}}`
-         on a parent machine's state node. The wrapper runs the request
-         on entry, transitions to :succeeded / :failed on the reply,
-         and dispatches `[<parent-id> [:succeeded value]]` (or :failed)
-         back to the parent."
+         on a parent machine's state node, or as a `:spawn-all` child.
+         The wrapper runs the request on entry and finishes in a :final?
+         :succeeded / :failed leaf carrying the value under :rf/result;
+         a :spawn parent also receives `[<parent-id> [:succeeded value]]`
+         (or :failed)."
    :initial :requesting
    :states
    {:requesting
@@ -86,13 +110,18 @@
      :on    {:rf.http/succeeded  {:target :succeeded :action :record-value}
              :rf.http/failed     {:target :failed    :action :record-failure}}}
 
+    ;; Spec 005 §Child completion protocol — `:meta {:terminal? true}` is not
+    ;; a synonym for `:final?`, and a join resolves only on `:final?`.
     :succeeded
-    {:entry :dispatch-done
-     :meta  {:terminal? true}}
+    {:entry      :dispatch-done
+     :final?     true
+     :output-key :rf/result}
 
     :failed
-    {:entry :dispatch-error
-     :meta  {:terminal? true}}}
+    {:entry      :dispatch-error
+     :final?     true
+     :error?     true
+     :output-key :rf/result}}
 
    :actions
    {:fire-request
@@ -104,37 +133,33 @@
       ;; transparent envelope around the fx surface.
       (let [self-id   (:rf/self-id data)
             fx-args   (-> data
-                          (dissoc :rf/self-id :rf/parent-id :rf/invoke-id)
+                          (dissoc :rf/self-id :rf/parent-id :rf/invoke-id :rf/join-child)
                           (assoc :on-success [self-id [:rf.http/succeeded]]
                                  :on-failure [self-id [:rf.http/failed]]))]
         {:fx [[:rf.http/managed fx-args]]}))
 
+    ;; `:rf/result` is what `:output-key` hands a join AND what the terminal
+    ;; `:entry` hands a `:spawn` parent, so both parents see one value.
     :record-value
-    (fn [{data :data [_ payload] :event}]
-      {:data (assoc data :rf/result payload)})
+    (fn [{data :data [_ reply] :event}]
+      {:data (assoc data :rf/result (:value reply))})
 
     :record-failure
-    (fn [{data :data [_ payload] :event}]
-      {:data (assoc data :rf/result payload)})
+    (fn [{data :data [_ reply] :event}]
+      ;; rf2-ibksxg — the reply payload is the canonical envelope; the
+      ;; classified `:rf.http/*` failure map rides under `:error`
+      ;; (`:status :error` / `:cancelled`), not the retired `:failure`.
+      {:data (assoc data :rf/result (:error reply))})
 
     :dispatch-done
     (fn [{data :data}]
-      (let [parent-id (:rf/parent-id data)
-            result    (:rf/result data)
-            value     (:value result)]
-        (when parent-id
-          {:fx [[:dispatch [parent-id [:succeeded value]]]]})))
+      (when-let [parent-id (parent-to-notify data)]
+        {:fx [[:dispatch [parent-id [:succeeded (:rf/result data)]]]]}))
 
     :dispatch-error
     (fn [{data :data}]
-      (let [parent-id (:rf/parent-id data)
-            result    (:rf/result data)
-            ;; rf2-ibksxg — the reply payload is the canonical envelope; the
-            ;; classified `:rf.http/*` failure map rides under `:error`
-            ;; (`:status :error` / `:cancelled`), not the retired `:failure`.
-            failure   (:error result)]
-        (when parent-id
-          {:fx [[:dispatch [parent-id [:failed failure]]]]})))}})
+      (when-let [parent-id (parent-to-notify data)]
+        {:fx [[:dispatch [parent-id [:failed (:rf/result data)]]]]}))}})
 
 (defn register-managed-machine!
   "Register the `:rf.http/managed` machine-shape wrapper via the

--- a/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
@@ -6,17 +6,24 @@
   confirms that on CLJS:
 
   - The wrapper machine registration succeeds when `re-frame.machines`
-    is on the classpath at http-managed load time.
+    is on the classpath at http-managed load time, and its `:succeeded` /
+    `:failed` terminals are `:final?` leaves (rf2-6gxs).
   - A parent machine `:spawn`ing `:rf.http/managed` with the canned
     success stub fires the wrapper, transitions to `:succeeded`, and
     dispatches `[<parent-id> [:succeeded value]]` back to the parent.
+  - Wrapper children under `:spawn-all` resolve the join (Spec 014
+    §Multiple wrappers per parent), hand a join parent the same value a
+    `:spawn` parent receives, and never message a join parent directly
+    (rf2-6gxs).
 
   The Fetch transport itself is covered by the broader CLJS test
   suite; this smoke is scoped to the wrapper's machine-shape envelope
   plus the back-channel to the parent."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as rf.adapter.reagent]
+            [re-frame.frame :as rf.frame]
+            [re-frame.fx :as rf.fx]
             ;; re-frame.machines and re-frame.http.managed cross-publish their
             ;; registration hooks through `re-frame.late-bind` (machines
             ;; publishes `:machines/reg-machine`; http-managed publishes
@@ -32,7 +39,8 @@
             ;; directly, so it requires that ns.
             [re-frame.http.test-support :as rf.http.test-support]
             [re-frame.registrar :as rf.registrar]
-            [re-frame.test-support :as rf.test-support]))
+            [re-frame.test-support :as rf.test-support]
+            [re-frame.trace.tooling :as rf.trace.tooling]))
 
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
@@ -57,9 +65,15 @@
         (is (contains? (:states spec) :requesting))
         (is (contains? (:states spec) :succeeded))
         (is (contains? (:states spec) :failed))
-        (is (true? (get-in spec [:states :succeeded :meta :terminal?]))
-            ":succeeded carries :meta {:terminal? true} for tooling visibility")
-        (is (true? (get-in spec [:states :failed :meta :terminal?])))))))
+        ;; rf2-6gxs — this used to assert `:meta {:terminal? true}`, which pinned
+        ;; the defect: `:terminal?` is not `:final?` (Spec 005 §Child completion
+        ;; protocol), so a `:spawn-all` join over these children never resolved.
+        (is (= {:final? true :output-key :rf/result}
+               (select-keys (get-in spec [:states :succeeded]) [:final? :error? :output-key]))
+            ":succeeded is a :final? leaf whose result is :rf/result")
+        (is (= {:final? true :error? true :output-key :rf/result}
+               (select-keys (get-in spec [:states :failed]) [:final? :error? :output-key]))
+            ":failed is an :error? :final? leaf whose result is :rf/result")))))
 
 ;; ---- (2) parent :spawn spawns wrapper, registry/snapshot wiring -------
 
@@ -176,3 +190,201 @@
             "wrapper actor's snapshot is gone after the parent's cancel"))
       (finally
         (rf.http.test-support/uninstall-managed-request-stubs!)))))
+
+;; ---- (4) wrapper children under :spawn-all (rf2-6gxs) -------------------
+;;
+;; Spec 014 §Multiple wrappers per parent puts `:rf.http/managed` children
+;; under `:spawn-all`. A join resolves only when each child reaches a `:final?`
+;; state (Spec 005 §Child completion protocol), which the wrapper's terminals
+;; did not declare — so before rf2-6gxs the parent stayed in `:hydrating` with
+;; `:done #{}` for ever, both requests having answered.
+
+(defn- stubbed-frame!
+  "An anon frame whose PER-FRAME `:fx-overrides` route every `:rf.http/managed`
+  to `stub-fx-id`. Per-frame, because the wrapper children fire their requests
+  on later ticks, and a per-call override on the opening `dispatch-sync` did
+  not reach a `:spawn-all` child's request (measured on the JVM under rf2-6gxs:
+  the real transport ran). Create it AFTER the stub fx and the machines are
+  registered — a frame seals its image generation at construction
+  (rf2-bxc8kf)."
+  [stub-fx-id]
+  (rf.frame/make-anon-frame-record!
+    {:doc          "rf2-6gxs — :rf.http/managed wrapper children"
+     :fx-overrides {:rf.http/managed stub-fx-id}}))
+
+(defn- snap-in [frame machine-id]
+  (get-in (:rf.db/runtime (rf/frame-state-value frame))
+          [:rf.runtime/machines :snapshots machine-id]))
+
+(defn- resolved-event
+  "The event the parent recorded when it left its waiting state."
+  [frame parent-id]
+  (get-in (snap-in frame parent-id) [:data :resolved]))
+
+(defn- settled? [frame parent-id]
+  #(contains? #{:done :failed :decoy} (:state (snap-in frame parent-id))))
+
+(defn- where-is [frame parent-id]
+  (let [join (get-in (:rf.db/runtime (rf/frame-state-value frame))
+                     [:rf.runtime/machines :spawned parent-id [:hydrating]])]
+    (str parent-id " :state " (pr-str (:state (snap-in frame parent-id)))
+         ", join :done " (pr-str (:done join)) " :failed " (pr-str (:failed join)))))
+
+(def ^:private record-event
+  {:record (fn [{data :data ev :event}] {:data (assoc data :resolved (vec ev))})})
+
+(defn- wrapper-child [id url]
+  {:id id :machine-id :rf.http/managed :data {:request {:url url :method :get}}})
+
+(defn- reg-join-parent!
+  "A parent that fans `children` out under `:spawn-all` and records the join
+  event it resolves on. `extra-on` merges into the `:hydrating` `:on` map; any
+  target it names should be `:decoy`."
+  ([parent-id join children] (reg-join-parent! parent-id join children {}))
+  ([parent-id join children extra-on]
+   (rf/reg-machine parent-id
+     {:initial :idle
+      :actions record-event
+      :states
+      (cond-> {:idle      {:on {:go :hydrating}}
+               :hydrating {:spawn-all (merge {:children      children
+                                              :join          join
+                                              :on-any-failed [:any-failed]}
+                                             (if (= :any join)
+                                               {:on-some-complete [:some-done]}
+                                               {:on-all-complete [:all-done]}))
+                           :on        (merge {:all-done   {:target :done   :action :record}
+                                              :some-done  {:target :done   :action :record}
+                                              :any-failed {:target :failed :action :record}}
+                                             extra-on)}
+               :done      {}
+               :failed    {}}
+        (seq extra-on) (assoc :decoy {}))})))
+
+(defn- reg-spawn-parent! [parent-id url]
+  (rf/reg-machine parent-id
+    {:initial :idle
+     :actions record-event
+     :states
+     {:idle       {:on {:go :requesting}}
+      :requesting {:spawn {:machine-id :rf.http/managed
+                           :data       {:request {:url url :method :get}}}
+                   :on    {:succeeded {:target :done   :action :record}
+                           :failed    {:target :failed :action :record}}}
+      :done       {}
+      :failed     {}}}))
+
+(deftest spawn-all-join-all-resolves-over-wrapper-children
+  (testing "two :rf.http/managed children under :spawn-all :join :all resolve the join once both reply; the join event carries the decisive child's decoded value and each child tore itself down at finality (rf2-6gxs)"
+    (async done
+      (rf.http.test-support/install-managed-request-stubs!
+        {[:get "/api/me"]    {:reply {:ok {:id 42}}}
+         [:get "/api/prefs"] {:reply {:ok {:theme "dark"}}}})
+      (reg-join-parent! :cljs/hydrate :all [(wrapper-child :user "/api/me")
+                                            (wrapper-child :prefs "/api/prefs")])
+      (let [f (stubbed-frame! :rf.http/managed-test-stub)]
+        (rf/dispatch-sync [:cljs/hydrate [:go]] {:frame f})
+        (-> (rf.test-support/poll-until (settled? f :cljs/hydrate)
+                                        {:timeout-ms 2000 :label "rf2-6gxs :join :all resolves"})
+            (.then (fn [_]
+                     (let [[ev child-id result] (resolved-event f :cljs/hydrate)]
+                       (is (= :done (:state (snap-in f :cljs/hydrate))))
+                       (is (= :all-done ev) ":on-all-complete fired")
+                       (is (contains? #{:user :prefs} child-id) "the join names its decisive child")
+                       (is (= (get {:user {:id 42} :prefs {:theme "dark"}} child-id) result)
+                           "the join result is the decisive child's (:value reply), not the reply envelope"))
+                     (is (nil? (snap-in f :rf.http/managed#1)) "finality tore the first child down")
+                     (is (nil? (snap-in f :rf.http/managed#2)) "finality tore the second child down")))
+            (.catch (fn [e] (is false (str "rf2-6gxs — " (where-is f :cljs/hydrate) " — " (.-message e))) nil))
+            (.then (fn [_] (rf.http.test-support/uninstall-managed-request-stubs!) (done))))))))
+
+(deftest spawn-and-spawn-all-parents-receive-the-same-value
+  (testing "one wrapper reply reaches a :spawn parent as [:succeeded value] / [:failed failure] and a :spawn-all parent as the join result — the SAME value on both paths, success and failure, so `:output-key` and the single-:spawn dispatch cannot drift apart; the failure path is also an accepted child error reaching :on-any-failed (rf2-6gxs)"
+    (async done
+      (rf.http.test-support/install-managed-request-stubs!
+        {[:get "/api/ok"]  {:reply {:ok {:id 42}}}
+         [:get "/api/bad"] {:reply {:failure {:kind :rf.http/http-5xx :status 503}}}})
+      (reg-spawn-parent! :cljs/spawn-ok  "/api/ok")
+      (reg-spawn-parent! :cljs/spawn-bad "/api/bad")
+      (reg-join-parent!  :cljs/join-ok   :any [(wrapper-child :only "/api/ok")])
+      (reg-join-parent!  :cljs/join-bad  :any [(wrapper-child :only "/api/bad")])
+      ;; One frame per parent, so the four wrapper children never share an
+      ;; actor address.
+      (let [frames (into {} (map (fn [pid] [pid (stubbed-frame! :rf.http/managed-test-stub)]))
+                         [:cljs/spawn-ok :cljs/spawn-bad :cljs/join-ok :cljs/join-bad])
+            ev     (fn [pid] (resolved-event (frames pid) pid))]
+        (doseq [[pid f] frames] (rf/dispatch-sync [pid [:go]] {:frame f}))
+        (-> (rf.test-support/poll-until #(every? (fn [[pid f]] ((settled? f pid))) frames)
+                                        {:timeout-ms 2000 :label "rf2-6gxs four parents settle"})
+            (.then (fn [_]
+                     (let [[s-ok v-ok]        (ev :cljs/spawn-ok)
+                           [s-bad v-bad]      (ev :cljs/spawn-bad)
+                           [j-ok _ jv-ok]     (ev :cljs/join-ok)
+                           [j-bad _ jv-bad]   (ev :cljs/join-bad)]
+                       (is (= [:succeeded {:id 42}] [s-ok v-ok]) "a :spawn parent receives [:succeeded (:value reply)]")
+                       (is (= :some-done j-ok))
+                       (is (= v-ok jv-ok) "success — the join result is the value the :spawn parent receives")
+                       (is (= :failed s-bad) "a :spawn parent receives [:failed …]")
+                       (is (= :any-failed j-bad) "an accepted child error reaches :on-any-failed")
+                       (is (= :rf.http/http-5xx (:kind v-bad)) "the :spawn parent's failure is the classified (:error reply)")
+                       (is (= v-bad jv-bad) "failure — the join result is the failure the :spawn parent receives"))))
+            (.catch (fn [e] (is false (str "rf2-6gxs — "
+                                           (pr-str (into {} (map (fn [[pid f]] [pid (:state (snap-in f pid))])) frames))
+                                           " — " (.-message e)))
+                      nil))
+            (.then (fn [_] (rf.http.test-support/uninstall-managed-request-stubs!) (done))))))))
+
+(deftest spawn-all-join-any-cancels-the-live-sibling
+  (testing "under :join :any the first wrapper to reply resolves the join, and the join cancels the sibling still waiting on its request (rf2-6gxs)"
+    (async done
+      (let [traces (atom [])
+            cb-id  (gensym "rf2-6gxs-any-")]
+        ;; Answers /api/fast only — /api/slow stays in flight.
+        (rf.fx/reg-fx :cljs/fast-only-stub
+          {:doc "rf2-6gxs — replies to /api/fast, never to /api/slow"}
+          (fn [frame-ctx args-map]
+            (when (= "/api/fast" (get-in args-map [:request :url]))
+              (rf.http.test-support/canned-success-handler
+                frame-ctx (assoc args-map :value {:fast true})))))
+        (rf.trace.tooling/register-listener! cb-id (fn [trace] (swap! traces conj trace)))
+        (reg-join-parent! :cljs/race :any [(wrapper-child :fast "/api/fast")
+                                           (wrapper-child :slow "/api/slow")])
+        (let [f (stubbed-frame! :cljs/fast-only-stub)]
+          (rf/dispatch-sync [:cljs/race [:go]] {:frame f})
+          (-> (rf.test-support/poll-until (settled? f :cljs/race)
+                                          {:timeout-ms 2000 :label "rf2-6gxs :join :any resolves"})
+              (.then (fn [_]
+                       (is (= [:some-done :fast {:fast true}] (resolved-event f :cljs/race))
+                           ":on-some-complete fired on the child that replied")
+                       (is (= [:slow]
+                              (->> @traces
+                                   (filter #(= :rf.machine.spawn/cancelled-on-join-resolution (:operation %)))
+                                   (mapv #(get-in % [:tags :child-id]))))
+                           "the join cancelled exactly the live sibling")))
+              (.catch (fn [e] (is false (str "rf2-6gxs — " (where-is f :cljs/race) " — " (.-message e))) nil))
+              (.then (fn [_]
+                       (rf.trace.tooling/unregister-listener! cb-id)
+                       (rf.registrar/unregister! :fx :cljs/fast-only-stub)
+                       (done)))))))))
+
+(deftest join-child-sends-no-succeeded-event-to-its-parent
+  (testing "a :spawn-all parent that also carries the single-:spawn habit `:on {:succeeded … :failed …}` resolves through its join: a join child's terminal :entry stays silent, so no spurious [:succeeded value] reaches the parent (rf2-6gxs). A :final? state's :entry still runs, so without the :rf/join-child gate the first child to finish would send it, the parent would leave :hydrating on it, and its own join would be torn down"
+    (async done
+      (rf.http.test-support/install-managed-request-stubs!
+        {[:get "/api/me"]    {:reply {:ok {:id 42}}}
+         [:get "/api/prefs"] {:reply {:ok {:theme "dark"}}}})
+      (reg-join-parent! :cljs/habit :all
+                        [(wrapper-child :user "/api/me") (wrapper-child :prefs "/api/prefs")]
+                        {:succeeded {:target :decoy :action :record}
+                         :failed    {:target :decoy :action :record}})
+      (let [f (stubbed-frame! :rf.http/managed-test-stub)]
+        (rf/dispatch-sync [:cljs/habit [:go]] {:frame f})
+        (-> (rf.test-support/poll-until (settled? f :cljs/habit)
+                                        {:timeout-ms 2000 :label "rf2-6gxs habit parent settles"})
+            (.then (fn [_]
+                     (is (= :done (:state (snap-in f :cljs/habit)))
+                         "the parent resolved through its join, not through a spurious :succeeded")
+                     (is (= :all-done (first (resolved-event f :cljs/habit)))
+                         (str "the parent recorded " (pr-str (resolved-event f :cljs/habit))))))
+            (.catch (fn [e] (is false (str "rf2-6gxs — " (where-is f :cljs/habit) " — " (.-message e))) nil))
+            (.then (fn [_] (rf.http.test-support/uninstall-managed-request-stubs!) (done))))))))

--- a/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_managed_machine_cljs_test.cljs
@@ -42,9 +42,12 @@
             [re-frame.test-support :as rf.test-support]
             [re-frame.trace.tooling :as rf.trace.tooling]))
 
+;; `:async? true` — the (4) :spawn-all rows are `async`, and cljs.test aborts a
+;; namespace holding async tests unless its fixtures are the map form.
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
     {:adapter rf.adapter.reagent/adapter
+     :async?  true
      :init-fn (fn []
                 (rf.machines/reset-timers!)
                 (rf.http.managed/clear-all-in-flight!))}))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -1136,10 +1136,15 @@ Internally the wrapper machine has:
 `:requesting` listens for three events:
 
 - `:rf.machine.spawn/spawned` — the synthetic event the runtime dispatches to spawns without a `:start` (per [Spec 005 §Spawning](005-StateMachines.md#spawning--dynamic-actors)). The wrapper's `:fire-request` action runs, emitting the underlying `:rf.http/managed` fx with `:on-success` / `:on-failure` pointing back at the wrapper actor's own id (so the reply lands at the wrapper, not at the user's handler).
-- `:rf.http/succeeded` — fired when the underlying fx succeeds; records the reply payload at `:data :rf/result` and transitions to `:succeeded`.
-- `:rf.http/failed` — fired when the underlying fx fails (any of the eight `:rf.http/*` failure categories, per [§Failure categories](#failure-categories-closed-set)); records the reply payload and transitions to `:failed`.
+- `:rf.http/succeeded` — fired when the underlying fx succeeds; records `value` at `:data :rf/result` and transitions to `:succeeded`.
+- `:rf.http/failed` — fired when the underlying fx fails (any of the eight `:rf.http/*` failure categories, per [§Failure categories](#failure-categories-closed-set)); records `failure` at `:data :rf/result` and transitions to `:failed`.
 
-The terminal states' `:entry` dispatches `[<parent-id> [:succeeded value]]` or `[<parent-id> [:failed failure]]` — where `value` is the decoded-and-accepted payload (`(:value reply)` off the canonical reply the wrapper's `:on-success` target received) and `failure` is the classified `:rf.http/*` map (`(:error reply)` per [§Reply payload shape](#reply-payload-shape--the-one-canonical-envelope)). The parent's id comes from `:rf/parent-id` in the wrapper actor's initial `:data` — stamped by `spawn-fx` per [Spec 005 §Spawning](005-StateMachines.md#spawning--dynamic-actors); the wrapper need not be told its parent at spec-write time.
+`value` is the decoded-and-accepted payload (`(:value reply)` off the canonical reply the wrapper's `:on-success` target received) and `failure` is the classified `:rf.http/*` map (`(:error reply)` per [§Reply payload shape](#reply-payload-shape--the-one-canonical-envelope)).
+
+`:succeeded` and `:failed` are `:final?` leaves with `:output-key :rf/result`, and `:failed` also declares `:error? true` — so the wrapper completes the way every child machine does ([Spec 005 §Child completion protocol](005-StateMachines.md#child-completion-protocol)), and a parent receives the same `value` or `failure` whichever spawn form it used:
+
+- **Under `:spawn`**, the terminal state's `:entry` dispatches `[<parent-id> [:succeeded value]]` or `[<parent-id> [:failed failure]]`. The parent's id comes from `:rf/parent-id` in the wrapper actor's initial `:data` — stamped by `spawn-fx` per [Spec 005 §Spawning](005-StateMachines.md#spawning--dynamic-actors); the wrapper need not be told its parent at spec-write time.
+- **Under `:spawn-all`** ([§Multiple wrappers per parent](#multiple-wrappers-per-parent)), that dispatch is suppressed: a join child carries the runtime's `:rf/join-child` record, and its finality alone folds into the join, whose resolution event carries `value` — or `failure`, on `:on-any-failed`. A parent keeping the `:spawn` habit of `:on {:succeeded … :failed …}` is therefore never moved by a join child.
 
 ### Args carrier
 
@@ -1160,7 +1165,7 @@ Every key the [§The args map](#the-args-map) surface accepts may be passed thro
           :failed    :login-failed}}
 ```
 
-The framework-reserved `:rf/*` keys the wrapper itself uses (`:rf/self-id`, `:rf/parent-id`, `:rf/invoke-id`, `:rf/result`) are stripped before the underlying fx call, so they never leak into the request envelope.
+The framework-reserved `:rf/*` keys the wrapper itself uses (`:rf/self-id`, `:rf/parent-id`, `:rf/invoke-id`, `:rf/join-child`, `:rf/result`) are stripped before the underlying fx call, so they never leak into the request envelope.
 
 `:on-success` / `:on-failure` are **not** passed through — the wrapper overrides them to route the reply back to itself. Apps that want explicit reply addressing should keep using the fx form directly; the machine wrapper is for the `:spawn`-orchestrated case.
 


### PR DESCRIPTION
Fixes **rf2-6gxs**, which is F3 of **rf2-fzbj.16** and its last open finding. F1 and F2 landed in #9773.

## The defect

Spec 014 §Multiple wrappers per parent (and `skills/re-frame2/patterns/managed-http.md`) puts `:rf.http/managed` children under `:spawn-all`. A join resolves only when each child reaches a `:final?` state (Spec 005 §Child completion protocol). The wrapper's `:succeeded` / `:failed` declared `:meta {:terminal? true}` instead. Spec 005 says in as many words that `:terminal?` is redundant with `:final?`, not a synonym for it. So the parent sat in `:hydrating` with `:done #{}` after both requests had answered.

## The change (`implementation/http/src/re_frame/http/machine_wrapper.cljc`)

1. `:succeeded` / `:failed` are `:final?` leaves with `:output-key :rf/result`, and `:failed` also declares `:error? true`.
2. `:record-value` / `:record-failure` store `(:value reply)` / `(:error reply)` under `:rf/result`. The terminal `:entry` reads that same slot, so a `:spawn` parent's `[:succeeded value]` / `[:failed failure]` and a `:spawn-all` parent's join result are **one value**. A test pins this on both paths, success and failure.
3. The terminal `:entry` dispatch to the parent only happens when there is no `:rf/join-child`. The bead flagged this part as a derivation, so it was **measured, not assumed**:
   - a `:final?` state's `:entry` does still run (Spec 005 §Composition with `:entry` / `:exit` says so too);
   - a `:spawn-all` child's `:data` carries `:rf/parent-id`;
   - so a join child also sent `[:succeeded value]` into its parent.

   On today's trunk that is already live. A join parent keeping the single-`:spawn` habit of `:on {:succeeded …}` leaves `:hydrating` on the first child's reply and tears its own join down. The GUARD control below shows the gate is load-bearing.
4. `:fire-request` also strips `:rf/join-child` from the fx args. Spec 014 already says that of the other reserved keys, and this change is what puts join children on that path.

## The test that pinned the defect

`http_managed_machine_cljs_test.cljs` asserted `(get-in spec [:states :succeeded :meta :terminal?])`, which **encoded the bug**. That is not a regression: it now asserts the `:final?` / `:error?` / `:output-key` shape, with a comment saying why it moved.

New rows, all in the same file (async, so the namespace fixture now uses the reset fixture's `:async? true` map form, which cljs.test requires):

- `:join :all` over two wrapper children resolves; the result is the decisive child's `(:value reply)`; each child tore itself down at finality.
- A `:spawn` parent and a `:spawn-all` parent receive the same value, for both success and failure. The failure half is an accepted child error reaching `:on-any-failed`.
- `:join :any` cancels the sibling still waiting on its request (`:rf.machine.spawn/cancelled-on-join-resolution` names only `:slow`).
- A join parent carrying `:on {:succeeded … :failed …}` resolves through its join and receives no spurious `:succeeded`.

The join rows route HTTP through a **per-frame** `:fx-overrides`. On the JVM, a per-call override on the opening `dispatch-sync` did not reach a `:spawn-all` child's request: the real transport ran.

## Controls (focused `:node-test` run of this namespace, plant verified by blob hash before each run and restore verified after)

| run | wrapper | result |
|---|---|---|
| RED | pre-fix blob from the base | 7 failures, all new assertions: every join parent at `:state :hydrating, join :done #{} :failed #{}` (single-`:spawn` parents were already fine) |
| GUARD | this fix with the `:rf/join-child` gate neutralised | 2 failures, only the no-spurious-`:succeeded` row (parent in `:decoy`, recorded `:succeeded`) |
| GREEN | HEAD | 0 failures |

## Spec

`spec/014-HTTPRequests.md` §Machine-shape wrapper is edited, which is outside the http surface this was dispatched on. That section described the wrapper recording the whole reply at `:rf/result` and always dispatching to the parent, and both statements changed here. It is not a hot zone. `spec/005-StateMachines.md` is cited, not edited. `skills/re-frame2/patterns/managed-http.md` is untouched and now works as written.

Declined: any change to the join machinery itself. The wrapper was the only thing out of step with the protocol.

## Quality gates

Base: rebased onto `84328e4c1c`. Trunk has since moved (to `8081354188`), but no commit touches `implementation/http`, `implementation/machines` or `spec/014-HTTPRequests.md`.

Local runs, each with its own captured exit code:

- **`jvm-http`** (test.yml job `jvm-http`, *JVM http (clojure -M:test)*) — `clojure -M:test` in `implementation/http`: exit 0, 505 tests, 4015 assertions. Its existing single-`:spawn` success / failure / cancellation / `:after` rows are the non-regression control for the unchanged `:spawn` path.
- **CLJS lane** (test.yml job `cljs`, *CLJS (shadow-cljs :node-test)* — the `:node-test` build that carries `http_managed_machine_cljs_test.cljs`) — `npm run test:cljs`: exit 0, compiled with 0 warnings, 12069 tests, 60160 assertions, 0 failures.
- **Fast-PR spine** (`scripts/test-fast-pr.sh`) on the rebased tree: PASS, exit 0. It ran:
  - the repo-wide ratchets;
  - the docs tier, including `check_doc_slugs.py` and `mkdocs build --strict`;
  - JVM core (2317 tests) and http (505 tests);
  - `test:cljs`;
  - pinned clj-kondo 2026.04.15.
- `python scripts/check_doc_slugs.py` on its own: exit 0.

CI: all 87 checks green at `fd9d427419`. That covers what the spine does not run: the JVM suites of untouched artefacts (including `machines`), browser, prod-elision, bundle-isolation and examples-compile.

Not machine-checked: the prose of the Spec 014 edit, which was read by hand. Its links are covered by the slug gate and the strict build.

## Tracker

Closes rf2-6gxs. With this merged, rf2-fzbj.16 has no open finding left: F1 and F2 landed in #9773. The spec/SSR remainder that audit routed to rf2-ex1r is in #9779, still open at the time of writing.
