### PR TITLE
ci(docs): run the source scans unconditionally, outside the surface-gated build (rf2-vc11)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -147,8 +147,8 @@ jobs:
   # lights so the build runs unconditionally (push is already path-filtered
   # above, and a manual dispatch always wants a build). The heavy MkDocs
   # build keys its `if:` on this output, while the always-present aggregator
-  # does not — so a docs-irrelevant PR runs only this ~5-second job plus the
-  # rollup, and the build skips.
+  # does not — so a docs-irrelevant PR runs only this ~5-second job, the
+  # unconditional `source-scans` job and the rollup, and the build skips.
   detect:
     name: Detect docs surface
     runs-on: ubuntu-latest
@@ -172,6 +172,10 @@ jobs:
       # core PR would run a duplicate ~15-minute MkDocs build on top of the
       # tools-playground job in test.yml that already builds + smokes the bundle
       # at PR time. Deploy-time coverage here, PR-time coverage there.
+      #
+      # No SCAN rides on this list any more (rf2-vc11): the source scans run in
+      # the unconditional `source-scans` job, so a path missing here can skip
+      # the MkDocs build but can no longer skip a scan.
       - name: Classify changed files against the docs surface
         id: detect
         run: |
@@ -414,6 +418,80 @@ jobs:
       # (rf2-ftkz swept the 26 broken anchors main carried at landing, so the
       # gate is fail-loud wherever it runs).
 
+      # THE SOURCE SCANS ARE NO LONGER HERE (rf2-vc11). The six self-test-then-
+      # live scanner pairs that stood here read only the SOURCE tree, never the
+      # built site, so they moved to the `source-scans` job below, which has no
+      # `docs_surface` guard. Same move, and the same reason, as the two gates
+      # above: behind this job's guard they ran on a PR only when the `detect`
+      # case list matched, and that list is narrower than `push.paths`.
+
+      # Stage the spec/ + migration/ trees under docs/ so MkDocs (which
+      # requires docs_dir to be a child of the config file) can see them.
+      # The local equivalent is `cp -r spec docs/spec && cp -r migration
+      # docs/migration` before `mkdocs build`. The staged copies are
+      # .gitignored — never commit them.
+      - name: Stage spec/ + migration/ into docs/
+        run: |
+          rm -rf docs/spec
+          cp -r spec docs/spec
+          rm -rf docs/migration
+          cp -r migration docs/migration
+
+      # --strict escalates MkDocs WARNINGs to a non-zero exit (rf2-eq90w):
+      # nav entries pointing at missing files (nav.not_found), unresolved
+      # internal links MkDocs can see, and plugin warnings now fail the
+      # build instead of slipping through. This is complementary to the
+      # check_doc_slugs.py gate above, which validates markdown-link
+      # target+anchor drift the WARNING set does not cover.
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        # v5 (transitively pins actions/upload-artifact to a SHA, which v3 did not — see rf2-xmmh).
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: site/
+
+  # ---------------------------------------------------------------------------
+  # Source scans (rf2-vc11) — UNCONDITIONAL, on purpose.
+  #
+  # Every step here reads the SOURCE tree (docs/, spec/, skills/, testbeds/,
+  # tools/*/spec, the root support files, implementation/ Clojure source) and
+  # none reads the built site, so none needs the `build` job's JVM, Node,
+  # Cairo or MkDocs setup: all six checkers are stdlib-only Python.
+  #
+  # They lived in `build` until rf2-vc11, behind `docs_surface`, so on a PR
+  # they ran only when the `detect` case list matched, and that list is
+  # deliberately narrower than `push.paths`. A path on push.paths but off the
+  # case list was therefore graded on the trunk push and not on the PR that
+  # introduced it: PR #9748 touched implementation/machines/** only, merged at
+  # a full rollup with `build` skipped, and the main push then ran
+  # check_retired_image_keys.py RED. The case list also omitted that gate's
+  # own script and fixtures, so a PR loosening the gate skipped it too.
+  #
+  # So this job has NO `if:` on detect's output and does not `needs:` detect
+  # at all. It runs on every PR, whatever the diff touches, which removes the
+  # class instead of re-syncing two lists that drift. The heavy MkDocs build
+  # stays narrow. test.yml's `verify-readme-links` made the same move for the
+  # corpus link scan (rf2-v7fui).
+  #
+  # It sits in `docs-required`'s `needs:` (a gate nothing aggregates is a gate
+  # nobody has to pass) and in `deploy`'s, so a red scan still blocks a
+  # publish exactly as it did from inside `build`.
+  # ---------------------------------------------------------------------------
+  source-scans:
+    name: Docs source scans
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
       # docs/EP/README.md restates each EP's `Status:` line in its index
       # table; the two drift by hand (EP-0001 sat at `accepted` while the
       # index still said `proposal`). This guard fails the build when an
