### PR TITLE
fix(epoch): a quiet replay never adopts a traced descendant's dispatch identity (rf2-1mudg)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -205,10 +205,15 @@
       ;; rather than whichever cascade happened to commit first. A no-op —
       ;; one map read — when nothing is armed, which is every ordinary
       ;; dispatch. Deliberately ahead of `skip-ops` and every routing branch
-      ;; below: this records identity, it buffers nothing.
+      ;; below: this records identity, it buffers nothing. The lineage parent
+      ;; rides along so a quiet caller's traced descendant — which reports
+      ;; first when the caller's own emit is suppressed — is told apart from
+      ;; the caller rather than adopted (rf2-1mudg).
       (when (and frame-id (= :rf.event/dispatched operation))
         (rf.epoch.state/note-observed-dispatch!
-          frame-id (:rf.trace/dispatch-id event-tags)))
+          frame-id
+          (:rf.trace/dispatch-id event-tags)
+          (:rf.trace/parent-dispatch-id event-tags)))
       ;; Any path below that can mutate epoch state first claims the id-keyed
       ;; stores for the exact live frame incarnation. This serialises a fresh
       ;; same-id B publication against stale A's final destroy hook.

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -21,7 +21,8 @@
   per-registration GENERATION token (see the listener-registry section) rather
   than a cross-atom update, so no operation requires an atomic update across two
   of these stores."
-  (:require [re-frame.privacy :as rf.privacy]))
+  (:require [re-frame.privacy :as rf.privacy]
+            [re-frame.trace :as rf.trace]))
 
 ;; ---- configuration --------------------------------------------------------
 
@@ -337,6 +338,24 @@
 ;; 1, another thread's epoch 2, no replay epoch, and a result saying
 ;; `:epoch-id 2`. No id means no evidence, and the slot answers nil.
 ;;
+;; AND THE FIRST ID IS THE CALLER'S ONLY WHEN ITS LINEAGE SAYS SO (rf2-1mudg).
+;; "First from the arming thread" presumes the caller's own dispatch reported
+;; at all. A quiet handler's does not, and nor does anything enqueued inside
+;; its handler scope — but a TRACED child it queued runs with tracing on
+;; again, so that child's own queued grandchild was the first
+;; `:rf.event/dispatched` the arming thread reported, was adopted, and its
+;; commit then correlated to it exactly. Measured: source epoch 1, no replay
+;; epoch, and a result saying `:epoch-id 3`, resolving to the grandchild.
+;; Spec 009's run lineage tells the two apart: a dispatch's
+;; `:rf.trace/parent-dispatch-id` is the dispatch whose handler scope enqueued
+;; it, absent at top level. The caller's own dispatch is made from the scope
+;; the caller ARMED in, and everything its cascade enqueues names a run inside
+;; that cascade instead, so the slot records the arming scope's dispatch-id
+;; and the first id the arming thread reports DECIDES: taken when its parent
+;; matches, and otherwise the slot closes with no id. Closing rather than
+;; waiting is what makes it exact — the caller's own emit precedes its drain,
+;; so once a descendant has reported, the caller's never will.
+;;
 ;; The arming token keeps a second, concurrent arming honest instead of
 ;; silently clobbering: `take-observed-commit!` answers nil for a caller whose
 ;; arming was replaced, which is the same "no retained epoch" the documented
@@ -352,12 +371,15 @@
   Arm it IMMEDIATELY before the dispatch whose epoch you want, on the thread
   that makes it: the armed caller's own dispatch has to be the first one epoch
   capture sees for the frame FROM THAT THREAD, which is what makes the
-  correlation above exact."
+  correlation above exact. The slot also records the dispatch-id of the
+  handler scope it is armed in (nil at top level): the armed dispatch carries
+  that as its parent, and nothing its cascade enqueues does (rf2-1mudg)."
   [frame-id]
