### PR TITLE
fix(epoch): a replay that commits no epoch reports nil, not a stranger's (rf2-c74lr)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -325,11 +325,17 @@
 ;; counterexample stays fixed for the same reason it was before, and now for a
 ;; second: the child is neither the first commit nor the armed dispatch-id.
 ;;
-;; `:fallback-epoch-id` keeps the historical first-commit reading for the one
-;; case correlation cannot reach: no `:rf.event/dispatched` was captured for
-;; the frame at all, so there is no id to correlate on. Dispatch ids and that
-;; emit are both dev-gated and vanish together, so this is the no-dispatch-id
-;; posture rather than a silent second-guess of a correlation that failed.
+;; THERE IS NO FIRST-COMMIT FALLBACK (rf2-c74lr). One used to answer when no
+;; id had been captured, kept for the posture in which dispatch ids do not
+;; exist. That posture has no epochs either — capture is a trace stage, and
+;; the ring stays empty under the production gate — so the fallback only ever
+;; fired in dev, when the armed caller's OWN dispatch emitted nothing: a
+;; handler registered with `:rf.trace/no-emit?`, whose dispatch commits no
+;; epoch at all. Every commit it could adopt was therefore somebody else's —
+;; another thread's dispatch, or the quiet handler's own queued child — and
+;; replay reported it under the replayed event's name. Measured: source epoch
+;; 1, another thread's epoch 2, no replay epoch, and a result saying
+;; `:epoch-id 2`. No id means no evidence, and the slot answers nil.
 ;;
 ;; The arming token keeps a second, concurrent arming honest instead of
 ;; silently clobbering: `take-observed-commit!` answers nil for a caller whose
@@ -356,15 +362,14 @@
 
 (defn take-observed-commit!
   "Disarm `frame-id`'s observation and return the epoch-id committed by the
-  DISPATCH the arming caller itself started — nil when it committed nothing,
+  DISPATCH the arming caller itself started — nil when it committed nothing
+  (including when capture never heard its id, so no commit is evidence of it),
   or when a later arming replaced this one."
   [frame-id token]
   (let [slot (get @commit-observations frame-id)]
     (when (identical? token (:token slot))
       (swap! commit-observations dissoc frame-id)
-      (if (contains? slot :dispatch-id)
-        (:epoch-id slot)
-        (:fallback-epoch-id slot)))))
+      (:epoch-id slot))))
 
 #?(:clj
    (defn- armed-on-this-thread?
@@ -396,27 +401,21 @@
 
 (defn- note-commit!
   "Record `record`'s epoch-id against `frame-id`'s armed observation, once,
-  when the record was committed by the dispatch the observation targets. A
-  no-op when nothing is armed (the ordinary hot path: one map read, no
-  write)."
+  when the record was committed by the dispatch the observation targets, and
+  never otherwise. A no-op when nothing is armed (the ordinary hot path: one
+  map read, no write)."
   [frame-id record]
   (let [epoch-id    (:epoch-id record)
         dispatch-id (:dispatch-id record)]
-    (when (and epoch-id (contains? @commit-observations frame-id))
+    (when (and epoch-id dispatch-id (contains? @commit-observations frame-id))
       (swap! commit-observations
              (fn [observations]
                (let [slot (get observations frame-id)]
-                 (if-not slot
-                   observations
-                   (let [slot (cond-> slot
-                                (not (contains? slot :fallback-epoch-id))
-                                (assoc :fallback-epoch-id epoch-id)
-
-                                (and (some? dispatch-id)
-                                     (= dispatch-id (:dispatch-id slot))
-                                     (not (contains? slot :epoch-id)))
-                                (assoc :epoch-id epoch-id))]
-                     (assoc observations frame-id slot))))))
+                 (if (and slot
+                          (= dispatch-id (:dispatch-id slot))
+                          (not (contains? slot :epoch-id)))
+                   (assoc observations frame-id (assoc slot :epoch-id epoch-id))
+                   observations))))
       nil)))
 
 (defn reset-commit-observations!

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -716,8 +716,8 @@
   the replayed dispatch recorded:
 
     {:ok? true :frame <id> :source-epoch-id <id> :event-id <kw>
-     :epoch-id <the replayed event's own new epoch, nil if the ring could
-                not retain it>}
+     :epoch-id <the replayed event's own new epoch, nil if it committed none
+                or the ring could not retain it>}
 
   `:epoch-id` names the epoch the REPLAYED EVENT committed and no other. The
   identity is taken from the DISPATCH — a one-shot observation armed on the

