### PR TITLE
fix(story-mcp): drop a record's respelled extension key in the success projection (rf2-8m1i)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -107,6 +107,26 @@
     (sequential? v) (mapv wire-safe-value v)
     :else           {unencodable-key (type-name v)}))
 
+(defn- rebuild-record
+  "`record` with each entry replaced by `(f entry)`, keeping the record's
+  type. A copy of the private `rebuild-record` in `re-frame.mcp-base.dedup`,
+  which solved the same problem for the dedup walk (rf2-gwye.31).
+
+  A record has no `empty`, so its entries are written back into the
+  original, and an extension key that `f` respells must therefore REPLACE
+  its original or both spellings survive. A fixed field's key is a keyword,
+  which the projection never respells, so the `dissoc` only ever meets
+  extension keys and the record keeps its type. Every entry is rebuilt
+  before any is written, so a new spelling that matches another entry's old
+  one cannot overwrite that entry before it is read."
+  [f record]
+  (let [rebuilt (mapv (fn [entry] [(key entry) (f entry)]) record)]
+    (reduce (fn [r [_ entry]] (conj r entry))
+            (reduce (fn [r [k [k' _]]] (if (= k k') r (dissoc r k)))
+                    record
+                    rebuilt)
+            rebuilt)))
+
 (defn wire-safe-success
   "Project ORDINARY SUCCESS data so the JSON encoder can write it, leaving
   everything that already IS data exactly as it was.
@@ -148,15 +168,29 @@
     collection through `{}` / `#{}` / `mapv`, which is right for an
     `ex-data` blob but would quietly turn a list into a vector, a sorted map
     into a hash map, and a record into a plain map — in a payload whose text
-    slot is the byte-stable EDN an agent DIFFS. `clojure.walk/postwalk`
-    rebuilds each collection as its own type (and visits map keys), so a
-    payload carrying no callable comes back equal to what went in."
+    slot is the byte-stable EDN an agent DIFFS. The walk rebuilds each
+    collection as its own type (and visits map keys), so a payload carrying
+    no callable comes back equal to what went in.
+
+  ## Records: a respelled key REPLACES its original (rf2-8m1i)
+
+  The walk is `clojure.walk/walk` everywhere except a record, which
+  `rebuild-record` handles. `clojure.walk` rebuilds a record by `conj`-ing
+  the walked entries back into the ORIGINAL record, so an extension key the
+  projection respells — `(assoc (->Sample pos?) pos? :extension)` — gained
+  its marker while the raw `pos?` key stayed too, and Cheshire wrote that
+  key as its identity string. Every other slot of that record was projected
+  correctly, which is why the leak was easy to miss."
   [v]
-  (walk/postwalk (fn [x]
-                   (if (or (edn-scalar? x) (coll? x))
-                     x
-                     {unencodable-key (type-name x)}))
-                 v))
+  (letfn [(project [x]
+            (if (or (edn-scalar? x) (coll? x))
+              x
+              {unencodable-key (type-name x)}))
+          (walk-success [form]
+            (project (if (record? form)
+                       (rebuild-record walk-success form)
+                       (walk/walk walk-success identity form))))]
+    (walk-success v)))
 
 (defn wire-safe-ex-data
   "Project a caught exception's `ex-data` into something the JSON encoder

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -538,3 +538,85 @@
             "plain data is never marked"))))
   (is (= "pass" (:status (structured (second (call-success-tool "run-variant" "story.button/equality" false)))))
       "and the equality-only run still crosses with its verdict"))
