### PR TITLE
docs(migration): O-18's canonical dev forwarder reads the live trace record (rf2-2cgzg, rf2-vin7n)

### DIFF
--- a/migration/from-re-frame-v1/observability-logging-sweep.md
+++ b/migration/from-re-frame-v1/observability-logging-sweep.md
@@ -10,7 +10,7 @@
 
 ## Why this is its own rule
 
-[M-13](README.md#m-13-reg-event-error-handler-is-dropped--error-policy-is-per-frame-on-error) and [M-17](README.md#m-17-reg-global-interceptor--clear-global-interceptor-removed--use-frame-level-interceptors) hand the operator a per-call-site decision — "this `reg-event-error-handler` was an observer; convert to `register-listener!`." That's the right shape for the *mechanical* part. What M-13 / M-17 leave on the floor is the **security and operational consequence** of the conversion: an audit-logger that worked in v1 by hooking the dispatch envelope sees the whole event vector, which may carry passwords / tokens / PII; the v2-canonical `register-listener!` listener receives the same event under `:tags :event-v` and ships it to wherever the listener's body forwards (Sentry, an external SIEM, a local log file). Per [Security.md §Privacy / secret handling](../../spec/Security.md#privacy--secret-handling), the framework defends with `:sensitive?` declarations + the wire-elision walker, but the defense is **declarative** — if the v1 site never declared its observability surface, the v2 port silently leaks the same payloads to a wider audience.
+[M-13](README.md#m-13-reg-event-error-handler-is-dropped--error-policy-is-per-frame-on-error) and [M-17](README.md#m-17-reg-global-interceptor--clear-global-interceptor-removed--use-frame-level-interceptors) hand the operator a per-call-site decision — "this `reg-event-error-handler` was an observer; convert to `register-listener!`." That's the right shape for the *mechanical* part. What M-13 / M-17 leave on the floor is the **security and operational consequence** of the conversion: an audit-logger that worked in v1 by hooking the dispatch envelope sees the whole event vector, which may carry passwords / tokens / PII; the v2-canonical `register-listener!` listener receives the same event under `[:tags :rf.event/v]` and ships it to wherever the listener's body forwards (Sentry, an external SIEM, a local log file). Per [Security.md §Privacy / secret handling](../../spec/Security.md#privacy--secret-handling), the framework defends with `:sensitive?` declarations + the wire-elision walker, but the defense is **declarative** — if the v1 site never declared its observability surface, the v2 port silently leaks the same payloads to a wider audience.
 
 This rule is the **dedicated sweep** that turns the post-M-13 / post-M-17 observer set into a v2-canonical set with privacy + oversize defenses composed at every egress. It has four sections:
 
@@ -171,28 +171,35 @@ Every listener body that walks a payload bounded by user input or by app-db size
 
 ### Surfacing the dropped count via `register-listener!`
 
-The cap silently elides — but silent elision is the wrong default for operational observability. Operators need to see that the listener filtered SOMETHING — otherwise a misconfigured schema (forgot `{:sensitive? true}` on a new field) leads to "the dashboard shows nothing" with no diagnostic signal. The pattern is to **emit a counter trace event** every time the listener drops slots:
+The cap silently elides — but silent elision is the wrong default for operational observability. Operators need to see that the listener filtered SOMETHING — otherwise a misconfigured schema (forgot `{:sensitive? true}` on a new field) leads to "the dashboard shows nothing" with no diagnostic signal. The pattern is to **dispatch a counter event** into the frame the trace record names every time the listener drops slots:
 
 ```clojure
 (rf/register-listener! :trace :my-app/audit-forwarder
   (fn [trace-event]
-    (when (and (#{:event/dispatched :event/handler-completed} (:operation trace-event))
+    (when (and (= :rf.event/dispatched (:operation trace-event))     ;; one record per dispatch
                (not (:sensitive? trace-event)))                      ;; default-drop sensitive cascades
-      (let [event-v   (-> trace-event :tags :event-v)
+      (let [{event-v     :rf.event/v                                 ;; event, frame and dispatch
+             frame       :frame                                      ;; identity all ride :tags
+             dispatch-id :rf.trace/dispatch-id} (:tags trace-event)
             [bounded
              dropped
              over?]   (cap-or-elide event-v
                                     {:budget-bytes 32768
-                                     :frame        (:frame trace-event)})]
+                                     :frame        frame})]
         (when (or (pos? dropped) over?)
-          ;; Per-batch counter: operator sees how often the cap fires
+          ;; Per-batch counter: operator sees how often the cap fires. Aimed at
+          ;; the SAME live frame; the counter handler opts out of tracing (§4),
+          ;; so this dispatch is never itself forwarded.
           (rf/dispatch [:audit/dropped-counter-inc {:dropped     dropped
                                                     :over-budget over?
-                                                    :operation   (:operation trace-event)}]))
+                                                    :operation   (:operation trace-event)}]
+                       {:frame frame}))
         (sentry/capture-message
           {:message "audit event"
            :extra   {:event/operation   (:operation trace-event)
                      :event/payload     bounded
+                     :event/frame       frame
+                     :event/dispatch-id dispatch-id
                      :event/dropped     dropped
                      :event/over-budget over?}})))))
 ```
@@ -200,13 +207,13 @@ The cap silently elides — but silent elision is the wrong default for operatio
 Two diagnostic signals:
 
 1. **The `:event/dropped` + `:event/over-budget` slots on every forwarded payload** — the operator opening the destination dashboard sees per-event how many declared slots were filtered and whether the byte-budget backstop dropped the payload. Reporting them separately keeps a declared-elision distinct from a genuine over-budget drop — the two must not be conflated.
-2. **The `[:audit/dropped-counter-inc ...]` dispatch into the runtime** — accumulates a counter the operator can query via `(rf/subscribe [:audit/dropped-counter])` for a continuous "how often is the cap firing" view.
+2. **The `[:audit/dropped-counter-inc ...]` dispatch into the runtime** — targeted at the frame the trace record names, it accumulates a counter the operator can query via `(rf/subscribe [:audit/dropped-counter] {:frame frame-id})` for a continuous "how often is the cap firing" view.
 
 The two together let the operator distinguish "the backstop fires twice a day" from "the backstop fires on every event because a misconfigured schema is leaking the whole `app-db`." Both signals MUST land on the rewrite — silent elision is the failure mode this rule defends against.
 
 ### Composition with the framework default
 
-The framework already drops `:sensitive? true` events on the off-box-forwarder default (per [009 §Privacy / sensitive data in traces](../../spec/009-Instrumentation.md#privacy--sensitive-data-in-traces) — "Framework-published listener integrations MUST default to suppressing `:sensitive? true` events"). The `(when-not (:sensitive? trace-event) ...)` guard in the listener body composes the default — the listener body never even sees a sensitive-scope cascade. The explicit `cap-or-elide` walk catches the **rest** of the payload — fields whose own schema didn't carry `:sensitive?` but match the floor checklist from §2, plus the size-cap.
+The framework already drops `:sensitive? true` events on the off-box-forwarder default (per [009 §Privacy / sensitive data in traces](../../spec/009-Instrumentation.md#privacy--sensitive-data-in-traces) — "Framework-published listener integrations MUST default to suppressing `:sensitive? true` events"). The `(not (:sensitive? trace-event))` guard in the listener body composes the default — the listener body never even sees a sensitive-scope cascade. That flag sits at the **root** of the trace record, not under `:tags`, and the framework stamps it when the run's scope overlaps a classified sensitive path. Event args declared `:sensitive` in `reg-event` registration metadata are already `:rf/redacted` at `[:tags :rf.event/v]` before the listener runs. The explicit `cap-or-elide` walk catches the **rest** of the payload — fields whose own schema didn't carry `:sensitive?` but match the floor checklist from §2, plus the size-cap.
 
 ## 4. Reference mediation interceptor
 
@@ -310,10 +317,11 @@ This is the v2-canonical target for the **majority** of "observer (off-box egres
 
 (rf/register-listener! :trace :my-app/audit-forwarder
   (fn audit-forwarder [trace-event]
-    (when (and (= :event/dispatched (:operation trace-event))         ;; one event per dispatch
+    (when (and (= :rf.event/dispatched (:operation trace-event))      ;; one record per dispatch
                (not (:sensitive? trace-event)))                       ;; honour framework default-drop
-      (let [event-v   (-> trace-event :tags :event-v)
-            frame     (:frame trace-event)
+      (let [{event-v     :rf.event/v                                  ;; event, frame and dispatch
+             frame       :frame                                       ;; identity all ride :tags
+             dispatch-id :rf.trace/dispatch-id} (:tags trace-event)
             [bounded
              dropped
              over?]   (cap-or-elide event-v {:budget-bytes 32768
@@ -322,25 +330,29 @@ This is the v2-canonical target for the **majority** of "observer (off-box egres
           (rf/dispatch [:audit/dropped-counter-inc
                         {:operation   (:operation trace-event)
                          :dropped     dropped
-                         :over-budget over?}]))
+                         :over-budget over?}]
+                       {:frame frame}))                               ;; the SAME live frame
         (sentry/capture-message
           {:message "audit event"
            :extra   {:event/operation   (:operation trace-event)
                      :event/payload     bounded
-                     :event/dispatch-id (:dispatch-id trace-event)
+                     :event/dispatch-id dispatch-id
                      :event/dropped     dropped
                      :event/over-budget over?
                      :event/frame       frame}})))))
 
 ;; --- The dropped-counter event + sub (operator-visible signal #2) ---
+;; :rf.trace/no-emit? keeps the counter's own run off the trace stream, so the
+;; forwarder above never sees, or forwards, the dispatch it just made.
 
-(rf/reg-event-db :audit/dropped-counter-inc
-  (fn [db [_ {:keys [operation dropped over-budget]}]]
-    (-> db
-        (update-in [:audit/counters :total-dropped]           (fnil + 0) (or dropped 0))
-        (update-in [:audit/counters :per-operation operation]  (fnil + 0) (or dropped 0))
-        (cond-> over-budget
-          (update-in [:audit/counters :over-budget]           (fnil inc 0))))))
+(rf/reg-event :audit/dropped-counter-inc
+  {:rf.trace/no-emit? true}
+  (fn [{:keys [db]} [_ {:keys [operation dropped over-budget]}]]
+    {:db (-> db
+             (update-in [:audit/counters :total-dropped]           (fnil + 0) (or dropped 0))
+             (update-in [:audit/counters :per-operation operation]  (fnil + 0) (or dropped 0))
+             (cond-> over-budget
+               (update-in [:audit/counters :over-budget]           (fnil inc 0))))}))
 
 (rf/reg-sub :audit/dropped-counter
   (fn [db _] (:audit/counters db)))
@@ -371,7 +383,8 @@ When the v1 observer assembled a per-cascade summary (an audit-log entry per dra
           (rf/dispatch [:audit/dropped-counter-inc
                         {:operation   :epoch/settled
                          :dropped     dropped
-                         :over-budget over?}]))
+                         :over-budget over?}]
+                       {:frame (:frame epoch-record)}))
         (if over?
           ;; Over budget even after projection — forward the bounded over-budget
           ;; marker, never the oversize record.


### PR DESCRIPTION
## What

The O-18 observability sweep calls its §3 and §4 Shape A bodies the canonical dev forwarder. Neither worked against the shipped runtime. This PR fixes both beads, which are two halves of the same forwarder.

**rf2-2cgzg: the counter registration aborted app init.** Shape A registered `:audit/dropped-counter-inc` with `rf/reg-event-db`. That name is an EP-0018 removal stub, so it raises `:rf.error/reg-event-db-removed` when the namespace is evaluated. It now uses `rf/reg-event` with the coeffects-to-effects signature (`(fn [{:keys [db]} ev] {:db …})`). The total-dropped, per-operation and over-budget arithmetic is unchanged, and so is the `:audit/dropped-counter` sub.

**rf2-vin7n: both trace forwarders selected zero real dispatches.** They filtered the retired `:event/dispatched` / `:event/handler-completed` operations. They also read the event at `[:tags :event-v]` and read frame and dispatch identity at the record root. Both forwarders now:

- filter on `:rf.event/dispatched`, which gives one record per dispatch;
- read the event, frame and dispatch id from `:tags` (`:rf.event/v`, `:frame`, `:rf.trace/dispatch-id`);
- forward all three to the spy;
- send the dropped-counter dispatch to the same live frame with `{:frame frame}`.

The field names were checked in the core source at this base, not taken from the audit. The emit is `emit-dispatched-trace!` in `router.cljc`, and the hoist logic is `build-event` in `trace.cljc`.

**No self-forwarding loop.** The counter handler carries `{:rf.trace/no-emit? true}`. That is the public reg-event metadata spec 009 provides for this case: bookkeeping dispatched from inside a trace listener. It keeps the counter's own dispatch off the trace stream, so the forwarder never sees or forwards it.

**Sensitivity was checked at source, not assumed.** Root `:sensitive?` is still where the trace contract puts it: `build-event` stamps it from the run scope's classified-path overlap, and projection-decided sensitivity is hoisted to the root. So the existing `(not (:sensitive? trace-event))` guard stays. The §3 prose now says where the flag lives. It also notes that event args declared `:sensitive` in reg-event metadata already arrive `:rf/redacted` at `[:tags :rf.event/v]`.

Also in this file:
- Line 13's prose named the retired `:tags :event-v`. It now names `[:tags :rf.event/v]`.
- §3's "emit a counter trace event" said something the counter no longer does, so it is corrected.
- Shape B's dropped-counter dispatch now targets `(:frame epoch-record)`, which the bead requires of any dropped-counter dispatch. `:frame` is a root key on epoch records per `re-frame.epoch`'s docstring. Shape B was not executed; its only change is that one opts argument.

PR #9776's Shape B heading, its `(rf/configure! {:observability …})` wording and its corpus-wide-door text are untouched.

## Quality gates

**Every change sits inside a fenced Clojure block or in the prose around one. Neither link gate reads inside a fence**: both strip fences before extracting links. So the two link gates below are green without having inspected the fenced changes. The real control is the executed probe.

**Executed control (scratch probe, not committed).** The probe:
- extracts the shipped fenced bodies from the markdown: the §3 `cap-or-elide` helper, the §3 forwarder, and the whole §4 Shape A block;
- evaluates them as shipped against real public dispatch delivery (`rf/init!` + plain-atom substrate, a real frame, `rf/dispatch-sync`);
- stubs only the Sentry SDK, with a local forwarding spy. The framework trace producer is not stubbed or fabricated.

Inputs are real dispatches:
- a normal event;
- a login event whose `:password` is declared `:sensitive` in reg-event metadata;
- a 40,000-character payload that exceeds the 32,768-byte budget;
- a child dispatched from a handler whose run scope overlaps a classified sensitive path. This produces a real record with root `:sensitive? true`.

Results:
- **Pre-fix (the base's doc): exit 1, 29 of 46 checks failed.** Shape A aborts at load with `:rf.error/reg-event-db-removed`. The §3 forwarder loads but forwards 0 of the 5 real dispatches.
- **Post-fix (this branch's doc): exit 0, 46 of 46 passed, for both §3 and Shape A.** Each input is forwarded exactly once with the correct event, frame and dispatch id. The dispatch id matches the one on the real trace record. The password arrives `:rf/redacted`, and the raw secret appears in no forward. The over-budget event forwards a bounded `:audit/over-budget` marker and never the blob. The sensitive-scope child is dropped. Counters land in the dispatching frame as `{:total-dropped 1 :per-operation {:rf.event/dispatched 1} :over-budget 1}`, with none in `:rf/default`, and the sub returns the same map. The counter event is neither traced nor forwarded.

Link and ratchet gates, each run from this worktree with its captured exit code:

| gate | exit |
|---|---|
| `scripts/check_doc_slugs.py` | 0 |
| `python -m mkdocs build --strict` (stages `migration/` via `mkdocs_hooks.py`; builds this page) | 0 |
| `scripts/check_skill_migration_contract_drift.py` (incl. Rule 7) | 0 |
| `scripts/check_retired_spellings.py` | 0 |
| `scripts/check_retired_composition_vocab.py` | 0 |
| `scripts/check_thrown_error_messages.py` | 0 |
| `scripts/check_inject_cofx_residue.py` | 0 |
| `scripts/check_flattened_lists.py` | 0 |
| `scripts/check_skill_migration_cites.py` | 0 |
| `scripts/check_skill_migration_o1617_router_drift.py` | 0 |

`check_readme_links.py` is deliberately not listed, because it excludes all of `migration/`. Anchors and table column counts in the edited region were checked by hand. No headings changed, so no anchors moved.

Closes rf2-2cgzg and rf2-vin7n.
