### PR TITLE
fix(test-quiet): refuse a selected .cljc that a .clj in another root would load instead (rf2-hq1o5)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -774,19 +774,50 @@
                [#{} []])
        second))
 
-(defn- resolved-through-classpath
-  "The file `require` will actually load for the classpath-relative resource
-  path `ns-path` — a forward-slashed canonical path — or nil when nothing on
-  THIS run's classpath answers to it.
+(defn- source-file
+  "The loose source file `url` names, as a forward-slashed canonical path,
+  or nil when it names anything else.
 
-  A resource answered from inside a jar is nil too: a jar entry is never one
-  of the loose source files the discovery walk just handed us, so it is
-  `some other file` by the only definition that matters here."
+  A resource answered from inside a jar is nil: a jar entry is never one of
+  the loose source files the discovery walk just handed us, so it is `some
+  other file` by the only definition that matters here."
+  [^java.net.URL url]
+  (when (= "file" (.getProtocol url))
+    (try (str/replace (.getCanonicalPath (io/file (.toURI url))) "\\" "/")
+         (catch Exception _ nil))))
+
+(defn- resolved-through-classpath
+  "The loose file THIS run's classpath answers the resource path `ns-path`
+  with, or nil when nothing answers it or a jar does.
+
+  Answering this one path is NOT the same as being what `require` loads:
+  `require` never asks for the extension a discovered file happens to carry.
+  That question is `load-winner`'s."
   [^String ns-path]
-  (when-let [url (io/resource ns-path)]
-    (when (= "file" (.getProtocol url))
-      (try (str/replace (.getCanonicalPath (io/file (.toURI url))) "\\" "/")
-           (catch Exception _ nil)))))
+  (some-> (io/resource ns-path) source-file))
+
+(def ^:private load-extensions
+  "The order `require` asks the classpath for a namespace's source.
+
+  `clojure.lang.RT/load` asks the WHOLE classpath for `<base>.clj`, and only
+  when nothing anywhere answers does it ask for `<base>.cljc` — so a `.clj`
+  in ANY root beats a `.cljc` in EVERY root, whatever the root order.
+  Measured on Clojure 1.12.0 (rf2-hq1o5): with a `.cljc` in the first root
+  and a `.clj` of the same namespace in the second, `require` loads the
+  `.clj`; swap the roots and it still loads the `.clj`; drop the `.clj` and
+  it loads the `.cljc`. (`RT/load` also takes a compiled `__init.class` over
+  either source when the class is newer; that door is not modelled here.)"
+  [".clj" ".cljc"])
+
+(defn- load-winner
+  "The source `require` will ACTUALLY load for `ns-sym` on this run's
+  classpath: a loose file's forward-slashed canonical path, the resource URL
+  of anything else (a jar entry), or nil when nothing answers at all."
+  [ns-sym]
+  (some (fn [ext]
+          (when-let [url (io/resource (ns->path ns-sym ext))]
+            (or (source-file url) (str url))))
+        load-extensions))
 
 (defn- own-path-defect
   "Why `file` will not reach the runner as ITS OWN namespace, or nil.
@@ -801,31 +832,55 @@
   `-d test/re_frame`, narrowing a large tree during local debugging, is an
   ordinary selection and not a defect, even though every file under it then
   spells a path relative to `-d` that differs from its resource path.  Two
-  answers therefore clear a file, and it is a defect only if NEITHER does:
+  answers therefore say a file spells its own path, and it is a defect if
+  NEITHER does:
 
     - its path relative to the scan directory already IS its resource path
       (the default `-d test` lane, and every temp-dir fixture, which is why
       this arm must stay: nothing there is on the classpath at all); or
-    - `require`'s own resolution of that resource path, on this run's real
-      classpath, lands on THIS VERY FILE.
+    - that resource path, on this run's real classpath, answers with THIS
+      VERY FILE.
 
-  The second arm is strictly weaker than the first, so this rule can only
-  ever clear a file the older path-string comparison reddened — never redden
-  one it cleared."
-  [{:keys [canonical rel ext declared complaint]}]
+  The second arm is strictly weaker than the first, so it can only ever
+  clear a file the older path-string comparison reddened.
+
+  NEITHER ANSWER SAYS THE FILE IS WHAT `require` LOADS (rf2-hq1o5).  Both
+  look the namespace up under the extension the discovered file carries,
+  while `require` asks the whole classpath for the `.clj` first (see
+  `load-extensions`).  So a selected failing `.cljc` in one root and an
+  unselected passing `.clj` of the same namespace in another satisfied both,
+  and `-main` ran the `.clj` and exited 0 without the selected failure ever
+  executing.  A file that spells its own path is therefore STILL a defect
+  when its namespace's `load-winner` is a source outside `discovered` — the
+  canonical paths of every file this run walked.  A winner INSIDE it is a
+  discovered sibling declaring the same namespace, which `collision-defects`
+  names together with this file."
+  [discovered {:keys [canonical rel ext declared complaint]}]
   (if complaint
     complaint
     (let [ns-path  (ns->path declared ext)
+          self     (str/replace canonical "\\" "/")
           resolved (resolved-through-classpath ns-path)]
-      (when-not (or (= rel ns-path)
-                    (= resolved (str/replace canonical "\\" "/")))
+      (if-not (or (= rel ns-path) (= resolved self))
         (str "it declares `" declared "`, which `require` loads from `"
              ns-path "` - "
              (if resolved
                (str "and on this run's classpath that is `" resolved
                     "`, a different file.")
                (str "and nothing on this run's classpath answers to that"
-                    " path, so `require` cannot load this file at all.")))))))
+                    " path, so `require` cannot load this file at all.")))
+        (let [winner (load-winner declared)]
+          (when (and winner
+                     (not= winner self)
+                     (not (contains? discovered winner)))
+            (str "it declares `" declared "`, but `require` loads that"
+                 " namespace from `" winner "`, a different file, so this"
+                 " file never runs"
+                 (if (and (= ext ".cljc") (str/ends-with? winner ".clj"))
+                   (str ": Clojure takes a namespace's `.clj` before its"
+                        " `.cljc` from anywhere on the classpath, whatever"
+                        " the root order.")
+                   "."))))))))
 
 (defn- collision-defects
   "One `[path complaint]` per file for every namespace declared by MORE
@@ -863,22 +918,24 @@
 
   Empty is the only acceptable answer.  Two rules, both required: a file
   must declare a namespace that resolves to ITS OWN FILE — by its path
-  relative to the scan directory, or by `require`'s own resolution against
-  the real classpath, which is what makes a nested `-d` an ordinary
-  selection rather than a defect (`own-path-defect`) — and no two files may
-  declare the SAME one (`collision-defects`).  The first alone leaves the
-  shadowing door open,
-  because it derives each file's extension from that file and so clears a
-  `.clj`/`.cljc` pair — and a repeated relative path under two roots —
-  where each half spells its own path perfectly and only one of them ever
-  loads."
+  relative to the scan directory, or by resolution against the real
+  classpath, which is what makes a nested `-d` an ordinary selection rather
+  than a defect — and that `require` will not load from some source outside
+  the scan instead (`own-path-defect`); and no two files may declare the
+  SAME one (`collision-defects`).  The first alone leaves the shadowing door
+  open inside the scan, because it derives each file's extension from that
+  file and so clears a `.clj`/`.cljc` pair — and a repeated relative path
+  under two roots — where each half spells its own path perfectly and only
+  one of them ever loads."
   [dirs]
-  (let [files (scan dirs)]
+  (let [files      (scan dirs)
+        discovered (set (map #(str/replace (:canonical %) "\\" "/") files))
+        defect     (partial own-path-defect discovered)]
     (vec
       (sort
-        (concat (for [f files :let [complaint (own-path-defect f)] :when complaint]
+        (concat (for [f files :let [complaint (defect f)] :when complaint]
                   [(:path f) complaint])
-                (collision-defects (remove own-path-defect files)))))))
+                (collision-defects (remove defect files)))))))
 
 (defn- verify-discovery!
   "Refuse the run when any file in this lane's discovery directories will

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -33,7 +33,9 @@
    - DISCOVERY: a file whose `(ns ...)` form the reader cannot read
      refuses the run (exit 1, named on stderr) instead of leaving it
      silently short a suite — and the same fixture is green the moment
-     before that file arrives.
+     before that file arrives. Likewise a selected `.cljc` that `require`
+     would never load, because a `.clj` of its namespace answers from
+     another classpath root (rf2-hq1o5).
    - FIXTURES: a namespace whose `use-fixtures` entry is DATA rather
      than a function — the cljs.test `{:before f :after g}` map, whether
      written at the call site or reached through a var — refuses the run
@@ -1676,21 +1678,23 @@
 ;; standing the guard down.
 
 (defn- invoke-quiet-runner-rooted
-  "Relaunch a fresh JVM on `-main` with `classpath-root` on the classpath
-  and `discovery-dir` — which may be nested arbitrarily deep beneath it —
-  as the `-d` value. The harness above passes ONE directory as both, which
-  is precisely the case that cannot distinguish a discovery directory from
-  a classpath root."
-  [^java.io.File classpath-root ^java.io.File discovery-dir & runner-args]
+  "Relaunch a fresh JVM on `-main` with `classpath-roots` appended to the
+  classpath in order and `discovery-dir` — which may be nested arbitrarily
+  deep beneath one of them — as the `-d` value. The harness above passes ONE
+  directory as both, which is precisely the case that cannot distinguish a
+  discovery directory from a classpath root."
+  [classpath-roots ^java.io.File discovery-dir & runner-args]
   (let [java-executable (str (io/file (System/getProperty "java.home") "bin"
                                       (if (str/includes?
                                             (str/lower-case
                                               (System/getProperty "os.name"))
                                             "win")
                                         "java.exe" "java")))
-        classpath       (str (System/getProperty "java.class.path")
-                             (System/getProperty "path.separator")
-                             (.getAbsolutePath classpath-root))
+        path-separator  (System/getProperty "path.separator")
+        classpath       (str/join path-separator
+                                  (cons (System/getProperty "java.class.path")
+                                        (map #(.getAbsolutePath ^java.io.File %)
+                                             classpath-roots)))
         command         (into [java-executable "-cp" classpath "clojure.main"
                                "-m" "re-frame.test-quiet.runner"
                                "-d" (.getAbsolutePath discovery-dir)]
@@ -1728,7 +1732,7 @@
                                 ["probe"      (io/file root "probe")]
                                 ["probe/deep" (io/file root "probe" "deep")]]]
           (let [{:keys [exit out err timed-out?]}
-                (invoke-quiet-runner-rooted root dir
+                (invoke-quiet-runner-rooted [root] dir
                                             "-n" "probe.deep.good-test")]
             (is (not timed-out?) (str "-d " relative " must terminate"))
             (is (zero? exit)
@@ -1755,7 +1759,7 @@
                "  (:require [clojure.test :refer [deftest is]]))\n"
                "(deftest silently-dropped (is (= 1 1)))"))
         (let [{:keys [exit out err]}
-              (invoke-quiet-runner-rooted root (io/file root "probe" "deep"))]
+              (invoke-quiet-runner-rooted [root] (io/file root "probe" "deep"))]
           (is (= 1 exit)
               (str "an unreadable file must still red the lane under a"
                    " nested `-d`; got exit " exit "\n--- stdout ---\n" out
@@ -1769,3 +1773,102 @@
           (is (not (str/includes? out "Ran "))
               (str "and the run is refused before any test executes; got:\n"
                    out)))))))
+
+;; ----------------------------------------------------------------------
+;; A `.cljc` IS NOT WHAT `require` LOADS WHEN A `.clj` ANSWERS (rf2-hq1o5).
+;;
+;; The repair above clears a file when its resource path, looked up on the
+;; real classpath, answers with that very file. It looked the path up under
+;; the DISCOVERED file's extension, and `require` does not: `RT/load` asks
+;; the whole classpath for the namespace's `.clj` first, and for its `.cljc`
+;; only when no `.clj` answers anywhere. So a selected FAILING `.cljc` and an
+;; unselected PASSING `.clj` of the same namespace, in two classpath roots,
+;; cleared the guard — and `collision-defects` could not see the pair,
+;; because the `.clj` sits outside every discovery directory. Measured
+;; before the fix, at a root and a nested `-d` and with the roots in either
+;; order: exit 0, `Ran 1 tests containing 1 assertions.`, and the SHADOW's
+;; marker on stdout. The selected failure never executed.
+;;
+;; The control is what makes the refusal evidence rather than opinion: with
+;; the shadow off the classpath, the identical command runs the `.cljc` and
+;; exits 1 on its failure — so the green above was a real lost failure.
+
+(def ^:private selected-failing-cljc
+  "The SELECTED file: a `.cljc` whose one test fails, and says so on stdout
+  so the output names which file actually ran."
+  (str "(ns probe.deep.mixed-test\n"
+       "  (:require [clojure.test :refer [deftest is]]))\n"
+       "(deftest the-selected-cljc-fails\n"
+       "  (println \"selected-cljc-ran\")\n"
+       "  (is (= :selected :shadow)))"))
+
+(def ^:private unselected-passing-clj
+  "The SHADOW: a `.clj` of the same namespace, in another classpath root and
+  under no discovery directory, whose one test passes."
+  (str "(ns probe.deep.mixed-test\n"
+       "  (:require [clojure.test :refer [deftest is]]))\n"
+       "(deftest the-shadow-clj-passes\n"
+       "  (println \"shadow-clj-ran\")\n"
+       "  (is (= 1 1)))"))
+
+(deftest a-cljc-shadowed-by-a-clj-in-another-root-is-refused
+  (with-fixture-dir
+    (fn [tmp]
+      (let [selected (io/file tmp "selected")
+            shadow   (io/file tmp "shadow")
+            depths   [["<selected root>" selected]
+                      ["probe"           (io/file selected "probe")]]]
+        (write-deep-fixture! selected "probe/deep/mixed_test.cljc"
+                             selected-failing-cljc)
+        (write-deep-fixture! shadow "probe/deep/mixed_test.clj"
+                             unselected-passing-clj)
+
+        (testing "THE GUARD: the selected `.cljc` is refused before any tally,
+                  naming it AND the `.clj` that would load instead — whichever
+                  root comes first, because the extension decides, not the
+                  root order"
+          (doseq [[order roots] [["selected root first" [selected shadow]]
+                                 ["shadow root first"   [shadow selected]]]
+                  [relative dir] depths]
+            (let [{:keys [exit out err timed-out?]}
+                  (invoke-quiet-runner-rooted roots dir
+                                              "-n" "probe.deep.mixed-test")
+                  context (str order ", -d " relative "\n--- stdout ---\n" out
+                               "\n--- stderr ---\n" err)]
+              (is (not timed-out?) (str "must terminate; " context))
+              (is (= 1 exit)
+                  (str "the selected file will never run, so the lane must be"
+                       " refused rather than go green over the shadow; got"
+                       " exit " exit ", " context))
+              (is (str/includes? err "selected/probe/deep/mixed_test.cljc")
+                  (str "the diagnostic names the SELECTED file; " context))
+              (is (str/includes? err "shadow/probe/deep/mixed_test.clj`")
+                  (str "and the file `require` actually loads; " context))
+              (is (str/includes? err "`.clj` before its `.cljc`")
+                  (str "and why that one wins; " context))
+              (is (not (str/includes? out "Ran "))
+                  (str "refused BEFORE a tally exists; " context))
+              (is (not (str/includes? out "shadow-clj-ran"))
+                  (str "so the shadow's test never ran either; " context)))))
+
+        (testing "THE CONTROL: with the shadow off the classpath, the same
+                  command runs the selected `.cljc` and exits 1 on its
+                  failure"
+          (doseq [[relative dir] depths]
+            (let [{:keys [exit out err]}
+                  (invoke-quiet-runner-rooted [selected] dir
+                                              "-n" "probe.deep.mixed-test")
+                  context (str "-d " relative "\n--- stdout ---\n" out
+                               "\n--- stderr ---\n" err)]
+              (is (= 1 exit)
+                  (str "the selected file fails, so the lane is red; got exit "
+                       exit ", " context))
+              (is (str/includes? out "selected-cljc-ran")
+                  (str "and it is the selected `.cljc` that ran; " context))
+              (is (str/includes? out "Ran 1 tests containing 1 assertions.")
+                  (str "exactly once; " context))
+              (is (str/includes? out "1 failures, 0 errors.")
+                  (str "reporting its failure; " context))
+              (is (not (str/includes? err "will not reach the runner"))
+                  (str "and nothing is refused, because nothing shadows it;"
+                       " " context)))))))))


### PR DESCRIPTION
Fixes rf2-hq1o5, filed by the merged-PR audit of #9778.

## The defect

The nested-discovery repair in #9778 cleared a discovered file when its resource path, looked up on the real classpath under the discovered file's own extension, answered with that very file. `require` does not look it up that way: `clojure.lang.RT/load` asks the whole classpath for the namespace's `.clj` first, and for its `.cljc` only when no `.clj` answers anywhere. So a selected failing `.cljc`, plus an unselected passing `.clj` of the same namespace in another classpath root, passed the guard. `collision-defects` could not see the pair, because the `.clj` sits outside every discovery directory. `-main` ran the `.clj`'s test and exited 0. The selected failure never executed.

## The fix

In `implementation/test-quiet/src/re_frame/test_quiet/runner.clj`:

- `load-winner` asks the classpath for the namespace's `.clj`, then its `.cljc` (`load-extensions`), which is `RT/load`'s order.
- `own-path-defect` now refuses a file that spells its own path when that load winner is a source outside the scanned set. The refusal names the winner and says why: a `.clj` beats a `.cljc` from anywhere on the classpath, whatever the root order.
- A winner INSIDE the scanned set is a discovered sibling that declares the same namespace. That case is left to `collision-defects`, so the existing duplicate diagnostics are unchanged.
- `resolved-through-classpath` no longer claims in its docstring to be what `require` loads.

Behaviour that is unchanged:

- the nested-`-d` repair itself;
- root-relative temp-dir fixtures: nothing answers on the classpath, so the winner is nil and the file clears as before;
- canonical same-file aliases;
- unreadable-form failures;
- the duplicate-file checks.

No allowlist and no policy layer.

## Precedence, confirmed against the runtime

I probed Clojure 1.12.0 with a `.cljc` in one root and a `.clj` of the same namespace in another:

| Classpath | What `require` loaded |
|---|---|
| `.cljc` root first, `.clj` root second | the `.clj` |
| roots swapped | the `.clj` |
| `.clj` removed | the `.cljc` |

## Regression

The new deftest is `a-cljc-shadowed-by-a-clj-in-another-root-is-refused` in `test_quiet_runner_contract_test.clj`. It runs as a subprocess through the real `-main`.

- **Fixture.** A selected failing `.cljc` at `selected/probe/deep/mixed_test.cljc` and an unselected passing `.clj` at `shadow/probe/deep/mixed_test.clj`, run with `-n probe.deep.mixed-test`.
- **Refused runs.** Four runs: `-d` at the selected root and at `selected/probe`, each with the roots in both orders. Each must exit 1, name both files and the reason on stderr, produce no tally, and never print the shadow's marker.
- **Control.** With the shadow off the classpath, the same command at both depths runs the `.cljc` and prints `Ran 1 tests containing 1 assertions.` and `1 failures, 0 errors.`, exit 1. That makes the green a real lost failure rather than a guessed resolution order.

The `invoke-quiet-runner-rooted` harness from #9778 now takes a vector of classpath roots.

**RED against the pre-fix source.**

1. I planted the pre-fix `runner.clj` from `HEAD~1`, and checked the plant applied: the working file's blob hash was `9ff1b92b7e`, which is the pre-fix blob.
2. The two affected deftests then exited 1 with 24 failures, all in the new deftest: 6 assertions × 4 refused runs, each child having printed its own green `Ran 1 tests containing 1 assertions.`.
3. The #9778 row and both controls stayed green.
4. I restored the file and checked the restore: its blob hash is `86e8155111`, equal to HEAD's blob, and `git diff --quiet` exited 0.
5. Green after the fix: 2 tests / 54 assertions, exit 0.

## Scope: one step past the bead's wording

The bead scopes the correction to the real-classpath arm. Under a ROOT `-d`, the path-relative arm clears the file, so the identical shadow was the same false green there too, and it predates #9778. The winner check therefore applies to any file that spells its own path. The regression pins both depths, and both were red before the fix.

One side effect: a discovered file whose namespace would load first from a jar entry is now refused, with the jar URL named. None of the lanes measured below has one.

## Named and left

- `RT/load` takes a compiled `__init.class` over either source when the class is newer. The winner check doesn't model that.
- `.cljs` needs nothing: JVM discovery never scans it and `require` never loads it.
- Data readers are not namespaces, so they are out of reach of this check.

## Quality gates

Every figure is a captured exit code from a run in this worktree, on base `92b220e32c`. Each lane run logged its git top-level, and it named this worktree.

**Test lanes, before and after**

| Lane | Before | After | Exit (both runs) |
|---|---|---|---|
| `jvm-test-quiet` (`clojure -M:test` in `implementation/test-quiet`) | 71 / 369 | 72 / 407 | 0 |
| `implementation/resources` `clojure -M:test` | 872 / 7763 | 872 / 7763 | 0 |
| `implementation/resources` `clojure -M:test -d test/re_frame` | 872 / 7763 | 872 / 7763 | 0 |
| `implementation/spec-resource` `clojure -M:test` | 3 / 126 | 3 / 126 | 0 |

- test-quiet's change is exactly the new deftest: 1 test and 38 assertions.
- The nested resources run sends every one of that lane's many `.cljc` test files through the classpath arm. An unchanged count there is the evidence that nothing real was refused.

**Lint and ratchets**

- clj-kondo on both changed files: 0 errors, 0 warnings.
- Splint `--fail-on-errors` over `implementation/test-quiet`: exit 0.
- `check_require_alias_dialect` (2914 files, 0 non-canonical), `check_test_lane_bijection` (1678 files, 45 lanes), `check_jvm_lane_rosters`, `check_retired_spellings`, `check_thrown_error_messages`, `check_ambient_durable_reads`, `check_keyword_catalogue_drift`, `check_inject_cofx_residue` and `check_egress_walker_residue`: all exit 0.

**Relying on CI** for every other job.