-  (let [token #?(:clj (Object.) :cljs (js-obj))]
+  (let [token  #?(:clj (Object.) :cljs (js-obj))
+        parent (some-> rf.trace/*handler-scope* :dispatch-id)]
     (swap! commit-observations assoc frame-id
-           #?(:clj  {:token token :thread (Thread/currentThread)}
-              :cljs {:token token}))
+           #?(:clj  {:token token :parent parent :thread (Thread/currentThread)}
+              :cljs {:token token :parent parent}))
     token))
 
 (defn take-observed-commit!
@@ -385,9 +407,14 @@
   ARMING THREAD is the armed caller's own dispatch and not one a listener
   started from inside it. An id reported by any other thread is refused: on
   the JVM another thread's same-frame dispatch can reach this first (rf2-k0nr).
+
+  That first id DECIDES, once: it is the caller's own only when its
+  `parent-dispatch-id` is the scope the caller armed in. Otherwise the
+  caller's own emit was suppressed and this is a descendant's, so the slot
+  closes with no id and no commit can fill it (rf2-1mudg).
   A no-op when nothing is armed (the ordinary hot path: one map read, no
   write), and after the first id has landed."
-  [frame-id dispatch-id]
+  [frame-id dispatch-id parent-dispatch-id]
   (when (and dispatch-id (contains? @commit-observations frame-id))
     (swap! commit-observations
            (fn [observations]
@@ -395,7 +422,10 @@
                (if (and slot
                         (not (contains? slot :dispatch-id))
                         #?(:clj (armed-on-this-thread? slot)))
-                 (assoc observations frame-id (assoc slot :dispatch-id dispatch-id))
+                 (assoc observations frame-id
+                        (assoc slot :dispatch-id
+                               (when (= parent-dispatch-id (:parent slot))
+                                 dispatch-id)))
                  observations))))
     nil))
 

--- a/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc
@@ -40,6 +40,8 @@
     9. rf2-c74lr — a replay that commits no epoch of its own (its handler now
        opts out of tracing) reports nil, never a record another dispatch
        committed: another thread's, or the replay's own queued child.
+   10. rf2-1mudg — nor its queued GRANDCHILD's: a traced descendant's
+       dispatch is never adopted as the quiet replay's own identity.
 
   `.cljc` under a `-cljs-test` name so the consolidated `:node-test` build
   (`cljs-test$`) AND the artefact's `clojure -M:test` (`.*-test$`) both run
@@ -909,3 +911,83 @@
           "the history is unchanged")
       (is (= {:n 2} (rf/app-db-value interleave-frame-id))
           "the replayed handler ran"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-1mudg — a quiet replay never adopts a traced DESCENDANT's identity
+;;
+;; What rf2-c74lr left open, one generation further down. The quiet parent's
+;; own `:rf.event/dispatched` is suppressed, and so is its child's enqueue emit
+;; (it happens inside the parent's no-emit handler scope). The child itself
+;; runs traced, so when IT queues a grandchild, that enqueue emit arrives —
+;; the first `:rf.event/dispatched` the arming thread reports. The observation
+;; took it for the replay's own dispatch and the commit funnel then correlated
+;; the grandchild's commit to it exactly. Measured on the bead: source epoch 1,
+;; no replay-parent epoch, and a result saying `:epoch-id 3`, resolving to
+;; `[:audit/grandchild]`.
+;;
+;; The first deftest is the tooth. The second is the traced control over the
+;; same three generations: the replay reports its own new parent record.
+;; ---------------------------------------------------------------------------
+
+(defn- register-three-generations!
+  "`:review/parent` enqueues `:review/child` from its SECOND run (see
+  `parent-handler`), and `:review/child` always enqueues `:review/grandchild`,
+  so only the replay settles a two-level queued cascade."
+  []
+  (rf/reg-event :review/grandchild
+    (fn [{:keys [db]} _] {:db (assoc db :grandchild true)}))
+  (rf/reg-event :review/child
+    (fn [{:keys [db]} _]
+      {:db (assoc db :child true)
+       :fx [[:dispatch [:review/grandchild]]]}))
+  (rf/reg-event :review/parent parent-handler))
+
+(deftest quiet-replay-reports-nil-not-its-queued-grandchilds-epoch
+  (testing "the quiet replayed parent enqueues a traced child that enqueues a
+            traced grandchild; all three run, only the source parent, the
+            child and the grandchild commit records, and nil rides back rather
+            than the grandchild's"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id evict-frame-id})
+    (register-three-generations!)
+    (rf/dispatch-sync [:review/parent] {:frame evict-frame-id})
+    (let [source (last (rf/epoch-history evict-frame-id))
+          _      (reg-quiet! :review/parent parent-handler)
+          res    (rf/replay-epoch! evict-frame-id (:epoch-id source))
+          after  (rf/epoch-history evict-frame-id)]
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= (:epoch-id source) (:source-epoch-id res)))
+      (is (= [[:review/parent] [:review/child] [:review/grandchild]]
+             (mapv :trigger-event after))
+          "the source parent, then the replay's child and grandchild; the
+           quiet parent added no record of its own")
+      (is (= {:runs 2 :child true :grandchild true}
+             (rf/app-db-value evict-frame-id))
+          "the replayed parent, its child and its grandchild all ran")
+      ;; THE TOOTH.
+      (is (nil? (:epoch-id res))
+          (str "the grandchild's record is not the replayed parent's epoch; got "
+               (pr-str (:epoch-id res)) ", resolving to "
+               (pr-str (resolves-to res after)))))))
+
+(deftest traced-replay-over-two-queued-levels-reports-its-own-epoch
+  (testing "the control: the same three generations with the parent traced;
+            the replay reports its OWN new parent record, never the child's or
+            the grandchild's"
+    (rf/configure! {:epoch-history {:depth 10}})
+    (rf/make-frame {:id evict-frame-id})
+    (register-three-generations!)
+    (rf/dispatch-sync [:review/parent] {:frame evict-frame-id})
+    (let [source (last (rf/epoch-history evict-frame-id))
+          res    (rf/replay-epoch! evict-frame-id (:epoch-id source))
+          after  (rf/epoch-history evict-frame-id)]
+      (is (true? (:ok? res)) (str "the replay itself succeeded: " (pr-str res)))
+      (is (= [:review/parent :review/parent :review/child :review/grandchild]
+             (mapv :event-id after))
+          "the source parent, the replay's parent, its child and grandchild")
+      (is (= {:runs 2 :child true :grandchild true}
+             (rf/app-db-value evict-frame-id)))
+      (is (= (:epoch-id (nth after 1)) (:epoch-id res))
+          (str "the reported epoch is the replay's own new parent record; got "
+               (pr-str (:epoch-id res)) ", resolving to "
+               (pr-str (resolves-to res after)))))))


### PR DESCRIPTION
## Summary

Completes rf2-c74lr (PR #9791). Before this change, a replay whose handler had been re-registered with `:rf.trace/no-emit?` returned the wrong `:epoch-id` when the handler queued a traced child that queued a traced grandchild: it returned the grandchild's epoch as the replay's own. Now it returns nil, because the replay committed no epoch of its own. An ordinary traced replay still returns its own retained epoch, or nil if that epoch was evicted.

## Cause

`note-observed-dispatch!` took the first `:rf.event/dispatched` id reported on the arming thread and treated it as the replay's own. With a quiet parent, two emits are suppressed: the parent's own, and its child's enqueue emit, which happens inside the parent's no-emit handler scope. The traced child's enqueue of the grandchild is therefore the first to arrive. The observation adopted it, and `note-commit!` then matched the grandchild's commit to it exactly.

## Fix (epoch only)

- `arm-commit-observation!` now records the dispatch-id of the handler scope it is armed in (`rf.trace/*handler-scope*`, nil at top level). Spec 009 §Dispatch correlation guarantees that the armed caller's own dispatch carries exactly that id as `:rf.trace/parent-dispatch-id`. Anything its cascade enqueues names a run inside the cascade as its parent instead.
- `note-observed-dispatch!` now also receives the trace's parent-dispatch-id. The first id reported on the arming thread decides the outcome, once:
  - if its parent is the arming scope, it is the caller's own id and is taken;
  - otherwise the slot closes with no id.

  Closing the slot is exact rather than premature: the caller's own emit comes before its drain starts, so once a descendant has reported, the caller's emit never will.
- `capture.cljc` passes `:rf.trace/parent-dispatch-id` through to it.

There is no event-vector matching, no public API change, no new diagnostic, and no core or spec change. Thread isolation (rf2-k0nr), trace-listener nesting (rf2-fzbj.19), strict replay inputs, and the `finally` that always disarms the observation are all unchanged.

## Tests

Two new deftests in `implementation/epoch/test/re_frame/epoch_replay_cljs_test.cljc`, which runs on both JVM and CLJS:

- `quiet-replay-reports-nil-not-its-queued-grandchilds-epoch` is the regression. All three handlers run. The only records are the source parent, the child and the grandchild. Replay returns `:epoch-id nil`.
- `traced-replay-over-two-queued-levels-reports-its-own-epoch` is the control: the same three generations with the parent traced. Replay returns the new parent record.

The existing child-only quiet case and all the older neighbouring tests are kept.

## Quality gates

**Red on the base.** The tests were committed before the fix.

| Run | Exit | Tests | Assertions | Failures |
|---|---|---|---|---|
| JVM replay namespace | 1 | 23 | 160 | 1 |
| CLJS replay namespace (compile exit 0) | 1 | 20 | 141 | 1 |

In both runs the single failure is the new regression, and it reports an epoch that resolves to `[:review/grandchild]`.

**Green with the fix.**

| Gate | Exit | Tests | Assertions | Failures |
|---|---|---|---|---|
| JVM replay namespace | 0 | 23 | 160 | 0 |
| `jvm-epoch` (`clojure -M:test` in `implementation/epoch`) | 0 | 548 | 7352 | 0 |
| `cljs` lane (`npm run test:cljs`) | 0 | 12084 | 60250 | 0 |

- rf2-c74lr landed `jvm-epoch` at 546 tests / 7343 assertions. The difference is exactly the two new deftests (+2 tests, +9 assertions).
- The CLJS run printed this checkout's `shadow-cljs.edn` as its config, so it tested this change.

**Lint and ratchets.**

- clj-kondo (`--fail-level error`) on the three changed files: 0 errors, 0 warnings.
- Splint (`--fail-on-errors`): exit 0. All 9 of its style warnings were already there at the merge base.
- `check_retired_spellings.py`, `check_retired_composition_vocab.py`, `check_retired_image_keys.py` and `check_require_alias_dialect.py` all exit 0.

**Base.** The branch is based on `a586921b94`. Trunk has gained one commit since, a beads checkpoint that touches no code, so the gates were not re-run for it.

**Left to CI:** `jvm-epoch-prod-gate`, and the browser, prod-elision, bundle-isolation and MCP conformance/live jobs that the classifier arms for this path.

## Owning `test.yml` jobs

Per `.github/scripts/report-changed-surfaces.sh`, a change under `implementation/epoch/*` arms:

- `implementation_jvm` → `jvm-epoch` ("JVM epoch (clojure -M:test)") and `jvm-epoch-prod-gate`
- `cljs_node_test` → `cljs` ("CLJS (shadow-cljs :node-test)")
- `cljs_browser`, `cljs_prod`, `bundle_isolation`, `mcp_conformance` and `mcp_live`

## Spec

No spec edit. `spec/Tool-Pair.md` already says `:epoch-id` names the replayed event's own epoch and never another record, and this change makes the code match. The lineage the fix relies on is Spec 009 §Dispatch correlation as written.