--- a/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
@@ -37,6 +37,9 @@
     8. rf2-k0nr (JVM only) — another thread's same-frame dispatch landing
        between replay's observation arming and its dispatch never becomes
        the reported epoch.
+    9. rf2-c74lr — a replay that commits no epoch of its own (its handler now
+       opts out of tracing) reports nil, never a record another dispatch
+       committed: another thread's, or the replay's own queued child.
 
   `.cljc` under a `-cljs-test` name so the consolidated `:node-test` build
   (`cljs-test$`) AND the artefact's `clojure -M:test` (`.*-test$`) both run
@@ -515,6 +518,10 @@
 
 (def ^:private evict-frame-id :epoch-replay/eviction)
 
+(defn- parent-handler [{:keys [db]} _]
+  (cond-> {:db (update db :runs (fnil inc 0))}
+    (:runs db) (assoc :fx [[:dispatch [:review/child]]])))
+
 (defn- register-parent-and-child!
   "`:review/parent` enqueues `:review/child` only on its SECOND run, so the
   original recording retains its own epoch (the replay preconditions genuinely
@@ -522,10 +529,7 @@
   []
   (rf/reg-event :review/child
     (fn [{:keys [db]} _] {:db (assoc db :child true)}))
-  (rf/reg-event :review/parent
-    (fn [{:keys [db]} _]
-      (cond-> {:db (update db :runs (fnil inc 0))}
-        (:runs db) (assoc :fx [[:dispatch [:review/child]]])))))
+  (rf/reg-event :review/parent parent-handler))
 
 (deftest replay-reports-nil-when-its-own-epoch-was-evicted
   (testing "a queued child that evicts the replayed event's own record does NOT
@@ -595,9 +599,11 @@
 
 (def ^:private interleave-frame-id :epoch-replay/interleave)
 
+(defn- add-handler [{:keys [db]} [_ amount]]
+  {:db (update db :n (fnil + 0) amount)})
+
 (defn- register-add-and-other! []
-  (rf/reg-event :review/add
-    (fn [{:keys [db]} [_ amount]] {:db (update db :n (fnil + 0) amount)}))
+  (rf/reg-event :review/add add-handler)
   (rf/reg-event :review/other
     (fn [{:keys [db]} _] {:db (assoc db :other true)})))
 
@@ -803,3 +809,103 @@
              "the ring could not retain the replay's own epoch, so nil rides back")
          (is (= {:runs 2 :child true :other true} (rf/app-db-value evict-frame-id))
              "the other thread's event, the replayed parent and its child all ran")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-c74lr — a replay that commits no epoch of its own reports nil
+;;
+;; The residual rf2-k0nr named. A handler registered with
+;; `:rf.trace/no-emit? true` emits no trace, so its dispatch commits no epoch
+;; and epoch capture never hears its `:rf.event/dispatched`. Replay runs
+;; against CURRENT code (Tool-Pair §Replay), so re-registering a recorded
+;; handler with that opt-out and then replaying it is ordinary use. The
+;; observation then had no dispatch id to correlate on, fell back to the first
+;; commit the frame saw from anywhere, and reported a stranger's record as the
+;; replay's own — measured on the bead as source epoch 1, another thread's
+;; epoch 2, no replay epoch at all, and a result saying `:epoch-id 2`.
+;;
+;; Without the replay's own dispatch id no commit is evidence of the replay,
+;; so the answer is nil. The first deftest is the bead's witness, where the
+;; stranger is another JVM thread. The second is the same defect on ONE
+;; thread — the quiet parent's own queued child — which is why confining the
+;; fallback to the arming thread could not have closed it. The third is the
+;; green control.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-quiet!
+  "Re-register `event-id` with `handler` and its tracing opted out: the replay
+  still runs the same body, but its dispatch now commits no epoch."
+  [event-id handler]
+  (rf/reg-event event-id {:rf.trace/no-emit? true} handler))
+
+(defn- resolves-to
+  "The trigger event of the record `res` names in `history`, for messages."
+  [res history]
+  (:trigger-event (first (filter #(= (:epoch-id res) (:epoch-id %)) history))))
+
+#?(:clj
+   (deftest quiet-replay-reports-nil-not-another-threads-epoch
+     (testing "the replayed handler now opts out of tracing, so the replay
+               commits no epoch; another thread's same-frame dispatch commits
+               one inside the armed window, and nil rides back rather than it"
+       (rf/configure! {:epoch-history {:depth 10}})
+       (rf/make-frame {:id interleave-frame-id})
+       (register-add-and-other!)
+       (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+       (let [source (last (rf/epoch-history interleave-frame-id))
+             _      (reg-quiet! :review/add add-handler)
+             res    (replay-with-foreign-dispatch-after-arming
+                      interleave-frame-id (:epoch-id source) [:review/other])
+             after  (rf/epoch-history interleave-frame-id)]
+         (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+         (is (= (:epoch-id source) (:source-epoch-id res)))
+         (is (= [[:review/add 1] [:review/other]] (mapv :trigger-event after))
+             "the other thread's dispatch committed; the quiet replay added no
+              record of its own")
+         (is (= {:n 2 :other true} (rf/app-db-value interleave-frame-id))
+             "both dispatches executed; only the returned evidence was at stake")
+         ;; THE TOOTH.
+         (is (nil? (:epoch-id res))
+             (str "no epoch of the replay's was committed, so none is reported; "
+                  "got " (pr-str (:epoch-id res)) ", resolving to "
+                  (pr-str (resolves-to res after))))))))
+
+(deftest quiet-replay-reports-nil-not-its-queued-childs-epoch
+  (testing "the same defect on one thread: the quiet replayed parent enqueues
+            a traced child, the child commits, and nil rides back rather than
+            the child's record"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id evict-frame-id})
+    (register-parent-and-child!)
+    (rf/dispatch-sync [:review/parent] {:frame evict-frame-id})
+    (let [source (last (rf/epoch-history evict-frame-id))
+          _      (reg-quiet! :review/parent parent-handler)
+          res    (rf/replay-epoch! evict-frame-id (:epoch-id source))
+          after  (rf/epoch-history evict-frame-id)]
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= [:review/parent :review/child] (mapv :event-id after))
+          "only the child committed; the quiet parent added no record of its own")
+      (is (= {:runs 2 :child true} (rf/app-db-value evict-frame-id))
+          "the replayed parent ran, and so did its child")
+      ;; THE TOOTH.
+      (is (nil? (:epoch-id res))
+          (str "the child's record is not the replayed parent's epoch; got "
+               (pr-str (:epoch-id res)) ", resolving to "
+               (pr-str (resolves-to res after)))))))
+
+(deftest quiet-replay-alone-reports-nil
+  (testing "the control: with nothing else committing, the quiet replay still
+            runs, adds no record, and reports nil"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id interleave-frame-id})
+    (register-add-and-other!)
+    (rf/dispatch-sync [:review/add 1] {:frame interleave-frame-id})
+    (let [source (last (rf/epoch-history interleave-frame-id))
+          _      (reg-quiet! :review/add add-handler)
+          res    (rf/replay-epoch! interleave-frame-id (:epoch-id source))]
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= (:epoch-id source) (:source-epoch-id res)))
+      (is (nil? (:epoch-id res)))
+      (is (= [[:review/add 1]] (mapv :trigger-event (rf/epoch-history interleave-frame-id)))
+          "the history is unchanged")
+      (is (= {:n 2} (rf/app-db-value interleave-frame-id))
+          "the replayed handler ran"))))


### PR DESCRIPTION
Closes the residual that rf2-k0nr (PR #9785) named: replay's uncorrelated first-commit fallback could still hand back another dispatch's epoch (rf2-c74lr).

## What was wrong

`note-commit!` filled `:fallback-epoch-id` from the frame's first commit, whatever dispatch made it. `take-observed-commit!` returned that value whenever capture had heard no `:rf.event/dispatched` from the arming thread. The fallback was kept for the posture in which dispatch ids do not exist. That posture has no epochs either, though: capture is a trace stage, and the ring stays empty under the production gate. So the fallback only ever fired in dev, when the replayed dispatch itself emitted nothing. That means a handler registered with `:rf.trace/no-emit?`, which commits no epoch at all. Every commit the fallback could adopt belonged to another dispatch, and replay reported it under the replayed event's name.

## Fix

The fallback is removed. With no id there is no evidence that any commit belongs to the replay, so the slot answers nil. `note-commit!` fills the slot only from the record carrying the observed dispatch id. The correlated path (arming-thread dispatch identity from rf2-fzbj.19 and rf2-k0nr) is unchanged. There is no public API change, no new diagnostics and no core edit.

## Tests (`epoch_replay_cljs_test.cljc`)

- `quiet-replay-reports-nil-not-another-threads-epoch` (JVM): the bead's reproducer. It records `[:review/add 1]` and re-registers `:review/add` with `{:rf.trace/no-emit? true}`. It then replays on a future parked by a latch after the real `arm-commit-observation!`, while the test thread dispatches `[:review/other]` into the same frame. Assertions: both events ran, history is `[[:review/add 1] [:review/other]]`, and `:epoch-id` is nil.
- `quiet-replay-reports-nil-not-its-queued-childs-epoch` (JVM and CLJS): the same defect on one thread. The quiet replayed parent enqueues a traced child. The child's enqueue emit is suppressed under the parent's no-emit scope, so the child's commit also rode the fallback. A fallback confined to the arming thread would therefore not have closed this case.
- `quiet-replay-alone-reports-nil` (JVM and CLJS): the control, the bead's step 6. The quiet replay runs and reports nil, and history is unchanged.

The existing neighbouring deftests are unchanged and still pin the behaviours the bead says must be preserved: ordinary traced replay, same-thread listener nesting (same handler, different arguments), rf2-k0nr thread isolation, queued-child retained and evicted results, and failed-dispatch cleanup. The test edit also factors the two handler bodies into `add-handler` and `parent-handler`, so the quiet re-registrations reuse them.

## Quality gates

- RED on trunk `state.cljc` with only the new tests added: `clojure -M:test -n re-frame.epoch-replay-cljs-test` exited 1 at 21 tests / 151 assertions with 2 failures, both of them teeth. The foreign-thread case got an epoch resolving to `[:review/other]`, and the child case got one resolving to `[:review/child]`. The control passed.
- GREEN with the fix, same namespace: exit 0, 21 / 151, 0 failures.
- `jvm-epoch` (test.yml job "JVM epoch (clojure -M:test)", which owns `implementation/epoch/**`), before rebase: exit 0, 546 tests / 7343 assertions. That is the rf2-k0nr baseline of 543 / 7328 plus these 3 tests and 15 assertions.
- clj-kondo (`--fail-level error`) and Splint (`--fail-on-errors`) are clean on the three changed files, and all 8 Splint style warnings predate this change. The retired-spellings, composition-vocab and image-keys ratchets exit 0.
- `jvm-epoch` after rebasing onto `215e9e305a`, which changed the test-quiet runner: exit 0, 546 tests / 7343 assertions, the same counts as before the rebase.
- `cljs` (test.yml job "CLJS (shadow-cljs :node-test)", `npm run test:cljs`, which compiles and runs `state.cljc`'s cljs half and this `.cljc` suite): exit 0, 12080 tests / 60219 assertions, 0 failures. The run printed this worktree's `shadow-cljs.edn` as its config, so it read this tree.

## Not in this PR

- `spec/Tool-Pair.md` (hot zone) already reads "`:epoch-id` names the REPLAYED event's own epoch and never another record", so this fix brings the behaviour into line with it rather than changing documented behaviour. An optional clarification for whoever holds that file: extend "or nil when the ring did not retain it" to "or nil when it committed none (its handler opts out of tracing) or the ring did not retain it".