+
+;; ---- success payloads: a record's respelled extension key (rf2-8m1i) -------
+;;
+;; `clojure.walk` rebuilds a record by conj-ing the walked entries back into
+;; the ORIGINAL record. So an extension key the projection respells gained its
+;; marker while the raw callable key stayed beside it, and Cheshire wrote that
+;; key as a JSON member name carrying its identity hash. The `:v` field was
+;; projected correctly all along; only the extension key leaked.
+
+(defrecord Sample [v])
+
+(def ^:private pos-marker
+  {:rf.story-mcp/unencodable "clojure.core$pos_QMARK_"})
+
+(def ^:private record-args
+  {:record (assoc (->Sample pos?) pos? :extension)
+   ;; Data-only shapes beside it, which the projection must leave alone.
+   :shapes {:list '(1 2 3) :set #{:a :b} :vec [1 [2 3]]}})
+
+(deftest record-extension-key-crosses-get-variant-as-a-marker
+  ;; The bead's reproducer, registered through Story's public surface.
+  (rf.story/reg-story :story.audit {})
+  (rf.story/reg-variant* :story.audit/record {:args record-args})
+  (doseq [dedup? [true false]]
+    (testing (str "get-variant dedup=" dedup?)
+      (let [[line frame] (call-success-tool "get-variant" "story.audit/record" dedup?)
+            text         (result-text frame)]
+        (is (nil? (:error frame))
+            (str "a result envelope, not a protocol fault: " line))
+        (is (nil? (get-in frame [:result :isError]))
+            "a success, not a tool error")
+        (is (not (str/includes? line "#object"))
+            "no raw printed object in the encoded frame")
+        (is (not (str/includes? text "#object"))
+            "nor in the text slot")
+        (is (not (str/includes? line "pos_QMARK_@"))
+            "no callable identity string, which is how the surviving key encoded")
+        (is (nil? (re-find address-in-line line))
+            "and no identity hash of any kind")
+
+        (testing "the structured slot carries the record's two entries, no third"
+          (is (= 2 (count (get-in (structured frame) [:body :args :record])))))
+
+        (testing "the text slot keeps the record's type and ordinary field"
+          (let [read-back (edn/read-string {:default tagged-literal} text)
+                rec       (get-in read-back [:body :args :record])
+                shapes    (get-in read-back [:body :args :shapes])]
+            (is (tagged-literal? rec)
+                "the record still prints as a record literal")
+            (is (= (symbol (.getName Sample)) (:tag rec))
+                "of its own type")
+            (is (= pos-marker (:v (:form rec)))
+                "the ordinary field is marked in place")
+            (is (= :extension (get (:form rec) pos-marker))
+                "the replacement marker carries the extension's value")
+            (is (= 2 (count (:form rec)))
+                "and the original callable key is gone")
+            (is (= (:shapes record-args) shapes)
+                "data-only shapes survive")
+            (is (and (list? (:list shapes)) (set? (:set shapes)) (vector? (:vec shapes)))
+                "each as its own collection type")))))))
+
+(deftest wire-safe-success-drops-a-record-key-it-respells
+  ;; The fast guard under the boundary test above.
+  (let [out (rf.story-mcp.tools.result/wire-safe-success
+              (assoc (->Sample pos?) pos? :extension :note "kept"))]
+    (is (instance? Sample out) "the record keeps its type")
+    (is (not (contains? out pos?)) "the original callable key is gone")
+    (is (= :extension (get out pos-marker)) "its replacement carries the value")
+    (is (= pos-marker (:v out)) "the fixed field is marked in place")
+    (is (= "kept" (:note out)) "a data-only extension key rides unchanged")
+    (is (= 3 (count out)) "and nothing else was added"))
+  (testing "control: data-only payloads come back equal AND of the same type"
+    (let [in  {:rec    (assoc (->Sample [1 2]) :ext {:a 1})
+               :sorted (sorted-map :b 2 :a 1)
+               :list   '(1 (2 3))
+               :set    #{:x}}
+          out (rf.story-mcp.tools.result/wire-safe-success in)]
+      (is (= in out))
+      (is (instance? Sample (:rec out)))
+      (is (sorted? (:sorted out)))
+      (is (and (list? (:list out)) (list? (second (:list out))))))))


### PR DESCRIPTION
Fixes rf2-8m1i (filed by the merged-PR audit of #9759, from closed rf2-gwye.58).

## The defect

`wire-safe-success` in `tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc` walked success payloads with `clojure.walk/postwalk`. That function rebuilds a **record** by conj-ing the walked entries back into the ORIGINAL record. So when the projection respells an extension key, the record gains the marker while the raw key stays beside it: in `(assoc (->Sample pos?) pos? :extension)`, a callable key becomes `{:rf.story-mcp/unencodable "clojure.core$pos_QMARK_"}`. Cheshire then writes the surviving key as a JSON member name carrying its identity hash, and the text slot prints it as `#object[...]`. The `:v` field was projected correctly all along, so the omission was only the extension key.

## The fix

The walk still uses `clojure.walk/walk` for every collection, with one exception: a record now goes through `rebuild-record`. That helper is a copy of the private `rebuild-record` in `re-frame.mcp-base.dedup`, which fixed the same hazard for the dedup walk under rf2-gwye.31. It rebuilds every entry first, `dissoc`s any key whose spelling changed, then writes the rebuilt entries back. The record keeps its type and its fixed fields, because a fixed field's key is a keyword and is never respelled.

- It's a copy, not a call, because the mcp-base helper is `^:private` in another artefact and that codec is outside this PR's fence.
- There is no new API and no new serialization layer, and nothing outside `tools/story-mcp/**` changed.

## Regression

These are in `wire_encodability_test.clj`, next to the existing predicate and exception wire tests.

- **`record-extension-key-crosses-get-variant-as-a-marker`** runs the bead's reproducer: a `defrecord` with a `pos?` extension key, registered via `reg-story` / `reg-variant*`. It drives that through `get-variant` over the real `run-loop!` with dedup on and off, reads the raw encoded line, and checks:
  - no `#object` appears in the frame or in the text slot;
  - no `pos_QMARK_@` identity string and no identity hash appear;
  - the structured record has exactly two entries;
  - the text slot reads back as a record literal of its own type, with `:v` marked in place, the marker key carrying `:extension`, and the original key gone;
  - the data-only list, set and vector come back unchanged and keep their collection types.
- **`wire-safe-success-drops-a-record-key-it-respells`** is a direct unit guard plus a control. The control checks that data-only payloads (a record with a plain extension key, a sorted map and nested lists) come back equal and keep their types.

## Quality gates

- `JVM tools/story-mcp (clojure -M:test)`, the `jvm-tools-story-mcp` job in `test.yml`: the result is in the comment below. It covers the red-before and green-after runs and the restore check by blob hash.
- The changed-surface classifier arms `tools_jvm` and `mcp_conformance` for these two paths. So `MCP conformance tools/story-mcp (rf2-cum40)` (`mcp-conformance-story`) is also in scope. Its result is in the comment below; if it wasn't run locally, CI covers it.
