### PR TITLE
fix(epoch): replay's commit observation hears only its arming thread (rf2-k0nr)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -305,6 +305,20 @@
 ;; different id and is refused. `note-commit!` fills the slot only from the
 ;; record carrying THAT id.
 ;;
+;; THAT ORDERING IS PER THREAD, NOT PER FRAME (rf2-k0nr). It puts the armed
+;; caller's emit ahead of anything the caller's OWN thread does next, and says
+;; nothing about another JVM thread. A same-frame dispatch there emits its
+;; `:rf.event/dispatched` on ITS thread and before any drain lock — the router
+;; emits ahead of `drain-block!`, and an async `dispatch!` emits at enqueue —
+;; so no frame boundary keeps it out of the gap between the arming and the
+;; armed caller's `dispatch-sync!`, and a frame-wide first arrival adopted it.
+;; Measured: source epoch 1, the other thread's epoch 2, the replay's own
+;; epoch 3, and the result said `:epoch-id 2`. So the slot also records the
+;; thread that armed it, and only that thread may supply the id. The armed
+;; caller's `dispatch-sync!` emits synchronously on the calling thread, so the
+;; first id that thread reports is its own. CLJS has one thread: there is no
+;; check to make and nothing changes.
+;;
 ;; The slot is still filled at COMMIT, so it names the armed caller's epoch
 ;; whether or not the ring still holds it, and the caller asks the ring —
 ;; separately — whether that epoch is retained. rf2-e0g2's queued-child
@@ -329,12 +343,15 @@
   hand back to `take-observed-commit!`. Always pair the two — a caller that
   arms and does not take leaves a slot the next commit writes into.
 
-  Arm it IMMEDIATELY before the dispatch whose epoch you want: the armed
-  caller's own dispatch has to be the first one epoch capture sees for the
-  frame, which is what makes the correlation above exact."
+  Arm it IMMEDIATELY before the dispatch whose epoch you want, on the thread
+  that makes it: the armed caller's own dispatch has to be the first one epoch
+  capture sees for the frame FROM THAT THREAD, which is what makes the
+  correlation above exact."
   [frame-id]
   (let [token #?(:clj (Object.) :cljs (js-obj))]
-    (swap! commit-observations assoc frame-id {:token token})
+    (swap! commit-observations assoc frame-id
+           #?(:clj  {:token token :thread (Thread/currentThread)}
+              :cljs {:token token}))
     token))
 
 (defn take-observed-commit!
@@ -349,12 +366,20 @@
         (:epoch-id slot)
         (:fallback-epoch-id slot)))))
 
+#?(:clj
+   (defn- armed-on-this-thread?
+     "True when `slot` was armed by the calling thread (rf2-k0nr)."
+     [slot]
+     (identical? (Thread/currentThread) (:thread slot))))
+
 (defn note-observed-dispatch!
   "Record `dispatch-id` as the armed observation's target for `frame-id`, once.
 
   Called from the epoch-capture stage on `:rf.event/dispatched`. Capture runs
-  ahead of the public tooling fan-out, so the first id to arrive here is the
-  armed caller's own dispatch and not one a listener started from inside it.
+  ahead of the public tooling fan-out, so the first id to arrive here FROM THE
+  ARMING THREAD is the armed caller's own dispatch and not one a listener
+  started from inside it. An id reported by any other thread is refused: on
+  the JVM another thread's same-frame dispatch can reach this first (rf2-k0nr).
   A no-op when nothing is armed (the ordinary hot path: one map read, no
   write), and after the first id has landed."
   [frame-id dispatch-id]
@@ -362,7 +387,9 @@
     (swap! commit-observations
            (fn [observations]
              (let [slot (get observations frame-id)]
-               (if (and slot (not (contains? slot :dispatch-id)))
+               (if (and slot
+                        (not (contains? slot :dispatch-id))
+                        #?(:clj (armed-on-this-thread? slot)))
                  (assoc observations frame-id (assoc slot :dispatch-id dispatch-id))
                  observations))))
     nil))

--- a/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
@@ -34,6 +34,9 @@
     7. rf2-e0g2 — the reported `:epoch-id` is the replayed dispatch's OWN
        epoch, or nil when the ring could not retain it — never a queued
        child's record that happened to survive the parent's eviction.
+    8. rf2-k0nr (JVM only) — another thread's same-frame dispatch landing
+       between replay's observation arming and its dispatch never becomes
+       the reported epoch.
 
   `.cljc` under a `-cljs-test` name so the consolidated `:node-test` build
   (`cljs-test$`) AND the artefact's `clojure -M:test` (`.*-test$`) both run
@@ -42,11 +45,13 @@
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.epoch :as rf.epoch]
+            #?(:clj [re-frame.epoch.state :as rf.epoch.state])
             [re-frame.substrate.plain-atom :as rf.substrate.plain-atom]
             [re-frame.test-support :as rf.test-support]
             ;; Side-effect require — publishes the machines late-bind hooks
             ;; for the restore→replay composition proof below.
