### PR TITLE
docs(xray): record the embed door as ratom-family by ruling (rf2-v4lx, rf2-u68x)

### DIFF
--- a/docs/xray/api/reference.md
+++ b/docs/xray/api/reference.md
@@ -112,7 +112,7 @@ Seven of the ten carry a standalone `mount-<panel>!` facade:
 | Reactive (Views) | `day8.re-frame2-xray.panels.reactive-panel` | `Panel` Fresco boundary |
 | Trace | `day8.re-frame2-xray.panels.trace` | `Panel` Fresco boundary |
 | Machine Inspector | `day8.re-frame2-xray.panels.machine-inspector` | `Panel` Fresco boundary |
-| Routing | `day8.re-frame2-xray.panels.routing` | `Panel`, not an `rf/reg-view` |
+| Routing | `day8.re-frame2-xray.panels.routing` | `Panel` bridge over a private Fresco boundary |
 | Resources | `day8.re-frame2-xray.panels.resources` | `Panel` Fresco boundary |
 
 The remaining three are **L4-only registry tabs** — registered for the tab strip and focusable through `focus!`, but shell-internal and not independently mountable into a host's own layout:
@@ -140,7 +140,7 @@ Five parallel Static-mode panels browse the registrar rather than the event spin
 Several surfaces are **publicly visible** in the CLJS source but explicitly *not part of the contract*. They're documented in the [developer-internal spec](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/API.md) for Xray's maintainers; this reference omits them on purpose.
 
 - **`config.cljc` atom handles.** Every state setter writes to a `defonce` atom (`auto-open?`, `editor`, `keybinding-enabled?`, …); the atoms are reachable as `@day8.re-frame2-xray.config/<atom>` due to CLJS-default-public visibility. The setters are the canonical write path, the getters are the canonical read path. Reaching for the atom directly is reading an internal seam.
-- **Internal `mount-<panel>!` aggregators.** The shell composer calls these to mount individual panels; they're not part of the host-facing embed contract. Full-shell embedding lives at [`008-Embedding-Contract.md`](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/008-Embedding-Contract.md).
+- **Internal `mount-<panel>!` aggregators.** Story's RHS inspector is the one consumer today; a host that builds its own Xray chrome MAY call them (manifest tier `internal-public`), an app never should. They take hiccup and so mount only on a ratom-family adapter — deliberately (rf2-l1jm); an element-shaped host uses the mount verbs. Full-shell embedding lives at [`008-Embedding-Contract.md`](https://github.com/day8/re-frame2/blob/main/tools/xray/spec/008-Embedding-Contract.md).
 - **Predicate / mutation helpers.** `suppress-sensitive?`, `note-suppressed!`, `clamp-panel-width-px`, `editor-uri` — thin wrappers Xray's own modules consume. (The `:sensitive?` stamp predicate itself is the framework's `rf/sensitive?`, called directly.)
 - **`register-toggle-off-callback!` / `unregister-toggle-off-callback!`.** Internal — Xray modules wire their buffer-clear hooks here. Host applications should NOT register.
 

--- a/tools/xray/spec/008-Embedding-Contract.md
+++ b/tools/xray/spec/008-Embedding-Contract.md
@@ -723,7 +723,10 @@ to `rf.substrate.adapter/render` with a HICCUP tree, so a host reaching for
 *that* door needs a `:render` that accepts hiccup, i.e. the ratom family.
 The mount verbs (`open!`, `open-overlay!`, `popout!`, and the preload
 auto-open) do not, and they are the host-facing contract. A host on an
-element-shaped adapter uses the mount verbs.
+element-shaped adapter uses the mount verbs. This is deliberate (ruled under
+rf2-l1jm, 2026-09-13): revisit only when a host on an element-shaped adapter
+actually needs a single panel in its own layout — Story moving stock Reagent
+to reagent-slim is NOT that, reagent-slim being ratom-family too.
 
 ## Rejected substrate options (recorded so they are not re-proposed)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -309,7 +309,7 @@
   rf2-2n8q — the 4-arity is an ADDITION and the couplings `mount-resources!`
   reserves this fn for are untouched: the frame-provider wrap and the
   `adapter/render` delegation are still written once, here, and are still