@@ -572,33 +650,6 @@ jobs:
       - name: Validate no unqualified warm-allocation claim on the publication surface
         run: python scripts/check_allocation_non_claim.py
 
-      # Stage the spec/ + migration/ trees under docs/ so MkDocs (which
-      # requires docs_dir to be a child of the config file) can see them.
-      # The local equivalent is `cp -r spec docs/spec && cp -r migration
-      # docs/migration` before `mkdocs build`. The staged copies are
-      # .gitignored — never commit them.
-      - name: Stage spec/ + migration/ into docs/
-        run: |
-          rm -rf docs/spec
-          cp -r spec docs/spec
-          rm -rf docs/migration
-          cp -r migration docs/migration
-
-      # --strict escalates MkDocs WARNINGs to a non-zero exit (rf2-eq90w):
-      # nav entries pointing at missing files (nav.not_found), unresolved
-      # internal links MkDocs can see, and plugin warnings now fail the
-      # build instead of slipping through. This is complementary to the
-      # check_doc_slugs.py gate above, which validates markdown-link
-      # target+anchor drift the WARNING set does not cover.
-      - name: Build site (strict)
-        run: mkdocs build --strict
-
-      - name: Upload Pages artifact
-        # v5 (transitively pins actions/upload-artifact to a SHA, which v3 did not — see rf2-xmmh).
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
-        with:
-          path: site/
-
   # ---------------------------------------------------------------------------
   # Provenance pins (rf2-kqac1), following rf2-owq6p's census.
   #
@@ -679,7 +730,7 @@ jobs:
     # Only deploy from main pushes — PRs run build only (catch regressions) but don't deploy.
     if: github.event_name == 'push'
     name: Deploy to GitHub Pages
-    needs: build
+    needs: [build, source-scans]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -722,6 +773,9 @@ jobs:
       - build
       # rf2-kqac1 — a gate nothing aggregates is a gate nobody has to pass.
       - provenance-pins
+      # rf2-vc11 — unconditional, so it reports on every PR; leaving it out
+      # would recreate the fail-open that moved it here.
+      - source-scans
     steps:
       - name: Fail if the docs build failed or was cancelled
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
Closes rf2-vc11. Implements option (b) from the bead.

## What

`docs.yml`'s source-scanning gates move out of the surface-gated `build` job and into a new job, `source-scans` ("Docs source scans"). The new job has no `if:` on `detect`'s output and does not `needs:` `detect`. The six scanner pairs move verbatim, commands and comments unchanged:
- EP status sync
- runtime-subsystem grading
- failure-corpus residue
- retired composition vocab
- retired EP-0026 image keys
- warm-allocation non-claim

The heavy MkDocs build keeps its `docs_surface` guard and now holds only build-site steps.

`source-scans` is wired into:
- `docs-required`'s `needs:`, so the aggregator grades it. Leaving it out would recreate the fail-open one level up.
- `deploy`'s `needs:`, so a red scan still blocks a Pages publish, as it did from inside `build`.

What decided the move: each moved step reads only the source tree, and all six checkers are stdlib-only Python. Every step that stayed reads the built site or needs `build`'s JVM, Node, Cairo or MkDocs setup.

## Why