-            [re-frame.machines]))
+            [re-frame.machines])
+  #?(:clj (:import [java.util.concurrent CountDownLatch TimeUnit])))
 
 (use-fixtures :each
   (rf.test-support/make-reset-runtime-fixture
@@ -692,3 +697,109 @@
       (is (= (:epoch-id (last after)) (:epoch-id res)))
       (is (= [:review/add 1] (:trigger-event named)))
       (is (= {:n 2} (rf/app-db-value interleave-frame-id))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-k0nr — another JVM thread's dispatch cannot steal replay's result
+;;
+;; The concurrent sibling of the listener case above. There the stranger's
+;; dispatch starts on the replay's OWN thread, after the replay's
+;; `:rf.event/dispatched`; here it starts on ANOTHER thread, in the gap between
+;; the replay arming its observation and entering `dispatch-sync!`. Its
+;; `:rf.event/dispatched` arrived first, the frame-wide observation adopted its
+;; id, and the response named its epoch — measured before the fix as source
+;; epoch 1, the other thread's epoch 2, the replay's own epoch 3, and a result
+;; saying `:epoch-id 2`.
+;;
+;; The gap is PLACED, not raced: the real `arm-commit-observation!` runs, then
+;; the replay thread parks on a latch until the other thread's dispatch has
+;; returned. No sleep decides anything. JVM only — CLJS has one thread and no
+;; such gap.
+;;
+;; The first deftest is the tooth. The eviction companion is not: the other
+;; thread's record is OLDER than the replay's, so the ring always evicts it
+;; first and the old code answered nil there too. It pins that the documented
+;; nil survives the interleave.
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (defn- replay-with-foreign-dispatch-after-arming
+     "Replay `source-epoch-id` in `fid` on a background thread, parking that
+     thread immediately AFTER the real observation arming while THIS thread
+     dispatch-syncs `foreign-event` into the same frame. Then release the
+     replay and return its result.
+
+     `with-redefs` is process-global, which is deliberate: only the replay
+     arms, so only the replay thread can reach the park. The latch bounds are
+     guards that turn a regression into one failed deftest, not waits."
+     [fid source-epoch-id foreign-event]
+     (let [armed    (CountDownLatch. 1)
+           release  (CountDownLatch. 1)
+           real-arm rf.epoch.state/arm-commit-observation!]
+       (with-redefs [rf.epoch.state/arm-commit-observation!
+                     (fn [frame]
+                       (let [token (real-arm frame)]
+                         (.countDown armed)
+                         (.await release 10 TimeUnit/SECONDS)
+                         token))]
+         (let [replay (future (rf/replay-epoch! fid source-epoch-id))]
+           (try
+             (is (.await armed 10 TimeUnit/SECONDS)
+                 "the replay thread armed its observation and parked")
+             (rf/dispatch-sync foreign-event {:frame fid})
+             (finally
+               (.countDown release)))
+           (deref replay 10000 ::timeout))))))
+
+#?(:clj
+   (deftest replay-result-names-its-own-dispatch-not-another-threads
+     (testing "another thread's same-frame dispatch commits between replay's
+               observation arming and its dispatch; the reported epoch is still
+               the replay's own record, and both dispatches run"
+       (rf/configure! {:epoch-history {:depth 10}})
+       (rf/make-frame {:id interleave-frame-id})
+       (register-add-and-other!)
+       (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+       (let [source  (last (rf/epoch-history interleave-frame-id))
+             res     (replay-with-foreign-dispatch-after-arming
+                       interleave-frame-id (:epoch-id source) [:review/add 100])
+             after   (rf/epoch-history interleave-frame-id)
+             named   (first (filter #(= (:epoch-id res) (:epoch-id %)) after))
+             foreign (first (filter #(= [:review/add 100] (:trigger-event %))
+                                    after))]
+         (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+         (is (= (:epoch-id source) (:source-epoch-id res)))
+         (is (= [[:review/add 1] [:review/add 100] [:review/add 1]]
+                (mapv :trigger-event after))
+             "the other thread's dispatch committed INSIDE replay's armed window,
+              before the replayed event ran")
+         (is (= {:n 102} (rf/app-db-value interleave-frame-id))
+             "both dispatches executed; only the returned evidence was at stake")
+         ;; THE TOOTH.
+         (is (= (:epoch-id (last after)) (:epoch-id res))
+             "the reported epoch is the replay's OWN new record")
+         (is (= [:review/add 1] (:trigger-event named))
+             (str "…and it resolves to the replayed arguments, not the other "
+                  "thread's; resolved " (pr-str (:trigger-event named))))
+         (is (not= (:epoch-id foreign) (:epoch-id res))
+             "the other thread's record is never the reported epoch")))))
+
+#?(:clj
+   (deftest replay-reports-nil-not-another-threads-epoch-when-its-own-was-evicted
+     (testing "the same interleave with the replay's own record evicted by its
+               queued child: the documented nil, never the other thread's id"
+       (rf/configure! {:epoch-history {:depth 1}})
+       (rf/make-frame {:id evict-frame-id})
+       (register-parent-and-child!)
+       (register-add-and-other!)
+       (rf/dispatch-sync [:review/parent] {:frame evict-frame-id})
+       (let [source (last (rf/epoch-history evict-frame-id))
+             res    (replay-with-foreign-dispatch-after-arming
+                      evict-frame-id (:epoch-id source) [:review/other])
+             after  (rf/epoch-history evict-frame-id)]
+         (is (true? (:ok? res)) (str "the dispatch itself succeeded: " (pr-str res)))
+         (is (= [:review/child] (mapv :event-id after))
+             "the replayed parent's queued child evicted the parent's record")
+         (is (nil? (:epoch-id res))
+             "the ring could not retain the replay's own epoch, so nil rides back")
+         (is (= {:runs 2 :child true :other true} (rf/app-db-value evict-frame-id))
+             "the other thread's event, the replayed parent and its child all ran")))))


### PR DESCRIPTION
Closes rf2-k0nr (filed by the merged-PR audit of #9769, from rf2-fzbj.19).

## The defect

`perform-replay!` arms a one-shot commit observation, then calls `dispatch-sync!`. The observation took the FIRST `:rf.event/dispatched` id that epoch capture reported for the frame. That ordering (capture runs before the public tooling fan-out) holds on the arming thread only. On the JVM another thread's same-frame dispatch emits its `:rf.event/dispatched` on its own thread and before any drain lock — `dispatch-sync!` emits ahead of `drain-block!`, and an async `dispatch!` emits at enqueue — so it can land between the arming and the replay's dispatch. Its epoch was then reported as the replay's. Measured: source epoch 1, the other thread's epoch 2, the replay's own epoch 3, and a result naming `:epoch-id 2`. Both dispatches always ran; only the dev tool's causal evidence was wrong.

## The correction taken: the bead's option 1 (own dispatch identity)

The slot records the arming thread, and `note-observed-dispatch!` accepts an id only from that thread. The replay's own `dispatch-sync!` emits synchronously on the calling thread, so the first id that thread reports is its own. A listener's nested dispatch on the same thread is still refused, as it was before (rf2-fzbj.19).

Option 2 (serializing the arming-to-dispatch interval on the frame boundary) cannot work. The foreign `:rf.event/dispatched` is emitted outside the drain lock, so holding that boundary would not keep it out of the window.

CLJS has one thread. The check sits under `#?(:clj ...)`, so the CLJS code path is unchanged. There is no public API change, no change to the router's dispatch return, and no new diagnostics. `implementation/core/**` is untouched.

## Regression

This is JVM-only, in `epoch_replay_cljs_test.cljc` under `#?(:clj ...)`, beside its fzbj.19 siblings. It drives the public `replay-epoch!` / `dispatch-sync` path. The replay runs on a future and parks on a `CountDownLatch` immediately AFTER the real `arm-commit-observation!`. The test thread then dispatches `[:review/add 100]` into the same frame and releases it. No sleeps.

- `replay-result-names-its-own-dispatch-not-another-threads` is the tooth. It asserts the reported epoch is the replay's own new record and resolves to `[:review/add 1]`; that app-db is `{:n 102}`, so both dispatches ran; and that the other thread's record is never reported.
- `replay-reports-nil-not-another-threads-epoch-when-its-own-was-evicted` is a companion, not a tooth. The other thread's record is older, so the ring always evicts it first. It pins that the documented nil survives the interleave.

The existing behaviours listed in the bead stay pinned by the unchanged neighbouring deftests: same handler with different arguments under listener nesting, ordinary replay, queued-child retained and evicted results, and failed-dispatch observation cleanup.

## Quality gates

In progress. This section will be updated with captured exit codes.

Every number below is the runner's own captured exit code (redirect and echo on one command line), never a harness-reported one.

- **Epoch JVM lane.** `clojure -M:test` in `implementation/epoch` is `test.yml` job `jvm-epoch`, "JVM epoch (clojure -M:test)". Result: exit **0**, 543 tests / 7328 assertions, 0 failures. The baseline at the merge base, on the same box, was 541 / 7315. The +2 deftests and +13 assertions are exactly the new code.
- **RED before the fix.** The pre-fix `state.cljc` blob (`02f542f6a3`) was planted, and the plant was checked by content hash (the planted file hashes to that blob) and by a match-count control. The replay namespace alone then exited **1**, with 3 failures, all in the tooth deftest: the reported epoch was 14 (the other thread's) where the replay's own was 15, and it resolved to `[:review/add 100]`. It ran 18 tests / 136 assertions, identical to the post-restore control run. The eviction companion passed pre-fix, as its comment predicts.
- **Restore.** The working file's default-form hash equals the committed blob `927e53d994`, and `git diff --quiet HEAD` exited 0. The same namespace then exited **0** at 18 / 136.
- **CLJS lane.** `npm run test:cljs`, run against a node_modules installed in this worktree with `npm ci` (not linked): exit **0**, 12065 tests / 60143 assertions, 0 failures. The new tests are `#?(:clj ...)`, so this lane shows the CLJS path unchanged.
- **Lane rosters and bijection.** `check_test_lane_bijection.py` and `check_jvm_lane_rosters.py` exited 0. The prod-gate lane (`scripts/test-epoch-prod-gate.sh`) already lists `re-frame.epoch-replay-cljs-test` in `known_red`, and no namespace was added, so its roster is untouched.
- **Ratchets covering these paths.** Exit 0 on all of: `check_require_alias_dialect`, `check_retired_spellings`, `check_retired_composition_vocab`, `check_keyword_catalogue_drift`, `check_escaped_continuations`, `check_flattened_lists`, `check_thrown_error_messages`, `check_architecture_census`, `check_runtime_subsystem_grading`, `check_ambient_durable_reads`, the four residue checks, `check-no-hardcoded-paths.sh`, and `check-commit-attribution.sh`.
- **Not rebased.** The branch sits on `bb87830298`. The 10 trunk commits since touch nothing under `implementation/epoch/**`, `trace.cljc` or `router.cljc`, and the three-dot diff carries only the two files here. The remaining PR checks are relied on from CI.

## Residual, named and not fixed

`note-commit!`'s `:fallback-epoch-id` still takes the frame's first commit from any thread. It is read only when no `:rf.event/dispatched` id was observed for the arming thread (the no-dispatch-id posture). Left alone to avoid broadening the change.