-  one edit when the shell becomes a Fresco tree."
+  one edit if the door ever moves (rf2-l1jm keeps it ratom-family)."
   ([panel-view mount-point opts]
    (render-panel! panel-view mount-point opts nil))
   ([panel-view mount-point opts props]
@@ -526,9 +526,10 @@
   ;; `*-bridge` when the shell itself becomes a Fresco tree.
   ;;
   ;; `render-panel!` ITSELF is deliberately untouched: it is the single
-  ;; chokepoint where the frame-provider and adapter/render couplings are
-  ;; severed for the whole embedding contract, and that is one edit in
-  ;; the final commit rather than N edits now.
+  ;; chokepoint where the frame-provider and adapter/render couplings
+  ;; would be severed for the whole embedding contract, and that severing
+  ;; is deliberately NOT made: the embed door is ratom-family by ruling
+  ;; (rf2-l1jm, 2026-09-13), and if it ever moves it is still one edit here.
   ([mount-point opts] (render-panel! resources/Panel-bridge mount-point opts)))
 
 (defn mount-event-spine!
@@ -795,11 +796,12 @@
   entry — composes every panel inside the shell's ribbon + event-list
   + tab-bar + detail-panel chrome.
 
-  This is the same mount path `mount.cljs/open!` uses for the
-  default in-app `[data-rf-xray-host]` mount; exposing it here lets
-  hosts that own their own DOM (Story, custom dev surfaces) mount
-  the shell at any element without going through Xray's auto-open
-  preload.
+  Unlike `mount.cljs/open!`, which paints through a Fresco client root
+  Xray owns (rf2-k97c.3), this door hands hiccup to the HOST's installed
+  adapter and so mounts only on the ratom family (deliberately —
+  rf2-l1jm); exposing it lets hosts that own their own DOM (Story, custom
+  dev surfaces) mount the shell at any element without going through
+  Xray's auto-open preload.
 
   `opts` carries the two props `008-Embedding-Contract.md` §Embed props
   inventory publishes:


### PR DESCRIPTION
## Summary

Closes rf2-v4lx and rf2-u68x. This PR changes prose, docstrings and comments only. No executable form moves.

**rf2-v4lx.** The rf2-l1jm ruling keeps the Xray embed door (`render-panel!`, `mount-shell!`) on `rf.substrate.adapter/render`, and it is deliberately ratom-family (Reagent / reagent-slim). A host on an element-shaped adapter (UIx, Fresco) uses the mount verbs. The prose below still described this as a gap or as a Fresco move still to come. The bead lists five sites; this PR corrects four and leaves one alone:

1. `docs/xray/api/reference.md`, the "Internal `mount-<panel>!` aggregators" clause. It claimed the shell composer calls the facades, but the shell composes panels through its registry. Now it says Story's RHS inspector is the one consumer, gives the manifest tier (`internal-public`), and says the facades are ratom-family by ruling.
2. `tools/xray/spec/008-Embedding-Contract.md`: one sentence added to the ONE HONEST EXCEPTION paragraph. It records that the exception is a ruling and states the reopen trigger, so the next reader doesn't re-file the question.
3. `panels.cljs`, the `mount-shell!` docstring. It no longer claims to share `open!`'s mount path. Since rf2-k97c.3, `open!` paints through a Fresco client root that Xray owns.
4. `panels.cljs`, the `render-panel!` docstring and the `mount-resources!` comment. The "one edit in the final commit" Fresco move is retired. The "written once, here" half is kept.
5. `tools/story/deps.edn`: **left alone on purpose.** The bead calls it the lowest-value site and says leaving it is acceptable. Touching it would arm `jvm-tools-story` next to the rf2-qvyr `:exclusions` value for a one-word gain.

**rf2-u68x.** The Routing row of the Dynamic panel table now reads "`Panel` bridge over a private Fresco boundary". It used to read "`Panel`, not an `rf/reg-view`", which was true but said nothing about what the export is. The measurement the bead was waiting on is answered: the bare `routing/Panel` at the `render-panel!` call site is **correct, not residue**. `routing/Panel` IS the `rf.fresco/as-component` bridge (`[:> Panel-component {}]`) over the private `defview` `PanelView`. The mechanism is the same as its six `Panel-bridge` siblings; only the name assignment is inverted, deliberately, per `routing.cljs`'s ns docstring. It needs no props bridge, because its 0-arity `Panel` takes none and `render-panel!` passes none. `cancellation-cascade/SidePanel` and `/Popover` follow the same inverted pattern, which confirms the reading rather than adding a second case. The other nine Dynamic rows were re-checked at tip and are correct. `tools/xray/spec/API.md` asserts nothing false about routing and is not edited.

Not touched, per the bead: `008:348`, `011-Launch-Modes.md`, `007-UX-IA.md`, `spec/API.md` and both `spec/api-manifest*.edn` sidecars. No name, arity or tier moves, so the `api-manifest` job stays unarmed.

## Quality gates

Exit codes are the runner's own, captured on one command line with the redirect.

- `scripts/check_doc_slugs.py --verbose`: **0**. Its roots cover `docs/` and `tools/*/spec`, so it covers both markdown pages.
- **Sabotage witness for that gate:** I planted a broken anchor on `docs/xray/api/reference.md:143`, a line this PR edits. The gate went to **1** and named that file, line and anchor, so it read this tree. I restored the file with `git checkout`; its default-form `git hash-object` equals the committed blob, and `git diff --quiet` is 0.
- `python -m mkdocs build --strict`: **0**. `docs/xray/` is not in `exclude_docs`. The built `site/xray/api/reference/index.html` carries the new aggregator wording (1 hit) and the new Routing cell (1 hit), and the old clause 0 times. This build does not cover `tools/xray/spec/**`, which is outside `docs_dir` and not staged.
- `scripts/check_retired_spellings.py`: **0**.
- Every other `scripts/check_*.py`, plus `check-no-hardcoded-paths.sh` and `check-ai-tracking-ratchet.sh`: **0** each.
- **Comment-only proof for `panels.cljs`:** the fixed-string count of `adapter/render` is 6 before and 6 after. The two executable sites (the bodies of `render-panel!` and `mount-shell!`) are unchanged; I read the diff by hand to confirm.
- **CLJS / JVM lanes that `panels.cljs` arms** (`cljs_node_test`, `cljs-browser`, `story-xray-browser`, `jvm-tools-xray`): **relying on CI**. The diff changes only a docstring and comment text.

**Checked by hand, because neither link gate reads prose or tables:**
- The one link on an edited line (the GitHub URL to `008-Embedding-Contract.md`) is unchanged, and no new link or anchor was added.
- The Dynamic table keeps 3 columns on every row.
- No edited line sits inside a fenced block.
- Line endings are unchanged (CR count equals CRLF count on all three files).