On a PR, `docs_surface` comes from `detect`'s inline case list, which is deliberately narrower than `push.paths`. A path that is on `push.paths` but not on the case list was graded on the trunk push and not on the PR that introduced it. PR #9748 touched `implementation/machines/**` only, so `build` was skipped and the PR merged green. Its main push then ran `check_retired_image_keys.py` red. The case list also omitted that gate's own script and fixtures, and `skills/`, which two of the moved scans read.

This moves the scans off the case list entirely, instead of re-syncing two lists that drift. It is the same move test.yml's `verify-readme-links` made for the corpus link scan (rf2-v7fui).

**Adds 1 PR-time check (band 87 → 88).** The `pull_request` trigger is unfiltered and the new job is unconditional, so every PR's rollup gains "Docs source scans". Job-key census over the merge-base diff: 1 added (`source-scans`), 0 removed. `check_fast_pr_gap.py` now counts 80 required jobs, up from 79.

## The live-cell paths (`implementation/{core,adapters/reagent-slim,machines,flows}/**`)

**The paths are not added to the case list.** The `build` job does consume them, because its playground rebuild compiles the SCI bundle from them through `:local/root` coords, so in principle a PR changing them could break the deploy-time bundle build while `build` is skipped at PR time. The MkDocs build proper does not read them. The PR-time coverage for that consumption is test.yml's `tools-playground`, which runs the same `npm run build` and smoke of that bundle. `report-changed-surfaces.sh` arms it for all four trees. Adding the paths here would duplicate a ~15-minute build on every core PR, which is the trade-off `detect`'s own comment already records. The measured incident was the scan, and the scan now runs on every PR.

## Quality gates

Each moved command was run locally from this worktree, with its exit code captured:

| Check | Result |
|---|---|
| Baseline, all 11 commands | exit 0 |
| Planted-fault run (see below) | every live scan exit 1, naming its own plant |
| After the restore, all 11 commands | exit 0 |

The six plants:
- `check_retired_image_keys.py`: a new file under `implementation/machines/src/` carrying `:rf.image/requires`, which is the #9748 shape.
- `check_failure_corpus_residue.py`: a new testbed `.cljs` file carrying `:where :cofx`.
- `check_retired_composition_vocab.py`: a new `skills/` page with a live `rf/realm` call.
- `check_ep_status_sync.py`: EP-0001's index status flipped.
- `check_runtime_subsystem_grading.py`: the `:rf.runtime/machines` grading heading renamed.
- `check_allocation_non_claim.py`: an unqualified `24,108 B per write` claim appended to `CHANGELOG.md`.

The new-file plants were deleted, and the three edited files match their committed blob ids after checkout. The tree was clean afterwards.

This PR cannot show the path-filter proof in CI, because it touches `docs.yml`, which is itself on the case list. By reading the parsed YAML instead: `source-scans` has no `if` key and no `needs` key, and `build` keeps `if: needs.detect.outputs.docs_surface == 'true'`.

Checks that grade `.github/workflows/`, run locally before and after the change, all exit 0:

| Script | Result after the change | CI job that runs it |
|---|---|---|
| `check_fast_pr_gap.py` (self-test + `--check`) | 79 → 80 required jobs, same 101 unrun checks; the `--list` diff is exactly `check_allocation_non_claim` relocating from "MkDocs build" to "Docs source scans" | test.yml `verify-skill-mcp-drift` |
| `check_workflow_job_timeouts.py` (self-test + sweep) | docs.yml 6/6 jobs capped | test.yml `verify-readme-links`, which is also CI's only workflow YAML parse |
| `implementation/scripts/_docs-workflow-policy.test.cjs` | 5 passed; the deploy push-only interlock still holds | test.yml `js-harness-self-tests`, via `npm run test:scripts` |
| `check_workflow_yaml.py` | pass | fast-PR spine only |
| `check_gate_scheduling.py` | pass | |

`check_ci_reproduce_commands.py` reads test.yml only. No lint.yml job grades docs.yml.

`python -m mkdocs build --strict`: exit 0. That build does not read `docs.yml`, so this shows the tree still builds, not that the extraction was exercised. The new job itself gets its first real run in this PR's CI.
